### PR TITLE
feat(examples): add mcp-notte integration example

### DIFF
--- a/examples/integrations/mcp-notte.ts
+++ b/examples/integrations/mcp-notte.ts
@@ -1,0 +1,67 @@
+/**
+ * MCP Notte Tools
+ *
+ * Connect Notte's MCP server (notte-mcp) over stdio and register all exposed
+ * Notte tools — observe, click, fill, scrape, navigate, run agent — as
+ * standard open-multi-agent tools. Gives any agent a hosted browser with
+ * residential proxies, captcha solving, stealth sessions, and credential
+ * vault for authenticated sites.
+ *
+ * Notte (notte.cc) is hosted browser infrastructure for AI agents:
+ *   https://github.com/nottelabs/notte
+ *
+ * Run:
+ *   npx tsx examples/integrations/mcp-notte.ts
+ *
+ * Prerequisites:
+ *   - NOTTE_API_KEY  (get one at https://notte.cc/dashboard)
+ *   - GEMINI_API_KEY (or set AGENT_PROVIDER + the matching key)
+ *   - uv installed: `brew install uv`  (or `pipx install notte-mcp` and use `notte-mcp` directly)
+ *   - @modelcontextprotocol/sdk installed
+ */
+
+import { Agent, ToolExecutor, ToolRegistry, registerBuiltInTools } from '../../src/index.js'
+import { connectMCPTools } from '../../src/mcp.js'
+
+if (!process.env.NOTTE_API_KEY?.trim()) {
+  console.error('Missing NOTTE_API_KEY: get one at https://notte.cc/dashboard and set it in the environment.')
+  process.exit(1)
+}
+
+const { tools, disconnect } = await connectMCPTools({
+  command: 'uvx',
+  args: ['notte-mcp'],
+  env: {
+    ...process.env,
+    NOTTE_API_KEY: process.env.NOTTE_API_KEY,
+  },
+  namePrefix: 'notte',
+})
+
+const registry = new ToolRegistry()
+registerBuiltInTools(registry)
+for (const tool of tools) registry.register(tool)
+const executor = new ToolExecutor(registry)
+
+const agent = new Agent(
+  {
+    name: 'web-researcher',
+    model: 'gemini-2.5-flash',
+    provider: 'gemini',
+    tools: tools.map((tool) => tool.name),
+    systemPrompt:
+      'Use the Notte browser tools to navigate the live web, scrape pages, and extract structured data. Notte handles anti-bot walls, captchas, and authenticated sessions automatically — prefer it over any built-in HTTP/fetch tool for live-web tasks.',
+  },
+  registry,
+  executor,
+)
+
+try {
+  const result = await agent.run(
+    'Go to news.ycombinator.com and return the top 5 posts as JSON with title, url, and points.',
+  )
+
+  console.log(result.output)
+} finally {
+  await disconnect()
+}


### PR DESCRIPTION
## What

Adds `examples/integrations/mcp-notte.ts` mirroring the shape of `mcp-github.ts`. Wires Notte (notte.cc, hosted browser infra) as a tool source via the existing `connectMCPTools()` path you shipped in #89. No core code changed.

## Why

The repo has six built-in tools and two example MCP integrations (`mcp-github.ts`, `with-engram/`) but no example for browser or web-research. Many real agent tasks need to drive a live browser: navigate, fill forms, scrape JS-rendered pages, get past anti-bot walls. Notte ships an MCP server (`notte-mcp`) over stdio, so this is the minimal wire-up.

## Context

- Notte recently merged into [Bitterbot-AI/bitterbot-desktop](https://github.com/Bitterbot-AI/bitterbot-desktop) as a bundled skill ([#30](https://github.com/Bitterbot-AI/bitterbot-desktop/pull/30), 2026-05-05).
- Notte is hosted browser infra: residential proxies, captcha solving, session vault, stealth profiles, and deploy-as-Function (a one-click way to turn an automation into a scheduled API endpoint). Open source: [github.com/nottelabs/notte](https://github.com/nottelabs/notte) (1,953 stars, SSPL-1.0).

## Test plan

- [ ] `NOTTE_API_KEY=xxx GEMINI_API_KEY=xxx npx tsx examples/integrations/mcp-notte.ts`
- [ ] Expected: agent returns 5 HN posts as JSON
- [ ] Verified the file follows the same shape as `mcp-github.ts` (single-Agent pattern, `try { ... } finally { await disconnect() }` cleanup)

## Licence

MIT, same as repo.

---

*If you'd prefer this routed via the `customTools` pattern (per the `with-engram/team-research.ts` shape) instead of single-Agent, happy to refactor; the single-Agent shape felt closer to the `mcp-github.ts` precedent.*
