### PR TITLE
docs: add OpenRouter provider example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Set the API key for your provider. Local models via Ollama require no API key. S
 - `ANTHROPIC_API_KEY`
 - `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_VERSION`, `AZURE_OPENAI_DEPLOYMENT` (for Azure OpenAI; deployment is optional fallback when `model` is blank)
 - `OPENAI_API_KEY`
+- `OPENROUTER_API_KEY` (for OpenRouter via the OpenAI-compatible adapter)
 - `GEMINI_API_KEY`
 - `XAI_API_KEY` (for Grok)
 - `MINIMAX_API_KEY` (for MiniMax)
@@ -148,7 +149,7 @@ For MapReduce-style fan-out without task dependencies, use `AgentPool.runParalle
 - [`integrations/trace-observability`](examples/integrations/trace-observability.ts): `onTrace` spans for LLM calls, tools, and tasks.
 - [`integrations/mcp-github`](examples/integrations/mcp-github.ts): expose an MCP server's tools to an agent via `connectMCPTools()`.
 - [`integrations/with-vercel-ai-sdk`](examples/integrations/with-vercel-ai-sdk/): Next.js app combining OMA `runTeam()` with AI SDK `useChat` streaming.
-- **Provider examples**: eight three-agent teams (one per supported provider) under [`examples/providers/`](examples/providers/).
+- **Provider examples**: three-agent teams under [`examples/providers/`](examples/providers/), including hosted providers, OpenAI-compatible endpoints, and local models.
 
 Run scripts with `npx tsx examples/basics/team-collaboration.ts`.
 
@@ -431,12 +432,13 @@ Pairs well with `compressToolResults` and `maxToolOutputChars` above.
 | GitHub Copilot | `provider: 'copilot'` | `GITHUB_TOKEN` | Verified |
 | Gemini | `provider: 'gemini'` | `GEMINI_API_KEY` | Verified |
 | Ollama / vLLM / LM Studio | `provider: 'openai'` + `baseURL` | none | Verified |
+| OpenRouter | `provider: 'openai'` + `baseURL` + `apiKey` | `OPENROUTER_API_KEY` | Verified via [`providers/openrouter`](examples/providers/openrouter.ts) |
 | Groq | `provider: 'openai'` + `baseURL` | `GROQ_API_KEY` | Verified |
 | llama.cpp server | `provider: 'openai'` + `baseURL` | none | Verified |
 
 Gemini requires `npm install @google/genai` (optional peer dependency).
 
-Any OpenAI-compatible API should work via `provider: 'openai'` + `baseURL` (Mistral, Qwen, Moonshot, Doubao, etc.). Groq is now verified in [`providers/groq`](examples/providers/groq.ts). **Grok, MiniMax, DeepSeek, and Qiniu now have first-class support** via `provider: 'grok'`, `provider: 'minimax'`, `provider: 'deepseek'`, and `provider: 'qiniu'`.
+Any OpenAI-compatible API should work via `provider: 'openai'` + `baseURL` (Mistral, Qwen, Moonshot, Doubao, etc.). OpenRouter is verified in [`providers/openrouter`](examples/providers/openrouter.ts); pass `process.env.OPENROUTER_API_KEY` as `apiKey` because the `openai` adapter otherwise reads `OPENAI_API_KEY`. Groq is verified in [`providers/groq`](examples/providers/groq.ts). **Grok, MiniMax, DeepSeek, and Qiniu now have first-class support** via `provider: 'grok'`, `provider: 'minimax'`, `provider: 'deepseek'`, and `provider: 'qiniu'`.
 
 ### Local Model Tool-Calling
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,6 +22,8 @@ node dist/cli/oma.js help
 
 Set the usual provider API keys in the environment (see [README](../README.md#quick-start)); the CLI does not read secrets from flags. MiniMax additionally reads `MINIMAX_BASE_URL` to select the global (`https://api.minimax.io/v1`) or China (`https://api.minimaxi.com/v1`) endpoint.
 
+OpenRouter works through the OpenAI-compatible adapter: set `provider` to `openai`, `baseURL` to `https://openrouter.ai/api/v1`, and pass `OPENROUTER_API_KEY` as the agent or orchestrator `apiKey`.
+
 ---
 
 ## Commands
@@ -61,6 +63,8 @@ Read-only helper for wiring JSON configs and env vars.
 
 - **`oma provider`** or **`oma provider list`** — Prints JSON: built-in provider ids, API key environment variable names, whether `baseURL` is supported, and short notes (e.g. OpenAI-compatible servers, Copilot in CI).
 - **`oma provider template <provider>`** — Prints a JSON object with example `orchestrator` and `agent` fields plus placeholder `env` entries. `<provider>` is one of: `anthropic`, `openai`, `gemini`, `grok`, `minimax`, `deepseek`, `qiniu`, `copilot`.
