### PR TITLE
Upstream/pr1 on plan ready

### DIFF
--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -814,8 +814,8 @@ async function buildTaskPrompt(task: Task, team: Team, queue: TaskQueue): Promis
  */
 export class OpenMultiAgent {
   private readonly config: Required<
-    Omit<OrchestratorConfig, 'onApproval' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget'>
-  > & Pick<OrchestratorConfig, 'onApproval' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget'>
+    Omit<OrchestratorConfig, 'onApproval' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget'>
+  > & Pick<OrchestratorConfig, 'onApproval' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget'>
 
   private readonly teams: Map<string, Team> = new Map()
   private completedTaskCount = 0
@@ -839,6 +839,7 @@ export class OpenMultiAgent {
       defaultApiKey: config.defaultApiKey,
       maxTokenBudget: config.maxTokenBudget,
       onApproval: config.onApproval,
+      onPlanReady: config.onPlanReady,
       onProgress: config.onProgress,
       onTrace: config.onTrace,
     }
@@ -1173,6 +1174,18 @@ export class OpenMultiAgent {
       budgetExceededTriggered: false,
       budgetExceededReason: undefined,
       taskMetrics,
+    }
+
+    if (this.config.onPlanReady) {
+      const tasks = queue.list()
+      const approved = await this.config.onPlanReady(tasks)
+      if (!approved) {
+        return {
+          success: false,
+          agentResults: new Map(),
+          totalTokenUsage: { input_tokens: 0, output_tokens: 0 },
+        }
+      }
     }
 
     await executeQueue(queue, ctx)

--- a/src/types.ts
+++ b/src/types.ts
@@ -645,6 +645,12 @@ export interface OrchestratorConfig {
    * undefined behavior.
    */
   readonly onApproval?: (completedTasks: readonly Task[], nextTasks: readonly Task[]) => Promise<boolean>
+  /**
+   * Called after the coordinator decomposes the goal into tasks and before
+   * execution begins. Return true to proceed, false to abort.
+   * Only invoked by runTeam(). Not called for runAgent() or runTasks().
+   */
+  readonly onPlanReady?: (tasks: Task[]) => Promise<boolean>
 }
 
 /**


### PR DESCRIPTION
## What
Adds an optional `onPlanReady` callback to `OrchestratorConfig` that fires after the coordinator decomposes a goal into tasks, before execution begins. Return `false` to abort the run.

## Why
Enables human-in-the-loop plan review before any agent work starts. Returning `false` aborts immediately with `{ success: false, agentResults: new Map() }`.

## Changes
- `src/types.ts` — add `onPlanReady?` to `OrchestratorConfig`
- `src/orchestrator/orchestrator.ts` — call hook before `executeQueue()`; update `Omit`/`Pick` types

## Checklist
- [x] `npm run lint` passes
- [x] `npm test` passes (459 tests)
- [x] No new runtime dependencies
- [x] Only fires for `runTeam()` — `runAgent()` and `runTasks()` are unaffected
