### PR TITLE
chore: sync docs, CLAUDE.md, and repo hygiene post 1.3.0 merges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage/
 .DS_Store
 oma-dashboards/
 .claude/
+.npmrc

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://registry.npmjs.org/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Tests live in `tests/` (vitest); E2E suite under `tests/e2e/`. Examples in `exam
 
 ## Architecture
 
-ES module TypeScript framework for multi-agent orchestration. Three runtime dependencies: `@anthropic-ai/sdk`, `openai`, `zod`. Optional peer deps `@google/genai` (Gemini) and `@modelcontextprotocol/sdk` (MCP) are loaded lazily so users only install what they use; the three-dependency promise covers `dependencies` only.
+ES module TypeScript framework for multi-agent orchestration. Three runtime dependencies: `@anthropic-ai/sdk`, `openai`, `zod`. Optional peer deps `@aws-sdk/client-bedrock-runtime` (Bedrock), `@google/genai` (Gemini), and `@modelcontextprotocol/sdk` (MCP) are loaded lazily so users only install what they use; the three-dependency promise covers `dependencies` only.
 
 ### Core Execution Flow
 
@@ -59,6 +59,16 @@ This is the framework's key feature. When `runTeam()` is called:
 ### Agent Conversation Loop (AgentRunner)
 
 `AgentRunner.run()`: send messages → extract tool-use blocks → execute tools in parallel batch → append results → loop until `end_turn` or `maxTurns` exhausted. Accumulates `TokenUsage` across all turns.
+
+### Context Compaction
+
+Long multi-turn runs risk exceeding the context window. `AgentRunner` offers three strategies (configured via `AgentConfig.contextStrategy`):
+
+- **`sliding-window`** — keeps the last N turns, dropping older ones. Preserves `tool_use`/`tool_result` pairs so the LLM never sees orphaned tool blocks.
+- **`compact`** — rewrites the conversation inline without an LLM call, collapsing large tool outputs that exceed a size threshold.
+- **`summarize`** — asks the LLM to summarise the history so far, replacing it with a concise digest. Image blocks are stripped before the summarise call to avoid ballooning token cost.
+
+Optionally, `compressToolResults` (default false) truncates large tool results to a head+tail excerpt, keeping the total under a configurable `minChars` threshold. Delegation tool_result blocks are exempt from compression so the parent agent retains the full sub-agent output.
 
 ### Concurrency Control
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <p align="center">
   <strong>From a goal to a task DAG, automatically.</strong><br/>
   TypeScript-native multi-agent orchestration. Three runtime dependencies.<br/>
-  9 native LLM adapters · MCP · token budgets · retries · context compaction · live tracing.
+  10 native LLM adapters · MCP · token budgets · retries · context compaction · live tracing.
 </p>
 
 <p align="center">
@@ -60,7 +60,7 @@ Tokens: 12847 output tokens
 | Capability | What you get |
 |------------|--------------|
 | **Goal-driven coordinator** | One `runTeam(team, goal)` call. The coordinator decomposes the goal into a task DAG, parallelizes independents, and synthesizes the result. |
