### PR TITLE
feat: add Qiniu provider support

### DIFF
--- a/src/cli/oma.ts
+++ b/src/cli/oma.ts
@@ -55,6 +55,7 @@ const PROVIDER_REFERENCE: ReadonlyArray<{
   { id: 'grok', apiKeyEnv: ['XAI_API_KEY'], baseUrlSupported: true },
   { id: 'minimax', apiKeyEnv: ['MINIMAX_API_KEY'], baseUrlSupported: true, notes: 'Global endpoint: https://api.minimax.io/v1 (default). China endpoint: https://api.minimaxi.com/v1. Set MINIMAX_BASE_URL to choose, or pass baseURL in agent config.' },
   { id: 'deepseek', apiKeyEnv: ['DEEPSEEK_API_KEY'], baseUrlSupported: true, notes: 'OpenAI-compatible endpoint at https://api.deepseek.com/v1. Models: deepseek-chat (V3), deepseek-reasoner (thinking).' },
+  { id: 'qiniu', apiKeyEnv: ['QINIU_API_KEY'], baseUrlSupported: true, notes: 'OpenAI-compatible endpoint at https://api.qnaigc.com/v1. Set provider to qiniu and choose a model available to your key.' },
   {
     id: 'copilot',
     apiKeyEnv: ['GITHUB_COPILOT_TOKEN', 'GITHUB_TOKEN'],
@@ -270,6 +271,7 @@ const DEFAULT_MODEL_HINT: Record<SupportedProvider, string> = {
   copilot: 'gpt-4o',
   minimax: 'MiniMax-M2.7',
   deepseek: 'deepseek-chat',
+  qiniu: 'deepseek-v3',
 }
 
 async function cmdProvider(sub: string | undefined, arg: string | undefined, pretty: boolean): Promise<number> {

--- a/src/llm/adapter.ts
+++ b/src/llm/adapter.ts
@@ -38,7 +38,7 @@ import type { LLMAdapter } from '../types.js'
  * Additional providers can be integrated by implementing {@link LLMAdapter}
  * directly and bypassing this factory.
  */
-export type SupportedProvider = 'anthropic' | 'azure-openai' | 'copilot' | 'deepseek' | 'grok' | 'minimax' | 'openai' | 'gemini'
+export type SupportedProvider = 'anthropic' | 'azure-openai' | 'copilot' | 'deepseek' | 'grok' | 'minimax' | 'openai' | 'gemini' | 'qiniu'
 
 /**
  * Instantiate the appropriate {@link LLMAdapter} for the given provider.
@@ -52,6 +52,7 @@ export type SupportedProvider = 'anthropic' | 'azure-openai' | 'copilot' | 'deep
  * - `grok`         → `XAI_API_KEY`
  * - `minimax`      → `MINIMAX_API_KEY`
  * - `deepseek`     → `DEEPSEEK_API_KEY`
+ * - `qiniu`        → `QINIU_API_KEY`
  * - `copilot`      → `GITHUB_COPILOT_TOKEN` / `GITHUB_TOKEN`, or interactive
  *                     OAuth2 device flow if neither is set
  *
@@ -99,6 +100,10 @@ export async function createAdapter(
     case 'deepseek': {
       const { DeepSeekAdapter } = await import('./deepseek.js')
       return new DeepSeekAdapter(apiKey, baseURL)
+    }
+    case 'qiniu': {
+      const { QiniuAdapter } = await import('./qiniu.js')
+      return new QiniuAdapter(apiKey, baseURL)
     }
     case 'azure-openai': {
       // For azure-openai, the `baseURL` parameter serves as the Azure endpoint URL.

--- a/src/llm/qiniu.ts
+++ b/src/llm/qiniu.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Qiniu adapter.
+ *
+ * Thin wrapper around OpenAIAdapter that hard-codes the official Qiniu
+ * OpenAI-compatible endpoint and QINIU_API_KEY environment variable fallback.
+ */
+
+import { OpenAIAdapter } from './openai.js'
+
+/**
+ * LLM adapter for Qiniu models (deepseek-v3 and future models).
+ *
+ * Thread-safe. Can be shared across agents.
+ *
+ * Usage:
+ *   provider: 'qiniu'
+ *   model: 'deepseek-v3' (or any model available to your Qiniu API key)
+ */
+export class QiniuAdapter extends OpenAIAdapter {
+  readonly name = 'qiniu'
+
+  constructor(apiKey?: string, baseURL?: string) {
+    // Allow override of baseURL (for proxies or future changes) but default to official Qiniu endpoint.
+    super(
+      apiKey ?? process.env['QINIU_API_KEY'],
+      baseURL ?? 'https://api.qnaigc.com/v1'
+    )
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,7 +269,7 @@ export interface BeforeRunHookContext {
 export interface AgentConfig {
   readonly name: string
   readonly model: string
-  readonly provider?: 'anthropic' | 'copilot' | 'grok' | 'openai' | 'gemini'
+  readonly provider?: 'anthropic' | 'copilot' | 'grok' | 'openai' | 'gemini' | 'qiniu'
   /**
    * Custom base URL for OpenAI-compatible APIs (Ollama, vLLM, LM Studio, etc.).
    * Note: local servers that don't require auth still need `apiKey` set to a
@@ -541,7 +541,7 @@ export interface OrchestratorConfig {
   /** Maximum cumulative tokens (input + output) allowed per orchestrator run. */
   readonly maxTokenBudget?: number
   readonly defaultModel?: string
-  readonly defaultProvider?: 'anthropic' | 'copilot' | 'grok' | 'openai' | 'gemini'
+  readonly defaultProvider?: 'anthropic' | 'copilot' | 'grok' | 'openai' | 'gemini' | 'qiniu'
   readonly defaultBaseURL?: string
   readonly defaultApiKey?: string
   readonly onProgress?: (event: OrchestratorEvent) => void
@@ -574,7 +574,7 @@ export interface OrchestratorConfig {
 export interface CoordinatorConfig {
   /** Coordinator model. Defaults to `OrchestratorConfig.defaultModel`. */
   readonly model?: string
-  readonly provider?: 'anthropic' | 'copilot' | 'grok' | 'openai' | 'gemini'
+  readonly provider?: 'anthropic' | 'copilot' | 'grok' | 'openai' | 'gemini' | 'qiniu'
   readonly baseURL?: string
   readonly apiKey?: string
   /**

--- a/tests/llm-adapters.test.ts
+++ b/tests/llm-adapters.test.ts
@@ -39,6 +39,11 @@ describe('createAdapter', () => {
     expect(adapter.name).toBe('gemini')
   })
 
+  it('creates a qiniu adapter', async () => {
+    const adapter = await createAdapter('qiniu', 'test-key')
+    expect(adapter.name).toBe('qiniu')
+  })
+
   it('throws on unknown provider', async () => {
     await expect(
       createAdapter('unknown' as any, 'test-key'),

--- a/tests/qiniu-adapter.test.ts
+++ b/tests/qiniu-adapter.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock OpenAI constructor (must be hoisted for Vitest)
+// ---------------------------------------------------------------------------
+const OpenAIMock = vi.hoisted(() => vi.fn())
+
+vi.mock('openai', () => ({
+  default: OpenAIMock,
+}))
+
+import { QiniuAdapter } from '../src/llm/qiniu.js'
+import { createAdapter } from '../src/llm/adapter.js'
+
+// ---------------------------------------------------------------------------
+// QiniuAdapter tests
+// ---------------------------------------------------------------------------
+
+describe('QiniuAdapter', () => {
+  beforeEach(() => {
+    OpenAIMock.mockClear()
+  })
+
+  it('has name "qiniu"', () => {
+    const adapter = new QiniuAdapter()
+    expect(adapter.name).toBe('qiniu')
+  })
+
+  it('uses QINIU_API_KEY by default', () => {
+    const original = process.env['QINIU_API_KEY']
+    process.env['QINIU_API_KEY'] = 'qiniu-test-key-123'
+
+    try {
+      new QiniuAdapter()
+      expect(OpenAIMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'qiniu-test-key-123',
+          baseURL: 'https://api.qnaigc.com/v1',
+        })
+      )
+    } finally {
+      if (original === undefined) {
+        delete process.env['QINIU_API_KEY']
+      } else {
+        process.env['QINIU_API_KEY'] = original
+      }
+    }
+  })
+
+  it('uses official Qiniu baseURL by default', () => {
+    new QiniuAdapter('some-key')
+    expect(OpenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'some-key',
+        baseURL: 'https://api.qnaigc.com/v1',
+      })
+    )
+  })
+
+  it('allows overriding apiKey and baseURL', () => {
+    new QiniuAdapter('custom-key', 'https://custom.endpoint/v1')
+    expect(OpenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'custom-key',
+        baseURL: 'https://custom.endpoint/v1',
+      })
+    )
+  })
+
+  it('createAdapter("qiniu") returns QiniuAdapter instance', async () => {
+    const adapter = await createAdapter('qiniu')
+    expect(adapter).toBeInstanceOf(QiniuAdapter)
+  })
+})


### PR DESCRIPTION
## Summary

Added support for Qiniu AI (七牛云) as a new model provider.

## What changed
- `src/types.ts` - This officially enables Qiniu as an optional model provider in the type system and configuration layer.

- `src/cli/oma.ts` - Add qiniu to the CLI provider list and default model mapping.

- `src/llm/adapter.ts` - This ensures that the runtime correctly instantiates the corresponding adapter according to provider: "qiniu".

- `src/llm/qiniu.ts` - Its purpose is to reuse the OpenAI-compatible protocol to access the Qiniu model with minimal modifications.

- `tests/llm-adapters.test.ts` - Add a factory test case for createAdapter("qiniu").

- `tests/qiniu-adapter.test.ts` -  Added Qiniu adapter-specific tests (name, default env/baseURL, overridable parameters, and factory integration).

## Testing
```
npm vitest run tests/built-in-tools.test.ts 	✅ 45/45
npm test 								✅ 44 files / 658 tests
```



## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
