### PR TITLE
docs(agent): fix wrong JSDoc example on Agent class

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -11,15 +11,28 @@
  *
  * @example
  * ```ts
- * const agent = new Agent({
- *   name: 'researcher',
- *   model: 'claude-opus-4-6',
- *   systemPrompt: 'You are a rigorous research assistant.',
- *   tools: ['web_search', 'read_file'],
- * })
+ * import { Agent, ToolRegistry, ToolExecutor, registerBuiltInTools } from 'open-multi-agent'
  *
- * const result = await agent.run('Summarise the last 3 IPCC reports.')
+ * const registry = new ToolRegistry()
+ * registerBuiltInTools(registry)
+ * const executor = new ToolExecutor(registry)
+ *
+ * const agent = new Agent(
+ *   {
+ *     name: 'researcher',
+ *     model: 'claude-sonnet-4-6',
+ *     systemPrompt: 'You are a rigorous research assistant.',
+ *     tools: ['file_read', 'grep'],
+ *   },
+ *   registry,
+ *   executor,
+ * )
+ *
+ * const result = await agent.run('Summarise the project README.')
  * console.log(result.output)
+ *
+ * // For one-shot runs without managing the Agent instance, use
+ * // `new OpenMultiAgent().runAgent(config, prompt)` instead.
  * ```
  */
 


### PR DESCRIPTION
## Summary
- The `@example` block in `src/agent/agent.ts` showed a single-arg `new Agent({...})` call that throws at runtime. The real constructor signature is `(config, ToolRegistry, ToolExecutor)`.
- Also referenced a non-existent model ID (`claude-opus-4-6`) and two non-existent built-in tools (`web_search`, `read_file`).
- Wrong since the v0.1.0 initial commit. Surfaced when an external user copied the JSDoc verbatim and hit a runtime error.

## Test plan
- [x] `npm run lint` passes
- Pure JSDoc change; no runtime behavior affected