### PR TITLE
chore: cosmetic polish following #161

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -206,7 +206,7 @@ export class Agent {
 
     const result = await this.executeRun([...this.messageHistory])
 
-    // Persist the new messages into history so the next prompt sees them.
+    // Persist the new messages into history so the next `prompt` sees them.
     for (const msg of result.messages) {
       this.messageHistory.push(msg)
     }

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -374,12 +374,10 @@ export class AgentRunner {
       : '[Conversation summary unavailable]'
 
     this.summarizeCache = { oldSignature, summaryPrefix }
-    
     const mergedRecent = prependSyntheticPrefixToFirstUser(
       recentPortion,
       `${summaryPrefix}\n\n`,
     )
-    
     return {
       messages: [firstUser, ...mergedRecent],
       usage: summaryResponse.usage,

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,11 @@ export type ContextStrategy =
     }
   | {
     type: 'custom'
+    /**
+     * Compaction callback. Invoked before every LLM turn including the first,
+     * so implementations that should only fire past a token threshold must
+     * self-gate inside this function.
+     */
     compress: (
       messages: LLMMessage[],
       estimatedTokens: number,

--- a/tests/context-strategy.test.ts
+++ b/tests/context-strategy.test.ts
@@ -205,13 +205,7 @@ describe('AgentRunner contextStrategy', () => {
 
     const result = await runner.run(initialMessages)
 
-    // 2 new messages were generated (the tool use, and the tool result).
-    // The `done` response is returned but not pushed as a new message to the list in `run()`.
-    // Wait, the `done` text response *is* pushed.
-    // Let's verify the exact length of new messages.
-    // The stream loop pushes the assistant message (tool use), then the user message (tool result),
-    // then loops back and pushes the final assistant message (text).
-    // So 3 new messages are added during this run.
+    // Three new messages produced: assistant tool_use, user tool_result, assistant text.
     expect(result.messages).toHaveLength(3)
     expect(result.messages[0]!.role).toBe('assistant')
     expect(result.messages[1]!.role).toBe('user') // The tool_result


### PR DESCRIPTION
Post-merge cleanup of small items deferred from #161.

- Restore backticks around \`prompt\` in `Agent.prompt()` comment so the reference is unambiguous.
- Drop two stray blank lines around `mergedRecent` in `summarizeMessages`.
- Collapse the deliberation-style comments in the new context-strategy test to a single line.
- Add a JSDoc note on `contextStrategy.custom.compress` clarifying it fires before every turn (including the first); implementations needing a token threshold must self-gate.

No behavior change. Lint clean, all 668 tests pass locally.