### PR TITLE
feat: add plan_ready and agent_stream as TraceEvent types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,8 @@ export type {
   ToolCallTrace,
   TaskTrace,
   AgentTrace,
+  PlanReadyTrace,
+  AgentStreamTrace,
 
   // Memory
   MemoryEntry,

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -1199,44 +1199,31 @@ export class OpenMultiAgent {
       taskMetrics,
     }
 
+    const planTasks = queue.list()
+    const planReadyStartMs = Date.now()
+    let approved = true
     if (this.config.onPlanReady) {
-      const planTasks = queue.list()
-      let approved: boolean
-      const planReadyStartMs = Date.now()
       try {
         approved = await this.config.onPlanReady(planTasks)
       } catch {
-        if (this.config.onTrace) {
-          const planReadyEndMs = Date.now()
-          emitTrace(this.config.onTrace, {
-            type: 'plan_ready',
-            runId: runId ?? '',
-            agent: 'coordinator',
-            taskCount: planTasks.length,
-            approved: false,
-            startMs: planReadyStartMs,
-            endMs: planReadyEndMs,
-            durationMs: planReadyEndMs - planReadyStartMs,
-          })
-        }
-        return { ...this.buildTeamRunResult(agentResults, goal, []), success: false }
+        approved = false
       }
-      if (this.config.onTrace) {
-        const planReadyEndMs = Date.now()
-        emitTrace(this.config.onTrace, {
-          type: 'plan_ready',
-          runId: runId ?? '',
-          agent: 'coordinator',
-          taskCount: planTasks.length,
-          approved,
-          startMs: planReadyStartMs,
-          endMs: planReadyEndMs,
-          durationMs: planReadyEndMs - planReadyStartMs,
-        })
-      }
-      if (!approved) {
-        return { ...this.buildTeamRunResult(agentResults, goal, []), success: false }
-      }
+    }
+    if (this.config.onTrace) {
+      const planReadyEndMs = Date.now()
+      emitTrace(this.config.onTrace, {
+        type: 'plan_ready',
+        runId: runId ?? '',
+        agent: 'coordinator',
+        taskCount: planTasks.length,
+        approved,
+        startMs: planReadyStartMs,
+        endMs: planReadyEndMs,
+        durationMs: planReadyEndMs - planReadyStartMs,
+      })
+    }
+    if (!approved) {
+      return { ...this.buildTeamRunResult(agentResults, goal, []), success: false }
     }
 
     await executeQueue(queue, ctx)

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -628,7 +628,22 @@ async function executeQueue(
           prompt,
           runOptions,
           config.onAgentStream
-            ? (event) => config.onAgentStream!(assignee, event)
+            ? (event) => {
+                if (config.onTrace) {
+                  const streamMs = Date.now()
+                  emitTrace(config.onTrace, {
+                    type: 'agent_stream',
+                    runId: ctx.runId ?? '',
+                    taskId: task.id,
+                    agent: assignee,
+                    streamType: event.type,
+                    startMs: streamMs,
+                    endMs: streamMs,
+                    durationMs: 0,
+                  })
+                }
+                config.onAgentStream!(assignee, event)
+              }
             : undefined,
         ),
         task,
@@ -1187,10 +1202,37 @@ export class OpenMultiAgent {
     if (this.config.onPlanReady) {
       const planTasks = queue.list()
       let approved: boolean
+      const planReadyStartMs = Date.now()
       try {
         approved = await this.config.onPlanReady(planTasks)
       } catch {
+        if (this.config.onTrace) {
+          const planReadyEndMs = Date.now()
+          emitTrace(this.config.onTrace, {
+            type: 'plan_ready',
+            runId: runId ?? '',
+            agent: 'coordinator',
+            taskCount: planTasks.length,
+            approved: false,
+            startMs: planReadyStartMs,
+            endMs: planReadyEndMs,
+            durationMs: planReadyEndMs - planReadyStartMs,
+          })
+        }
         return { ...this.buildTeamRunResult(agentResults, goal, []), success: false }
+      }
+      if (this.config.onTrace) {
+        const planReadyEndMs = Date.now()
+        emitTrace(this.config.onTrace, {
+          type: 'plan_ready',
+          runId: runId ?? '',
+          agent: 'coordinator',
+          taskCount: planTasks.length,
+          approved,
+          startMs: planReadyStartMs,
+          endMs: planReadyEndMs,
+          durationMs: planReadyEndMs - planReadyStartMs,
+        })
       }
       if (!approved) {
         return { ...this.buildTeamRunResult(agentResults, goal, []), success: false }

--- a/src/types.ts
+++ b/src/types.ts
@@ -732,7 +732,13 @@ export interface CoordinatorConfig {
 // ---------------------------------------------------------------------------
 
 /** Trace event type discriminants. */
-export type TraceEventType = 'llm_call' | 'tool_call' | 'task' | 'agent'
+export type TraceEventType =
+  | 'llm_call'
+  | 'tool_call'
+  | 'task'
+  | 'agent'
+  | 'plan_ready'
+  | 'agent_stream'
 
 /** Shared fields present on every trace event. */
 export interface TraceEventBase {
@@ -785,8 +791,30 @@ export interface AgentTrace extends TraceEventBase {
   readonly toolCalls: number
 }
 
+/** Emitted when runTeam reaches the plan approval boundary. */
+export interface PlanReadyTrace extends TraceEventBase {
+  readonly type: 'plan_ready'
+  /** Number of tasks produced by coordinator decomposition. */
+  readonly taskCount: number
+  /** Approval decision returned by onPlanReady callback. */
+  readonly approved: boolean
+}
+
+/** Emitted for each streaming event forwarded through onAgentStream in runTeam. */
+export interface AgentStreamTrace extends TraceEventBase {
+  readonly type: 'agent_stream'
+  /** Underlying stream event type (`text`, `tool_use`, `done`, etc.). */
+  readonly streamType: StreamEvent['type']
+}
+
 /** Discriminated union of all trace event types. */
-export type TraceEvent = LLMCallTrace | ToolCallTrace | TaskTrace | AgentTrace
+export type TraceEvent =
+  | LLMCallTrace
+  | ToolCallTrace
+  | TaskTrace
+  | AgentTrace
+  | PlanReadyTrace
+  | AgentStreamTrace
 
 // ---------------------------------------------------------------------------
 // Memory

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -9,6 +9,7 @@ import type {
   LLMResponse,
   OrchestratorEvent,
   TeamConfig,
+  TraceEvent,
 } from '../src/types.js'
 
 // ---------------------------------------------------------------------------
@@ -634,6 +635,68 @@ describe('OpenMultiAgent', () => {
       expect(Array.isArray(tasksArg)).toBe(true)
       expect(tasksArg).toHaveLength(1)
       expect(tasksArg?.[0]?.title).toBe('Research')
+    })
+
+    it('emits plan_ready trace with approval decision', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title": "Research", "description": "Research", "assignee": "worker"}]\n```',
+      ]
+      const traces: TraceEvent[] = []
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onTrace: (event) => { traces.push(event) },
+        onPlanReady: async () => false,
+      })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker')]))
+
+      const result = await oma.runTeam(team, complexGoal)
+
+      expect(result.success).toBe(false)
+      const planReadyTraces = traces.filter((t) => t.type === 'plan_ready')
+      expect(planReadyTraces).toHaveLength(1)
+      const planReady = planReadyTraces[0]!
+      expect(planReady.type).toBe('plan_ready')
+      expect(planReady.agent).toBe('coordinator')
+      expect(planReady.taskCount).toBe(1)
+      expect(planReady.approved).toBe(false)
+      expect(planReady.runId).toMatch(/.+/)
+      expect(planReady.durationMs).toBeGreaterThanOrEqual(0)
+      expect(planReady.startMs).toBeLessThanOrEqual(planReady.endMs)
+    })
+  })
+
+  describe('stream trace events', () => {
+    it('emits agent_stream trace events when onAgentStream is configured', async () => {
+      const complexGoal = 'First research the topic, then write a comprehensive guide based on the findings'
+      mockAdapterResponses = [
+        '```json\n[{"title": "Research", "description": "Research", "assignee": "worker"}]\n```',
+        'worker output',
+        'final synthesis',
+      ]
+      const traces: TraceEvent[] = []
+      const streamedTypes: string[] = []
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onTrace: (event) => { traces.push(event) },
+        onAgentStream: (_agentName, event) => { streamedTypes.push(event.type) },
+      })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker')]))
+
+      const result = await oma.runTeam(team, complexGoal)
+
+      expect(result.success).toBe(true)
+      expect(streamedTypes.length).toBeGreaterThan(0)
+
+      const streamTraces = traces.filter((t) => t.type === 'agent_stream')
+      expect(streamTraces.length).toBeGreaterThan(0)
+      expect(streamTraces.some((t) => t.streamType === 'text')).toBe(true)
+      expect(streamTraces.some((t) => t.streamType === 'done')).toBe(true)
+      for (const trace of streamTraces) {
+        expect(trace.agent).toBe('worker')
+        expect(trace.taskId).toMatch(/.+/)
+        expect(trace.runId).toMatch(/.+/)
+        expect(trace.durationMs).toBe(0)
+      }
     })
   })
 })

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -572,6 +572,31 @@ describe('OpenMultiAgent', () => {
   describe('onPlanReady gate', () => {
     const complexGoal = 'First research the topic, then write a comprehensive guide based on the findings'
 
+    it('emits plan_ready trace even when onPlanReady callback is not configured', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title": "Research", "description": "Research", "assignee": "worker"}]\n```',
+        'worker output',
+        'final synthesis',
+      ]
+      const traces: TraceEvent[] = []
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onTrace: (event) => { traces.push(event) },
+      })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker')]))
+
+      const result = await oma.runTeam(team, complexGoal)
+
+      expect(result.success).toBe(true)
+      const planReadyTraces = traces.filter((t) => t.type === 'plan_ready')
+      expect(planReadyTraces).toHaveLength(1)
+      const planReady = planReadyTraces[0]!
+      expect(planReady.type).toBe('plan_ready')
+      expect(planReady.taskCount).toBe(1)
+      expect(planReady.approved).toBe(true)
+      expect(planReady.runId).toMatch(/.+/)
+    })
+
     it('aborts when callback returns false, preserving coordinator token usage', async () => {
       mockAdapterResponses = [
         '```json\n[{"title": "Research", "description": "Research", "assignee": "worker"}]\n```',


### PR DESCRIPTION
## What

Introduces TraceEvent types (`plan_ready`, `agent_stream`) for the observation layer.

## Why

To enable observability and streaming visibility into the system

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Added/updated tests for changed behavior
- [x] No new runtime dependencies (or justified in the PR description)
