### PR TITLE
fix(orchestrator): polish onPlanReady abort path

### DIFF
--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -1177,14 +1177,15 @@ export class OpenMultiAgent {
     }
 
     if (this.config.onPlanReady) {
-      const tasks = queue.list()
-      const approved = await this.config.onPlanReady(tasks)
+      const planTasks = queue.list()
+      let approved: boolean
+      try {
+        approved = await this.config.onPlanReady(planTasks)
+      } catch {
+        return { ...this.buildTeamRunResult(agentResults, goal, []), success: false }
+      }
       if (!approved) {
-        return {
-          success: false,
-          agentResults: new Map(),
-          totalTokenUsage: { input_tokens: 0, output_tokens: 0 },
-        }
+        return { ...this.buildTeamRunResult(agentResults, goal, []), success: false }
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -646,11 +646,21 @@ export interface OrchestratorConfig {
    */
   readonly onApproval?: (completedTasks: readonly Task[], nextTasks: readonly Task[]) => Promise<boolean>
   /**
-   * Called after the coordinator decomposes the goal into tasks and before
-   * execution begins. Return true to proceed, false to abort.
-   * Only invoked by runTeam(). Not called for runAgent() or runTasks().
+   * Optional approval gate called once after the coordinator decomposes the
+   * goal into tasks and before execution begins.
+   *
+   * Receives the full plan as a {@link Task} array. Return `true` to proceed
+   * or `false` to abort. A thrown callback is treated as an abort.
+   *
+   * Only invoked by `runTeam()`. `runAgent()` and `runTasks()` are
+   * unaffected. The `TeamRunResult` returned on abort still reflects the
+   * coordinator's decomposition tokens.
+   *
+   * **Note:** Do not mutate the {@link Task} objects passed to this
+   * callback. They are live references to queue state; mutation is
+   * undefined behavior.
    */
-  readonly onPlanReady?: (tasks: Task[]) => Promise<boolean>
+  readonly onPlanReady?: (tasks: readonly Task[]) => Promise<boolean>
 }
 
 /**

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -567,4 +567,73 @@ describe('OpenMultiAgent', () => {
       expect(result.agentResults.size).toBeLessThanOrEqual(1)
     })
   })
+
+  describe('onPlanReady gate', () => {
+    const complexGoal = 'First research the topic, then write a comprehensive guide based on the findings'
+
+    it('aborts when callback returns false, preserving coordinator token usage', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title": "Research", "description": "Research", "assignee": "worker"}]\n```',
+      ]
+      const onPlanReadySpy = vi.fn().mockResolvedValue(false)
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onPlanReady: onPlanReadySpy,
+      })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker')]))
+
+      const result = await oma.runTeam(team, complexGoal)
+
+      expect(result.success).toBe(false)
+      expect(result.agentResults.has('coordinator')).toBe(true)
+      expect(result.totalTokenUsage.input_tokens).toBe(10)
+      expect(result.totalTokenUsage.output_tokens).toBe(20)
+      expect(onPlanReadySpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('aborts when callback throws, treating it as a controlled abort', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title": "Research", "description": "Research", "assignee": "worker"}]\n```',
+      ]
+      const onPlanReadySpy = vi.fn().mockRejectedValue(new Error('boom'))
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onPlanReady: onPlanReadySpy,
+      })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker')]))
+
+      const result = await oma.runTeam(team, complexGoal)
+
+      expect(result.success).toBe(false)
+      expect(result.agentResults.has('coordinator')).toBe(true)
+      expect(result.totalTokenUsage.input_tokens).toBe(10)
+      expect(result.totalTokenUsage.output_tokens).toBe(20)
+      expect(onPlanReadySpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('proceeds when callback returns true, receiving the decomposed plan', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title": "Research", "description": "Research", "assignee": "worker"}]\n```',
+        'worker output',
+        'final synthesis',
+      ]
+      const onPlanReadySpy = vi.fn().mockResolvedValue(true)
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onPlanReady: onPlanReadySpy,
+      })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker')]))
+
+      const result = await oma.runTeam(team, complexGoal)
+
+      expect(result.success).toBe(true)
+      expect(result.agentResults.has('worker')).toBe(true)
+      expect(result.agentResults.has('coordinator')).toBe(true)
+      expect(onPlanReadySpy).toHaveBeenCalledTimes(1)
+      const tasksArg = onPlanReadySpy.mock.calls[0]?.[0] as { title: string }[] | undefined
+      expect(Array.isArray(tasksArg)).toBe(true)
+      expect(tasksArg).toHaveLength(1)
+      expect(tasksArg?.[0]?.title).toBe('Research')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Follow-up to #181. Fixes three issues in the `onPlanReady` abort path:

1. **Token reporting:** the abort early-return was using hard-coded `totalTokenUsage: 0`, which under-reports actual cost since the coordinator decomposition has already burned tokens. Now routes through `buildTeamRunResult` and overrides `success: false`, so callers tracking spend/quotas see real usage while still getting the abort signal. (Codex flagged this as P1 on #181.)
2. **Thrown callbacks:** wraps the `onPlanReady` invocation in `try/catch` to match `onApproval`'s pattern. A thrown callback is now a controlled abort instead of crashing the entire run.
3. **Parameter type:** tightens `(tasks: Task[])` to `(tasks: readonly Task[])` for consistency with `onApproval`. This is technically source-breaking under `strictFunctionTypes` for any caller that explicitly typed their callback as `(tasks: Task[]) => ...`. Calling out the timing: `onPlanReady` was added in #181 and is not yet on npm (latest published is 1.3.0; #181 will ship in 1.4.0). Tightening before the initial release avoids a future semver-major to align with `onApproval`'s `readonly` parameters.

JSDoc on `onPlanReady` is expanded to document the abort semantics and the no-mutation rule.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes (694 tests, +3 new)
- [x] New tests cover the three abort paths (`returns false`, `throws`, `returns true → proceeds`) and assert that the result preserves coordinator decompose token usage on abort