### PR TITLE
chore: add source field to feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,17 @@ labels: enhancement
 assignees: ''
 ---
 
+## Source
+
+**Where did this idea come from?** (Pick one — helps maintainers triage and prioritize.)
+
+- [ ] **Real use case** — I'm using open-multi-agent and hit this limit. Describe the use case in "Problem" below.
+- [ ] **Competitive reference** — Another framework has this (LangChain, AutoGen, CrewAI, Mastra, XCLI, etc.). Please name or link it.
+- [ ] **Systematic gap** — A missing piece in the framework matrix (provider not supported, tool not covered, etc.).
+- [ ] **Discussion / inspiration** — Came up in a tweet, Reddit post, Discord, or AI conversation. Please link or paste the source if possible.
+
+> **Maintainer note**: after triage, label with one of `community-feedback`, `source:competitive`, `source:analysis`, `source:owner` (multiple OK if the source is mixed — e.g. competitive analysis + user feedback).
+
 ## Problem
 
 A clear description of the problem or limitation you're experiencing.


### PR DESCRIPTION
## Summary

- Add a **Source** section to the feature request issue template with four origin categories: real use case, competitive reference, systematic gap, and discussion/inspiration
- Helps maintainers triage and prioritize by understanding where ideas come from
- Includes maintainer note for post-triage labeling convention

No code changes, template only.