### PR TITLE
docs(readme): add capability enum tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 
 <p align="center">
   <strong>From a goal to a task DAG, automatically.</strong><br/>
-  TypeScript-native multi-agent orchestration. Three runtime dependencies.
+  TypeScript-native multi-agent orchestration. Three runtime dependencies.<br/>
+  9 native LLM adapters · MCP · token budgets · retries · context compaction · live tracing.
 </p>
 
 <p align="center">

--- a/README_zh.md
+++ b/README_zh.md
@@ -14,7 +14,8 @@
 
 <p align="center">
   <strong>给一个目标，自动得到任务 DAG。</strong><br/>
-  原生 TypeScript 多智能体编排，3 个运行时依赖。
+  原生 TypeScript 多智能体编排，3 个运行时依赖。<br/>
+  9 个原生 LLM 适配器 · MCP · token 预算 · 重试 · 上下文压缩 · 实时追踪。
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Add a third tagline line to both English and Chinese READMEs. The original goal-first hook stays as the differentiation thesis; the new line surfaces execution + production capabilities so technical evaluators can read off whether the framework covers their production checklist without scrolling.

```
From a goal to a task DAG, automatically.
TypeScript-native multi-agent orchestration. Three runtime dependencies.
9 native LLM adapters · MCP · token budgets · retries · context compaction · live tracing.
```

## Why

- Line 1 (goal-first) is the differentiation thesis vs LangGraph / Mastra
- Line 2 (TypeScript + 3 deps) is the engineering identity
- Line 3 (capabilities) was missing — without it, deeper-evaluating users had to scroll into `Features`, `Built-in Tools`, `Production Checklist`, and `Supported Providers` sections to confirm the framework spans the execution and production layers, not only orchestration

No code changes. Tagline-only.

## Test plan

- [x] EN tagline renders correctly
- [x] ZH tagline renders correctly with matching content
- [x] No structural HTML changes beyond one extra `<br/>` line