### PR TITLE
fix(runner): strip image blocks before summarize compression call

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -260,6 +260,33 @@ function groupIntoTurns(messages: LLMMessage[]): Turn[] {
   return turns
 }
 
+/**
+ * Replace `image` blocks with text placeholders so binary attachment data
+ * never leaks into the summarisation prompt.
+ *
+ * `summarizeMessages` flattens old turns via `JSON.stringify(message)` and
+ * inlines the result into a text user-message it ships to the summary model.
+ * For an `ImageBlock`, that serialisation includes the full base64 payload —
+ * a 1MB image would balloon the "compression" call by ~250k tokens, defeating
+ * its purpose and risking context-limit rejection.
+ *
+ * The placeholder still tells the summariser that media was present at this
+ * turn, so the produced summary can reference it. Modelled on chef Janitor's
+ * `stripAttachmentsForCompression`.
+ */
+function stripImageBlocksForSummary(messages: LLMMessage[]): LLMMessage[] {
+  return messages.map((msg) => {
+    if (!msg.content.some(b => b.type === 'image')) return msg
+    const newContent: ContentBlock[] = msg.content.map((block) => {
+      if (block.type === 'image') {
+        return { type: 'text', text: `[image: ${block.source.media_type}]` } satisfies TextBlock
+      }
+      return block
+    })
+    return { role: msg.role, content: newContent }
+  })
+}
+
 /** Add two {@link TokenUsage} values together, returning a new object. */
 function addTokenUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
   return {
@@ -417,7 +444,14 @@ export class AgentRunner {
     const oldPortion = rest.slice(0, splitAt)
     const recentPortion = rest.slice(splitAt)
 
-    const oldSignature = oldPortion.map(m => this.serializeMessage(m)).join('\n')
+    // Strip image attachments before serialising — JSON.stringify on an
+    // ImageBlock would inline the entire base64 payload into the summary
+    // prompt, so a 1MB image would defeat the very purpose of compression.
+    // The placeholder still flags that media existed at this turn so the
+    // summariser can mention it. recentPortion is untouched (returned to
+    // the caller verbatim, never serialised here).
+    const oldPortionForSummary = stripImageBlocksForSummary(oldPortion)
+    const oldSignature = oldPortionForSummary.map(m => this.serializeMessage(m)).join('\n')
     if (this.summarizeCache !== null && this.summarizeCache.oldSignature === oldSignature) {
       const mergedRecent = prependSyntheticPrefixToFirstUser(
         recentPortion,

--- a/tests/context-strategy.test.ts
+++ b/tests/context-strategy.test.ts
@@ -284,6 +284,78 @@ describe('AgentRunner contextStrategy', () => {
     expect(rolesAfterFirstUser).not.toMatch(/^user,user/)
   })
 
+  it('summarize strategy strips image attachments before compression call', async () => {
+    // Bug: summarizeMessages serializes oldPortion via JSON.stringify and
+    // splices the result into the summary prompt text. ImageBlock.source.data
+    // is a base64 string — when present, the entire base64 payload leaks
+    // into the compression call, blowing token cost and risking context-limit
+    // rejection on the very call meant to *reduce* context.
+    const FAKE_IMAGE_DATA = 'A'.repeat(100_000)
+    // estimateTokens charges only 64 chars per ImageBlock, so summarize must
+    // be triggered by surrounding text. Stuff some text-heavy turns alongside.
+    const FILLER = 'lorem ipsum dolor sit amet '.repeat(50)  // ~1.3k chars
+    const calls: { messages: LLMMessage[]; options: LLMChatOptions }[] = []
+    let callCount = 0
+    const adapter: LLMAdapter = {
+      name: 'mock',
+      async chat(messages, options) {
+        calls.push({ messages, options })
+        callCount++
+        if (callCount === 1) {
+          return toolUseResponse('echo', { message: 'x' })
+        }
+        return textResponse('done')
+      },
+      async *stream() {
+        /* unused */
+      },
+    }
+    const { registry, executor } = buildRegistryAndExecutor()
+    const runner = new AgentRunner(adapter, registry, executor, {
+      model: 'mock-model',
+      allowedTools: ['echo'],
+      maxTurns: 8,
+      contextStrategy: { type: 'summarize', maxTokens: 100 },
+    })
+
+    const history: LLMMessage[] = [
+      // firstUser (preserved as-is, never enters oldPortion)
+      { role: 'user', content: [{ type: 'text', text: 'start' }] },
+      { role: 'assistant', content: [{ type: 'text', text: FILLER }] },
+      // Image is on a NON-first user message so it lands in oldPortion
+      // (the slice that gets serialised into the summary prompt).
+      { role: 'user', content: [
+        { type: 'text', text: 'analyze this image' },
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: FAKE_IMAGE_DATA } },
+      ] },
+      { role: 'assistant', content: [{ type: 'text', text: FILLER }] },
+      { role: 'user', content: [{ type: 'text', text: FILLER }] },
+      { role: 'assistant', content: [{ type: 'text', text: FILLER }] },
+    ]
+
+    await runner.run(history)
+
+    // Summary call signature: no tools, exactly one synthesised user message.
+    const summaryCall = calls.find(
+      c => c.options.tools === undefined && c.messages.length === 1,
+    )
+    expect(summaryCall).toBeDefined()
+
+    const promptText = summaryCall!.messages[0]!.content
+      .filter((b): b is import('../src/types.js').TextBlock => b.type === 'text')
+      .map(b => b.text)
+      .join('\n')
+
+    // Base64 payload must NOT have leaked into the compression prompt.
+    expect(promptText.includes(FAKE_IMAGE_DATA)).toBe(false)
+    // Sanity: the prompt should be small. 100k base64 chars + JSON overhead
+    // would push it well past 100k chars without the strip.
+    expect(promptText.length).toBeLessThan(10_000)
+    // The image should still be referenced by some placeholder so the
+    // summarizer knows media existed at that point.
+    expect(promptText.toLowerCase().includes('image')).toBe(true)
+  })
+
   it('does not drop turns when context strategy shrinks array size', async () => {
     // The core bug from #152: if the strategy replaces the array with fewer messages than it started with,
     // the old `slice()` logic would incorrectly drop newly generated turns.


### PR DESCRIPTION
## Problem

`summarizeMessages` flattens the old portion of conversation history via `JSON.stringify(message)` and inlines the result into the user-message it ships to the summary model. For a `ContentBlock` of `type: 'image'`, that serialisation includes the entire `source.data` (base64) payload.

A single 1MB image therefore inflates the "compression" call by ~1.3M chars (~250k input tokens) — defeating the very purpose of summarisation, and tripping context-window limits on smaller summary models.

## Repro

`tests/context-strategy.test.ts` ▶ `summarize strategy strips image attachments before compression call` constructs a 6-message history with a 100k-char base64 image on a non-first user turn (so it lands in `oldPortion`). Pre-fix the summary adapter receives a prompt containing the full base64 string; post-fix it sees only `[image: image/png]`.

## Scope (important)

- **In scope**: structured content blocks of `type: 'image'`. Replaced with a `[image: <media_type>]` text placeholder before serialisation, so the summariser still knows media existed at that turn.
- **Out of scope**: text blocks that happen to *contain* base64 strings. If a user manually pastes base64 into a `TextBlock`, that's caller intent — we don't try to detect or strip it (would be both fragile and surprising).
- **Out of scope today, symmetric extension later**: OMA's `ContentBlock` union currently has only one binary form (`ImageBlock`). If a future `FileBlock` / generic attachment is added, this helper should extend by analogy — strip the structured binary, not the text.

## Behaviour preserved

- `recentPortion` (the slice returned to the runner for the next regular LLM call) is untouched — images stay intact downstream.
- `firstUser` is preserved as-is (never inside the summarised portion).
- `summarizeCache` keying still works: two histories differing only in image bytes were going to summarise to the same content anyway, so cache hits remain valid.

## Prior art

[context-chef](https://github.com/MyPrototypeWhat/context-chef)'s Janitor module (`packages/core/src/modules/janitor/index.ts`, `stripAttachmentsForCompression`) solves the exact same class of bug.

## Test plan

- [x] New regression test (`summarize strategy strips image attachments before compression call`) fails on \`main\` (commit \`8234522\`), passes after this fix
- [x] Existing 17 context-strategy tests still pass
- [x] Full suite: 709/709 pass
- [x] \`tsc --noEmit\` clean