### PR TITLE
[Feature]PlanOnly mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ console.log(`Tokens: ${result.totalTokenUsage.output_tokens} output tokens`)
 
 For MapReduce-style fan-out without task dependencies, use `AgentPool.runParallel()` directly. See [`patterns/fan-out-aggregate`](examples/patterns/fan-out-aggregate.ts).
 
+### Preview the plan without running it
+
+Pass `planOnly: true` to `runTeam()` and the coordinator decomposes the goal but no task agents execute. The result carries `planOnly: true`, populated `tasks` (no metrics), and only the coordinator's token usage. Useful for asserting on the task DAG in integration tests, or previewing cost before a real run.
+
+```ts
+const plan = await orchestrator.runTeam(team, goal, { planOnly: true })
+
+for (const task of plan.tasks ?? []) {
+  console.log(`${task.title} → ${task.assignee} (deps: ${task.dependsOn.length})`)
+}
+```
+
 ### Run from the shell
 
 For shell and CI, the package exposes a JSON-first binary. See [docs/cli.md](./docs/cli.md) for `oma run`, `oma task`, `oma provider`, exit codes, and file formats.

--- a/README_zh.md
+++ b/README_zh.md
@@ -148,6 +148,18 @@ console.log(`Tokens: ${result.totalTokenUsage.output_tokens} output tokens`)
 
 要 MapReduce 风格的 fan-out 但不需要任务依赖，直接用 `AgentPool.runParallel()`。例子见 [`patterns/fan-out-aggregate`](examples/patterns/fan-out-aggregate.ts)。
 
