### PR TITLE
feat(examples): add Doubao (ByteDance) provider example

### DIFF
--- a/examples/providers/doubao.ts
+++ b/examples/providers/doubao.ts
@@ -11,8 +11,8 @@
  *   ARK_API_KEY environment variable must be set.
  *
  * Available models:
- *   doubao-pro-32k  — Doubao production model (recommended for coding tasks)
- *   doubao-lite-32k — Doubao lightweight model (faster, lower cost)
+ *   doubao-1-5-pro-32k-250115  — Doubao 1.5 production model (recommended for coding tasks)
+ *   doubao-1-5-lite-32k-250115 — Doubao 1.5 lightweight model (faster, lower cost)
  */
 
 import { OpenMultiAgent } from '../../src/index.js'
@@ -30,7 +30,7 @@ if (!DOUBAO_API_KEY) {
 // ---------------------------------------------------------------------------
 const architect: AgentConfig = {
   name: 'architect',
-  model: 'doubao-pro-32k',
+  model: 'doubao-1-5-pro-32k-250115',
   provider: 'openai',
   baseURL: DOUBAO_BASE_URL,
   apiKey: DOUBAO_API_KEY,
@@ -44,7 +44,7 @@ Output concise plans in markdown — no unnecessary prose.`,
 
 const developer: AgentConfig = {
   name: 'developer',
-  model: 'doubao-pro-32k',
+  model: 'doubao-1-5-pro-32k-250115',
   provider: 'openai',
   baseURL: DOUBAO_BASE_URL,
   apiKey: DOUBAO_API_KEY,
@@ -57,7 +57,7 @@ Write clean, runnable code with proper error handling. Use the tools to write fi
 
 const reviewer: AgentConfig = {
   name: 'reviewer',
-  model: 'doubao-lite-32k',
+  model: 'doubao-1-5-lite-32k-250115',
   provider: 'openai',
   baseURL: DOUBAO_BASE_URL,
   apiKey: DOUBAO_API_KEY,
@@ -106,7 +106,7 @@ function handleProgress(event: OrchestratorEvent): void {
 // Orchestrate
 // ---------------------------------------------------------------------------
 const orchestrator = new OpenMultiAgent({
-  defaultModel: 'doubao-pro-32k',
+  defaultModel: 'doubao-1-5-pro-32k-250115',
   defaultProvider: 'openai',
   defaultBaseURL: DOUBAO_BASE_URL,
   defaultApiKey: DOUBAO_API_KEY,

--- a/examples/providers/doubao.ts
+++ b/examples/providers/doubao.ts
@@ -1,0 +1,173 @@
+/**
+ * Multi-Agent Team Collaboration with Doubao (ByteDance)
+ *
+ * Three specialized agents (architect, developer, reviewer) collaborate via `runTeam()`
+ * to build a minimal Express.js REST API. Every agent uses Doubao via the OpenAI-compatible adapter.
+ *
+ * Run:
+ *   npx tsx examples/providers/doubao.ts
+ *
+ * Prerequisites:
+ *   ARK_API_KEY environment variable must be set.
+ *
+ * Available models:
+ *   doubao-pro-32k  — Doubao production model (recommended for coding tasks)
+ *   doubao-lite-32k — Doubao lightweight model (faster, lower cost)
+ */
+
+import { OpenMultiAgent } from '../../src/index.js'
+import type { AgentConfig, OrchestratorEvent } from '../../src/types.js'
+
+const DOUBAO_BASE_URL = 'https://ark.cn-beijing.volces.com/api/v3'
+const DOUBAO_API_KEY = process.env.ARK_API_KEY
+
+if (!DOUBAO_API_KEY) {
+  throw new Error('ARK_API_KEY environment variable must be set.')
+}
+
+// ---------------------------------------------------------------------------
+// Agent definitions (all using Doubao via the OpenAI-compatible adapter)
+// ---------------------------------------------------------------------------
+const architect: AgentConfig = {
+  name: 'architect',
+  model: 'doubao-pro-32k',
+  provider: 'openai',
+  baseURL: DOUBAO_BASE_URL,
+  apiKey: DOUBAO_API_KEY,
+  systemPrompt: `You are a software architect with deep experience in Node.js and REST API design.
+Your job is to design clear, production-quality API contracts and file/directory structures.
+Output concise plans in markdown — no unnecessary prose.`,
+  tools: ['bash', 'file_write'],
+  maxTurns: 5,
+  temperature: 0.2,
+}
+
+const developer: AgentConfig = {
+  name: 'developer',
+  model: 'doubao-pro-32k',
+  provider: 'openai',
+  baseURL: DOUBAO_BASE_URL,
+  apiKey: DOUBAO_API_KEY,
+  systemPrompt: `You are a TypeScript/Node.js developer. You implement what the architect specifies.
+Write clean, runnable code with proper error handling. Use the tools to write files and run tests.`,
+  tools: ['bash', 'file_read', 'file_write', 'file_edit'],
+  maxTurns: 12,
+  temperature: 0.1,
+}
+
+const reviewer: AgentConfig = {
+  name: 'reviewer',
+  model: 'doubao-lite-32k',
+  provider: 'openai',
+  baseURL: DOUBAO_BASE_URL,
+  apiKey: DOUBAO_API_KEY,
+  systemPrompt: `You are a senior code reviewer. Review code for correctness, security, and clarity.
+Provide a structured review with: LGTM items, suggestions, and any blocking issues.
+Read files using the tools before reviewing.`,
+  tools: ['bash', 'file_read', 'grep'],
+  maxTurns: 5,
+  temperature: 0.3,
+}
+
+// ---------------------------------------------------------------------------
+// Progress tracking
+// ---------------------------------------------------------------------------
+const startTimes = new Map<string, number>()
+
+function handleProgress(event: OrchestratorEvent): void {
+  const ts = new Date().toISOString().slice(11, 23) // HH:MM:SS.mmm
+  switch (event.type) {
+    case 'agent_start':
+      startTimes.set(event.agent ?? '', Date.now())
+      console.log(`[${ts}] AGENT START → ${event.agent}`)
+      break
+    case 'agent_complete': {
+      const elapsed = Date.now() - (startTimes.get(event.agent ?? '') ?? Date.now())
+      console.log(`[${ts}] AGENT DONE ← ${event.agent} (${elapsed}ms)`)
+      break
+    }
+    case 'task_start':
+      console.log(`[${ts}] TASK START ↓ ${event.task}`)
+      break
+    case 'task_complete':
+      console.log(`[${ts}] TASK DONE ↑ ${event.task}`)
+      break
+    case 'message':
+      console.log(`[${ts}] MESSAGE • ${event.agent} → (team)`)
+      break
+    case 'error':
+      console.error(`[${ts}] ERROR ✗ agent=${event.agent} task=${event.task}`)
+      if (event.data instanceof Error) console.error(` ${event.data.message}`)
+      break
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrate
+// ---------------------------------------------------------------------------
+const orchestrator = new OpenMultiAgent({
+  defaultModel: 'doubao-pro-32k',
+  defaultProvider: 'openai',
+  defaultBaseURL: DOUBAO_BASE_URL,
+  defaultApiKey: DOUBAO_API_KEY,
+  maxConcurrency: 1, // sequential for readable output
+  onProgress: handleProgress,
+})
+
+const team = orchestrator.createTeam('api-team', {
+  name: 'api-team',
+  agents: [architect, developer, reviewer],
+  sharedMemory: true,
+  maxConcurrency: 1,
+})
+
+console.log(`Team "${team.name}" created with agents: ${team.getAgents().map(a => a.name).join(', ')}`)
+console.log('\nStarting team run...\n')
+console.log('='.repeat(60))
+
+const goal = `Create a minimal Express.js REST API in /tmp/doubao-api/ with:
+- GET /health → { status: "ok" }
+- GET /users → returns a hardcoded array of 2 user objects
+- POST /users → accepts { name, email } body, logs it, returns 201
+- Proper error handling middleware
+- The server should listen on port 3001
+- Include a package.json with the required dependencies`
+
+const result = await orchestrator.runTeam(team, goal)
+
+console.log('\n' + '='.repeat(60))
+
+// ---------------------------------------------------------------------------
+// Results
+// ---------------------------------------------------------------------------
+console.log('\nTeam run complete.')
+console.log(`Success: ${result.success}`)
+console.log(`Total tokens — input: ${result.totalTokenUsage.input_tokens}, output: ${result.totalTokenUsage.output_tokens}`)
+
+console.log('\nPer-agent results:')
+for (const [agentName, agentResult] of result.agentResults) {
+  const status = agentResult.success ? 'OK' : 'FAILED'
+  const tools = agentResult.toolCalls.length
+  console.log(` ${agentName.padEnd(12)} [${status}] tool_calls=${tools}`)
+  if (!agentResult.success) {
+    console.log(` Error: ${agentResult.output.slice(0, 120)}`)
+  }
+}
+
+// Sample outputs
+const developerResult = result.agentResults.get('developer')
+if (developerResult?.success) {
+  console.log('\nDeveloper output (last 600 chars):')
+  console.log('─'.repeat(60))
+  const out = developerResult.output
+  console.log(out.length > 600 ? '...' + out.slice(-600) : out)
+  console.log('─'.repeat(60))
+}
+
+const reviewerResult = result.agentResults.get('reviewer')
+if (reviewerResult?.success) {
+  console.log('\nReviewer output:')
+  console.log('─'.repeat(60))
+  console.log(reviewerResult.output)
+  console.log('─'.repeat(60))
+}


### PR DESCRIPTION
## What

Adds a working multi-agent example for [Doubao](https://www.volcengine.com/product/ark) (ByteDance) via the OpenAI-compatible adapter.

- New file: `examples/providers/doubao.ts` — three-agent team (architect / developer / reviewer) running via `runTeam()`
- Updated `docs/providers.md` — added Doubao to the OpenAI-Compatible Providers table

## Why

Part of  #25. Doubao is ByteDance's LLM platform with an OpenAI-compatible API. This example shows how to connect via `provider: 'openai'` + `baseURL`.

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Follows the same structure as other provider examples (`groq.ts`, `mistral.ts`)
- [x] No new runtime dependencies added