+
+For OpenRouter, use the `openai` provider template, set `baseURL` to `https://openrouter.ai/api/v1`, and set `apiKey` from `OPENROUTER_API_KEY` in your JSON config.
 
 Supports `--pretty`.
 
@@ -259,4 +263,3 @@ esac
 - No built-in **`cwd`** or metadata passed into `ToolUseContext` (tools use process cwd unless the library adds other hooks later).
 - No **`onApproval`** from JSON; non-interactive batch only.
 - Coordinator **`runTeam`** path still requires network and API keys like any other run.
-

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,6 +31,7 @@ One example per supported provider. All follow the same three-agent (architect /
 | [`providers/gemini`](providers/gemini.ts) | Google Gemini | `GEMINI_API_KEY` |
 | [`providers/minimax`](providers/minimax.ts) | MiniMax M2.7 | `MINIMAX_API_KEY` |
 | [`providers/deepseek`](providers/deepseek.ts) | DeepSeek Chat | `DEEPSEEK_API_KEY` |
+| [`providers/openrouter`](providers/openrouter.ts) | OpenRouter (OpenAI-compatible) | `OPENROUTER_API_KEY` |
 | [`providers/groq`](providers/groq.ts) | Groq (OpenAI-compatible) | `GROQ_API_KEY` |
 
 ## patterns — orchestration patterns

--- a/examples/providers/openrouter.ts
+++ b/examples/providers/openrouter.ts
@@ -1,0 +1,177 @@
+/**
+ * Multi-Agent Team Collaboration with OpenRouter
+ *
+ * Three specialized agents (architect, developer, reviewer) collaborate via `runTeam()`
+ * to build a minimal Express.js REST API. Every agent uses OpenRouter through the
+ * framework's OpenAI-compatible adapter.
+ *
+ * Run:
+ *   npx tsx examples/providers/openrouter.ts
+ *
+ * Prerequisites:
+ *   OPENROUTER_API_KEY environment variable must be set.
+ *
+ * Optional:
+ *   OPENROUTER_MODEL overrides the default model. OpenRouter model names use
+ *   provider/model slugs, such as `openai/gpt-4o-mini`.
+ */
+
+import { OpenMultiAgent } from '../../src/index.js'
+import type { AgentConfig, OrchestratorEvent } from '../../src/types.js'
+
+const OPENROUTER_BASE_URL = 'https://openrouter.ai/api/v1'
+const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY
+const OPENROUTER_MODEL = process.env.OPENROUTER_MODEL ?? 'openai/gpt-4o-mini'
+
+if (!OPENROUTER_API_KEY) {
+  throw new Error('OPENROUTER_API_KEY environment variable must be set.')
+}
+
+const openRouterConfig = {
+  provider: 'openai', // OpenRouter speaks the OpenAI-compatible Chat Completions API.
+  baseURL: OPENROUTER_BASE_URL,
+  apiKey: OPENROUTER_API_KEY,
+  model: OPENROUTER_MODEL,
+} satisfies Pick<AgentConfig, 'provider' | 'baseURL' | 'apiKey' | 'model'>
+
+// ---------------------------------------------------------------------------
+// Agent definitions (all using OpenRouter via the OpenAI-compatible adapter)
+// ---------------------------------------------------------------------------
+const architect: AgentConfig = {
+  name: 'architect',
+  ...openRouterConfig,
+  systemPrompt: `You are a software architect with deep experience in Node.js and REST API design.
+Your job is to design clear, production-quality API contracts and file/directory structures.
+Output concise plans in markdown — no unnecessary prose.`,
+  tools: ['bash', 'file_write'],
+  maxTurns: 5,
+  temperature: 0.2,
+}
+
+const developer: AgentConfig = {
+  name: 'developer',
+  ...openRouterConfig,
+  systemPrompt: `You are a TypeScript/Node.js developer. You implement what the architect specifies.
+Write clean, runnable code with proper error handling. Use the tools to write files and run tests.
+Do not leave long-running foreground processes active; validate with one-shot commands or start and stop servers explicitly.`,
+  tools: ['bash', 'file_read', 'file_write', 'file_edit'],
+  maxTurns: 12,
+  temperature: 0.1,
+}
+
+const reviewer: AgentConfig = {
+  name: 'reviewer',
+  ...openRouterConfig,
+  systemPrompt: `You are a senior code reviewer. Review code for correctness, security, and clarity.
+Provide a structured review with: LGTM items, suggestions, and any blocking issues.
+Read files using the tools before reviewing.`,
+  tools: ['bash', 'file_read', 'grep'],
+  maxTurns: 5,
+  temperature: 0.3,
+}
+
+// ---------------------------------------------------------------------------
+// Progress tracking
+// ---------------------------------------------------------------------------
+const startTimes = new Map<string, number>()
+
+function handleProgress(event: OrchestratorEvent): void {
+  const ts = new Date().toISOString().slice(11, 23) // HH:MM:SS.mmm
+  switch (event.type) {
+    case 'agent_start':
+      startTimes.set(event.agent ?? '', Date.now())
+      console.log(`[${ts}] AGENT START -> ${event.agent}`)
+      break
+    case 'agent_complete': {
+      const elapsed = Date.now() - (startTimes.get(event.agent ?? '') ?? Date.now())
+      console.log(`[${ts}] AGENT DONE <- ${event.agent} (${elapsed}ms)`)
+      break
+    }
+    case 'task_start':
+      console.log(`[${ts}] TASK START v ${event.task}`)
+      break
+    case 'task_complete':
+      console.log(`[${ts}] TASK DONE ^ ${event.task}`)
+      break
+    case 'message':
+      console.log(`[${ts}] MESSAGE * ${event.agent} -> (team)`)
+      break
+    case 'error':
+      console.error(`[${ts}] ERROR x agent=${event.agent} task=${event.task}`)
+      if (event.data instanceof Error) console.error(` ${event.data.message}`)
+      break
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrate
+// ---------------------------------------------------------------------------
+const orchestrator = new OpenMultiAgent({
+  defaultModel: OPENROUTER_MODEL,
+  defaultProvider: 'openai',
+  defaultBaseURL: OPENROUTER_BASE_URL,
+  defaultApiKey: OPENROUTER_API_KEY,
+  maxConcurrency: 1, // sequential for readable output
+  onProgress: handleProgress,
+})
+
+const team = orchestrator.createTeam('api-team', {
+  name: 'api-team',
+  agents: [architect, developer, reviewer],
+  sharedMemory: true,
+  maxConcurrency: 1,
+})
+
+console.log(`Team "${team.name}" created with agents: ${team.getAgents().map(a => a.name).join(', ')}`)
+console.log(`Using OpenRouter model: ${OPENROUTER_MODEL}`)
+console.log('\nStarting team run...\n')
+console.log('='.repeat(60))
+
+const goal = `Create a minimal Express.js REST API in /tmp/express-api/ with:
+- GET /health -> { status: "ok" }
+- GET /users -> returns a hardcoded array of 2 user objects
+- POST /users -> accepts { name, email } body, logs it, returns 201
+- Proper error handling middleware
+- The server should listen on port 3001
+- Include a package.json with the required dependencies
+- Include a test or verification script that can be run without leaving a server process running
+- Do not start a foreground server as the final step`
+
+const result = await orchestrator.runTeam(team, goal)
+
+console.log('\n' + '='.repeat(60))
+
+// ---------------------------------------------------------------------------
+// Results
+// ---------------------------------------------------------------------------
+console.log('\nTeam run complete.')
+console.log(`Success: ${result.success}`)
+console.log(`Total tokens — input: ${result.totalTokenUsage.input_tokens}, output: ${result.totalTokenUsage.output_tokens}`)
+
+console.log('\nPer-agent results:')
+for (const [agentName, agentResult] of result.agentResults) {
+  const status = agentResult.success ? 'OK' : 'FAILED'
+  const tools = agentResult.toolCalls.length
+  console.log(` ${agentName.padEnd(12)} [${status}] tool_calls=${tools}`)
+  if (!agentResult.success) {
+    console.log(` Error: ${agentResult.output.slice(0, 120)}`)
+  }
+}
+
+// Sample outputs
+const developerResult = result.agentResults.get('developer')
+if (developerResult?.success) {
+  console.log('\nDeveloper output (last 600 chars):')
+  console.log('-'.repeat(60))
+  const out = developerResult.output
+  console.log(out.length > 600 ? '...' + out.slice(-600) : out)
+  console.log('-'.repeat(60))
+}
+
+const reviewerResult = result.agentResults.get('reviewer')
+if (reviewerResult?.success) {
+  console.log('\nReviewer output:')
+  console.log('-'.repeat(60))
+  console.log(reviewerResult.output)
+  console.log('-'.repeat(60))
+}


### PR DESCRIPTION
## Summary
- add a runnable OpenRouter provider example using the existing OpenAI-compatible adapter
- document `OPENROUTER_API_KEY` in the quick start provider env vars
- list OpenRouter in the provider examples and supported providers docs
- add CLI guidance for using OpenRouter with `provider: 'openai'` and `baseURL`

## Why
OpenRouter already works through the OpenAI-compatible adapter, and a few pattern examples reference it, but it was not visible in the main provider example path. This gives users a direct copy/paste example without adding runtime dependencies or a new adapter.

## Test plan
- npm run lint
- npm test