### PR TITLE
fix: address Codex review for structured output

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -335,29 +335,33 @@ export class Agent {
       ? firstAttemptError.message
       : String(firstAttemptError)
 
+    const errorFeedbackMessage: LLMMessage = {
+      role: 'user' as const,
+      content: [{
+        type: 'text' as const,
+        text: [
+          'Your previous response did not produce valid JSON matching the required schema.',
+          '',
+          `Error: ${errorMsg}`,
+          '',
+          'Please try again. Respond with ONLY valid JSON, no other text.',
+        ].join('\n'),
+      }],
+    }
+
     const retryMessages: LLMMessage[] = [
       ...originalMessages,
       ...result.messages,
-      {
-        role: 'user' as const,
-        content: [{
-          type: 'text' as const,
-          text: [
-            'Your previous response did not produce valid JSON matching the required schema.',
-            '',
-            `Error: ${errorMsg}`,
-            '',
-            'Please try again. Respond with ONLY valid JSON, no other text.',
-          ].join('\n'),
-        }],
-      },
+      errorFeedbackMessage,
     ]
 
     const retryResult = await runner.run(retryMessages, runOptions)
     this.state.tokenUsage = addUsage(this.state.tokenUsage, retryResult.tokenUsage)
 
     const mergedTokenUsage = addUsage(result.tokenUsage, retryResult.tokenUsage)
-    const mergedMessages = [...result.messages, ...retryResult.messages]
+    // Include the error feedback turn to maintain alternating user/assistant roles,
+    // which is required by Anthropic's API for subsequent prompt() calls.
+    const mergedMessages = [...result.messages, errorFeedbackMessage, ...retryResult.messages]
     const mergedToolCalls = [...result.toolCalls, ...retryResult.toolCalls]
 
     try {

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -845,7 +845,7 @@ export class OpenMultiAgent {
           messages: [...existing.messages, ...result.messages],
           tokenUsage: addUsage(existing.tokenUsage, result.tokenUsage),
           toolCalls: [...existing.toolCalls, ...result.toolCalls],
-          structured: result.structured ?? existing.structured,
+          structured: result.structured !== undefined ? result.structured : existing.structured,
         })
       }
 


### PR DESCRIPTION
## Summary

Addresses Codex review comments on #36:

- **P1**: Include the error feedback user turn in `mergedMessages` so `prompt()` multi-turn history maintains alternating user/assistant roles (required by Anthropic API)
- **P2**: Use `!== undefined` instead of `??` when merging `structured` field, so `null` is preserved as a valid structured output value

## Test plan

- [x] `npm run build` + `npm run lint` pass
- [x] 86/86 tests pass