### PR TITLE
chore: silence codecov PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
## Summary
- Add \`codecov.yml\` with \`comment: false\` to stop the codecov bot from posting on PRs.
- README badge keeps working. CI coverage upload keeps working. Only the per-PR comment (including the \"install Codecov app\" nudge) is suppressed.

## Test plan
- [ ] Confirm no codecov comment appears on this PR or subsequent PRs.
- [ ] Badge continues to update on main after merges.