### PR TITLE
fix(runner): defer maxTokenBudget break until after tool_result is appended

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -796,6 +796,10 @@ export class AgentRunner {
         }
 
         const totalTokens = totalUsage.input_tokens + totalUsage.output_tokens
+        // Defer the break to after tool_result is appended so we never leave
+        // an unmatched tool_use block in conversationMessages (which would
+        // cause a 400 on any subsequent API call that replays the history).
+        let pendingBudgetExceeded = false
         if (this.options.maxTokenBudget !== undefined && totalTokens > this.options.maxTokenBudget) {
           budgetExceeded = true
           finalOutput = turnText
@@ -807,7 +811,7 @@ export class AgentRunner {
               this.options.maxTokenBudget,
             ),
           } satisfies StreamEvent
-          break
+          pendingBudgetExceeded = true
         }
 
         // Extract tool-use blocks for detection and execution.
@@ -1008,6 +1012,9 @@ export class AgentRunner {
         // and the tool_result user message has been appended, so stream
         // consumers see matched tool_use/tool_result pairs and the returned
         // `messages` remain resumable against the Anthropic/OpenAI APIs.
+        if (pendingBudgetExceeded) {
+          break
+        }
         if (delegationTurnUsage !== undefined && this.options.maxTokenBudget !== undefined) {
           const totalAfterDelegation = totalUsage.input_tokens + totalUsage.output_tokens
           if (totalAfterDelegation > this.options.maxTokenBudget) {

--- a/tests/delegation-budget.test.ts
+++ b/tests/delegation-budget.test.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 import { AgentRunner } from '../src/agent/runner.js'
 import { ToolRegistry, defineTool } from '../src/tool/framework.js'
 import { ToolExecutor } from '../src/tool/executor.js'
-import type { LLMAdapter, LLMMessage, LLMResponse, StreamEvent, ToolUseBlock, ToolResultBlock } from '../src/types.js'
+import type { LLMAdapter, LLMMessage, LLMResponse, StreamEvent, ToolUseBlock, ToolResultBlock, ContentBlock } from '../src/types.js'
 
 function toolUseResponse(toolName: string, input: Record<string, unknown>): LLMResponse {
   return {
@@ -107,6 +107,93 @@ describe('delegation-triggered budget_exceeded', () => {
     const toolResultIdx = events.findIndex(e => e.type === 'tool_result')
     const budgetIdx = events.findIndex(e => e.type === 'budget_exceeded')
     expect(toolResultIdx).toBeLessThan(budgetIdx)
+
+    // 5. LLM was only called once — we broke before a second turn.
+    expect(idx).toBe(1)
+  })
+})
+
+describe('regular budget_exceeded on a tool-call turn', () => {
+  it('does not leave an orphaned tool_use block when LLM-token budget fires mid-turn', async () => {
+    // The LLM returns a tool_use response whose token cost alone exceeds the
+    // budget. Before the fix, AgentRunner broke immediately (before tool
+    // execution) leaving an unmatched tool_use block in conversationMessages,
+    // which caused a 400 on any subsequent API call. After the fix, the break
+    // is deferred until after the matching tool_result has been appended.
+    const toolUseId = 'tu-regular-budget'
+    const responses: LLMResponse[] = [
+      {
+        id: 'resp-1',
+        content: [{ type: 'tool_use', id: toolUseId, name: 'noop', input: {} }] as ContentBlock[],
+        model: 'mock-model',
+        stop_reason: 'tool_use',
+        usage: { input_tokens: 90, output_tokens: 60 }, // 150 > budget of 100
+      },
+      {
+        id: 'resp-2',
+        content: [{ type: 'text', text: 'should not be reached' }],
+        model: 'mock-model',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 5, output_tokens: 5 },
+      },
+    ]
+    let idx = 0
+    const adapter: LLMAdapter = {
+      name: 'mock',
+      async chat() { return responses[idx++]! },
+      async *stream() { /* unused */ },
+    }
+
+    const registry = new ToolRegistry()
+    registry.register(
+      defineTool({
+        name: 'noop',
+        description: 'No-op tool for testing',
+        inputSchema: z.object({}),
+        async execute() { return { data: 'ok' } },
+      }),
+    )
+
+    const runner = new AgentRunner(adapter, registry, new ToolExecutor(registry), {
+      model: 'mock-model',
+      allowedTools: ['noop'],
+      maxTurns: 5,
+      maxTokenBudget: 100,
+      agentName: 'test-agent',
+    })
+
+    const events: StreamEvent[] = []
+    for await (const ev of runner.stream([{ role: 'user', content: [{ type: 'text', text: 'go' }] }])) {
+      events.push(ev)
+    }
+
+    const toolUseEvents = events.filter((e): e is StreamEvent & { type: 'tool_use'; data: ToolUseBlock } => e.type === 'tool_use')
+    const toolResultEvents = events.filter((e): e is StreamEvent & { type: 'tool_result'; data: ToolResultBlock } => e.type === 'tool_result')
+    const budgetEvents = events.filter(e => e.type === 'budget_exceeded')
+    const doneEvents = events.filter((e): e is StreamEvent & { type: 'done'; data: { messages: LLMMessage[]; budgetExceeded?: boolean } } => e.type === 'done')
+
+    // 1. tool_use and tool_result events are both emitted (paired).
+    expect(toolUseEvents).toHaveLength(1)
+    expect(toolResultEvents).toHaveLength(1)
+    expect(toolResultEvents[0]!.data.tool_use_id).toBe(toolUseId)
+
+    // 2. Budget event fires and run ends with budgetExceeded=true.
+    expect(budgetEvents).toHaveLength(1)
+    expect(doneEvents).toHaveLength(1)
+    expect(doneEvents[0]!.data.budgetExceeded).toBe(true)
+
+    // 3. Returned messages end with a tool_result user message — conversation
+    //    is API-resumable (no orphaned tool_use block at the tail).
+    const messages = doneEvents[0]!.data.messages
+    const lastMsg = messages[messages.length - 1]!
+    expect(lastMsg.role).toBe('user')
+    expect(lastMsg.content.some(b => b.type === 'tool_result' && b.tool_use_id === toolUseId)).toBe(true)
+
+    // 4. tool_result event appears before done (i.e. is emitted, not dropped).
+    const toolResultIdx = events.findIndex(e => e.type === 'tool_result')
+    const doneIdx = events.findIndex(e => e.type === 'done')
+    expect(toolResultIdx).toBeGreaterThanOrEqual(0)
+    expect(toolResultIdx).toBeLessThan(doneIdx)
 
     // 5. LLM was only called once — we broke before a second turn.
     expect(idx).toBe(1)

--- a/tests/delegation-budget.test.ts
+++ b/tests/delegation-budget.test.ts
@@ -195,7 +195,7 @@ describe('regular budget_exceeded on a tool-call turn', () => {
     expect(toolResultIdx).toBeGreaterThanOrEqual(0)
     expect(toolResultIdx).toBeLessThan(doneIdx)
 
-    // 5. LLM was only called once — we broke before a second turn.
+    // 5. LLM should only be called once — we broke before a second turn.
     expect(idx).toBe(1)
   })
 })


### PR DESCRIPTION
## What
When the LLM-token budget tripped on a tool-using turn, AgentRunner broke immediately after pushing the assistant tool_use message, leaving an orphaned tool_use in conversationMessages. Replaying that history via `agent.prompt()` returned a 400 from the Anthropic/Open AI API. Now the break is deferred until after the matching tool_result has been executed and appended, mirroring the existing pattern in the delegation-triggered budget check. 

A new regression test is also added.

## Why

Fixes #216.

