### PR TITLE
fix(llm): guard `choices[0]` with optional chaining across OpenAI-family adapters

### DIFF
--- a/src/llm/azure-openai.ts
+++ b/src/llm/azure-openai.ts
@@ -221,7 +221,7 @@ export class AzureOpenAIAdapter implements LLMAdapter {
           outputTokens = chunk.usage.completion_tokens
         }
 
-        const choice: ChatCompletionChunk.Choice | undefined = chunk.choices[0]
+        const choice: ChatCompletionChunk.Choice | undefined = chunk.choices?.[0]
         if (choice === undefined) continue
 
         const delta = choice.delta

--- a/src/llm/copilot.ts
+++ b/src/llm/copilot.ts
@@ -370,7 +370,7 @@ export class CopilotAdapter implements LLMAdapter {
           outputTokens = chunk.usage.completion_tokens
         }
 
-        const choice: ChatCompletionChunk.Choice | undefined = chunk.choices[0]
+        const choice: ChatCompletionChunk.Choice | undefined = chunk.choices?.[0]
         if (choice === undefined) continue
 
         const delta = choice.delta

--- a/src/llm/openai-common.ts
+++ b/src/llm/openai-common.ts
@@ -217,7 +217,7 @@ export function fromOpenAICompletion(
   completion: ChatCompletion,
   knownToolNames?: string[],
 ): LLMResponse {
-  const choice = completion.choices[0]
+  const choice = completion.choices?.[0]
   if (choice === undefined) {
     throw new Error('OpenAI returned a completion with no choices')
   }

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -199,7 +199,7 @@ export class OpenAIAdapter implements LLMAdapter {
           outputTokens = chunk.usage.completion_tokens
         }
 
-        const choice: ChatCompletionChunk.Choice | undefined = chunk.choices[0]
+        const choice: ChatCompletionChunk.Choice | undefined = chunk.choices?.[0]
         if (choice === undefined) continue
 
         const delta = choice.delta


### PR DESCRIPTION
## Summary

Fixes #207.

Four OpenAI-family adapters read `choices[0]` from the API response/stream without guarding against an empty `choices` array. While the OpenAI SDK types annotate the destination as `| undefined`, the runtime access `arr[0]` does not actually return `undefined` safely if `arr` itself is `undefined` (which can happen with certain proxy/middleware responses, content-filter blocks, or providers that diverge from the spec). The reporter in #207 hit `TypeError: Cannot read properties of undefined (reading '0')`.

Fix: add optional chaining `?.[0]`. This is the same pattern the SDK examples use defensively.

## Changes

Four one-line edits:

- `src/llm/openai-common.ts:220` — `completion.choices[0]` → `completion.choices?.[0]`
- `src/llm/openai.ts:202` — `chunk.choices[0]` → `chunk.choices?.[0]`
- `src/llm/azure-openai.ts:224` — same
- `src/llm/copilot.ts:373` — same

The downstream code already handles the `undefined` case (e.g. `if (!choice) continue` / type annotated `| undefined`), so no further changes are needed.

## Test plan

- [x] Edits are syntactically equivalent under TS strict mode
- [x] Existing typing `ChatCompletionChunk.Choice | undefined` already permits the change
- [x] CI green
