### PR TITLE
fix(agent): polish onAgentStream stream path

### DIFF
--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -537,7 +537,10 @@ export class Agent {
         ? mergeAbortSignals(timeoutSignal, callerAbort)
         : timeoutSignal ?? callerAbort
 
-      for await (const event of runner.stream(messages, effectiveAbort ? { abortSignal: effectiveAbort } : {})) {
+      for await (const event of runner.stream(messages, {
+        ...callerOptions,
+        ...(effectiveAbort ? { abortSignal: effectiveAbort } : {}),
+      })) {
         if (event.type === 'done') {
           const result = event.data as import('./runner.js').RunResult
           this.state.tokenUsage = addUsage(this.state.tokenUsage, result.tokenUsage)

--- a/src/agent/pool.ts
+++ b/src/agent/pool.ts
@@ -162,7 +162,14 @@ export class AgentPool {
         if (streamCallback) {
           let result: AgentRunResult | null = null
           for await (const event of agent.stream(prompt, runOptions)) {
-            streamCallback(event)
+            try {
+              streamCallback(event)
+            } catch {
+              // Streaming callback must not affect execution; mirrors the
+              // observability contract of `emitTrace`. A throwing callback
+              // here would otherwise be caught by `executeWithRetry` and
+              // burn another LLM call on every retry until exhausted.
+            }
             if (event.type === 'done') result = event.data as AgentRunResult
             if (event.type === 'error') throw event.data as Error
           }

--- a/tests/onAgentStream.test.ts
+++ b/tests/onAgentStream.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Agent } from '../src/agent/agent.js'
+import { AgentRunner } from '../src/agent/runner.js'
+import { AgentPool } from '../src/agent/pool.js'
+import { ToolRegistry } from '../src/tool/framework.js'
+import { ToolExecutor } from '../src/tool/executor.js'
+import type {
+  AgentConfig,
+  AgentRunResult,
+  LLMAdapter,
+  LLMMessage,
+  LLMResponse,
+  StreamEvent,
+  TraceEvent,
+} from '../src/types.js'
+
+// ---------------------------------------------------------------------------
+// Mock helpers
+// ---------------------------------------------------------------------------
+
+function mockAdapter(responseText: string) {
+  const calls: { messages: LLMMessage[]; abortSignal?: AbortSignal }[] = []
+  const adapter: LLMAdapter = {
+    name: 'mock',
+    async chat(messages, options) {
+      calls.push({ messages: [...messages], abortSignal: options?.abortSignal })
+      // Honor caller-supplied abort: reject like a real SDK would.
+      if (options?.abortSignal?.aborted) {
+        const err = new Error('aborted')
+        err.name = 'AbortError'
+        throw err
+      }
+      return {
+        id: 'mock-1',
+        content: [{ type: 'text' as const, text: responseText }],
+        model: 'mock-model',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 10, output_tokens: 20 },
+      } satisfies LLMResponse
+    },
+    async *stream() {
+      /* unused — runner.stream synthesizes events from chat() */
+    },
+  }
+  return { adapter, calls }
+}
+
+function buildMockAgent(config: AgentConfig, responseText: string) {
+  const { adapter, calls } = mockAdapter(responseText)
+  const registry = new ToolRegistry()
+  const executor = new ToolExecutor(registry)
+  const agent = new Agent(config, registry, executor)
+
+  const runner = new AgentRunner(adapter, registry, executor, {
+    model: config.model,
+    systemPrompt: config.systemPrompt,
+    maxTurns: config.maxTurns,
+    agentName: config.name,
+  })
+  ;(agent as any).runner = runner
+
+  return { agent, calls }
+}
+
+const baseConfig: AgentConfig = {
+  name: 'streamer',
+  model: 'mock-model',
+  systemPrompt: 'You stream.',
+}
+
+// ---------------------------------------------------------------------------
+// agent.stream() forwards full caller options through to the runner
+// ---------------------------------------------------------------------------
+
+describe('agent.stream() RunOptions forwarding', () => {
+  it('forwards onTrace from caller options so traces fire during streaming', async () => {
+    const { agent } = buildMockAgent(baseConfig, 'streamed text')
+    const traces: TraceEvent[] = []
+
+    const events: StreamEvent[] = []
+    for await (const event of agent.stream('hi', {
+      onTrace: (e) => { traces.push(e) },
+      runId: 'run-1',
+      traceAgent: 'streamer',
+    })) {
+      events.push(event)
+    }
+
+    const llmCallTraces = traces.filter(t => t.type === 'llm_call')
+    expect(llmCallTraces.length).toBeGreaterThan(0)
+    expect(llmCallTraces[0]!.runId).toBe('run-1')
+    expect(events.some(e => e.type === 'done')).toBe(true)
+  })
+
+  it('pre-aborted caller signal short-circuits the stream before any LLM call', async () => {
+    const { agent, calls } = buildMockAgent(baseConfig, 'unused')
+    const controller = new AbortController()
+    controller.abort()
+
+    const events: StreamEvent[] = []
+    for await (const event of agent.stream('hi', { abortSignal: controller.signal })) {
+      events.push(event)
+    }
+
+    expect(calls).toHaveLength(0)
+    expect(events.some(e => e.type === 'done')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// AgentPool.run() must isolate streamCallback failures
+// ---------------------------------------------------------------------------
+
+describe('AgentPool streamCallback error isolation', () => {
+  it('does not propagate a throwing streamCallback', async () => {
+    const { agent } = buildMockAgent(baseConfig, 'ok')
+    const pool = new AgentPool(1)
+    pool.add(agent)
+
+    const events: StreamEvent[] = []
+    const callback = vi.fn((event: StreamEvent) => {
+      events.push(event)
+      throw new Error('callback bug')
+    })
+
+    const result: AgentRunResult = await pool.run('streamer', 'hi', undefined, callback)
+
+    expect(result.success).toBe(true)
+    expect(callback).toHaveBeenCalled()
+    expect(events.some(e => e.type === 'done')).toBe(true)
+  })
+})


### PR DESCRIPTION
Follow-up polish for the `onAgentStream` hook added in #182.

## Changes

- **`src/agent/agent.ts`** — forward the caller's full `RunOptions` into `runner.stream` instead of only `abortSignal`. The previous code dropped `onTrace`, `runId`, `traceAgent`, and `team`, meaning agents in streaming mode silently lost per-task tracing and could not invoke `delegate_to_agent` (which reads `team` off the runner options).
- **`src/agent/pool.ts`** — wrap `streamCallback` in try/catch, mirroring `emitTrace`'s observability contract. A throwing user callback would otherwise escape `pool.run` and trigger `executeWithRetry` to retry the whole task, burning another LLM call on every retry until `maxRetries` is exhausted.
- **`tests/onAgentStream.test.ts`** — new file covering:
  - `onTrace` fires during streaming when forwarded via `runOptions`
  - pre-aborted caller signal short-circuits the stream before any LLM call
  - `AgentPool.run` isolates a throwing `streamCallback` so the run still succeeds

## Why now

Both issues were flagged in #182 review (one independently corroborated by Codex P1). They are opt-in regressions: only users who pass `onAgentStream` are affected, and only when they also use `onTrace` / `delegate_to_agent` (P1) or have a buggy callback (P2). Shipping the polish in a separate PR preserves tizerluo's authorship on the original feature.

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes (697/697)
- [x] No new runtime dependencies

Refs #182