-| **Mix providers in one team** | 9 native: Anthropic, OpenAI, Azure, Gemini, Grok, DeepSeek, MiniMax, Qiniu, Copilot. Ollama / vLLM / LM Studio / OpenRouter / Groq via OpenAI-compatible. ([full list](#supported-providers)) |
+| **Mix providers in one team** | 10 native: Anthropic, OpenAI, Azure, Bedrock, Gemini, Grok, DeepSeek, MiniMax, Qiniu, Copilot. Ollama / vLLM / LM Studio / OpenRouter / Groq via OpenAI-compatible. ([full list](#supported-providers)) |
 | **Tools + MCP** | 6 built-in (`bash`, `file_*`, `grep`, `glob`), opt-in `delegate_to_agent`, custom tools via `defineTool()` + Zod, any MCP server via `connectMCPTools()`. |
 | **Streaming + structured output** | Token-by-token streaming on every adapter; Zod-validated final answer with auto-retry on parse failure. ([`structured-output`](examples/patterns/structured-output.ts)) |
 | **Observability** | `onProgress` events, `onTrace` spans, post-run HTML dashboard rendering the executed task DAG. ([`trace-observability`](examples/integrations/trace-observability.ts)) |
@@ -251,6 +251,7 @@ For products and platforms with a deep `open-multi-agent` integration. See the [
 │  - stream()       │    │  - AnthropicAdapter    │
 └────────┬──────────┘    │  - OpenAIAdapter       │
          │               │  - AzureOpenAIAdapter  │
+         │               │  - BedrockAdapter      │
          │               │  - CopilotAdapter      │
          │               │  - GeminiAdapter       │
          │               │  - GrokAdapter         │
@@ -429,6 +430,8 @@ Issues, feature requests, and PRs are welcome. Some areas where contributions wo
 - [@EchoOfZion](https://github.com/EchoOfZion) (coordinator skip for simple goals)
 - [@voidborne-d](https://github.com/voidborne-d) (OpenAI mixed content fix)
 - [@hamzarstar](https://github.com/hamzarstar) (agent delegation co-author)
+- [@MyPrototypeWhat](https://github.com/MyPrototypeWhat) (trace input/output)
+- [@SiMinus](https://github.com/SiMinus) (streaming reasoning events)
 
 **Provider integrations**
 
@@ -438,6 +441,7 @@ Issues, feature requests, and PRs are welcome. Some areas where contributions wo
 - [@Klarline](https://github.com/Klarline) (Azure OpenAI)
 - [@Deathwing](https://github.com/Deathwing) (GitHub Copilot)
 - [@JackChiang233](https://github.com/JackChiang233) and [@jiangzhuo](https://github.com/jiangzhuo) (Qiniu)
+- [@CodingBangboo](https://github.com/CodingBangboo) (AWS Bedrock)
 
 **Examples & cookbook**
 
@@ -449,6 +453,9 @@ Issues, feature requests, and PRs are welcome. Some areas where contributions wo
 - [@HuXiangyu123](https://github.com/HuXiangyu123) (cost-tiered example)
 - [@zouhh22333-beep](https://github.com/zouhh22333-beep) (translation/backtranslation)
 - [@pei-pei45](https://github.com/pei-pei45) (competitive monitoring)
+- [@mmjwxbc](https://github.com/mmjwxbc) (interview simulator)
+- [@binghuaren96](https://github.com/binghuaren96) (incident postmortem DAG)
+- [@CodingBangboo](https://github.com/CodingBangboo) (Express customer support pipeline)
 
 **Docs & tests**
 
@@ -457,7 +464,7 @@ Issues, feature requests, and PRs are welcome. Some areas where contributions wo
 - [@jadegold55](https://github.com/jadegold55) (LLM adapter test coverage)
 
 <a href="https://github.com/JackChen-me/open-multi-agent/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=JackChen-me/open-multi-agent&max=100&v=20260427" />
+  <img src="https://contrib.rocks/image?repo=JackChen-me/open-multi-agent&max=100&v=20260501" />
 </a>
 
 ## Star History

--- a/README_zh.md
+++ b/README_zh.md
@@ -15,7 +15,7 @@
 <p align="center">
   <strong>给一个目标，自动得到任务 DAG。</strong><br/>
   原生 TypeScript 多智能体编排，3 个运行时依赖。<br/>
-  9 个原生 LLM 适配器 · MCP · token 预算 · 重试 · 上下文压缩 · 实时追踪。
+  10 个原生 LLM 适配器 · MCP · token 预算 · 重试 · 上下文压缩 · 实时追踪。
 </p>
 
 <p align="center">
@@ -60,7 +60,7 @@ Tokens: 12847 output tokens
 | 能力 | 说明 |
 |------|------|
 | **目标驱动协调者** | 一句 `runTeam(team, goal)`，协调者把目标拆成任务 DAG，并行执行独立任务，合成最终结果。 |
-| **同队混用 provider** | 9 家原生：Anthropic、OpenAI、Azure、Gemini、Grok、DeepSeek、MiniMax、Qiniu、Copilot；Ollama / vLLM / LM Studio / OpenRouter / Groq 走 OpenAI 兼容协议。([完整列表](#支持的-provider)) |
+| **同队混用 provider** | 10 家原生：Anthropic、OpenAI、Azure、Bedrock、Gemini、Grok、DeepSeek、MiniMax、Qiniu、Copilot；Ollama / vLLM / LM Studio / OpenRouter / Groq 走 OpenAI 兼容协议。([完整列表](#支持的-provider)) |
 | **工具 + MCP** | 6 个内置（`bash`、`file_*`、`grep`、`glob`），可选启用 `delegate_to_agent`，用 `defineTool()` + Zod 自定义，任意 MCP server 通过 `connectMCPTools()` 接入。 |
 | **流式 + 结构化输出** | 每个 adapter 都支持 token 级流式输出；用 Zod schema 校验最终答复，解析失败自动重试。([`structured-output`](examples/patterns/structured-output.ts)) |
 | **可观测性** | `onProgress` 事件、`onTrace` span，运行结束后渲染任务 DAG 的 HTML dashboard。([`trace-observability`](examples/integrations/trace-observability.ts)) |
@@ -251,6 +251,7 @@ console.log(`Tokens: ${result.totalTokenUsage.output_tokens} output tokens`)
 │  - stream()       │    │  - AnthropicAdapter    │
 └────────┬──────────┘    │  - OpenAIAdapter       │
          │               │  - AzureOpenAIAdapter  │
+         │               │  - BedrockAdapter      │
          │               │  - CopilotAdapter      │
          │               │  - GeminiAdapter       │
          │               │  - GrokAdapter         │
@@ -429,6 +430,8 @@ Issue、feature request、PR 都欢迎。特别想要：
 - [@EchoOfZion](https://github.com/EchoOfZion)（简单目标跳过 Coordinator）
 - [@voidborne-d](https://github.com/voidborne-d)（OpenAI 混合内容修复）
 - [@hamzarstar](https://github.com/hamzarstar)（agent 委托机制共建）
+- [@MyPrototypeWhat](https://github.com/MyPrototypeWhat)（trace 输入输出）
+- [@SiMinus](https://github.com/SiMinus)（流式 reasoning 事件）
 
 **Provider 集成**
 
@@ -438,6 +441,7 @@ Issue、feature request、PR 都欢迎。特别想要：
 - [@Klarline](https://github.com/Klarline)（Azure OpenAI）
 - [@Deathwing](https://github.com/Deathwing)（GitHub Copilot）
 - [@JackChiang233](https://github.com/JackChiang233) 与 [@jiangzhuo](https://github.com/jiangzhuo)（七牛云）
+- [@CodingBangboo](https://github.com/CodingBangboo)（AWS Bedrock）
 
 **示例与 Cookbook**
 
@@ -449,6 +453,9 @@ Issue、feature request、PR 都欢迎。特别想要：
 - [@HuXiangyu123](https://github.com/HuXiangyu123)（分级成本示例）
 - [@zouhh22333-beep](https://github.com/zouhh22333-beep)（翻译/回译）
 - [@pei-pei45](https://github.com/pei-pei45)（竞品监测）
+- [@mmjwxbc](https://github.com/mmjwxbc)（面试模拟器）
+- [@binghuaren96](https://github.com/binghuaren96)（事故复盘 DAG）
+- [@CodingBangboo](https://github.com/CodingBangboo)（Express 客服流水线）
 
 **文档与测试**
 
@@ -457,7 +464,7 @@ Issue、feature request、PR 都欢迎。特别想要：
 - [@jadegold55](https://github.com/jadegold55)（LLM adapter 测试覆盖）
 
 <a href="https://github.com/JackChen-me/open-multi-agent/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=JackChen-me/open-multi-agent&max=100&v=20260427" />
+  <img src="https://contrib.rocks/image?repo=JackChen-me/open-multi-agent&max=100&v=20260501" />
 </a>
 
 ## Star 趋势


### PR DESCRIPTION
## Summary

- Remove `.npmrc` (default registry, no auth needed), add to `.gitignore` to prevent re-commit
- CLAUDE.md: add Context Compaction section, fix optional peer deps list (add `@aws-sdk/client-bedrock-runtime`), fix `sliding-window` type value (was camelCase)
- README/README_zh: 9→10 native adapters, add BedrockAdapter to architecture diagram, add 5 missing contributors, bump contrib.rocks cache to today

## Test plan

- [x] tsc --noEmit clean
- [x] All 710 tests pass
- [x] Verified all referenced file paths exist
- [x] Verified SupportedProvider union matches provider tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)