+### 只预览计划，不真跑
+
+给 `runTeam()` 传 `{ planOnly: true }`，coordinator会把目标拆成任务，但不执行任何 agent。结果里会带上 `planOnly: true`、完整的 `tasks`（不带 metrics），以及仅coordinator部分的 token 消耗。适合在integration tests里assert任务 DAG，或在真跑之前先看看成本。
+
+```ts
+const plan = await orchestrator.runTeam(team, goal, { planOnly: true })
+
+for (const task of plan.tasks ?? []) {
+  console.log(`${task.title} → ${task.assignee}（依赖：${task.dependsOn.length}）`)
+}
+```
+
 ### 从命令行运行
 
 包里还自带一个叫 `oma` 的命令行工具，给 shell 和 CI 场景用，输出都是 JSON。`oma run`、`oma task`、`oma provider`、退出码、文件格式都在 [docs/cli.md](./docs/cli.md) 里。

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ export type {
   // Team
   TeamConfig,
   TeamRunResult,
+  RunTeamOptions,
 
   // Dashboard (static HTML)
   TaskExecutionMetrics,

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -45,6 +45,7 @@ import type {
   AgentConfig,
   AgentRunResult,
   CoordinatorConfig,
+  RunTeamOptions,
   OrchestratorConfig,
   OrchestratorEvent,
   Task,
@@ -998,7 +999,7 @@ export class OpenMultiAgent {
   async runTeam(
     team: Team,
     goal: string,
-    options?: { abortSignal?: AbortSignal; coordinator?: CoordinatorConfig },
+    options?: RunTeamOptions,
   ): Promise<TeamRunResult> {
     const agentConfigs = team.getAgents()
     const coordinatorOverrides = options?.coordinator
@@ -1013,7 +1014,7 @@ export class OpenMultiAgent {
     // The best-matching agent is selected via keyword affinity scoring
     // (same algorithm as the `capability-match` scheduler strategy).
     // ------------------------------------------------------------------
-    if (agentConfigs.length > 0 && isSimpleGoal(goal)) {
+    if (!options?.planOnly && agentConfigs.length > 0 && isSimpleGoal(goal)) {
       const bestAgent = selectBestAgent(goal, agentConfigs)
 
       // Use buildAgent() + agent.run() directly instead of this.runAgent()
@@ -1224,6 +1225,21 @@ export class OpenMultiAgent {
     }
     if (!approved) {
       return { ...this.buildTeamRunResult(agentResults, goal, []), success: false }
+    }
+
+    if (options?.planOnly) {
+      const planOnlyTasks: readonly TaskExecutionRecord[] = queue.list().map((task) => ({
+        id: task.id,
+        title: task.title,
+        assignee: task.assignee,
+        status: task.status,
+        dependsOn: task.dependsOn ?? [],
+        metrics: undefined,
+      }))
+      return {
+        ...this.buildTeamRunResult(agentResults, goal, planOnlyTasks),
+        planOnly: true,
+      }
     }
 
     await executeQueue(queue, ctx)

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -1236,6 +1236,11 @@ export class OpenMultiAgent {
         dependsOn: task.dependsOn ?? [],
         metrics: undefined,
       }))
+      this.config.onProgress?.({
+        type: 'agent_complete',
+        agent: 'coordinator',
+        data: decompositionResult,
+      })
       return {
         ...this.buildTeamRunResult(agentResults, goal, planOnlyTasks),
         planOnly: true,

--- a/src/types.ts
+++ b/src/types.ts
@@ -586,11 +586,39 @@ export interface TeamConfig {
   readonly maxConcurrency?: number
 }
 
+/**
+ * Per-call options for {@link OpenMultiAgent.runTeam}. Differs from
+ * {@link OrchestratorConfig} by being scoped to a single invocation.
+ */
+export interface RunTeamOptions {
+  readonly abortSignal?: AbortSignal
+  readonly coordinator?: CoordinatorConfig
+  /**
+   * When true, the coordinator decomposes the goal but no task agents run.
+   * The returned {@link TeamRunResult} has `planOnly: true`, `success: true`,
+   * `tasks` populated (all `pending`, no metrics), and `agentResults`
+   * containing only the coordinator's decomposition call. `totalTokenUsage`
+   * reflects the coordinator only.
+   *
+   * Bypasses the simple-goal short-circuit so the coordinator always runs.
+   *
+   * If {@link OrchestratorConfig.onPlanReady} is wired up and returns false,
+   * the rejection wins: result is `success: false` and `planOnly` is undefined.
+   */
+  readonly planOnly?: boolean
+}
+
 /** Aggregated result for a full team run. */
 export interface TeamRunResult {
   readonly success: boolean
   readonly goal?: string
   readonly tasks?: readonly TaskExecutionRecord[]
+  /**
+   * True when the run was a plan-only invocation (`runTeam(team, goal, { planOnly: true })`).
+   * The coordinator decomposed the goal but no task agents executed.
+   * Undefined on normal runs and on `onPlanReady`-rejection results.
+   */
+  readonly planOnly?: boolean
   /** Keyed by agent name. */
   readonly agentResults: Map<string, AgentRunResult>
   readonly totalTokenUsage: TokenUsage

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -690,6 +690,113 @@ describe('OpenMultiAgent', () => {
     })
   })
 
+  describe('planOnly mode', () => {
+    const complexGoal = 'First research the topic, then write a comprehensive guide based on the findings'
+
+    it('returns the decomposed plan without executing tasks', async () => {
+      mockAdapterResponses = [
+        '```json\n[' +
+          '{"title": "Research", "description": "Research the topic", "assignee": "worker"},' +
+          '{"title": "Write", "description": "Write the guide", "assignee": "worker", "dependsOn": ["Research"]}' +
+          ']\n```',
+        'should-not-be-called-1',
+        'should-not-be-called-2',
+      ]
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker')]))
+
+      const result = await oma.runTeam(team, complexGoal, { planOnly: true })
+
+      expect(result.success).toBe(true)
+      expect(result.planOnly).toBe(true)
+      expect(result.tasks).toBeDefined()
+      expect(result.tasks!.length).toBe(2)
+
+      // Tasks should be in pre-execution states only. Independent tasks remain
+      // 'pending'; tasks with unmet dependencies are 'blocked' (set by the
+      // queue at insert time). Neither has executed.
+      for (const task of result.tasks!) {
+        expect(['pending', 'blocked']).toContain(task.status)
+        expect(task.metrics).toBeUndefined()
+      }
+
+      const taskIds = new Set(result.tasks!.map((t) => t.id))
+      for (const task of result.tasks!) {
+        for (const dep of task.dependsOn) {
+          expect(taskIds.has(dep)).toBe(true)
+        }
+      }
+
+      expect(result.agentResults.size).toBe(1)
+      expect(result.agentResults.has('coordinator')).toBe(true)
+      expect(result.totalTokenUsage.input_tokens).toBe(10)
+      expect(result.totalTokenUsage.output_tokens).toBe(20)
+
+      // Only the coordinator should have been called.
+      expect(capturedChatOptions.length).toBe(1)
+    })
+
+    it('still fires onPlanReady when planOnly is true', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title": "Research", "description": "Research", "assignee": "worker"}]\n```',
+      ]
+      const onPlanReadySpy = vi.fn().mockResolvedValue(true)
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onPlanReady: onPlanReadySpy,
+      })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker')]))
+
+      const result = await oma.runTeam(team, complexGoal, { planOnly: true })
+
+      expect(onPlanReadySpy).toHaveBeenCalledTimes(1)
+      const tasksArg = onPlanReadySpy.mock.calls[0]?.[0] as { title: string }[] | undefined
+      expect(Array.isArray(tasksArg)).toBe(true)
+      expect(tasksArg).toHaveLength(1)
+      expect(tasksArg?.[0]?.title).toBe('Research')
+      expect(result.success).toBe(true)
+      expect(result.planOnly).toBe(true)
+    })
+
+    it('honors onPlanReady rejection over planOnly', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title": "Research", "description": "Research", "assignee": "worker"}]\n```',
+      ]
+      const onPlanReadySpy = vi.fn().mockResolvedValue(false)
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onPlanReady: onPlanReadySpy,
+      })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker')]))
+
+      const result = await oma.runTeam(team, complexGoal, { planOnly: true })
+
+      expect(result.success).toBe(false)
+      expect(result.planOnly).toBeUndefined()
+      expect(onPlanReadySpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('bypasses simple-goal short-circuit when planOnly is true', async () => {
+      const simpleGoal = 'summarize this document'
+      mockAdapterResponses = [
+        '```json\n[{"title": "Summarize", "description": "Summarize", "assignee": "worker"}]\n```',
+      ]
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker')]))
+
+      const result = await oma.runTeam(team, simpleGoal, { planOnly: true })
+
+      expect(result.planOnly).toBe(true)
+      expect(result.success).toBe(true)
+      expect(result.tasks).toBeDefined()
+      expect(result.tasks!.length).toBeGreaterThan(0)
+      expect(result.agentResults.has('coordinator')).toBe(true)
+      // Exactly one chat call — the coordinator. The simple-goal short-circuit
+      // would have called the worker directly instead.
+      expect(capturedChatOptions.length).toBe(1)
+    })
+  })
+
   describe('stream trace events', () => {
     it('emits agent_stream trace events when onAgentStream is configured', async () => {
       const complexGoal = 'First research the topic, then write a comprehensive guide based on the findings'

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -795,6 +795,28 @@ describe('OpenMultiAgent', () => {
       // would have called the worker directly instead.
       expect(capturedChatOptions.length).toBe(1)
     })
+
+    it('emits balanced agent_start / agent_complete for the coordinator when planOnly is true', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title": "Research", "description": "Research", "assignee": "worker"}]\n```',
+      ]
+      const events: OrchestratorEvent[] = []
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onProgress: (e) => events.push(e),
+      })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker')]))
+
+      await oma.runTeam(team, complexGoal, { planOnly: true })
+
+      const coordinatorEvents = events.filter((e) => e.agent === 'coordinator')
+      const types = coordinatorEvents.map((e) => e.type)
+      expect(types).toContain('agent_start')
+      expect(types).toContain('agent_complete')
+      expect(types.filter((t) => t === 'agent_start').length).toBe(
+        types.filter((t) => t === 'agent_complete').length,
+      )
+    })
   })
 
   describe('stream trace events', () => {


### PR DESCRIPTION
## What

<!-- What does this PR do? One or two sentences. -->
Adds a `planOnly` option to `runTeam()` that lets the coordinator decompose a goal into tasks without executing any task agents. The result has `success: true`, `planOnly: true`, and `tasks` populated with pending/blocked task records: useful for integration testing the task DAG or previewing cost before a real run.

## What changed

- **`src/types.ts`** — new `RunTeamOptions` interface (replaces the inline anonymous options type on `runTeam()`); adds `planOnly?: boolean` to both `RunTeamOptions` and `TeamRunResult`
- **`src/orchestrator/orchestrator.ts`** — `runTeam()` now accepts `RunTeamOptions`; bypasses the simple-goal short circuit when `planOnly: true`; inserts a short-circuit after `onPlanReady` fires (but before `executeQueue`) that returns `success: true` with tasks from `queue.list()`
- **`src/index.ts`** — exports `RunTeamOptions` as part of the public API
- **`tests/orchestrator.test.ts`** — four new test cases covering: plan returned without executing tasks, `onPlanReady` still fires, `onPlanReady` rejection wins over `planOnly`, and simple-goal short-circuit is bypassed

## Behavior notes

- `onPlanReady` still fires when `planOnly: true`. If the callback returns `false`, the rejection wins — result is `success: false` and `planOnly` is `undefined` (same as today's abort behavior).
- `planOnly` is a per-call option on the third argument, not on `OrchestratorConfig`: consistent with the scope guidance in the issue.
- The simple-goal short-circuit is bypassed so the coordinator always runs, which means `planOnly` on a single-agent team is valid and returns a single-task plan.


## Why

fixed #192 


