### PR TITLE
docs: add Translations section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ Issues, feature requests, and PRs are welcome. Some areas where contributions wo
  </picture>
 </a>
 
+## Translations
+
+Help translate this README — [open a PR](https://github.com/JackChen-me/open-multi-agent/pulls).
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

- Add a Translations section above License, inviting community PRs for README translations

## Test plan

- [ ] Verify the PR link works on GitHub