### PR TITLE
Add learning assistant cookbook example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -57,6 +57,7 @@ End-to-end examples framed around a concrete problem (meeting summarization, tra
 | [`cookbook/meeting-summarizer`](cookbook/meeting-summarizer.ts) | Fan-out post-processing of a transcript into summary, structured action items, and sentiment. |
 | [`cookbook/contract-review-dag`](cookbook/contract-review-dag.ts) | 4-task DAG (extract → compliance-check + summary → notify) with step-level retry. Run normally or with `FORCE_FAIL=task2` to exercise retry. |
 | [`cookbook/competitive-monitoring`](cookbook/competitive-monitoring.ts) | Parallel source monitoring (Twitter/Reddit/News), contradiction detection, and aggregated intelligence reporting. |
+| [`cookbook/learning-assistant`](cookbook/learning-assistant.ts) | Education-domain planning: a multi-agent team builds a React learning roadmap, starter resources, and a week-by-week practice plan. |
 
 ## integrations — external systems
 

--- a/examples/cookbook/learning-assistant.ts
+++ b/examples/cookbook/learning-assistant.ts
@@ -2,10 +2,10 @@
  * Learning Assistant (Education Planning with Multi-Agent Teamwork)
  *
  * Demonstrates:
- * - A practical education-domain use case built with `runTeam()`
- * - Three specialized agents collaborating on the same learning goal
- * - Shared memory between agents so later steps can build on earlier outputs
- * - A readable terminal trace of team progress and final recommendations
+ * - A practical education-domain use case built with `runTasks()`
+ * - Three specialized agents collaborating through an explicit task pipeline
+ * - Dependency-scoped context so the final plan can build on earlier outputs
+ * - A readable terminal trace of task progress and final recommendations
  *
  * Run:
  *   npx tsx examples/cookbook/learning-assistant.ts
@@ -15,7 +15,14 @@
  */
 
 import { OpenMultiAgent } from '../../src/index.js'
-import type { AgentConfig, OrchestratorEvent } from '../../src/types.js'
+import type { AgentConfig, OrchestratorEvent, Task } from '../../src/types.js'
+
+const AGENT_TIMEOUT_MS = 60_000
+const TASK_LABELS = new Map<string, string>([
+  ['Design React learning roadmap', 'Step 1/3 - Learning Roadmap'],
+  ['Curate React starter resources', 'Step 2/3 - Recommended Resources'],
+  ['Build step-by-step React study plan', 'Step 3/3 - 4-Week Study Plan'],
+])
 
 // ---------------------------------------------------------------------------
 // Agent definitions
@@ -28,7 +35,9 @@ const roadmapPlanner: AgentConfig = {
   systemPrompt: `You are a learning strategist who designs beginner-friendly technical learning roadmaps.
 Break goals into clear stages, call out prerequisites, and define what "done" looks like for each stage.
 Write concise markdown that is practical and encouraging.`,
+  tools: [],
   maxTurns: 4,
+  timeoutMs: AGENT_TIMEOUT_MS,
   temperature: 0.2,
 }
 
@@ -39,7 +48,9 @@ const resourceCurator: AgentConfig = {
   systemPrompt: `You are an education curator for software learners.
 Recommend a small, high-quality set of resources for beginners: official docs, tutorials, exercises, and project ideas.
 Prefer focused recommendations over long lists. Write concise markdown.`,
+  tools: [],
   maxTurns: 4,
+  timeoutMs: AGENT_TIMEOUT_MS,
   temperature: 0.2,
 }
 
@@ -51,7 +62,9 @@ const practiceCoach: AgentConfig = {
 Turn a learning goal into a step-by-step practice plan with a realistic weekly cadence.
 Include milestones, suggested mini-projects, and advice on how to know when the learner is ready to move on.
 Write concise markdown.`,
+  tools: [],
   maxTurns: 4,
+  timeoutMs: AGENT_TIMEOUT_MS,
   temperature: 0.3,
 }
 
@@ -59,35 +72,30 @@ Write concise markdown.`,
 // Progress tracking
 // ---------------------------------------------------------------------------
 
-const startTimes = new Map<string, number>()
+const taskTimes = new Map<string, number>()
+const taskLabelsById = new Map<string, string>()
 
 function handleProgress(event: OrchestratorEvent): void {
   const ts = new Date().toISOString().slice(11, 23)
 
   switch (event.type) {
-    case 'agent_start':
-      startTimes.set(event.agent ?? '', Date.now())
-      console.log(`[${ts}] AGENT START  -> ${event.agent}`)
-      break
-
-    case 'agent_complete': {
-      const elapsed = Date.now() - (startTimes.get(event.agent ?? '') ?? Date.now())
-      console.log(`[${ts}] AGENT DONE   <- ${event.agent} (${elapsed}ms)`)
+    case 'task_start': {
+      taskTimes.set(event.task ?? '', Date.now())
+      const task = event.data as Task | undefined
+      const title = task?.title ?? event.task ?? 'Unknown task'
+      const label = TASK_LABELS.get(title) ?? title
+      if (event.task) {
+        taskLabelsById.set(event.task, label)
+      }
+      console.log(`[${ts}] START        :: ${label}`)
       break
     }
-
-    case 'task_start':
-      console.log(`[${ts}] TASK START   :: ${event.task}`)
+    case 'task_complete': {
+      const elapsed = Date.now() - (taskTimes.get(event.task ?? '') ?? Date.now())
+      const label = (event.task ? taskLabelsById.get(event.task) : undefined) ?? event.task ?? 'Unknown task'
+      console.log(`[${ts}] DONE         :: ${label} (${elapsed}ms)`)
       break
-
-    case 'task_complete':
-      console.log(`[${ts}] TASK DONE    :: ${event.task}`)
-      break
-
-    case 'message':
-      console.log(`[${ts}] MESSAGE      :: ${event.agent} shared an update`)
-      break
-
+    }
     case 'error':
       console.error(`[${ts}] ERROR        :: agent=${event.agent} task=${event.task}`)
       if (event.data instanceof Error) {
@@ -110,7 +118,6 @@ const orchestrator = new OpenMultiAgent({
 const team = orchestrator.createTeam('learning-team', {
   name: 'learning-team',
   agents: [roadmapPlanner, resourceCurator, practiceCoach],
-  sharedMemory: true,
   maxConcurrency: 1,
 })
 
@@ -118,18 +125,56 @@ console.log(`Team "${team.name}" created with agents: ${team.getAgents().map(a =
 console.log('\nStarting learning assistant run...\n')
 console.log('='.repeat(60))
 
-const goal = `Create a beginner-friendly learning plan for this learner:
-"I want to learn React."
+const learnerGoal = `I want to learn React.`
 
-The final answer should help a beginner understand:
-- A staged learning roadmap
-- The best starter resources
-- A step-by-step practice plan for the first few weeks
+const tasks: Array<{
+  title: string
+  description: string
+  assignee?: string
+  dependsOn?: string[]
+}> = [
+  {
+    title: 'Design React learning roadmap',
+    description: `The learner's goal is: "${learnerGoal}"
 
-Assume the learner knows basic JavaScript but has not built with React before.
-Keep the advice practical, realistic, and easy to follow.`
+Create a beginner-friendly React learning roadmap in markdown.
+Requirements:
+- Assume the learner knows basic JavaScript but is new to React
+- Break the roadmap into 3-4 stages
+- For each stage, include the goal, key topics, and a simple milestone
+- Keep the roadmap practical and easy to follow`,
+    assignee: 'roadmap-planner',
+  },
+  {
+    title: 'Curate React starter resources',
+    description: `The learner's goal is: "${learnerGoal}"
 
-const result = await orchestrator.runTeam(team, goal)
+Recommend a focused set of starter resources in markdown.
+Requirements:
+- Include official documentation, one beginner tutorial, one practice source, and 2 mini-project ideas
+- Prefer a short, high-quality list over a long directory
+- Explain in one sentence why each resource is worth the learner's time`,
+    assignee: 'resource-curator',
+  },
+  {
+    title: 'Build step-by-step React study plan',
+    description: `Create the final learner-facing study plan in markdown.
+Use the prerequisite task outputs to produce one cohesive answer.
+
+Required sections:
+- ## Learning Roadmap
+- ## Recommended Resources
+- ## 4-Week Practice Plan
+- ## Progress Checks
+
+The 4-week plan should be realistic for a beginner studying a few times per week.
+Make the final answer practical, encouraging, and easy to act on.`,
+    assignee: 'practice-coach',
+    dependsOn: ['Design React learning roadmap', 'Curate React starter resources'],
+  },
+]
+
+const result = await orchestrator.runTasks(team, tasks)
 
 console.log('\n' + '='.repeat(60))
 
@@ -146,13 +191,18 @@ console.log(
 console.log('\nPer-agent results:')
 for (const [agentName, agentResult] of result.agentResults) {
   const status = agentResult.success ? 'OK' : 'FAILED'
-  console.log(`  ${agentName.padEnd(18)} [${status}]  tool_calls=${agentResult.toolCalls.length}`)
+  console.log(
+    `  ${agentName.padEnd(18)} [${status}]  tokens=${agentResult.tokenUsage.input_tokens}/${agentResult.tokenUsage.output_tokens}  tool_calls=${agentResult.toolCalls.length}`,
+  )
   if (!agentResult.success) {
     console.log(`    Error: ${agentResult.output.slice(0, 120)}`)
   }
 }
 
-console.log('\nFinal learning plan:')
-console.log('-'.repeat(60))
-console.log(result.output)
-console.log('-'.repeat(60))
+const finalPlan = result.agentResults.get('practice-coach')
+if (finalPlan?.success) {
+  console.log('\nFinal learning plan:')
+  console.log('-'.repeat(60))
+  console.log(finalPlan.output)
+  console.log('-'.repeat(60))
+}

--- a/examples/cookbook/learning-assistant.ts
+++ b/examples/cookbook/learning-assistant.ts
@@ -1,0 +1,158 @@
+/**
+ * Learning Assistant (Education Planning with Multi-Agent Teamwork)
+ *
+ * Demonstrates:
+ * - A practical education-domain use case built with `runTeam()`
+ * - Three specialized agents collaborating on the same learning goal
+ * - Shared memory between agents so later steps can build on earlier outputs
+ * - A readable terminal trace of team progress and final recommendations
+ *
+ * Run:
+ *   npx tsx examples/cookbook/learning-assistant.ts
+ *
+ * Prerequisites:
+ *   ANTHROPIC_API_KEY env var must be set.
+ */
+
+import { OpenMultiAgent } from '../../src/index.js'
+import type { AgentConfig, OrchestratorEvent } from '../../src/types.js'
+
+// ---------------------------------------------------------------------------
+// Agent definitions
+// ---------------------------------------------------------------------------
+
+const roadmapPlanner: AgentConfig = {
+  name: 'roadmap-planner',
+  model: 'claude-sonnet-4-6',
+  provider: 'anthropic',
+  systemPrompt: `You are a learning strategist who designs beginner-friendly technical learning roadmaps.
+Break goals into clear stages, call out prerequisites, and define what "done" looks like for each stage.
+Write concise markdown that is practical and encouraging.`,
+  maxTurns: 4,
+  temperature: 0.2,
+}
+
+const resourceCurator: AgentConfig = {
+  name: 'resource-curator',
+  model: 'claude-sonnet-4-6',
+  provider: 'anthropic',
+  systemPrompt: `You are an education curator for software learners.
+Recommend a small, high-quality set of resources for beginners: official docs, tutorials, exercises, and project ideas.
+Prefer focused recommendations over long lists. Write concise markdown.`,
+  maxTurns: 4,
+  temperature: 0.2,
+}
+
+const practiceCoach: AgentConfig = {
+  name: 'practice-coach',
+  model: 'claude-sonnet-4-6',
+  provider: 'anthropic',
+  systemPrompt: `You are a technical learning coach.
+Turn a learning goal into a step-by-step practice plan with a realistic weekly cadence.
+Include milestones, suggested mini-projects, and advice on how to know when the learner is ready to move on.
+Write concise markdown.`,
+  maxTurns: 4,
+  temperature: 0.3,
+}
+
+// ---------------------------------------------------------------------------
+// Progress tracking
+// ---------------------------------------------------------------------------
+
+const startTimes = new Map<string, number>()
+
+function handleProgress(event: OrchestratorEvent): void {
+  const ts = new Date().toISOString().slice(11, 23)
+
+  switch (event.type) {
+    case 'agent_start':
+      startTimes.set(event.agent ?? '', Date.now())
+      console.log(`[${ts}] AGENT START  -> ${event.agent}`)
+      break
+
+    case 'agent_complete': {
+      const elapsed = Date.now() - (startTimes.get(event.agent ?? '') ?? Date.now())
+      console.log(`[${ts}] AGENT DONE   <- ${event.agent} (${elapsed}ms)`)
+      break
+    }
+
+    case 'task_start':
+      console.log(`[${ts}] TASK START   :: ${event.task}`)
+      break
+
+    case 'task_complete':
+      console.log(`[${ts}] TASK DONE    :: ${event.task}`)
+      break
+
+    case 'message':
+      console.log(`[${ts}] MESSAGE      :: ${event.agent} shared an update`)
+      break
+
+    case 'error':
+      console.error(`[${ts}] ERROR        :: agent=${event.agent} task=${event.task}`)
+      if (event.data instanceof Error) {
+        console.error(`               ${event.data.message}`)
+      }
+      break
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Team execution
+// ---------------------------------------------------------------------------
+
+const orchestrator = new OpenMultiAgent({
+  defaultModel: 'claude-sonnet-4-6',
+  maxConcurrency: 1,
+  onProgress: handleProgress,
+})
+
+const team = orchestrator.createTeam('learning-team', {
+  name: 'learning-team',
+  agents: [roadmapPlanner, resourceCurator, practiceCoach],
+  sharedMemory: true,
+  maxConcurrency: 1,
+})
+
+console.log(`Team "${team.name}" created with agents: ${team.getAgents().map(a => a.name).join(', ')}`)
+console.log('\nStarting learning assistant run...\n')
+console.log('='.repeat(60))
+
+const goal = `Create a beginner-friendly learning plan for this learner:
+"I want to learn React."
+
+The final answer should help a beginner understand:
+- A staged learning roadmap
+- The best starter resources
+- A step-by-step practice plan for the first few weeks
+
+Assume the learner knows basic JavaScript but has not built with React before.
+Keep the advice practical, realistic, and easy to follow.`
+
+const result = await orchestrator.runTeam(team, goal)
+
+console.log('\n' + '='.repeat(60))
+
+// ---------------------------------------------------------------------------
+// Results
+// ---------------------------------------------------------------------------
+
+console.log('\nLearning assistant run complete.')
+console.log(`Success: ${result.success}`)
+console.log(
+  `Total tokens - input: ${result.totalTokenUsage.input_tokens}, output: ${result.totalTokenUsage.output_tokens}`,
+)
+
+console.log('\nPer-agent results:')
+for (const [agentName, agentResult] of result.agentResults) {
+  const status = agentResult.success ? 'OK' : 'FAILED'
+  console.log(`  ${agentName.padEnd(18)} [${status}]  tool_calls=${agentResult.toolCalls.length}`)
+  if (!agentResult.success) {
+    console.log(`    Error: ${agentResult.output.slice(0, 120)}`)
+  }
+}
+
+console.log('\nFinal learning plan:')
+console.log('-'.repeat(60))
+console.log(result.output)
+console.log('-'.repeat(60))


### PR DESCRIPTION
## Summary

Add a new cookbook example for an education-domain learning assistant.

## Why

This repo already has examples for summarization, contract review, and competitive monitoring, but it does not yet have a simple education-focused vertical example.

This example is meant to show a practical multi-agent workflow for a common learning problem: turning "I want to learn React" into a usable study plan. It is intentionally small and easy to follow, so new users can understand how to structure a real multi-agent pipeline without extra tools or framework changes.

It is not a single LLM call wrapped as an example:
- `roadmap-planner` creates the staged learning roadmap
- `resource-curator` selects beginner-friendly resources
- `practice-coach` consumes both upstream outputs and produces the final 4-week study plan

## What changed

- added `examples/cookbook/learning-assistant.ts`
- updated `examples/README.md`

## Design notes

- uses `runTasks()` instead of `runTeam()` to keep the workflow explicit and easy to inspect
- keeps the example tool-free with `tools: []`
- adds a per-agent timeout so the demo does not wait indefinitely
- adds token usage output so the example has honest cost visibility
- adds no new runtime dependencies

## Run

```bash
npx tsx examples/cookbook/learning-assistant.ts
```

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] No new runtime dependencies
