### PR TITLE
feat: enforce optional outputSchema validation and wire defineTool passthrough (#120)

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,15 @@ Long tool outputs can blow up conversation size and cost. Two controls work toge
 
 **Validation (optional).** Add `outputSchema` to catch malformed tool results before they are forwarded:
 
+> **Note — two different `outputSchema` fields.** The one on `defineTool()` /
+> `ToolDefinition` (shown below) validates a single **tool's** `ToolResult.data`
+> — it is always a `ZodSchema<string>` because tool output is serialised as
+> text. The `outputSchema` on [`AgentConfig`](examples/patterns/structured-output.ts)
+> is different: it validates the **agent's final answer** as parsed JSON
+> against an arbitrary Zod schema (see _Structured output_ in `examples/`).
+> Different types, different scopes — TypeScript won't warn you if you mix
+> them up, so pick the one that matches the layer you're working at.
+
 ```typescript
 const jsonTool = defineTool({
   name: 'json_tool',

--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ import { z } from 'zod'
 const weatherTool = defineTool({
   name: 'get_weather',
   description: 'Look up current weather for a city.',
-  schema: z.object({ city: z.string() }),
-  execute: async ({ city }) => ({ content: await fetchWeather(city) }),
+  inputSchema: z.object({ city: z.string() }),
+  execute: async ({ city }) => ({ data: await fetchWeather(city) }),
 })
 
 const agent: AgentConfig = {
@@ -283,6 +283,25 @@ const agent: AgentConfig = {
 ### Tool Output Control
 
 Long tool outputs can blow up conversation size and cost. Two controls work together.
+
+**Validation (optional).** Add `outputSchema` to catch malformed tool results before they are forwarded:
+
+```typescript
+const jsonTool = defineTool({
+  name: 'json_tool',
+  description: 'Return JSON payload as string.',
+  inputSchema: z.object({}),
+  outputSchema: z.string().refine((value) => {
+    try {
+      JSON.parse(value)
+      return true
+    } catch {
+      return false
+    }
+  }, 'Output must be valid JSON'),
+  execute: async () => ({ data: '{"ok": true}' }),
+})
+```
 
 **Truncation.** Cap an individual tool result to a head + tail excerpt with a marker in between:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -281,6 +281,14 @@ const agent: AgentConfig = {
 
 **校验（可选）。** 给工具加 `outputSchema`，在结果回传前拦截结构错误：
 
+> **注意 —— 有两个同名的 `outputSchema`。** 这里 `defineTool()` / `ToolDefinition`
+> 上的 `outputSchema`（下例所示）校验的是单个**工具**的 `ToolResult.data`，类型
+> 固定为 `ZodSchema<string>`，因为工具输出始终以字符串形式序列化。
+> [`AgentConfig`](examples/patterns/structured-output.ts) 上同名的 `outputSchema`
+> 则完全不同：它把 **agent 的最终回答**按 JSON 解析后，用任意 Zod schema 进行
+> 校验（详见 `examples/` 里的"结构化输出"示例）。两者类型和作用域都不一样，
+> 且 TypeScript 不会提示混用，请根据所处层级选用对应的那个。
+
 ```typescript
 const jsonTool = defineTool({
   name: 'json_tool',

--- a/README_zh.md
+++ b/README_zh.md
@@ -262,8 +262,8 @@ import { z } from 'zod'
 const weatherTool = defineTool({
   name: 'get_weather',
   description: '查询某城市当前天气。',
-  schema: z.object({ city: z.string() }),
-  execute: async ({ city }) => ({ content: await fetchWeather(city) }),
+  inputSchema: z.object({ city: z.string() }),
+  execute: async ({ city }) => ({ data: await fetchWeather(city) }),
 })
 
 const agent: AgentConfig = {
@@ -278,6 +278,25 @@ const agent: AgentConfig = {
 ### 工具输出控制
 
 工具返回太长会快速撑大对话和成本。两个开关配合着用。
+
+**校验（可选）。** 给工具加 `outputSchema`，在结果回传前拦截结构错误：
+
+```typescript
+const jsonTool = defineTool({
+  name: 'json_tool',
+  description: '以字符串返回 JSON 载荷。',
+  inputSchema: z.object({}),
+  outputSchema: z.string().refine((value) => {
+    try {
+      JSON.parse(value)
+      return true
+    } catch {
+      return false
+    }
+  }, '输出必须是合法 JSON'),
+  execute: async () => ({ data: '{"ok": true}' }),
+})
+```
 
 **截断。** 把单次工具结果压成 head + tail 摘要（中间放一个标记）：
 

--- a/src/tool/executor.ts
+++ b/src/tool/executor.ts
@@ -135,10 +135,14 @@ export class ToolExecutor {
 
   /**
    * Validate input with the tool's Zod schema, then call `execute`.
-   * When configured, output is validated against `tool.outputSchema` before
-   * truncation is applied.
-   * Any synchronous or asynchronous error is caught and turned into an error
-   * ToolResult.
+   *
+   * When `tool.outputSchema` is configured and the tool returned a
+   * **non-error** result, `result.data` is validated against the schema
+   * before truncation is applied. Error results are forwarded as-is so the
+   * LLM still sees the original failure message.
+   *
+   * Any synchronous or asynchronous error thrown by the tool is caught and
+   * turned into an error {@link ToolResult} instead of propagating.
    */
   private async runTool(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -147,7 +151,7 @@ export class ToolExecutor {
     context: ToolUseContext,
   ): Promise<ToolResult> {
     // --- Zod validation ---
-    const inputParseResult = this.runZodSchema(tool.inputSchema, rawInput);
+    const inputParseResult = this.runZodSchema(tool.inputSchema, rawInput)
     if (!inputParseResult.success) {
       return this.errorResult(
         `Invalid input for tool "${tool.name}":\n${inputParseResult.issuesMessage}`,
@@ -164,8 +168,8 @@ export class ToolExecutor {
     // --- Execute ---
     try {
       const result = await tool.execute(inputParseResult.data, context)
-      if (tool.outputSchema) {
-        const outputParseResult = this.runZodSchema(tool.outputSchema, result.data);
+      if (!result.isError && tool.outputSchema) {
+        const outputParseResult = this.runZodSchema(tool.outputSchema, result.data)
         if (!outputParseResult.success) {
           return this.errorResult(
             `Invalid output for tool "${tool.name}":\n${outputParseResult.issuesMessage}`,
@@ -196,7 +200,7 @@ export class ToolExecutor {
         issuesMessage,
       }
     }
-    return parseResult;
+    return parseResult
   }
 
   /**

--- a/src/tool/executor.ts
+++ b/src/tool/executor.ts
@@ -13,6 +13,7 @@ import type { ToolResult, ToolUseContext } from '../types.js'
 import type { ToolDefinition } from '../types.js'
 import { ToolRegistry } from './framework.js'
 import { Semaphore } from '../utils/semaphore.js'
+import type { ZodSchema } from 'zod'
 
 // ---------------------------------------------------------------------------
 // ToolExecutor
@@ -143,13 +144,10 @@ export class ToolExecutor {
     context: ToolUseContext,
   ): Promise<ToolResult> {
     // --- Zod validation ---
-    const parseResult = tool.inputSchema.safeParse(rawInput)
-    if (!parseResult.success) {
-      const issues = parseResult.error.issues
-        .map((issue) => `  • ${issue.path.join('.')}: ${issue.message}`)
-        .join('\n')
+    const inputParseResult = this.runZodSchema(tool.inputSchema, rawInput);
+    if (!inputParseResult.success) {
       return this.errorResult(
-        `Invalid input for tool "${tool.name}":\n${issues}`,
+        `Invalid input for tool "${tool.name}":\n${inputParseResult.issuesMessage}`,
       )
     }
 
@@ -162,7 +160,15 @@ export class ToolExecutor {
 
     // --- Execute ---
     try {
-      const result = await tool.execute(parseResult.data, context)
+      const result = await tool.execute(inputParseResult.data, context)
+      if (tool.outputSchema) {
+        const outputParseResult = this.runZodSchema(tool.outputSchema, result.data);
+        if (!outputParseResult.success) {
+          return this.errorResult(
+            `Invalid output for tool "${tool.name}":\n${outputParseResult.issuesMessage}`,
+          )
+        }
+      }
       return this.maybeTruncate(tool, result)
     } catch (err) {
       const message =
@@ -173,6 +179,20 @@ export class ToolExecutor {
             : JSON.stringify(err)
       return this.maybeTruncate(tool, this.errorResult(`Tool "${tool.name}" threw an error: ${message}`))
     }
+  }
+
+  private runZodSchema<T>(schema: ZodSchema<T>, rawInput: T) {
+    const parseResult = schema.safeParse(rawInput)
+    if (!parseResult.success) {
+      const issuesMessage = parseResult.error.issues
+        .map((issue) => `  • ${issue.path.join('.')}: ${issue.message}`)
+        .join('\n')
+      return {
+        ...parseResult,
+        issuesMessage,
+      }
+    }
+    return parseResult;
   }
 
   /**

--- a/src/tool/executor.ts
+++ b/src/tool/executor.ts
@@ -1,9 +1,10 @@
 /**
  * Parallel tool executor with concurrency control and error isolation.
  *
- * Validates input via Zod schemas, enforces a maximum concurrency limit using
- * a lightweight semaphore, tracks execution duration, and surfaces any
- * execution errors as ToolResult objects rather than thrown exceptions.
+ * Validates input via Zod schemas, optionally validates tool output via
+ * `tool.outputSchema`, enforces a maximum concurrency limit using a lightweight
+ * semaphore, and surfaces any execution errors as ToolResult objects rather
+ * than thrown exceptions.
  *
  * Types are imported from `../types` to ensure consistency with the rest of
  * the framework.
@@ -134,6 +135,8 @@ export class ToolExecutor {
 
   /**
    * Validate input with the tool's Zod schema, then call `execute`.
+   * When configured, output is validated against `tool.outputSchema` before
+   * truncation is applied.
    * Any synchronous or asynchronous error is caught and turned into an error
    * ToolResult.
    */
@@ -181,6 +184,7 @@ export class ToolExecutor {
     }
   }
 
+  /** Run a Zod schema and return a flattened issue string on failure. */
   private runZodSchema<T>(schema: ZodSchema<T>, rawInput: T) {
     const parseResult = schema.safeParse(rawInput)
     if (!parseResult.success) {

--- a/src/tool/framework.ts
+++ b/src/tool/framework.ts
@@ -68,10 +68,12 @@ export type JSONSchemaProperty =
  * })
  * ```
  */
-export function defineTool<TInput>(config: {
+export function defineTool<TInput, TOutput>(config: {
   name: string
   description: string
   inputSchema: ZodSchema<TInput>
+  /** optional outputScehma */
+  outputSchema?: ZodSchema<TOutput>
   /**
    * Optional JSON Schema for the LLM (bypasses Zod → JSON Schema conversion).
    */
@@ -83,11 +85,14 @@ export function defineTool<TInput>(config: {
    */
   maxOutputChars?: number
   execute: (input: TInput, context: ToolUseContext) => Promise<ToolResult>
-}): ToolDefinition<TInput> {
+}): ToolDefinition<TInput, TOutput> {
   return {
     name: config.name,
     description: config.description,
     inputSchema: config.inputSchema,
+    ...(config.outputSchema !== undefined
+      ? { outputSchema: config.outputSchema }
+      : {}),
     ...(config.llmInputSchema !== undefined
       ? { llmInputSchema: config.llmInputSchema }
       : {}),

--- a/src/tool/framework.ts
+++ b/src/tool/framework.ts
@@ -68,7 +68,7 @@ export type JSONSchemaProperty =
  * })
  * ```
  */
-export function defineTool<TInput, TOutput = string>(config: {
+export function defineTool<TInput>(config: {
   name: string
   description: string
   inputSchema: ZodSchema<TInput>
@@ -76,9 +76,11 @@ export function defineTool<TInput, TOutput = string>(config: {
    * Optional runtime validator for `ToolResult.data`.
    * When omitted, output validation is skipped.
    *
-   * `TOutput` defaults to `string` because `ToolResult.data` is string-based.
+   * `ToolResult.data` is always a `string`, so the schema is fixed to
+   * `ZodSchema<string>` — use `z.string().refine(...)` / `z.string().regex(...)`
+   * (or similar) to enforce structural constraints on the serialised output.
    */
-  outputSchema?: ZodSchema<TOutput>
+  outputSchema?: ZodSchema<string>
   /**
    * Optional JSON Schema for the LLM (bypasses Zod → JSON Schema conversion).
    */
@@ -90,7 +92,7 @@ export function defineTool<TInput, TOutput = string>(config: {
    */
   maxOutputChars?: number
   execute: (input: TInput, context: ToolUseContext) => Promise<ToolResult>
-}): ToolDefinition<TInput, TOutput> {
+}): ToolDefinition<TInput> {
   return {
     name: config.name,
     description: config.description,

--- a/src/tool/framework.ts
+++ b/src/tool/framework.ts
@@ -68,11 +68,16 @@ export type JSONSchemaProperty =
  * })
  * ```
  */
-export function defineTool<TInput, TOutput>(config: {
+export function defineTool<TInput, TOutput = string>(config: {
   name: string
   description: string
   inputSchema: ZodSchema<TInput>
-  /** optional outputScehma */
+  /**
+   * Optional runtime validator for `ToolResult.data`.
+   * When omitted, output validation is skipped.
+   *
+   * `TOutput` defaults to `string` because `ToolResult.data` is string-based.
+   */
   outputSchema?: ZodSchema<TOutput>
   /**
    * Optional JSON Schema for the LLM (bypasses Zod → JSON Schema conversion).

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,12 +234,16 @@ export interface ToolResult {
  * `inputSchema` is a Zod schema used for validation before `execute` is called.
  * At API call time it is converted to JSON Schema for {@link LLMToolDef}, unless
  * `llmInputSchema` is set (e.g. MCP tools ship JSON Schema from the server).
+ *
+ * `outputSchema` is optional runtime validation for `ToolResult.data`.  When
+ * set and validation fails, execution returns an error ToolResult instead of
+ * propagating invalid output.
  */
 export interface ToolDefinition<TInput = Record<string, unknown>, TOutput = string> {
   readonly name: string
   readonly description: string
   readonly inputSchema: ZodSchema<TInput>
-  /** optional outputSchema to detect invalid output */
+  /** Optional runtime validator for `ToolResult.data`. */
   readonly outputSchema?: ZodSchema<TOutput>
   /**
    * When present, used as {@link LLMToolDef.inputSchema} as-is instead of

--- a/src/types.ts
+++ b/src/types.ts
@@ -235,10 +235,12 @@ export interface ToolResult {
  * At API call time it is converted to JSON Schema for {@link LLMToolDef}, unless
  * `llmInputSchema` is set (e.g. MCP tools ship JSON Schema from the server).
  */
-export interface ToolDefinition<TInput = Record<string, unknown>> {
+export interface ToolDefinition<TInput = Record<string, unknown>, TOutput = string> {
   readonly name: string
   readonly description: string
   readonly inputSchema: ZodSchema<TInput>
+  /** optional outputSchema to detect invalid output */
+  readonly outputSchema?: ZodSchema<TOutput>
   /**
    * When present, used as {@link LLMToolDef.inputSchema} as-is instead of
    * deriving JSON Schema from `inputSchema` (Zod).

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,12 +239,18 @@ export interface ToolResult {
  * set and validation fails, execution returns an error ToolResult instead of
  * propagating invalid output.
  */
-export interface ToolDefinition<TInput = Record<string, unknown>, TOutput = string> {
+export interface ToolDefinition<TInput = Record<string, unknown>> {
   readonly name: string
   readonly description: string
   readonly inputSchema: ZodSchema<TInput>
-  /** Optional runtime validator for `ToolResult.data`. */
-  readonly outputSchema?: ZodSchema<TOutput>
+  /**
+   * Optional runtime validator for `ToolResult.data` (always a string).
+   *
+   * **Not to be confused with {@link AgentConfig.outputSchema}**, which
+   * validates an agent's final JSON answer. This one only guards a single
+   * tool's serialised output.
+   */
+  readonly outputSchema?: ZodSchema<string>
   /**
    * When present, used as {@link LLMToolDef.inputSchema} as-is instead of
    * deriving JSON Schema from `inputSchema` (Zod).
@@ -345,6 +351,10 @@ export interface AgentConfig {
    * Optional Zod schema for structured output.  When set, the agent's final
    * output is parsed as JSON and validated against this schema.  A single
    * retry with error feedback is attempted on validation failure.
+   *
+   * **Distinct from {@link ToolDefinition.outputSchema}**, which validates an
+   * individual tool's `ToolResult.data` string. This one operates on the
+   * agent's final answer as parsed JSON.
    */
   readonly outputSchema?: ZodSchema
   /**

--- a/tests/tool-executor.test.ts
+++ b/tests/tool-executor.test.ts
@@ -497,4 +497,24 @@ describe('ToolExecutor outputSchema validation', () => {
     expect(result.isError).toBeFalsy()
     expect(result.data).toBe('not-json-but-valid-without-schema')
   })
+
+  it('error result bypasses outputSchema validation and forwards original message', async () => {
+    const originalErrorMessage = 'upstream service unavailable'
+    const tool = defineTool({
+      name: 'json-errored',
+      description: 'Always fails with a non-JSON error message.',
+      inputSchema: z.object({}),
+      outputSchema: jsonPayloadStringSchema(),
+      execute: async () => ({ data: originalErrorMessage, isError: true }),
+    })
+    const { executor } = makeExecutor(tool)
+
+    // Should not throw; errors from execute are surfaced as ToolResult.
+    const result = await executor.execute('json-errored', {}, dummyContext)
+
+    expect(result.isError).toBe(true)
+    expect(result.data).toBe(originalErrorMessage)
+    // Ensure the error was NOT rewritten by the outputSchema validator.
+    expect(result.data).not.toContain('Invalid output for tool')
+  })
 })

--- a/tests/tool-executor.test.ts
+++ b/tests/tool-executor.test.ts
@@ -38,6 +38,38 @@ function makeExecutor(...tools: ReturnType<typeof defineTool>[]) {
   return { executor: new ToolExecutor(registry), registry }
 }
 
+function jsonPayloadStringSchema() {
+  return z.string().superRefine((value, ctx) => {
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(value)
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Output must be valid JSON',
+      })
+      return
+    }
+    const shape = z.object({
+      ok: z.boolean(),
+      payload: z.object({
+        id: z.string(),
+      }),
+      traceId: z.string(),
+    })
+    const result = shape.safeParse(parsed)
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: issue.message,
+          path: issue.path,
+        })
+      }
+    }
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -408,5 +440,61 @@ describe('ToolExecutor output truncation', () => {
 
     const result = await executor.execute('big', {}, dummyContext)
     expect(result.data.length).toBe(50000)
+  })
+})
+
+describe('ToolExecutor outputSchema validation', () => {
+  it('valid output passes schema validation', async () => {
+    const tool = defineTool({
+      name: 'json-ok',
+      description: 'Returns valid JSON output.',
+      inputSchema: z.object({}),
+      outputSchema: jsonPayloadStringSchema(),
+      execute: async () => ({
+        data: JSON.stringify({ ok: true, payload: { id: 'abc-123' }, traceId: 'trace-1' }),
+      }),
+    })
+    const { executor } = makeExecutor(tool)
+    const result = await executor.execute('json-ok', {}, dummyContext)
+    expect(result.isError).toBeFalsy()
+    expect(result.data).toBe(JSON.stringify({ ok: true, payload: { id: 'abc-123' }, traceId: 'trace-1' }))
+  })
+
+  it('truncated JSON fails output schema validation', async () => {
+    const fullJson = JSON.stringify({
+      ok: true,
+      payload: { id: 'x'.repeat(200) },
+      traceId: 'trace-2',
+    })
+    // Simulate "broken but deceptive" truncation: payload looks complete, but
+    // the outer object is missing its final `}` and ends with punctuation.
+    // Example shape: {"ok":...,"payload":{"id":"..." }
+    const brokenButDeceptiveJson = fullJson
+      .replace(/,"traceId":"[^"]*"/, '')
+      .slice(0, -1)
+    const tool = defineTool({
+      name: 'json-truncated',
+      description: 'Returns broken-but-deceptive JSON output.',
+      inputSchema: z.object({}),
+      outputSchema: jsonPayloadStringSchema(),
+      execute: async () => ({ data: brokenButDeceptiveJson }),
+    })
+    const { executor } = makeExecutor(tool)
+    const result = await executor.execute('json-truncated', {}, dummyContext)
+    expect(result.isError).toBe(true)
+    expect(result.data).toContain('Invalid output for tool "json-truncated"')
+  })
+
+  it('missing outputSchema is a no-op', async () => {
+    const tool = defineTool({
+      name: 'no-schema',
+      description: 'No output schema configured.',
+      inputSchema: z.object({}),
+      execute: async () => ({ data: 'not-json-but-valid-without-schema' }),
+    })
+    const { executor } = makeExecutor(tool)
+    const result = await executor.execute('no-schema', {}, dummyContext)
+    expect(result.isError).toBeFalsy()
+    expect(result.data).toBe('not-json-but-valid-without-schema')
   })
 })


### PR DESCRIPTION
## What

This PR adds optional tool output validation using Zod, so each tool can validate its ToolResult.data before the result is returned to the agent loop.

- **Core feature**

  - Added optional outputSchema support for tools and wired it through defineTool/framework registration.
  - Enforced runtime validation of ToolResult.data in the executor when a tool-level schema is configured.
  - Added test coverage for output-schema behavior.
**Primary files**: executor.ts, framework.ts, types.ts, tool-executor.test.ts

- **Follow-up docs/examples pass**
  - Updated English/Chinese docs to reflect the feature and usage.
  - Included stale-example cleanup in README docs to keep field naming current.

**Primary files**: README.md, README_zh.md

- **Scope notes**
In scope: tool-level output-schema feature, executor validation behavior, regression safety, type alignment, and related docs.

Out-of-scope but included as cleanup: stale README example naming updates, called out separately to keep review scope clear.

## Why

Issue [#120 ](https://github.com/JackChen-me/open-multi-agent/issues/120) requests stronger guardrails against malformed tool outputs (especially JSON-like text that looks plausible but is invalid/incomplete). This change catches those failures at tool execution time and surfaces clear errors instead of letting invalid output propagate.

Fixes [#120 ](https://github.com/JackChen-me/open-multi-agent/issues/120)

## Backward compatibility
Existing tools without outputSchema are unaffected.
ToolResult.data remains string-based.
Type defaults preserve current usage patterns.
## Validation performed
npm run lint passes.
npm test -- tests/tool-executor.test.ts passes.
npm test -- tests/built-in-tools.test.ts passes.
Full test suite passes locally.

## Checklist

- [✅] `npm run lint` passes
- [✅] `npm test` passes
- [✅] Added/updated tests for changed behavior
- [✅] No new runtime dependencies (or justified in the PR description)
