### PR TITLE
feat: integrate Vercel AI SDK support and update dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ This is the framework's key feature. When `runTeam()` is called:
 | Utils | `utils/semaphore.ts`, `utils/tokens.ts`, `utils/keywords.ts`, `utils/trace.ts` | Concurrency primitive, token accounting, keyword helpers, trace plumbing |
 | Errors | `errors.ts` | Shared error types |
 | Types | `types.ts` | All interfaces in one file to avoid circular deps |
-| Exports | `index.ts` (root, `'@open-multi-agent/core'`), `mcp.ts` (subpath, `'@open-multi-agent/core/mcp'`) | Public API surface; MCP integration is a separate entry point so non-MCP users don't pay the import cost |
+| Exports | `index.ts` (root, `'@open-multi-agent/core'`), `mcp.ts` (subpath, `'@open-multi-agent/core/mcp'`), `ai-sdk.ts` (subpath, `'@open-multi-agent/core/ai-sdk'`) | Public API surface; MCP and AI SDK bridges are separate entry points so users without those optional peers don't break TS on the main import |
 
 ### Agent Conversation Loop (AgentRunner)
 
@@ -99,6 +99,10 @@ Optional `maxRetries`, `retryDelayMs`, `retryBackoff` on task config (used via `
 ### MCP Integration
 
 `connectMCPTools()` (in `tool/mcp.ts`) bridges Model Context Protocol servers into the `ToolRegistry`. Imported lazily and exposed via the dedicated `@open-multi-agent/core/mcp` package subpath (`src/mcp.ts`) so users who don't need MCP don't load `@modelcontextprotocol/sdk`.
+
+### Vercel AI SDK bridge
+
+`AISdkAdapter` (in `llm/ai-sdk.ts`) implements `LLMAdapter` via AI SDK `generateText` / `streamText`. Exposed via `@open-multi-agent/core/ai-sdk` (`src/ai-sdk.ts`) so users without the optional peer `ai` are not forced to resolve those types on the main barrel import.
 
 ### Loop Detection
 

--- a/README.md
+++ b/README.md
@@ -283,8 +283,31 @@ const agent: AgentConfig = {
 |------|------------------|----------|
 | Built-in shortcuts | Set `provider` to `anthropic`, `gemini`, `openai`, `azure-openai`, `copilot`, `grok`, `deepseek`, `minimax`, `qiniu`, or `bedrock`; the framework supplies the endpoint. | Anthropic, Gemini, OpenAI, Azure OpenAI, GitHub Copilot, xAI Grok, DeepSeek, MiniMax, Qiniu, AWS Bedrock |
 | OpenAI-compatible endpoints | Set `provider: 'openai'` plus `baseURL` and, when needed, `apiKey`. | Ollama, vLLM, LM Studio, llama.cpp server, OpenRouter, Groq, Mistral |
+| Vercel AI SDK | Set `adapter: new AISdkAdapter(yourModel)`; install optional peer `ai` plus an `@ai-sdk/*` provider. | [Any AI SDK provider](https://ai-sdk.dev/providers) (60+ models and hosts) |
 
 See [docs/providers.md](./docs/providers.md) for env vars, model examples, local tool-calling, timeouts, and troubleshooting.
+
+### Vercel AI SDK (optional)
+
+Install the optional peer [`ai`](https://www.npmjs.com/package/ai) plus any [`@ai-sdk` provider](https://ai-sdk.dev/providers) you need (for example [`@ai-sdk/openai`](https://www.npmjs.com/package/@ai-sdk/openai)). Pass `adapter: new AISdkAdapter(model)` on `AgentConfig` to route that agent through the AI SDK instead of the built-in `provider` factory. `provider`, `apiKey`, `baseURL`, and `region` are ignored when `adapter` is set. Mixed teams work as usual: only agents with `adapter` use the AI SDK.
+
+```typescript
+import { openai } from '@ai-sdk/openai'
+import { AISdkAdapter, OpenMultiAgent } from '@open-multi-agent/core'
+
+const oma = new OpenMultiAgent()
+await oma.runAgent(
+  {
+    name: 'researcher',
+    model: 'gpt-4o',
+    adapter: new AISdkAdapter(openai('gpt-4o')),
+    systemPrompt: 'You are a researcher.',
+  },
+  'What are the latest AI trends?',
+)
+```
+
+The coordinator accepts the same hook via `runTeam(team, goal, { coordinator: { adapter: new AISdkAdapter(...) } })`.
 
 ## Production Checklist
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ const agent: AgentConfig = {
 |------|------------------|----------|
 | Built-in shortcuts | Set `provider` to `anthropic`, `gemini`, `openai`, `azure-openai`, `copilot`, `grok`, `deepseek`, `minimax`, `qiniu`, or `bedrock`; the framework supplies the endpoint. | Anthropic, Gemini, OpenAI, Azure OpenAI, GitHub Copilot, xAI Grok, DeepSeek, MiniMax, Qiniu, AWS Bedrock |
 | OpenAI-compatible endpoints | Set `provider: 'openai'` plus `baseURL` and, when needed, `apiKey`. | Ollama, vLLM, LM Studio, llama.cpp server, OpenRouter, Groq, Mistral |
-| Vercel AI SDK | Set `adapter: new AISdkAdapter(yourModel)`; install optional peer `ai` plus an `@ai-sdk/*` provider. | [Any AI SDK provider](https://ai-sdk.dev/providers) (60+ models and hosts) |
+| Vercel AI SDK | Import `AISdkAdapter` from `@open-multi-agent/core/ai-sdk`; install optional peer `ai` plus an `@ai-sdk/*` provider. | [Any AI SDK provider](https://ai-sdk.dev/providers) (60+ models and hosts) |
 
 See [docs/providers.md](./docs/providers.md) for env vars, model examples, local tool-calling, timeouts, and troubleshooting.
 
@@ -293,7 +293,8 @@ Install the optional peer [`ai`](https://www.npmjs.com/package/ai) plus any [`@a
 
 ```typescript
 import { openai } from '@ai-sdk/openai'
-import { AISdkAdapter, OpenMultiAgent } from '@open-multi-agent/core'
+import { AISdkAdapter } from '@open-multi-agent/core/ai-sdk'
+import { OpenMultiAgent } from '@open-multi-agent/core'
 
 const oma = new OpenMultiAgent()
 await oma.runAgent(

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,14 @@
         "oma": "dist/cli/oma.js"
       },
       "devDependencies": {
+        "@ai-sdk/openai": "^2.0.106",
+        "@ai-sdk/provider": "^2.0.3",
         "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
         "@google/genai": "^1.48.0",
         "@modelcontextprotocol/sdk": "^1.18.0",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^2.1.9",
+        "ai": "^5.0.188",
         "tsx": "^4.21.0",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
@@ -32,7 +35,8 @@
       "peerDependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.700.0",
         "@google/genai": "^1.48.0",
-        "@modelcontextprotocol/sdk": "^1.18.0"
+        "@modelcontextprotocol/sdk": "^1.18.0",
+        "ai": "^5.0.0"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/client-bedrock-runtime": {
@@ -43,7 +47,76 @@
         },
         "@modelcontextprotocol/sdk": {
           "optional": true
+        },
+        "ai": {
+          "optional": true
         }
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "2.0.89",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.89.tgz",
+      "integrity": "sha512-oIIsLOTgfuFIg6HGQ3d5gXjUvgx2YKav10T4t+sexnQj1anw6WoMDdSAT24igbfgWrC+Cf2tmlLeRhBUxdsZ9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "2.0.106",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.106.tgz",
+      "integrity": "sha512-EFC0rpo1wfe4HIz5KZCE72edP2J7fOeR7wPXzjCDljaTRB1wectKDIKRLowpU4F0mbcJ+XScAsoYNPK/Z20aVQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
+      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.25",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.25.tgz",
+      "integrity": "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.3",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1539,6 +1612,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2656,6 +2739,13 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2688,6 +2778,16 @@
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "2.1.9",
@@ -2908,6 +3008,25 @@
       },
       "engines": {
         "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "5.0.188",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.188.tgz",
+      "integrity": "sha512-ABV+wRB1hz3UTZJTTqFIDi85tzUyr9o1ZKO5ZYZluFYlhZgKGOaInWaYv+OnBAb+qLpXWsrTWemd9/XShZJN0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "2.0.89",
+        "@ai-sdk/provider": "2.0.3",
+        "@ai-sdk/provider-utils": "3.0.25",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -4697,6 +4816,13 @@
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "./mcp": {
       "types": "./dist/mcp.d.ts",
       "import": "./dist/mcp.js"
+    },
+    "./ai-sdk": {
+      "types": "./dist/ai-sdk.d.ts",
+      "import": "./dist/ai-sdk.js"
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   "peerDependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.700.0",
     "@google/genai": "^1.48.0",
-    "@modelcontextprotocol/sdk": "^1.18.0"
+    "@modelcontextprotocol/sdk": "^1.18.0",
+    "ai": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-bedrock-runtime": {
@@ -81,14 +82,20 @@
     },
     "@modelcontextprotocol/sdk": {
       "optional": true
+    },
+    "ai": {
+      "optional": true
     }
   },
   "devDependencies": {
+    "@ai-sdk/openai": "^2.0.106",
+    "@ai-sdk/provider": "^2.0.3",
     "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
     "@google/genai": "^1.48.0",
     "@modelcontextprotocol/sdk": "^1.18.0",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^2.1.9",
+    "ai": "^5.0.188",
     "tsx": "^4.21.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -142,7 +142,9 @@ export class Agent {
     }
 
     const provider = this.config.provider ?? 'anthropic'
-    const adapter = await createAdapter(provider, this.config.apiKey, this.config.baseURL, this.config.region)
+    const adapter =
+      this.config.adapter ??
+      (await createAdapter(provider, this.config.apiKey, this.config.baseURL, this.config.region))
 
     // Append structured-output instructions when an outputSchema is configured.
     let effectiveSystemPrompt = this.config.systemPrompt

--- a/src/ai-sdk.ts
+++ b/src/ai-sdk.ts
@@ -1,0 +1,1 @@
+export { AISdkAdapter, llmMessagesToAiSdkModelMessages } from './llm/ai-sdk.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,6 +113,7 @@ export type { RegisterBuiltInToolsOptions } from './tool/built-in/index.js'
 
 export { createAdapter } from './llm/adapter.js'
 export type { SupportedProvider } from './llm/adapter.js'
+export { AISdkAdapter, llmMessagesToAiSdkModelMessages } from './llm/ai-sdk.js'
 export { TokenBudgetExceededError } from './errors.js'
 
 // ---------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,6 @@ export type { RegisterBuiltInToolsOptions } from './tool/built-in/index.js'
 
 export { createAdapter } from './llm/adapter.js'
 export type { SupportedProvider } from './llm/adapter.js'
-export { AISdkAdapter, llmMessagesToAiSdkModelMessages } from './llm/ai-sdk.js'
 export { TokenBudgetExceededError } from './errors.js'
 
 // ---------------------------------------------------------------------------

--- a/src/llm/adapter.ts
+++ b/src/llm/adapter.ts
@@ -37,7 +37,7 @@ import type { LLMAdapter } from '../types.js'
  * The set of LLM providers supported out of the box.
  * Additional providers can be integrated by implementing {@link LLMAdapter}
  * directly and bypassing this factory, or via {@link AISdkAdapter} from
- * `./ai-sdk.js` (optional peer `ai`).
+ * `@open-multi-agent/core/ai-sdk` (optional peer `ai`).
  */
 export type SupportedProvider = 'anthropic' | 'azure-openai' | 'bedrock' | 'copilot' | 'deepseek' | 'grok' | 'minimax' | 'openai' | 'gemini' | 'qiniu'
 

--- a/src/llm/adapter.ts
+++ b/src/llm/adapter.ts
@@ -36,7 +36,8 @@ import type { LLMAdapter } from '../types.js'
 /**
  * The set of LLM providers supported out of the box.
  * Additional providers can be integrated by implementing {@link LLMAdapter}
- * directly and bypassing this factory.
+ * directly and bypassing this factory, or via {@link AISdkAdapter} from
+ * `./ai-sdk.js` (optional peer `ai`).
  */
 export type SupportedProvider = 'anthropic' | 'azure-openai' | 'bedrock' | 'copilot' | 'deepseek' | 'grok' | 'minimax' | 'openai' | 'gemini' | 'qiniu'
 

--- a/src/llm/ai-sdk.ts
+++ b/src/llm/ai-sdk.ts
@@ -215,20 +215,23 @@ export class AISdkAdapter implements LLMAdapter {
         : undefined
 
     const result = await generateText({
-      model: this.#model,
-      messages: aiMessages,
-      system: options.systemPrompt,
-      tools,
+      // Sampling params first so extraBody can override them. Structural
+      // fields (model/messages/system/tools) come after extraBody so users
+      // cannot accidentally clobber them via extraBody.
       maxOutputTokens: options.maxTokens,
       temperature: options.temperature,
       topP: options.topP,
       topK: options.topK,
       frequencyPenalty: options.frequencyPenalty,
       presencePenalty: options.presencePenalty,
+      ...(options.extraBody as Record<string, unknown> | undefined),
+      model: this.#model,
+      messages: aiMessages,
+      system: options.systemPrompt,
+      tools,
       abortSignal: options.abortSignal,
       maxRetries: 0,
       providerOptions: buildProviderOptions(options),
-      ...(options.extraBody as Record<string, unknown> | undefined),
     })
 
     return buildLlmResponseFromGenerateText(result)
@@ -261,20 +264,21 @@ export class AISdkAdapter implements LLMAdapter {
 
     try {
       const result = streamText({
-        model: this.#model,
-        messages: aiMessages,
-        system: options.systemPrompt,
-        tools,
+        // See chat() above for the rationale behind this field ordering.
         maxOutputTokens: options.maxTokens,
         temperature: options.temperature,
         topP: options.topP,
         topK: options.topK,
         frequencyPenalty: options.frequencyPenalty,
         presencePenalty: options.presencePenalty,
+        ...(options.extraBody as Record<string, unknown> | undefined),
+        model: this.#model,
+        messages: aiMessages,
+        system: options.systemPrompt,
+        tools,
         abortSignal: options.abortSignal,
         maxRetries: 0,
         providerOptions: buildProviderOptions(options),
-        ...(options.extraBody as Record<string, unknown> | undefined),
       })
 
       for await (const part of result.fullStream) {

--- a/src/llm/ai-sdk.ts
+++ b/src/llm/ai-sdk.ts
@@ -1,0 +1,353 @@
+/**
+ * @fileoverview {@link AISdkAdapter} — bridge to the Vercel AI SDK (`ai` + `@ai-sdk/*`).
+ *
+ * When {@link AgentConfig.adapter} is set, {@link Agent} skips {@link createAdapter}
+ * and uses this implementation instead. Install the optional peer `ai` and the
+ * provider package you need (for example `@ai-sdk/openai`).
+ */
+
+import type { JSONSchema7, JSONValue, SharedV2ProviderOptions } from '@ai-sdk/provider'
+import type { LanguageModel, ModelMessage } from 'ai'
+
+import type {
+  ContentBlock,
+  LLMAdapter,
+  LLMChatOptions,
+  LLMMessage,
+  LLMResponse,
+  LLMStreamOptions,
+  StreamEvent,
+  TextBlock,
+  TokenUsage,
+  ToolUseBlock,
+} from '../types.js'
+import { normalizeFinishReason } from './openai-common.js'
+
+// ---------------------------------------------------------------------------
+// Message conversion — OMA <-> AI SDK ModelMessage
+// ---------------------------------------------------------------------------
+
+function collectToolNamesByCallId(messages: readonly LLMMessage[]): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const msg of messages) {
+    if (msg.role !== 'assistant') continue
+    for (const block of msg.content) {
+      if (block.type === 'tool_use') map.set(block.id, block.name)
+    }
+  }
+  return map
+}
+
+/**
+ * Convert framework {@link LLMMessage}s to AI SDK {@link ModelMessage}s.
+ * Exported for unit tests and for callers who need to preflight prompts.
+ */
+export function llmMessagesToAiSdkModelMessages(messages: readonly LLMMessage[]): ModelMessage[] {
+  const toolNamesByCallId = collectToolNamesByCallId(messages)
+  const out: ModelMessage[] = []
+
+  for (const msg of messages) {
+    if (msg.role === 'assistant') {
+      const acc: Array<
+        | { type: 'text'; text: string }
+        | { type: 'reasoning'; text: string }
+        | { type: 'tool-call'; toolCallId: string; toolName: string; input: unknown }
+      > = []
+      for (const block of msg.content) {
+        if (block.type === 'text') {
+          acc.push({ type: 'text', text: block.text })
+        } else if (block.type === 'reasoning') {
+          const text =
+            block.redactedData !== undefined && block.redactedData.length > 0
+              ? `[redacted_thinking]${block.redactedData}`
+              : block.text
+          acc.push({ type: 'reasoning', text })
+        } else if (block.type === 'tool_use') {
+          acc.push({
+            type: 'tool-call',
+            toolCallId: block.id,
+            toolName: block.name,
+            input: block.input,
+          })
+        }
+        // image / tool_result in assistant role are ignored (non-canonical)
+      }
+      if (acc.length > 0) out.push({ role: 'assistant', content: acc } as ModelMessage)
+    } else {
+      const toolResults = msg.content.filter((b): b is Extract<ContentBlock, { type: 'tool_result' }> => b.type === 'tool_result')
+      const other = msg.content.filter(b => b.type !== 'tool_result')
+
+      for (const tr of toolResults) {
+        const toolName = toolNamesByCallId.get(tr.tool_use_id) ?? 'unknown_tool'
+        const output = tr.is_error
+          ? ({ type: 'error-text', value: tr.content } as const)
+          : ({ type: 'text', value: tr.content } as const)
+        out.push({
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: tr.tool_use_id,
+              toolName,
+              output,
+            },
+          ],
+        } as ModelMessage)
+      }
+
+      if (other.length === 0) continue
+
+      if (other.length === 1 && other[0]?.type === 'text') {
+        out.push({ role: 'user', content: other[0].text })
+        continue
+      }
+
+      const userParts: Array<
+        | { type: 'text'; text: string }
+        | { type: 'image'; image: Uint8Array; mediaType?: string }
+      > = []
+      for (const block of other) {
+        if (block.type === 'text') userParts.push({ type: 'text', text: block.text })
+        else if (block.type === 'image') {
+          const bytes = Buffer.from(block.source.data, 'base64')
+          userParts.push({
+            type: 'image',
+            image: new Uint8Array(bytes),
+            mediaType: block.source.media_type,
+          })
+        }
+      }
+      if (userParts.length > 0) out.push({ role: 'user', content: userParts } as ModelMessage)
+    }
+  }
+
+  return out
+}
+
+function mapFinishReason(reason: string, hasToolCalls: boolean): string {
+  if (hasToolCalls && reason === 'stop') return 'tool_use'
+  const mapped =
+    reason === 'tool-calls'
+      ? 'tool_calls'
+      : reason === 'content-filter'
+        ? 'content_filter'
+        : reason
+  return normalizeFinishReason(mapped === 'tool_calls' ? 'tool_calls' : mapped === 'content_filter' ? 'content_filter' : mapped)
+}
+
+function usageToOma(u: { inputTokens?: number | undefined; outputTokens?: number | undefined }): TokenUsage {
+  return {
+    input_tokens: u.inputTokens ?? 0,
+    output_tokens: u.outputTokens ?? 0,
+  }
+}
+
+function buildLlmResponseFromGenerateText(result: {
+  readonly text: string
+  readonly reasoningText: string | undefined
+  readonly toolCalls: ReadonlyArray<{ toolCallId: string; toolName: string; input: unknown }>
+  readonly finishReason: string
+  readonly usage: { inputTokens?: number; outputTokens?: number }
+  readonly response: { id?: string; modelId?: string }
+}): LLMResponse {
+  const content: ContentBlock[] = []
+  if (result.reasoningText !== undefined && result.reasoningText.length > 0) {
+    content.push({ type: 'reasoning', text: result.reasoningText })
+  }
+  if (result.text.length > 0) {
+    content.push({ type: 'text', text: result.text } satisfies TextBlock)
+  }
+  for (const tc of result.toolCalls) {
+    const input =
+      tc.input !== null && typeof tc.input === 'object' && !Array.isArray(tc.input)
+        ? (tc.input as Record<string, unknown>)
+        : {}
+    content.push({
+      type: 'tool_use',
+      id: tc.toolCallId,
+      name: tc.toolName,
+      input,
+    } satisfies ToolUseBlock)
+  }
+
+  const hasToolCalls = content.some(b => b.type === 'tool_use')
+  return {
+    id: result.response.id ?? '',
+    content,
+    model: result.response.modelId ?? '',
+    stop_reason: mapFinishReason(result.finishReason, hasToolCalls),
+    usage: usageToOma(result.usage),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AISdkAdapter
+// ---------------------------------------------------------------------------
+
+/**
+ * {@link LLMAdapter} implementation backed by the Vercel AI SDK `generateText` /
+ * `streamText` APIs. Pass any `LanguageModel` from an `@ai-sdk/*` provider.
+ */
+export class AISdkAdapter implements LLMAdapter {
+  readonly name = 'ai-sdk'
+
+  readonly #model: LanguageModel
+
+  constructor(model: LanguageModel) {
+    this.#model = model
+  }
+
+  async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
+    const { generateText, tool, jsonSchema } = await import('ai')
+    const aiMessages = llmMessagesToAiSdkModelMessages(messages)
+
+    const tools =
+      options.tools !== undefined && options.tools.length > 0
+        ? Object.fromEntries(
+            options.tools.map((def) => [
+              def.name,
+              tool({
+                description: def.description,
+                inputSchema: jsonSchema(def.inputSchema as JSONSchema7),
+              }),
+            ]),
+          )
+        : undefined
+
+    const result = await generateText({
+      model: this.#model,
+      messages: aiMessages,
+      system: options.systemPrompt,
+      tools,
+      maxOutputTokens: options.maxTokens,
+      temperature: options.temperature,
+      topP: options.topP,
+      topK: options.topK,
+      frequencyPenalty: options.frequencyPenalty,
+      presencePenalty: options.presencePenalty,
+      abortSignal: options.abortSignal,
+      maxRetries: 0,
+      providerOptions: buildProviderOptions(options),
+      ...(options.extraBody as Record<string, unknown> | undefined),
+    })
+
+    return buildLlmResponseFromGenerateText(result)
+  }
+
+  async *stream(messages: LLMMessage[], options: LLMStreamOptions): AsyncIterable<StreamEvent> {
+    const { streamText, tool, jsonSchema } = await import('ai')
+    const aiMessages = llmMessagesToAiSdkModelMessages(messages)
+
+    const tools =
+      options.tools !== undefined && options.tools.length > 0
+        ? Object.fromEntries(
+            options.tools.map((def) => [
+              def.name,
+              tool({
+                description: def.description,
+                inputSchema: jsonSchema(def.inputSchema as JSONSchema7),
+              }),
+            ]),
+          )
+        : undefined
+
+    let fullText = ''
+    let fullReasoning = ''
+    const toolBlocks: ToolUseBlock[] = []
+    let finishReason = 'stop'
+    let usage: TokenUsage = { input_tokens: 0, output_tokens: 0 }
+    let responseId = ''
+    let responseModel = ''
+
+    try {
+      const result = streamText({
+        model: this.#model,
+        messages: aiMessages,
+        system: options.systemPrompt,
+        tools,
+        maxOutputTokens: options.maxTokens,
+        temperature: options.temperature,
+        topP: options.topP,
+        topK: options.topK,
+        frequencyPenalty: options.frequencyPenalty,
+        presencePenalty: options.presencePenalty,
+        abortSignal: options.abortSignal,
+        maxRetries: 0,
+        providerOptions: buildProviderOptions(options),
+        ...(options.extraBody as Record<string, unknown> | undefined),
+      })
+
+      for await (const part of result.fullStream) {
+        if (part.type === 'text-delta') {
+          fullText += part.text
+          yield { type: 'text', data: part.text }
+        } else if (part.type === 'reasoning-delta') {
+          fullReasoning += part.text
+          yield { type: 'reasoning', data: part.text }
+        } else if (part.type === 'tool-call') {
+          const input =
+            part.input !== null && typeof part.input === 'object' && !Array.isArray(part.input)
+              ? (part.input as Record<string, unknown>)
+              : {}
+          const block: ToolUseBlock = {
+            type: 'tool_use',
+            id: part.toolCallId,
+            name: part.toolName,
+            input,
+          }
+          toolBlocks.push(block)
+          yield { type: 'tool_use', data: block }
+        } else if (part.type === 'error') {
+          const err = part.error instanceof Error ? part.error : new Error(String(part.error))
+          yield { type: 'error', data: err }
+          return
+        } else if (part.type === 'finish') {
+          finishReason = part.finishReason
+          usage = usageToOma(part.totalUsage)
+        }
+      }
+
+      const meta = await result.response
+      responseId = meta.id ?? ''
+      responseModel = meta.modelId ?? ''
+
+      const totalUsage = await result.totalUsage.catch(() => undefined)
+      if (totalUsage !== undefined) {
+        usage = usageToOma(totalUsage)
+      }
+
+      const doneContent: ContentBlock[] = []
+      if (fullReasoning.length > 0) doneContent.push({ type: 'reasoning', text: fullReasoning })
+      if (fullText.length > 0) doneContent.push({ type: 'text', text: fullText })
+      doneContent.push(...toolBlocks)
+
+      const hasToolCalls = toolBlocks.length > 0
+      const finalResponse: LLMResponse = {
+        id: responseId,
+        content: doneContent,
+        model: responseModel,
+        stop_reason: mapFinishReason(finishReason, hasToolCalls),
+        usage,
+      }
+
+      yield { type: 'done', data: finalResponse }
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err))
+      yield { type: 'error', data: error }
+    }
+  }
+}
+
+function buildProviderOptions(options: LLMChatOptions): SharedV2ProviderOptions | undefined {
+  const out: Record<string, Record<string, JSONValue>> = {}
+  if (options.thinking?.effort !== undefined) {
+    out['openai'] = { ...(out['openai'] ?? {}), reasoningEffort: options.thinking.effort }
+  }
+  if (options.parallelToolCalls !== undefined) {
+    out['openai'] = { ...(out['openai'] ?? {}), parallelToolCalls: options.parallelToolCalls }
+  }
+  if (options.minP !== undefined) {
+    out['openai'] = { ...(out['openai'] ?? {}), minP: options.minP }
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -1097,6 +1097,7 @@ export class OpenMultiAgent {
     const coordinatorConfig: AgentConfig = {
       name: 'coordinator',
       model: coordinatorOverrides?.model ?? this.config.defaultModel,
+      ...(coordinatorOverrides?.adapter !== undefined ? { adapter: coordinatorOverrides.adapter } : {}),
       provider: coordinatorOverrides?.provider ?? this.config.defaultProvider,
       baseURL: coordinatorOverrides?.baseURL ?? this.config.defaultBaseURL,
       apiKey: coordinatorOverrides?.apiKey ?? this.config.defaultApiKey,

--- a/src/types.ts
+++ b/src/types.ts
@@ -351,6 +351,12 @@ export interface BeforeRunHookContext {
 export interface AgentConfig {
   readonly name: string
   readonly model: string
+  /**
+   * Optional custom {@link LLMAdapter}. When set, the agent uses this adapter
+   * directly and skips {@link createAdapter} — `provider`, `apiKey`, `baseURL`,
+   * and `region` are ignored for LLM calls.
+   */
+  readonly adapter?: LLMAdapter
   readonly provider?: SupportedProvider
   /**
    * Custom base URL for OpenAI-compatible APIs (Ollama, vLLM, LM Studio, etc.).
@@ -786,6 +792,11 @@ export interface OrchestratorConfig {
 export interface CoordinatorConfig {
   /** Coordinator model. Defaults to `OrchestratorConfig.defaultModel`. */
   readonly model?: string
+  /**
+   * Optional {@link LLMAdapter} for the coordinator agent. When set, coordinator
+   * LLM calls use this adapter and ignore `provider` / `apiKey` / `baseURL`.
+   */
+  readonly adapter?: LLMAdapter
   readonly provider?: SupportedProvider
   readonly baseURL?: string
   readonly apiKey?: string

--- a/tests/ai-sdk-adapter.test.ts
+++ b/tests/ai-sdk-adapter.test.ts
@@ -127,6 +127,67 @@ describe('AISdkAdapter', () => {
     ])
   })
 
+  it('lets extraBody override sampling defaults like temperature', async () => {
+    generateTextMock.mockResolvedValue({
+      text: 'ok',
+      reasoningText: undefined,
+      toolCalls: [],
+      finishReason: 'stop',
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      response: { id: 'r', modelId: 'm' },
+    })
+
+    const adapter = new AISdkAdapter(dummyModel)
+    await adapter.chat([{ role: 'user', content: [{ type: 'text', text: 'x' }] }], {
+      model: 'm',
+      temperature: 0.5,
+      extraBody: { temperature: 0.99 },
+    })
+
+    const body = generateTextMock.mock.calls[0]![0] as Record<string, unknown>
+    expect(body['temperature']).toBe(0.99)
+  })
+
+  it('refuses to let extraBody override structural fields (model, messages, tools)', async () => {
+    generateTextMock.mockResolvedValue({
+      text: 'ok',
+      reasoningText: undefined,
+      toolCalls: [],
+      finishReason: 'stop',
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      response: { id: 'r', modelId: 'm' },
+    })
+
+    const adapter = new AISdkAdapter(dummyModel)
+    const messages = [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'real' }] }]
+    const tools = [
+      {
+        name: 'lookup',
+        description: 'Look up',
+        inputSchema: { type: 'object' as const, properties: {} },
+      },
+    ]
+
+    await adapter.chat(messages, {
+      model: 'm',
+      systemPrompt: 'real system',
+      tools,
+      extraBody: {
+        model: { spoofed: true },
+        messages: [],
+        system: 'evil',
+        tools: {},
+      } as Record<string, unknown>,
+    })
+
+    const body = generateTextMock.mock.calls[0]![0] as Record<string, unknown>
+    expect(body['model']).toBe(dummyModel)
+    expect(body['messages']).toEqual([{ role: 'user', content: 'real' }])
+    expect(body['system']).toBe('real system')
+    expect(body['tools']).toBeDefined()
+    expect(Object.keys(body['tools'] as object)).toEqual(['lookup'])
+  })
+
   it('streams text deltas and a terminal done event', async () => {
     streamTextMock.mockReturnValue({
       fullStream: (async function* () {

--- a/tests/ai-sdk-adapter.test.ts
+++ b/tests/ai-sdk-adapter.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { LanguageModel } from 'ai'
+
+const generateTextMock = vi.fn()
+const streamTextMock = vi.fn()
+
+vi.mock('ai', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('ai')>()
+  return {
+    ...mod,
+    generateText: (...args: unknown[]) => generateTextMock(...args),
+    streamText: (...args: unknown[]) => streamTextMock(...args),
+  }
+})
+
+import { AISdkAdapter, llmMessagesToAiSdkModelMessages } from '../src/llm/ai-sdk.js'
+
+describe('llmMessagesToAiSdkModelMessages', () => {
+  it('maps a simple user text message', () => {
+    const out = llmMessagesToAiSdkModelMessages([
+      { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+    ])
+    expect(out).toEqual([{ role: 'user', content: 'Hello' }])
+  })
+
+  it('splits tool results into tool-role messages before remaining user parts', () => {
+    const out = llmMessagesToAiSdkModelMessages([
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_1', name: 'lookup', input: { q: 'x' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          { type: 'tool_result', tool_use_id: 'call_1', content: '{"ok":true}' },
+          { type: 'text', text: 'Continue.' },
+        ],
+      },
+    ])
+    expect(out[0]).toMatchObject({ role: 'assistant' })
+    expect(out[1]).toEqual({
+      role: 'tool',
+      content: [
+        {
+          type: 'tool-result',
+          toolCallId: 'call_1',
+          toolName: 'lookup',
+          output: { type: 'text', value: '{"ok":true}' },
+        },
+      ],
+    })
+    expect(out[2]).toEqual({ role: 'user', content: 'Continue.' })
+  })
+
+  it('marks errored tool results as error-text output', () => {
+    const out = llmMessagesToAiSdkModelMessages([
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'c2', name: 'fail', input: {} }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'c2', content: 'boom', is_error: true }],
+      },
+    ])
+    const toolMsg = out[1] as { role: string; content: Array<{ output: { type: string; value: string } }> }
+    expect(toolMsg.role).toBe('tool')
+    expect(toolMsg.content[0]?.output).toEqual({ type: 'error-text', value: 'boom' })
+  })
+})
+
+describe('AISdkAdapter', () => {
+  const dummyModel = { _brand: 'test' } as unknown as LanguageModel
+
+  beforeEach(() => {
+    generateTextMock.mockReset()
+    streamTextMock.mockReset()
+  })
+
+  it('calls generateText and maps the result to LLMResponse', async () => {
+    generateTextMock.mockResolvedValue({
+      text: 'Hello',
+      reasoningText: undefined,
+      toolCalls: [],
+      finishReason: 'stop',
+      usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+      response: { id: 'gen-1', modelId: 'gpt-test' },
+    })
+
+    const adapter = new AISdkAdapter(dummyModel)
+    const res = await adapter.chat([{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }], {
+      model: 'gpt-test',
+    })
+
+    expect(generateTextMock).toHaveBeenCalledTimes(1)
+    const arg = generateTextMock.mock.calls[0]![0] as { model: unknown; messages: unknown[]; system?: string }
+    expect(arg.model).toBe(dummyModel)
+    expect(arg.messages).toEqual([{ role: 'user', content: 'Hi' }])
+
+    expect(res.id).toBe('gen-1')
+    expect(res.model).toBe('gpt-test')
+    expect(res.stop_reason).toBe('end_turn')
+    expect(res.usage).toEqual({ input_tokens: 2, output_tokens: 3 })
+    expect(res.content).toEqual([{ type: 'text', text: 'Hello' }])
+  })
+
+  it('maps tool-calls finish reason to tool_use', async () => {
+    generateTextMock.mockResolvedValue({
+      text: '',
+      reasoningText: undefined,
+      toolCalls: [{ toolCallId: 'tc1', toolName: 'add', input: { a: 1 } }],
+      finishReason: 'tool-calls',
+      usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+      response: { id: 'r2', modelId: 'gpt-test' },
+    })
+
+    const adapter = new AISdkAdapter(dummyModel)
+    const res = await adapter.chat([{ role: 'user', content: [{ type: 'text', text: 'x' }] }], {
+      model: 'gpt-test',
+    })
+
+    expect(res.stop_reason).toBe('tool_use')
+    expect(res.content).toEqual([
+      { type: 'tool_use', id: 'tc1', name: 'add', input: { a: 1 } },
+    ])
+  })
+
+  it('streams text deltas and a terminal done event', async () => {
+    streamTextMock.mockReturnValue({
+      fullStream: (async function* () {
+        yield { type: 'text-delta', id: 't1', text: 'Hi' }
+        yield {
+          type: 'finish',
+          finishReason: 'stop',
+          totalUsage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+        }
+      })(),
+      response: Promise.resolve({ id: 's1', modelId: 'stream-model' }),
+      totalUsage: Promise.resolve({ inputTokens: 1, outputTokens: 2, totalTokens: 3 }),
+    })
+
+    const adapter = new AISdkAdapter(dummyModel)
+    const events: Array<{ type: string; data?: unknown }> = []
+    for await (const ev of adapter.stream([{ role: 'user', content: [{ type: 'text', text: 'Go' }] }], {
+      model: 'stream-model',
+    })) {
+      events.push(ev)
+    }
+
+    expect(events.map(e => e.type)).toEqual(['text', 'done'])
+    expect(events[0]).toEqual({ type: 'text', data: 'Hi' })
+    const done = events[1] as { type: 'done'; data: { content: unknown[]; usage: { input_tokens: number; output_tokens: number } } }
+    expect(done.type).toBe('done')
+    expect(done.data.usage).toEqual({
+      input_tokens: 1,
+      output_tokens: 2,
+    })
+  })
+})


### PR DESCRIPTION
## What

Adds an optional Vercel AI SDK bridge: AISdkAdapter implements LLMAdapter via generateText / streamText, plus llmMessagesToAiSdkModelMessages() for OMA <-> AI SDK message and tool-call mapping. Agents (and the runTeam coordinator) can set adapter on config to skip createAdapter(); ai is an optional peer dependency. README, tests, and public exports are updated.

## Why

Lets users plug in any AI SDK-backed model (OpenAI, Anthropic, Google, Groq, and the rest of the ecosystem) without waiting for native SupportedProvider entries or maintaining OpenAI-compatible baseURL setups per host. Keeps existing provider: 'anthropic' | 'openai' | … flows unchanged and supports mixed teams where only some agents use the AI SDK.

Resolves https://github.com/open-multi-agent/open-multi-agent/issues/106

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Added/updated tests for changed behavior
- [x] No new runtime dependencies (or justified in the PR description)
