### PR TITLE
fix: widen provider type to SupportedProvider

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ZodSchema } from 'zod'
+import type { SupportedProvider } from './llm/adapter.js'
 
 // ---------------------------------------------------------------------------
 // Content blocks
@@ -269,7 +270,7 @@ export interface BeforeRunHookContext {
 export interface AgentConfig {
   readonly name: string
   readonly model: string
-  readonly provider?: 'anthropic' | 'copilot' | 'grok' | 'openai' | 'gemini'
+  readonly provider?: SupportedProvider
   /**
    * Custom base URL for OpenAI-compatible APIs (Ollama, vLLM, LM Studio, etc.).
    * Note: local servers that don't require auth still need `apiKey` set to a
@@ -550,7 +551,7 @@ export interface OrchestratorConfig {
   /** Maximum cumulative tokens (input + output) allowed per orchestrator run. */
   readonly maxTokenBudget?: number
   readonly defaultModel?: string
-  readonly defaultProvider?: 'anthropic' | 'copilot' | 'grok' | 'openai' | 'gemini'
+  readonly defaultProvider?: SupportedProvider
   readonly defaultBaseURL?: string
   readonly defaultApiKey?: string
   readonly onProgress?: (event: OrchestratorEvent) => void
@@ -583,7 +584,7 @@ export interface OrchestratorConfig {
 export interface CoordinatorConfig {
   /** Coordinator model. Defaults to `OrchestratorConfig.defaultModel`. */
   readonly model?: string
-  readonly provider?: 'anthropic' | 'copilot' | 'grok' | 'openai' | 'gemini'
+  readonly provider?: SupportedProvider
   readonly baseURL?: string
   readonly apiKey?: string
   /**


### PR DESCRIPTION
Surfaced in #153 review (Engram integration example used `as AgentProvider` to work around the narrow type).

## Summary

`AgentConfig.provider`, `CoordinatorConfig.provider`, and `OrchestratorConfig.defaultProvider` were typed as a narrow 5-provider union (`'anthropic' | 'copilot' | 'grok' | 'openai' | 'gemini'`) while `createAdapter()` in `src/llm/adapter.ts` already accepts the full 8-provider `SupportedProvider` union (adds `azure-openai`, `deepseek`, `minimax`). This forced users to cast when passing statically-valid providers.

## Changes

- `src/types.ts`: three config fields now reference `SupportedProvider` directly. One new `import type` from `./llm/adapter.js`.

## Backward compatibility

Fully additive. Any code that compiled against the narrow 5-provider union still compiles; only previously-rejected valid providers now type-check without a cast.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes (667/667; provider dispatch coverage via existing `tests/{deepseek,minimax,grok,gemini,openai,anthropic,copilot}-adapter.test.ts` and `tests/azure-openai-adapter.test.ts`)

## Follow-up

Once merged, #153 can drop the `as AgentProvider` cast after rebase.