### PR TITLE
docs(context-management): document compressToolResults and maxToolOutputChars

### DIFF
--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -21,4 +21,44 @@ const agent: AgentConfig = {
 | `compact` | Rule-based: truncate large assistant text blocks and tool results, keep recent turns intact. No extra LLM call. |
 | `custom` | Supply your own `compress(messages, estimatedTokens)` function. |
 
-Pairs well with `compressToolResults` and `maxToolOutputChars`.
+## Compressing Tool Results
+
+Tool outputs persist in the conversation history across turns even after the agent has acted on them. In long runs this can consume a significant portion of the context budget.
+
+`compressToolResults` replaces already-consumed tool results (those followed by an assistant response) with a short marker before each new LLM call:
+
+```typescript
+const agent: AgentConfig = {
+  name: 'long-runner',
+  model: 'claude-sonnet-4-6',
+  // Enable with the default threshold (500 chars):
+  compressToolResults: true,
+  // Or only compress results longer than N characters:
+  // compressToolResults: { minChars: 2000 },
+}
+```
+
+| Value | Behaviour |
+|-------|-----------|
+| `true` | Compress results longer than 500 characters (default threshold) |
+| `{ minChars: N }` | Compress results longer than N characters |
+| `false` / `undefined` | Disabled (default) |
+
+**Notes:**
+- Error tool results are never compressed.
+- Delegation `tool_result` blocks (from `delegate_to_agent`) are exempt — the parent agent always retains the full sub-agent output.
+- Works alongside `contextStrategy`; combine both for maximum context headroom.
+
+## Truncating Tool Output
+
+`maxToolOutputChars` caps the raw output length for every tool used by an agent. Outputs longer than the limit are truncated to a head + tail excerpt with a marker in between. This applies at execution time, before the result enters the conversation.
+
+```typescript
+const agent: AgentConfig = {
+  name: 'long-runner',
+  model: 'claude-sonnet-4-6',
+  maxToolOutputChars: 10_000, // truncate any single tool output to 10 k chars
+}
+```
+
+Per-tool `maxOutputChars` (set on `ToolDefinition`) takes priority over the agent-level `maxToolOutputChars`.


### PR DESCRIPTION
## What

Expands `docs/context-management.md` with two new sections:

- **Compressing Tool Results** — documents `compressToolResults` (`true` / `{ minChars: N }` / disabled), its default threshold, the delegation exemption, and how it pairs with `contextStrategy`
- **Truncating Tool Output** — documents `maxToolOutputChars` at the agent level and `ToolDefinition.maxOutputChars` per-tool override

Previously the file ended with "Pairs well with `compressToolResults` and `maxToolOutputChars`." with no further explanation of either option.

## Why

Both options are surfaced in `AgentConfig` and `ToolDefinition` with JSDoc, but the context-management guide didn't explain them. Users had no single place to learn the difference between compressing already-consumed results vs. truncating output at execution time.

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Docs-only change — no runtime code modified