### PR TITLE
feat(trace): include tool input/output in ToolCallTrace (closes #124)

### DIFF
--- a/examples/integrations/trace-observability.ts
+++ b/examples/integrations/trace-observability.ts
@@ -42,6 +42,11 @@ const writer: AgentConfig = {
 // Trace handler — log every span with timing
 // ---------------------------------------------------------------------------
 
+/** Truncate long strings for log readability — full payload stays in the event. */
+function truncate(s: string, max = 80): string {
+  return s.length > max ? `${s.slice(0, max)}…(+${s.length - max} chars)` : s
+}
+
 function handleTrace(event: TraceEvent): void {
   const dur = `${event.durationMs}ms`.padStart(7)
 
@@ -53,9 +58,14 @@ function handleTrace(event: TraceEvent): void {
       )
       break
     case 'tool_call':
+      // Truncation here is for log readability only — the full payload remains
+      // on `event.input` / `event.output` for downstream consumers (OpenTelemetry,
+      // structured log shippers, audit pipelines, etc.).
       console.log(
         `  [TOOL]  ${dur}  agent=${event.agent}  tool=${event.tool}` +
-        `  error=${event.isError}`,
+        `  error=${event.isError}` +
+        `  input=${truncate(JSON.stringify(event.input))}` +
+        `  output=${truncate(event.output)}`,
       )
       break
     case 'task':

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -920,6 +920,8 @@ export class AgentRunner {
               agent: options.traceAgent ?? this.options.agentName ?? 'unknown',
               tool: block.name,
               isError: result.isError ?? false,
+              input: block.input,
+              output: result.data,
               startMs: startTime,
               endMs: endTime,
               durationMs: duration,

--- a/src/types.ts
+++ b/src/types.ts
@@ -779,6 +779,10 @@ export interface ToolCallTrace extends TraceEventBase {
   readonly type: 'tool_call'
   readonly tool: string
   readonly isError: boolean
+  /** The input arguments passed to the tool — mirrors the originating ToolUseBlock.input. */
+  readonly input: Record<string, unknown>
+  /** The serialised output returned by the tool — mirrors ToolResult.data (truncation, if any, has already been applied by the executor). */
+  readonly output: string
 }
 
 /** Emitted when a task completes (wraps the full retry sequence). */

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -246,6 +246,8 @@ describe('AgentRunner trace events', () => {
     expect(tool.agent).toBe('tooler')
     expect(tool.tool).toBe('echo')
     expect(tool.isError).toBe(false)
+    expect(tool.input).toEqual({ msg: 'hello' })
+    expect(tool.output).toBe('hello')
     expect(tool.durationMs).toBeGreaterThanOrEqual(0)
   })
 
@@ -279,6 +281,52 @@ describe('AgentRunner trace events', () => {
     const toolTraces = traces.filter(t => t.type === 'tool_call')
     expect(toolTraces).toHaveLength(1)
     expect(toolTraces[0]!.isError).toBe(true)
+    // The tool's thrown error message must be surfaced via `output` so trace
+    // consumers can diagnose failures without reaching for separate channels.
+    expect(toolTraces[0]!.output).toContain('fail')
+    expect(toolTraces[0]!.input).toEqual({})
+  })
+
+  it('tool_call trace.output reflects executor truncation', async () => {
+    // Pins the jsdoc contract on `ToolCallTrace.output`: whatever truncation
+    // ToolExecutor applies (per-tool maxOutputChars or agent-level maxToolOutputChars)
+    // must already be reflected in the trace event — trace consumers should
+    // never see raw, untruncated tool output that the LLM itself never saw.
+    const traces: TraceEvent[] = []
+    const registry = new ToolRegistry()
+    registry.register(
+      defineTool({
+        name: 'big_output',
+        description: 'returns a large string',
+        inputSchema: z.object({}),
+        maxOutputChars: 50,
+        execute: async () => ({ data: 'X'.repeat(200) }),
+      }),
+    )
+    const executor = new ToolExecutor(registry)
+    const adapter = mockAdapter([
+      toolUseResponse('big_output', {}),
+      textResponse('done'),
+    ])
+
+    const runner = new AgentRunner(adapter, registry, executor, {
+      model: 'test-model',
+      agentName: 'tooler',
+    })
+
+    await runner.run(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+      { onTrace: (e) => { traces.push(e) }, runId: 'run-trunc', traceAgent: 'tooler' },
+    )
+
+    const toolTraces = traces.filter(t => t.type === 'tool_call')
+    expect(toolTraces).toHaveLength(1)
+    const out = toolTraces[0]!.output
+    // Length stays within the per-tool cap (executor honours `maxOutputChars`).
+    expect(out.length).toBeLessThanOrEqual(50)
+    // The raw 200-char payload was rewritten to a head + truncation marker + tail.
+    expect(out).toContain('truncated')
+    expect(out).not.toBe('X'.repeat(200))
   })
 
   it('does not call Date.now for LLM timing when onTrace is absent', async () => {


### PR DESCRIPTION
## What this does

`ToolCallTrace` previously surfaced only `tool`, `isError`, and `durationMs`. To diagnose a tool call you had to dig through provider server logs (LM Studio, vLLM) or wire up `onToolCall` / `onToolResult` as a parallel channel — exactly what `onTrace` is supposed to replace.

This PR adds two readonly fields to `ToolCallTrace`:

- `input: Record<string, unknown>` — mirrors the originating `ToolUseBlock.input`
- `output: string` — mirrors `ToolResult.data`, including any executor truncation (per-tool `maxOutputChars` / agent `maxToolOutputChars`) so trace consumers see exactly what the LLM will see in the next turn

A single `onTrace` callback now sees the full tool-call lifecycle.

Closes #124.

## Scope

| File | Change |
|------|-------|
| `src/types.ts` | `ToolCallTrace` gains `input` + `output` (both `readonly`) with jsdoc |
| `src/agent/runner.ts` | `emitTrace('tool_call', ...)` populates the two new fields with `block.input` and `result.data` |
| `tests/trace.test.ts` | Extended success + error tests assert the new fields; new regression `tool_call trace.output reflects executor truncation` pins the jsdoc contract |
| `examples/integrations/trace-observability.ts` | `[TOOL]` log line shows truncated input/output for readability; comment notes the full payload remains on the event |

## Behaviour preserved

- **Pure type-additive**: code that *reads* trace events keeps working — the new fields are opt-in by access
- **Single source of truth for output length**: `ToolExecutor.execute` is where truncation happens; `output` reflects the same string the LLM sees on the next turn
- **No new public API**: no orchestrator option, no callback shape change

## Type-level note

These are required `readonly` fields, so code that *constructs* a `ToolCallTrace` literally — e.g. test mocks, trace proxies — must populate `input` and `output`. The fix is mechanical and tsc points straight at the call site. Code that only reads trace events (the 99% case) is unaffected.

Other `TraceEvent` variants are unchanged.

## Test plan

- [x] Extended `emits tool_call trace with correct fields` and `tool_call trace has isError: true on tool failure` to assert the new \`input\` / \`output\` fields
- [x] New regression \`tool_call trace.output reflects executor truncation\` pins the contract that per-tool \`maxOutputChars\` is reflected in the trace
- [x] Full suite: 710/710 pass
- [x] \`tsc --noEmit\` clean