### PR TITLE
fix(runner): preserve tool_use/tool_result pairs in sliding-window truncation

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -210,6 +210,56 @@ function extractToolUseBlocks(content: readonly ContentBlock[]): ToolUseBlock[] 
   return content.filter((b): b is ToolUseBlock => b.type === 'tool_use')
 }
 
+/**
+ * Boundaries (`startIndex` inclusive, `endIndex` exclusive) of a single
+ * atomic conversation turn within a flat message array.
+ */
+interface Turn {
+  startIndex: number
+  endIndex: number
+}
+
+/**
+ * Group a flat message array into atomic turns so context-management
+ * strategies can split on safe boundaries.
+ *
+ * A turn is one of:
+ *   - a single user / assistant text message, or
+ *   - an assistant message containing one or more `tool_use` blocks plus the
+ *     immediately following user message containing the matching `tool_result`
+ *     blocks (kept together so neither half can be dropped on its own).
+ *
+ * Splitting on turn boundaries — instead of slicing by raw message count —
+ * prevents orphaned `tool_use_id` references that the Anthropic and OpenAI
+ * APIs reject. Modelled on `groupIntoTurns` from the context-chef library.
+ */
+function groupIntoTurns(messages: LLMMessage[]): Turn[] {
+  const turns: Turn[] = []
+  let i = 0
+  while (i < messages.length) {
+    const msg = messages[i]!
+    const hasToolUse =
+      msg.role === 'assistant' && msg.content.some(b => b.type === 'tool_use')
+    if (hasToolUse) {
+      const start = i
+      i++
+      // Absorb the matching tool_result user message, when present.
+      if (
+        i < messages.length
+        && messages[i]!.role === 'user'
+        && messages[i]!.content.some(b => b.type === 'tool_result')
+      ) {
+        i++
+      }
+      turns.push({ startIndex: start, endIndex: i })
+    } else {
+      turns.push({ startIndex: i, endIndex: i + 1 })
+      i++
+    }
+  }
+  return turns
+}
+
 /** Add two {@link TokenUsage} values together, returning a new object. */
 function addTokenUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
   return {
@@ -296,21 +346,28 @@ export class AgentRunner {
       ? messages.slice(firstUserIndex + 1)
       : messages.slice()
 
-    if (afterFirst.length <= maxTurns * 2) {
+    // Split on atomic turn boundaries so a tool_use is never separated from
+    // its tool_result. Slicing raw message count (the pre-fix behaviour) could
+    // strand a tool_result whose tool_use was just dropped — and the LLM API
+    // rejects orphan tool_use_id references.
+    const turns = groupIntoTurns(afterFirst)
+    if (turns.length <= maxTurns) {
       return messages
     }
 
-    const kept = afterFirst.slice(-maxTurns * 2)
-    const result: LLMMessage[] = []
+    const keptTurns = turns.slice(-maxTurns)
+    const keepStartIdx = keptTurns[0]!.startIndex
+    const kept = afterFirst.slice(keepStartIdx)
+    const droppedTurns = turns.length - keptTurns.length
 
+    const result: LLMMessage[] = []
     if (firstUser !== null) {
       result.push(firstUser)
     }
 
-    const droppedPairs = Math.floor((afterFirst.length - kept.length) / 2)
-    if (droppedPairs > 0) {
+    if (droppedTurns > 0) {
       const notice =
-        `[Earlier conversation history truncated — ${droppedPairs} turn(s) removed]\n\n`
+        `[Earlier conversation history truncated — ${droppedTurns} turn(s) removed]\n\n`
       result.push(...prependSyntheticPrefixToFirstUser(kept, notice))
       return result
     }

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -346,16 +346,27 @@ export class AgentRunner {
       ? messages.slice(firstUserIndex + 1)
       : messages.slice()
 
-    // Split on atomic turn boundaries so a tool_use is never separated from
-    // its tool_result. Slicing raw message count (the pre-fix behaviour) could
-    // strand a tool_result whose tool_use was just dropped — and the LLM API
-    // rejects orphan tool_use_id references.
-    const turns = groupIntoTurns(afterFirst)
-    if (turns.length <= maxTurns) {
+    // Walk turns from the tail, accumulating message count until we have at
+    // least `maxTurns * 2` messages — preserving the historical "message-pair
+    // count" semantics of `maxTurns` for plain conversations while never
+    // splitting a tool_use/tool_result pair (see `groupIntoTurns`). The kept
+    // slice may exceed the target by one message when the boundary lands
+    // inside an atomic tool turn — that's the smallest safe slice.
+    const target = maxTurns * 2
+    if (afterFirst.length <= target) {
       return messages
     }
 
-    const keptTurns = turns.slice(-maxTurns)
+    const turns = groupIntoTurns(afterFirst)
+    let cumulative = 0
+    let cutoffTurnIdx = turns.length
+    for (let i = turns.length - 1; i >= 0; i--) {
+      cumulative += turns[i]!.endIndex - turns[i]!.startIndex
+      cutoffTurnIdx = i
+      if (cumulative >= target) break
+    }
+
+    const keptTurns = turns.slice(cutoffTurnIdx)
     const keepStartIdx = keptTurns[0]!.startIndex
     const kept = afterFirst.slice(keepStartIdx)
     const droppedTurns = turns.length - keptTurns.length

--- a/tests/context-strategy.test.ts
+++ b/tests/context-strategy.test.ts
@@ -109,6 +109,63 @@ describe('AgentRunner contextStrategy', () => {
     expect(flattenedText.some(c => c.type === 'text' && c.text.includes('truncated'))).toBe(true)
   })
 
+  it('sliding-window keeps tool_use/tool_result pairs together', async () => {
+    // Regression: previously truncateToSlidingWindow sliced by message count
+    // (`afterFirst.slice(-maxTurns * 2)`), which could drop an `assistant` block
+    // carrying a `tool_use` while keeping the matching `user` `tool_result`.
+    // This produces an orphan `tool_use_id` that Anthropic's API rejects.
+    const calls: LLMMessage[][] = []
+    const adapter: LLMAdapter = {
+      name: 'mock',
+      async chat(messages) {
+        calls.push(messages.map(m => ({ role: m.role, content: m.content })))
+        return textResponse('ack')
+      },
+      async *stream() {
+        /* unused */
+      },
+    }
+    const { registry, executor } = buildRegistryAndExecutor()
+    const runner = new AgentRunner(adapter, registry, executor, {
+      model: 'mock-model',
+      allowedTools: ['echo'],
+      maxTurns: 4,
+      // maxTurns=2 + a 6-message history is sized so the naive slice(-4)
+      // lands on the user_tool_result, leaving its tool_use upstream.
+      contextStrategy: { type: 'sliding-window', maxTurns: 2 },
+    })
+
+    const history: LLMMessage[] = [
+      { role: 'user', content: [{ type: 'text', text: 'original prompt' }] },
+      { role: 'assistant', content: [
+        { type: 'tool_use', id: 'tu-1', name: 'echo', input: { message: 'hi' } },
+      ] },
+      { role: 'user', content: [
+        { type: 'tool_result', tool_use_id: 'tu-1', content: 'hi' },
+      ] },
+      { role: 'assistant', content: [{ type: 'text', text: 'response 1' }] },
+      { role: 'user', content: [{ type: 'text', text: 'follow up' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'response 2' }] },
+    ]
+
+    await runner.run(history)
+
+    // Every tool_result reaching the adapter must reference a tool_use that
+    // also reached the adapter. Otherwise the API call is invalid.
+    const sent = calls[0]!
+    const toolUseIds = new Set<string>()
+    const toolResultIds: string[] = []
+    for (const msg of sent) {
+      for (const block of msg.content) {
+        if (block.type === 'tool_use') toolUseIds.add(block.id)
+        if (block.type === 'tool_result') toolResultIds.push(block.tool_use_id)
+      }
+    }
+    for (const trId of toolResultIds) {
+      expect(toolUseIds.has(trId)).toBe(true)
+    }
+  })
+
   it('summarize strategy replaces old context and emits summary trace call', async () => {
     const calls: Array<{ messages: LLMMessage[]; options: LLMChatOptions }> = []
     const traces: TraceEvent[] = []

--- a/tests/context-strategy.test.ts
+++ b/tests/context-strategy.test.ts
@@ -166,6 +166,68 @@ describe('AgentRunner contextStrategy', () => {
     }
   })
 
+  it('sliding-window preserves message-pair count for plain conversations', async () => {
+    // The bug fix above changes how we slice (turn boundaries instead of raw
+    // message count), but `maxTurns` must still mean "message pair count" for
+    // plain text histories — i.e. `maxTurns=N` keeps the last `2*N` messages
+    // when no tool round-trips are involved. This test pins that contract.
+    const calls: LLMMessage[][] = []
+    const adapter: LLMAdapter = {
+      name: 'mock',
+      async chat(messages) {
+        calls.push(messages.map(m => ({ role: m.role, content: m.content })))
+        return textResponse('ack')
+      },
+      async *stream() {
+        /* unused */
+      },
+    }
+    const { registry, executor } = buildRegistryAndExecutor()
+    const runner = new AgentRunner(adapter, registry, executor, {
+      model: 'mock-model',
+      allowedTools: ['echo'],
+      maxTurns: 4,
+      contextStrategy: { type: 'sliding-window', maxTurns: 2 },
+    })
+
+    // 7-message plain history. afterFirst = 6 msgs, target = maxTurns*2 = 4.
+    // Expected kept slice (excluding the always-preserved first user): last 4.
+    const history: LLMMessage[] = [
+      { role: 'user', content: [{ type: 'text', text: 'q1' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'a1' }] },
+      { role: 'user', content: [{ type: 'text', text: 'q2' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'a2' }] },
+      { role: 'user', content: [{ type: 'text', text: 'q3' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'a3' }] },
+      { role: 'user', content: [{ type: 'text', text: 'q4' }] },
+    ]
+
+    await runner.run(history)
+
+    const sent = calls[0]!
+    // Expected: [q1 (firstUser), a2, u3 (with truncation notice), a3, q4]
+    // = 1 firstUser + last 4 of afterFirst = 5 messages.
+    expect(sent).toHaveLength(5)
+    expect(sent[0]!.content[0]).toMatchObject({ type: 'text', text: 'q1' })
+
+    // Confirm the kept slice carries exactly the last 4 messages of the
+    // pre-truncation history (a2, q3, a3, q4) — i.e. `maxTurns=2` kept 4 msgs.
+    const keptText = sent.slice(1).flatMap(m =>
+      m.content
+        .filter((c): c is import('../src/types.js').TextBlock => c.type === 'text')
+        .map(c => c.text)
+    )
+    expect(keptText.some(t => t.includes('a2'))).toBe(true)
+    expect(keptText.some(t => t === 'q3')).toBe(true)
+    expect(keptText.some(t => t.includes('a3'))).toBe(true)
+    expect(keptText.some(t => t === 'q4')).toBe(true)
+    // q2 and a1 must have been truncated away.
+    expect(keptText.every(t => !t.includes('q2'))).toBe(true)
+    expect(keptText.every(t => !t.includes('a1'))).toBe(true)
+
+    expect(keptText.some(t => t.includes('truncated'))).toBe(true)
+  })
+
   it('summarize strategy replaces old context and emits summary trace call', async () => {
     const calls: Array<{ messages: LLMMessage[]; options: LLMChatOptions }> = []
     const traces: TraceEvent[] = []


### PR DESCRIPTION
## Problem

`AgentRunner.truncateToSlidingWindow` slices raw message count (`afterFirst.slice(-maxTurns * 2)`), assuming "2 messages = 1 user/assistant pair". Tool round-trips violate that assumption: an `assistant` message carrying `tool_use` blocks is followed by a `user` message carrying `tool_result` blocks — the role order is reversed compared to a plain conversation pair.

When the slice boundary lands on a `tool_result`, the matching `tool_use` upstream gets dropped. The next chat call then ships an orphan `tool_use_id` that Anthropic and OpenAI APIs reject.

## Repro (added as a regression test)

```
history = [user, asst_tool_use, user_tool_result, asst_text, user_text, asst_text]
contextStrategy: { type: 'sliding-window', maxTurns: 2 }
```

Pre-fix: `afterFirst.slice(-4) = [user_tool_result, asst_text, user_text, asst_text]` → `tool_result(tu-1)` reaches the adapter without its matching `tool_use`.

Verified locally with a standalone mock-adapter demo: pre-fix output shows `🚨 ORPHAN tool_result_ids: ['tu-1']`; post-fix shows `✅ Every tool_result has a matching tool_use`.

## Fix

New top-level `groupIntoTurns(messages)` helper fuses each `assistant`-with-`tool_use` together with its following `user`-with-`tool_result` into one atomic turn. `truncateToSlidingWindow` now slices on turn boundaries instead of message indices, so tool pairs stay intact (or get dropped together).

The same primitive solves the same class of bug in [context-chef](https://github.com/MyPrototypeWhat/context-chef)'s Janitor module (`packages/core/src/modules/janitor/index.ts:28-51`) — referenced as prior art in the source comment.

## Test plan

- [x] New regression test (`sliding-window keeps tool_use/tool_result pairs together`) fails on `main`, passes after the fix
- [x] Existing 15 context-strategy tests still pass
- [x] Full suite: 707/707 passed
- [x] `tsc --noEmit` clean
- [x] No `package-lock.json` noise