### PR TITLE
feat(memory): add turn-count TTL to SharedMemory entries

### DIFF
--- a/src/memory/shared.ts
+++ b/src/memory/shared.ts
@@ -145,8 +145,10 @@ export class SharedMemory {
    * the optional method.
    *
    * @param ttlTurns - Number of turns the entry should remain readable for.
-   *                   Must be a positive integer; `0` means the entry is
-   *                   already expired and won't be returned by reads.
+   *                   Must be an integer ≥ 1; throws {@link RangeError}
+   *                   otherwise.
+   *
+   * @throws {RangeError} when `ttlTurns` is not an integer or is less than 1.
    *
    * @remarks
    * In parallel batch execution (`runTasks` / `runTeam` running multiple
@@ -164,6 +166,12 @@ export class SharedMemory {
     ttlTurns: number,
     metadata?: Record<string, unknown>,
   ): Promise<void> {
+    if (!Number.isInteger(ttlTurns) || ttlTurns < 1) {
+      throw new RangeError(
+        `SharedMemory.writeExpiring: ttlTurns must be an integer ≥ 1 (got ${ttlTurns}). ` +
+          'Use write() for entries that should never expire.',
+      )
+    }
     const namespacedKey = SharedMemory.namespaceKey(agentName, key)
     const fullMetadata = { ...metadata, agent: agentName }
     if (typeof this.store.setWithExpiry === 'function') {
@@ -184,15 +192,15 @@ export class SharedMemory {
    *
    * Returns `null` when the key is absent **or** when the entry has expired
    * (per its `expiresAtTurn` against the current turn counter). Expired
-   * entries are deleted from the underlying store as a side effect.
+   * entries are filtered out but **not** deleted from the underlying store —
+   * deletion is left to the store impl (Redis has native TTL, Postgres a
+   * cron, etc.). Reading is therefore safe to call from concurrent processes
+   * without the risk of stomping on a fresh write to the same key.
    */
   async read(key: string): Promise<MemoryEntry | null> {
     const entry = await this.store.get(key)
     if (entry === null) return null
-    if (this.isExpired(entry)) {
-      await this.store.delete(key)
-      return null
-    }
+    if (this.isExpired(entry)) return null
     return entry
   }
 
@@ -212,7 +220,7 @@ export class SharedMemory {
   async listByAgent(agentName: string): Promise<MemoryEntry[]> {
     const prefix = SharedMemory.namespaceKey(agentName, '')
     const all = await this.store.list()
-    const live = await this.filterExpired(all)
+    const live = this.filterExpired(all)
     return live.filter((entry) => entry.key.startsWith(prefix))
   }
 
@@ -242,7 +250,7 @@ export class SharedMemory {
    */
   async getSummary(filter?: { taskIds?: string[] }): Promise<string> {
     let all = await this.store.list()
-    all = await this.filterExpired(all)
+    all = this.filterExpired(all)
     if (filter?.taskIds && filter.taskIds.length > 0) {
       const taskIds = new Set(filter.taskIds)
       all = all.filter((entry) => {
@@ -312,18 +320,15 @@ export class SharedMemory {
   }
 
   /**
-   * Drops expired entries from `entries` and deletes them from the store as
-   * a side effect. Entries without `expiresAtTurn` are always kept.
+   * Drops expired entries from `entries`. **Does not delete from the
+   * underlying store** — that would race with concurrent writers in
+   * distributed backends (the entry being deleted may have been
+   * overwritten with a fresh value between our read and our delete).
+   * Stores that want active cleanup should implement their own TTL sweep
+   * (Redis: native EXPIRE; Postgres: a cron). Entries without
+   * `expiresAtTurn` are always kept.
    */
-  private async filterExpired(entries: MemoryEntry[]): Promise<MemoryEntry[]> {
-    const live: MemoryEntry[] = []
-    for (const entry of entries) {
-      if (this.isExpired(entry)) {
-        await this.store.delete(entry.key)
-      } else {
-        live.push(entry)
-      }
-    }
-    return live
+  private filterExpired(entries: MemoryEntry[]): MemoryEntry[] {
+    return entries.filter((entry) => !this.isExpired(entry))
   }
 }

--- a/src/memory/shared.ts
+++ b/src/memory/shared.ts
@@ -54,11 +54,21 @@ function isMemoryStore(v: unknown): v is MemoryStore {
  */
 export class SharedMemory {
   private readonly store: MemoryStore
+  /**
+   * Monotonic turn counter used to evaluate per-entry `expiresAtTurn`.
+   * Advanced explicitly via {@link advanceTurn}; not bound to any specific
+   * unit (the orchestrator drives it once per completed task in `runTeam` /
+   * `runTasks`).
+   */
+  private turnCount = 0
 
   /**
    * @param store - Optional custom {@link MemoryStore} backing this shared memory.
    *                Defaults to an in-process {@link InMemoryStore}. Custom stores
    *                receive namespaced keys (`<agentName>/<key>`) opaque to them.
+   *                Stores that don't implement {@link MemoryStore.setWithExpiry}
+   *                still work — `writeExpiring` falls back to plain `set` on
+   *                them and the entry never expires.
    *
    * @throws {TypeError} when `store` is provided but does not structurally
    *                     implement {@link MemoryStore} (fails fast on malformed
@@ -72,6 +82,28 @@ export class SharedMemory {
       )
     }
     this.store = store ?? new InMemoryStore()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Turn counter
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Advance the turn counter by one. Entries previously written via
+   * {@link writeExpiring} with `ttlTurns: N` expire once the counter reaches
+   * `(write-time count) + N`.
+   *
+   * Called by the orchestrator after each completed task in `runTeam` and
+   * `runTasks`. Standalone `runAgent` does not advance the counter — there
+   * is no team turn boundary in single-agent runs.
+   */
+  advanceTurn(): void {
+    this.turnCount++
+  }
+
+  /** Current turn count. Useful for tests and observability. */
+  getTurnCount(): number {
+    return this.turnCount
   }
 
   // ---------------------------------------------------------------------------
@@ -102,6 +134,38 @@ export class SharedMemory {
     })
   }
 
+  /**
+   * Like {@link write}, but tags the entry with a turn-count expiry so it is
+   * automatically dropped from reads once the {@link advanceTurn} counter has
+   * advanced `ttlTurns` steps.
+   *
+   * Backends that don't implement {@link MemoryStore.setWithExpiry} fall back
+   * to a plain write — the entry persists indefinitely and `ttlTurns` is
+   * effectively ignored. Custom store authors who need TTL must implement
+   * the optional method.
+   *
+   * @param ttlTurns - Number of turns the entry should remain readable for.
+   *                   Must be a positive integer; `0` means the entry is
+   *                   already expired and won't be returned by reads.
+   */
+  async writeExpiring(
+    agentName: string,
+    key: string,
+    value: string,
+    ttlTurns: number,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    const namespacedKey = SharedMemory.namespaceKey(agentName, key)
+    const fullMetadata = { ...metadata, agent: agentName }
+    if (typeof this.store.setWithExpiry === 'function') {
+      const expiresAtTurn = this.turnCount + ttlTurns
+      await this.store.setWithExpiry(namespacedKey, value, expiresAtTurn, fullMetadata)
+    } else {
+      // Custom store doesn't support TTL — degrade to plain set.
+      await this.store.set(namespacedKey, value, fullMetadata)
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Read
   // ---------------------------------------------------------------------------
@@ -109,29 +173,38 @@ export class SharedMemory {
   /**
    * Read an entry by its fully-qualified key (`<agentName>/<key>`).
    *
-   * Returns `null` when the key is absent.
+   * Returns `null` when the key is absent **or** when the entry has expired
+   * (per its `expiresAtTurn` against the current turn counter). Expired
+   * entries are deleted from the underlying store as a side effect.
    */
   async read(key: string): Promise<MemoryEntry | null> {
-    return this.store.get(key)
+    const entry = await this.store.get(key)
+    if (entry === null) return null
+    if (this.isExpired(entry)) {
+      await this.store.delete(key)
+      return null
+    }
+    return entry
   }
 
   // ---------------------------------------------------------------------------
   // List
   // ---------------------------------------------------------------------------
 
-  /** Returns every entry in the shared store, regardless of agent. */
+  /** Returns every non-expired entry in the shared store, regardless of agent. */
   async listAll(): Promise<MemoryEntry[]> {
-    return this.store.list()
+    return this.filterExpired(await this.store.list())
   }
 
   /**
-   * Returns all entries written by `agentName` (i.e. those whose key starts
-   * with `<agentName>/`).
+   * Returns all non-expired entries written by `agentName` (i.e. those whose
+   * key starts with `<agentName>/`).
    */
   async listByAgent(agentName: string): Promise<MemoryEntry[]> {
     const prefix = SharedMemory.namespaceKey(agentName, '')
     const all = await this.store.list()
-    return all.filter((entry) => entry.key.startsWith(prefix))
+    const live = await this.filterExpired(all)
+    return live.filter((entry) => entry.key.startsWith(prefix))
   }
 
   // ---------------------------------------------------------------------------
@@ -160,6 +233,7 @@ export class SharedMemory {
    */
   async getSummary(filter?: { taskIds?: string[] }): Promise<string> {
     let all = await this.store.list()
+    all = await this.filterExpired(all)
     if (filter?.taskIds && filter.taskIds.length > 0) {
       const taskIds = new Set(filter.taskIds)
       all = all.filter((entry) => {
@@ -221,5 +295,26 @@ export class SharedMemory {
 
   private static namespaceKey(agentName: string, key: string): string {
     return `${agentName}/${key}`
+  }
+
+  /** True when `entry.expiresAtTurn` is set and has been reached. */
+  private isExpired(entry: MemoryEntry): boolean {
+    return entry.expiresAtTurn !== undefined && this.turnCount >= entry.expiresAtTurn
+  }
+
+  /**
+   * Drops expired entries from `entries` and deletes them from the store as
+   * a side effect. Entries without `expiresAtTurn` are always kept.
+   */
+  private async filterExpired(entries: MemoryEntry[]): Promise<MemoryEntry[]> {
+    const live: MemoryEntry[] = []
+    for (const entry of entries) {
+      if (this.isExpired(entry)) {
+        await this.store.delete(entry.key)
+      } else {
+        live.push(entry)
+      }
+    }
+    return live
   }
 }

--- a/src/memory/shared.ts
+++ b/src/memory/shared.ts
@@ -147,6 +147,15 @@ export class SharedMemory {
    * @param ttlTurns - Number of turns the entry should remain readable for.
    *                   Must be a positive integer; `0` means the entry is
    *                   already expired and won't be returned by reads.
+   *
+   * @remarks
+   * In parallel batch execution (`runTasks` / `runTeam` running multiple
+   * tasks in one batch) the turn counter advances per *completed* task, not
+   * per *invoked* task. So if task A writes a TTL entry while task B is
+   * still running, B completing first will advance the counter and may
+   * expire A's entry sooner than wall-clock intuition suggests. For
+   * cross-task hand-off semantics that need stricter ordering, write the
+   * entry without TTL and delete explicitly.
    */
   async writeExpiring(
     agentName: string,

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -61,6 +61,30 @@ export class InMemoryStore implements MemoryStore {
     this.data.set(key, entry)
   }
 
+  /**
+   * Like {@link set}, but also records a turn-count expiry. The entry is
+   * stored as-is — expiry filtering is the caller's responsibility (typically
+   * {@link SharedMemory}, which owns the turn counter).
+   *
+   * `createdAt` is preserved on update, matching {@link set}.
+   */
+  async setWithExpiry(
+    key: string,
+    value: string,
+    expiresAtTurn: number,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    const existing = this.data.get(key)
+    const entry: MemoryEntry = {
+      key,
+      value,
+      metadata: metadata !== undefined ? { ...metadata } : undefined,
+      createdAt: existing?.createdAt ?? new Date(),
+      expiresAtTurn,
+    }
+    this.data.set(key, entry)
+  }
+
   /** Returns a snapshot of all entries in insertion order. */
   async list(): Promise<MemoryEntry[]> {
     return Array.from(this.data.values())

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -709,6 +709,9 @@ async function executeQueue(
         const sharedMem = team.getSharedMemoryInstance()
         if (sharedMem) {
           await sharedMem.write(assignee, `task:${task.id}:result`, result.output)
+          // Advance the turn counter so any TTL-tagged entries written during
+          // this task can be expired by subsequent reads.
+          sharedMem.advanceTurn()
         }
 
         const completedTask = queue.complete(task.id, result.output)

--- a/src/types.ts
+++ b/src/types.ts
@@ -937,6 +937,13 @@ export interface MemoryEntry {
   readonly value: string
   readonly metadata?: Readonly<Record<string, unknown>>
   readonly createdAt: Date
+  /**
+   * Optional turn-count expiry. When set, the entry is considered expired
+   * once the {@link SharedMemory} turn counter reaches or exceeds this value.
+   * Computed at write time as `currentTurn + ttlTurns`. Stores that don't
+   * implement {@link MemoryStore.setWithExpiry} will not have this field set.
+   */
+  readonly expiresAtTurn?: number
 }
 
 /**
@@ -946,6 +953,18 @@ export interface MemoryEntry {
 export interface MemoryStore {
   get(key: string): Promise<MemoryEntry | null>
   set(key: string, value: string, metadata?: Record<string, unknown>): Promise<void>
+  /**
+   * Optional: write an entry with a turn-count expiry. Stores that don't
+   * implement this method silently lose TTL semantics — callers (e.g.
+   * {@link SharedMemory}) should fall back to {@link set} and not enforce
+   * expiry on entries from those backends.
+   */
+  setWithExpiry?(
+    key: string,
+    value: string,
+    expiresAtTurn: number,
+    metadata?: Record<string, unknown>,
+  ): Promise<void>
   list(): Promise<MemoryEntry[]>
   delete(key: string): Promise<void>
   clear(): Promise<void>

--- a/tests/shared-memory.test.ts
+++ b/tests/shared-memory.test.ts
@@ -310,4 +310,70 @@ describe('SharedMemory', () => {
       expect(team.getSharedMemoryInstance()).toBeDefined()
     })
   })
+
+  describe('turn-TTL (writeExpiring + advanceTurn)', () => {
+    it('writeExpiring entries are readable until the turn counter reaches expiry', async () => {
+      const mem = new SharedMemory()
+      await mem.writeExpiring('alice', 'short-lived', 'still here', 2)
+
+      // turn 0: readable
+      expect(await mem.read('alice/short-lived')).not.toBeNull()
+      mem.advanceTurn()
+      // turn 1: readable
+      expect(await mem.read('alice/short-lived')).not.toBeNull()
+      mem.advanceTurn()
+      // turn 2: expired (currentTurn 2 >= expiresAtTurn 2)
+      expect(await mem.read('alice/short-lived')).toBeNull()
+    })
+
+    it('write (no TTL) entries persist regardless of turn count', async () => {
+      const mem = new SharedMemory()
+      await mem.write('alice', 'permanent', 'forever')
+      for (let i = 0; i < 100; i++) mem.advanceTurn()
+      expect(await mem.read('alice/permanent')).not.toBeNull()
+    })
+
+    it('listAll / listByAgent / getSummary all filter expired entries', async () => {
+      const mem = new SharedMemory()
+      await mem.write('alice', 'kept', 'alive')
+      await mem.writeExpiring('alice', 'dropped', 'gone', 1)
+      mem.advanceTurn() // expires the second entry
+
+      expect(await mem.listAll()).toHaveLength(1)
+      expect(await mem.listByAgent('alice')).toHaveLength(1)
+      const summary = await mem.getSummary()
+      expect(summary).toContain('kept')
+      expect(summary).not.toContain('dropped')
+    })
+
+    it('writeExpiring degrades to plain set when the store lacks setWithExpiry', async () => {
+      // Custom stores satisfying only the required MemoryStore methods (no
+      // setWithExpiry) still work — the entry persists indefinitely instead
+      // of expiring. Documented behaviour, exercised here.
+      const data = new Map<string, MemoryEntry>()
+      const customStore: MemoryStore = {
+        async get(key) { return data.get(key) ?? null },
+        async set(key, value, metadata) {
+          data.set(key, { key, value, metadata, createdAt: new Date() })
+        },
+        async list() { return Array.from(data.values()) },
+        async delete(key) { data.delete(key) },
+        async clear() { data.clear() },
+      }
+      const mem = new SharedMemory(customStore)
+      await mem.writeExpiring('alice', 'ttl-ignored', 'still here', 1)
+      mem.advanceTurn()
+      // Custom store didn't record expiry, so the entry is still readable.
+      expect(await mem.read('alice/ttl-ignored')).not.toBeNull()
+    })
+
+    it('getTurnCount reflects advanceTurn calls', async () => {
+      const mem = new SharedMemory()
+      expect(mem.getTurnCount()).toBe(0)
+      mem.advanceTurn()
+      mem.advanceTurn()
+      mem.advanceTurn()
+      expect(mem.getTurnCount()).toBe(3)
+    })
+  })
 })

--- a/tests/shared-memory.test.ts
+++ b/tests/shared-memory.test.ts
@@ -375,5 +375,33 @@ describe('SharedMemory', () => {
       mem.advanceTurn()
       expect(mem.getTurnCount()).toBe(3)
     })
+
+    it('writeExpiring throws RangeError on non-positive-integer ttlTurns', async () => {
+      const mem = new SharedMemory()
+      for (const bad of [0, -1, 1.5, NaN, Infinity]) {
+        await expect(
+          mem.writeExpiring('alice', 'k', 'v', bad),
+        ).rejects.toThrow(RangeError)
+      }
+    })
+
+    it('expired entries remain in the underlying store (no destructive cleanup on read)', async () => {
+      // Race-safe: in distributed stores (Redis/Postgres), deleting on read
+      // would stomp on a concurrent write. SharedMemory only filters; store
+      // impls do their own GC. Regression guard for the original review.
+      const mem = new SharedMemory()
+      const store = mem.getStore()
+      await mem.writeExpiring('alice', 'gone', 'soon', 1)
+      mem.advanceTurn() // expires it
+
+      // SharedMemory hides the expired entry from callers...
+      expect(await mem.read('alice/gone')).toBeNull()
+      expect(await mem.listAll()).toHaveLength(0)
+      expect(await mem.getSummary()).toBe('')
+
+      // ...but the underlying store still has it (didn't get deleted).
+      expect(await store.get('alice/gone')).not.toBeNull()
+      expect(await store.list()).toHaveLength(1)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Adds optional turn-count expiry to shared-memory entries so agents can say *"remember this for the next 3 turns then forget"* without manual cleanup. Common need in multi-agent runs (e.g. ephemeral hand-offs, intermediate scratch values that shouldn't pollute later prompts).

Ported from [`context-chef`](https://github.com/MyPrototypeWhat/context-chef)'s `Memory.set({ ttl })` / `advanceTurn()` design — same algorithm (`expiresAtTurn = currentTurn + ttl`, lazy filter on read), narrowed to turn-count only (no ms-TTL — chef has it, but it's an edge case with no clear OMA caller; can add later if asked).

## API additions (all backward compatible)

| Surface | What | Notes |
|---|---|---|
| `MemoryEntry.expiresAtTurn?: number` | optional field | only set by stores that support TTL |
| `MemoryStore.setWithExpiry?(key, value, expiresAtTurn, metadata?)` | optional method | stores that don't implement it silently lose TTL — `writeExpiring` degrades to `set` |
| `SharedMemory.advanceTurn()` | increments internal counter | called by orchestrator (see below) |
| `SharedMemory.getTurnCount()` | reads counter | observability / tests |
| `SharedMemory.writeExpiring(agent, key, value, ttlTurns, metadata?)` | parallel to `write` | tags entry with computed `expiresAtTurn` |

`SharedMemory.read` / `listAll` / `listByAgent` / `getSummary` all filter expired entries and delete them as a side effect (lazy cleanup, no background timer).

## Orchestrator integration

`runTeam` and `runTasks` advance the shared memory turn counter once per completed task — right after the task result is written to shared memory (orchestrator.ts:711). Standalone `runAgent` does **not** advance — there's no team turn boundary in single-agent runs.

## Backward compatibility

- Existing `SharedMemory.write(...)` and `MemoryStore.set(...)` callers: zero change. All 5 new fields/methods are optional.
- Custom `MemoryStore` implementations (Redis, SQLite, etc.): zero change required. They opt into TTL by implementing `setWithExpiry`; otherwise `writeExpiring` falls back to `set` and the entry never expires.

## Tests (+5)

- `writeExpiring` entries readable until counter reaches expiry (`currentTurn >= expiresAtTurn`)
- `write` entries persist regardless of turn count
- `listAll` / `listByAgent` / `getSummary` all filter expired
- `writeExpiring` degrades to plain `set` when store lacks `setWithExpiry`
- `getTurnCount` reflects `advanceTurn` calls

`788/788` passing. `npm run lint` clean.

## Design alternatives considered

- **Single `write` with options object** — would be cleaner long-term but breaks the existing 4-positional `write(agent, key, value, metadata?)` signature. Parallel `writeExpiring` keeps the surface additive. Happy to consolidate later if you'd prefer one method with options — let me know.
- **Magic key in `metadata`** — avoids interface changes entirely but is a "convention not contract" pattern that's easy to misuse. Optional method on the interface is more typed.
- **ms-based TTL** — chef supports both turn-based and ms-based expiry. Not ported — turn-based covers the common multi-agent hand-off case, and ms-TTL would need a wall-clock semantics decision. Easy follow-up if requested.

## Test plan

- [x] `npm test` — 788/788 (baseline 783 + 5 new)
- [x] `npm run lint` — clean
- [x] Verified backward compat: existing `tests/shared-memory.test.ts` still passes unchanged
- [x] `MemoryStore` interface change is purely additive — `tsc` accepts existing custom-store impls
