### PR TITLE
docs(README): use absolute GitHub URLs for hero logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset=".github/brand/logo-mark-dark.svg">
-    <source media="(prefers-color-scheme: light)" srcset=".github/brand/logo-mark-light.svg">
-    <img alt="Open Multi-Agent" src=".github/brand/logo-mark-light.svg" width="96">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-light.svg">
+    <img alt="Open Multi-Agent" src="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-light.svg" width="96">
   </picture>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<br />
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-dark.svg">
@@ -5,6 +7,8 @@
     <img alt="Open Multi-Agent" src="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-light.svg" width="96">
   </picture>
 </p>
+
+<br />
 
 <h1 align="center">Open Multi-Agent</h1>
 
@@ -25,7 +29,7 @@
   <strong>English</strong> · <a href="./README_zh.md">中文</a>
 </p>
 
----
+<br />
 
 `open-multi-agent` is a multi-agent orchestration framework for TypeScript backends. Give it a goal; a coordinator agent decomposes it into a task DAG, parallelizes independents, and synthesizes the result. Three runtime dependencies, drops into any Node.js backend, so your engineers describe the goal, not the graph.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,3 +1,5 @@
+<br />
+
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-dark.svg">
@@ -5,6 +7,8 @@
     <img alt="Open Multi-Agent" src="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-light.svg" width="96">
   </picture>
 </p>
+
+<br />
 
 <h1 align="center">Open Multi-Agent</h1>
 
@@ -25,7 +29,7 @@
   <a href="./README.md">English</a> · <strong>中文</strong>
 </p>
 
----
+<br />
 
 `open-multi-agent` 是面向 TypeScript 后端的多智能体编排框架。给定一个目标，协调者 agent 会将其拆解为任务 DAG，并行执行独立任务，合成最终结果。仅 3 个运行时依赖，可直接嵌入任意现有 Node.js 后端，让工程师专注于目标，而非任务图。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset=".github/brand/logo-mark-dark.svg">
-    <source media="(prefers-color-scheme: light)" srcset=".github/brand/logo-mark-light.svg">
-    <img alt="Open Multi-Agent" src=".github/brand/logo-mark-light.svg" width="96">
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-light.svg">
+    <img alt="Open Multi-Agent" src="https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-light.svg" width="96">
   </picture>
 </p>
 


### PR DESCRIPTION
## Summary

Replace the relative `.github/brand/logo-mark-*.svg` paths in the hero `<picture>` (English + 中文) with absolute `raw.githubusercontent.com/.../main/...` URLs.

## Why

`package.json` `files` ships only `["dist", "docs", "README.md", "LICENSE"]` — `.github/` is not in the npm tarball, so the npm-published README renders the hero logo as broken images. Switching to absolute URLs on `main` fixes npm without bloating the published package.

## Test plan
- [x] `curl -I https://raw.githubusercontent.com/JackChen-me/open-multi-agent/main/.github/brand/logo-mark-light.svg` → 200 (assets landed on main via #176)
- [x] Diff is exactly 6 lines per README, only the hero `<source>` and `<img>` srcset/src fields
- [x] GitHub web view + local IDE preview unchanged (raw URLs resolve identically there too)
- [ ] Next npm release picks this up; npmjs.com hero renders correctly