### PR TITLE
openai: downgrade reasoning blocks to <thinking> text fallback

### DIFF
--- a/src/llm/openai-common.ts
+++ b/src/llm/openai-common.ts
@@ -72,6 +72,13 @@ export function getOpenAIReasoningText(source: unknown): string {
   return extractReasoningText((source as Record<string, unknown>)['reasoning_content'])
 }
 
+function reasoningBlockToThinkingText(block: ReasoningBlock): string {
+  if (typeof block.redactedData === 'string' && block.redactedData.length > 0) {
+    return '<thinking>[redacted]</thinking>'
+  }
+  return `<thinking>${block.text}</thinking>`
+}
+
 /**
  * Determine whether a framework message contains any `tool_result` content
  * blocks, which must be serialised as separate OpenAI `tool`-role messages.
@@ -168,6 +175,7 @@ function toOpenAIUserMessage(msg: LLMMessage): ChatCompletionUserMessageParam {
 function toOpenAIAssistantMessage(msg: LLMMessage): ChatCompletionAssistantMessageParam {
   const toolCalls: ChatCompletionMessageToolCall[] = []
   const textParts: string[] = []
+  const pendingThinkingParts: string[] = []
 
   for (const block of msg.content) {
     if (block.type === 'tool_use') {
@@ -179,9 +187,20 @@ function toOpenAIAssistantMessage(msg: LLMMessage): ChatCompletionAssistantMessa
           arguments: JSON.stringify(block.input),
         },
       })
+    } else if (block.type === 'reasoning') {
+      pendingThinkingParts.push(reasoningBlockToThinkingText(block))
     } else if (block.type === 'text') {
-      textParts.push(block.text)
+      if (pendingThinkingParts.length > 0) {
+        textParts.push(`${pendingThinkingParts.join('')}${block.text}`)
+        pendingThinkingParts.length = 0
+      } else {
+        textParts.push(block.text)
+      }
     }
+  }
+
+  if (pendingThinkingParts.length > 0) {
+    textParts.push(pendingThinkingParts.join(''))
   }
 
   const assistantMsg: ChatCompletionAssistantMessageParam = {

--- a/src/llm/openai-common.ts
+++ b/src/llm/openai-common.ts
@@ -28,6 +28,24 @@ import type {
 } from '../types.js'
 import { extractToolCallsFromText } from '../tool/text-tool-extractor.js'
 
+const DEFAULT_REASONING_REPLAY_MAX_CHARS = 1200
+
+export interface OpenAIReasoningReplayOptions {
+  /**
+   * Opt-in switch for replaying framework `reasoning` blocks as inline
+   * `<thinking>...</thinking>` text in OpenAI-family request payloads.
+   *
+   * Defaults to `false` so existing users keep historical behavior:
+   * `reasoning` blocks are ignored on outbound assistant message conversion.
+   */
+  readonly enableReasoningTextReplay?: boolean
+  /**
+   * Maximum character budget for each replayed reasoning block after
+   * truncation. Explicit invalid values are clamped to a minimum of 1 char.
+   */
+  readonly maxReasoningReplayChars?: number
+}
+
 // ---------------------------------------------------------------------------
 // Framework → OpenAI
 // ---------------------------------------------------------------------------
@@ -72,11 +90,33 @@ export function getOpenAIReasoningText(source: unknown): string {
   return extractReasoningText((source as Record<string, unknown>)['reasoning_content'])
 }
 
-function reasoningBlockToThinkingText(block: ReasoningBlock): string {
+function resolveReasoningReplayMaxChars(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_REASONING_REPLAY_MAX_CHARS
+  if (!Number.isFinite(value)) return 1
+  const floored = Math.floor(value)
+  if (floored < 1) return 1
+  return floored
+}
+
+function truncateReasoningForReplay(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text
+
+  const marker = '...[truncated]...'
+  if (marker.length >= maxChars) return text.slice(0, maxChars)
+
+  const budget = maxChars - marker.length
+  const head = Math.ceil(budget * 0.7)
+  const tail = budget - head
+  return `${text.slice(0, head)}${marker}${text.slice(text.length - tail)}`
+}
+
+function reasoningBlockToThinkingText(block: ReasoningBlock, maxChars: number): string {
   if (typeof block.redactedData === 'string' && block.redactedData.length > 0) {
     return '<thinking>[redacted]</thinking>'
   }
-  return `<thinking>${block.text}</thinking>`
+  if (block.text.length === 0) return ''
+  const bounded = truncateReasoningForReplay(block.text, maxChars)
+  return `<thinking>${bounded}</thinking>`
 }
 
 /**
@@ -105,12 +145,18 @@ function hasToolResults(msg: LLMMessage): boolean {
  * runner's loop-detection warning injection (see {@link AgentRunner}, which
  * appends a text warning to a tool_result message when a loop is detected).
  */
-export function toOpenAIMessages(messages: LLMMessage[]): ChatCompletionMessageParam[] {
+export function toOpenAIMessages(
+  messages: LLMMessage[],
+  replayOptions?: OpenAIReasoningReplayOptions,
+): ChatCompletionMessageParam[] {
   const result: ChatCompletionMessageParam[] = []
 
   for (const msg of messages) {
     if (msg.role === 'assistant') {
-      result.push(toOpenAIAssistantMessage(msg))
+      const assistantMsg = toOpenAIAssistantMessage(msg, replayOptions)
+      if (assistantMsg !== null) {
+        result.push(assistantMsg)
+      }
     } else {
       // user role
       if (!hasToolResults(msg)) {
@@ -172,10 +218,15 @@ function toOpenAIUserMessage(msg: LLMMessage): ChatCompletionUserMessageParam {
  * Convert an `assistant`-role framework message into an OpenAI assistant message.
  * `tool_use` blocks become `tool_calls`; `text` blocks become message content.
  */
-function toOpenAIAssistantMessage(msg: LLMMessage): ChatCompletionAssistantMessageParam {
+function toOpenAIAssistantMessage(
+  msg: LLMMessage,
+  replayOptions?: OpenAIReasoningReplayOptions,
+): ChatCompletionAssistantMessageParam | null {
   const toolCalls: ChatCompletionMessageToolCall[] = []
   const textParts: string[] = []
   const pendingThinkingParts: string[] = []
+  const enableReasoningReplay = replayOptions?.enableReasoningTextReplay === true
+  const maxReasoningChars = resolveReasoningReplayMaxChars(replayOptions?.maxReasoningReplayChars)
 
   for (const block of msg.content) {
     if (block.type === 'tool_use') {
@@ -187,8 +238,11 @@ function toOpenAIAssistantMessage(msg: LLMMessage): ChatCompletionAssistantMessa
           arguments: JSON.stringify(block.input),
         },
       })
-    } else if (block.type === 'reasoning') {
-      pendingThinkingParts.push(reasoningBlockToThinkingText(block))
+    } else if (block.type === 'reasoning' && enableReasoningReplay) {
+      const serialized = reasoningBlockToThinkingText(block, maxReasoningChars)
+      if (serialized.length > 0) {
+        pendingThinkingParts.push(serialized)
+      }
     } else if (block.type === 'text') {
       if (pendingThinkingParts.length > 0) {
         textParts.push(`${pendingThinkingParts.join('')}${block.text}`)
@@ -201,6 +255,10 @@ function toOpenAIAssistantMessage(msg: LLMMessage): ChatCompletionAssistantMessa
 
   if (pendingThinkingParts.length > 0) {
     textParts.push(pendingThinkingParts.join(''))
+  }
+
+  if (toolCalls.length === 0 && textParts.length === 0) {
+    return null
   }
 
   const assistantMsg: ChatCompletionAssistantMessageParam = {
@@ -345,6 +403,7 @@ export function normalizeFinishReason(reason: string): string {
 export function buildOpenAIMessageList(
   messages: LLMMessage[],
   systemPrompt: string | undefined,
+  replayOptions?: OpenAIReasoningReplayOptions,
 ): ChatCompletionMessageParam[] {
   const result: ChatCompletionMessageParam[] = []
 
@@ -352,6 +411,6 @@ export function buildOpenAIMessageList(
     result.push({ role: 'system', content: systemPrompt })
   }
 
-  result.push(...toOpenAIMessages(messages))
+  result.push(...toOpenAIMessages(messages, replayOptions))
   return result
 }

--- a/tests/openai-common.test.ts
+++ b/tests/openai-common.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { toOpenAIMessages } from '../src/llm/openai-common.js'
+import type { LLMMessage } from '../src/types.js'
+
+function getAssistantContent(messages: LLMMessage[]): string | null {
+  const output = toOpenAIMessages(messages)
+  const first = output[0]
+  if (first === undefined || first.role !== 'assistant') {
+    throw new Error('expected first message to be assistant')
+  }
+  return first.content
+}
+
+describe('toOpenAIMessages reasoning fallback', () => {
+  it('prepends reasoning fallback to the next text block', () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'plan first' },
+          { type: 'text', text: 'Now execute.' },
+        ],
+      },
+    ]
+
+    expect(getAssistantContent(messages)).toBe('<thinking>plan first</thinking>Now execute.')
+  })
+
+  it('keeps redacted reasoning with placeholder text', () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: '', redactedData: 'opaque' },
+          { type: 'text', text: 'Proceeding.' },
+        ],
+      },
+    ]
+
+    expect(getAssistantContent(messages)).toBe('<thinking>[redacted]</thinking>Proceeding.')
+  })
+
+  it('retains fallback text when no regular text block exists', () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'assistant',
+        content: [{ type: 'reasoning', text: 'intermediate chain' }],
+      },
+    ]
+
+    expect(getAssistantContent(messages)).toBe('<thinking>intermediate chain</thinking>')
+  })
+})

--- a/tests/openai-common.test.ts
+++ b/tests/openai-common.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest'
 import { toOpenAIMessages } from '../src/llm/openai-common.js'
 import type { LLMMessage } from '../src/types.js'
 
-function getAssistantContent(messages: LLMMessage[]): string | null {
-  const output = toOpenAIMessages(messages)
+function getAssistantContent(
+  messages: LLMMessage[],
+  replayOptions?: { enableReasoningTextReplay?: boolean; maxReasoningReplayChars?: number },
+): string | null {
+  const output = toOpenAIMessages(messages, replayOptions)
   const first = output[0]
   if (first === undefined || first.role !== 'assistant') {
     throw new Error('expected first message to be assistant')
@@ -11,8 +14,19 @@ function getAssistantContent(messages: LLMMessage[]): string | null {
   return first.content
 }
 
+function extractThinkingContent(content: string | null): string {
+  if (content === null) {
+    throw new Error('expected assistant content')
+  }
+  const match = content.match(/<thinking>([\s\S]*?)<\/thinking>/)
+  if (match?.[1] === undefined) {
+    throw new Error('expected thinking tag in assistant content')
+  }
+  return match[1]
+}
+
 describe('toOpenAIMessages reasoning fallback', () => {
-  it('prepends reasoning fallback to the next text block', () => {
+  it('keeps historical default behavior when fallback is disabled', () => {
     const messages: LLMMessage[] = [
       {
         role: 'assistant',
@@ -23,7 +37,21 @@ describe('toOpenAIMessages reasoning fallback', () => {
       },
     ]
 
-    expect(getAssistantContent(messages)).toBe('<thinking>plan first</thinking>Now execute.')
+    expect(getAssistantContent(messages)).toBe('Now execute.')
+  })
+
+  it('prepends reasoning fallback only when explicitly enabled', () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'plan first' },
+          { type: 'text', text: 'Now execute.' },
+        ],
+      },
+    ]
+
+    expect(getAssistantContent(messages, { enableReasoningTextReplay: true })).toBe('<thinking>plan first</thinking>Now execute.')
   })
 
   it('keeps redacted reasoning with placeholder text', () => {
@@ -37,7 +65,7 @@ describe('toOpenAIMessages reasoning fallback', () => {
       },
     ]
 
-    expect(getAssistantContent(messages)).toBe('<thinking>[redacted]</thinking>Proceeding.')
+    expect(getAssistantContent(messages, { enableReasoningTextReplay: true })).toBe('<thinking>[redacted]</thinking>Proceeding.')
   })
 
   it('retains fallback text when no regular text block exists', () => {
@@ -48,6 +76,61 @@ describe('toOpenAIMessages reasoning fallback', () => {
       },
     ]
 
-    expect(getAssistantContent(messages)).toBe('<thinking>intermediate chain</thinking>')
+    expect(getAssistantContent(messages, { enableReasoningTextReplay: true })).toBe('<thinking>intermediate chain</thinking>')
+  })
+
+  it('bounds replay size with truncation when enabled', () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'abcdefghijklmnopqrstuvwxyz0123456789' },
+          { type: 'text', text: 'Done.' },
+        ],
+      },
+    ]
+
+    const content = getAssistantContent(messages, {
+      enableReasoningTextReplay: true,
+      maxReasoningReplayChars: 32,
+    })
+    expect(content).not.toBeNull()
+    expect(content!).toContain('<thinking>')
+    expect(content!).toContain('[truncated')
+    expect(extractThinkingContent(content).length).toBeLessThanOrEqual(32)
+    expect(content!.endsWith('Done.')).toBe(true)
+  })
+
+  it('omits reasoning-only assistant messages when fallback is disabled', () => {
+    const messages: LLMMessage[] = [
+      {
+        role: 'assistant',
+        content: [{ type: 'reasoning', text: 'intermediate chain' }],
+      },
+    ]
+
+    expect(toOpenAIMessages(messages)).toEqual([])
+  })
+
+  it('clamps explicit invalid max chars to minimum bound', () => {
+    const invalidValues = [0, -3, 0.5, Number.NaN, Number.POSITIVE_INFINITY]
+    const baseMessages: LLMMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: 'abcdef' },
+          { type: 'text', text: 'Done.' },
+        ],
+      },
+    ]
+
+    for (const value of invalidValues) {
+      const content = getAssistantContent(baseMessages, {
+        enableReasoningTextReplay: true,
+        maxReasoningReplayChars: value,
+      })
+      expect(extractThinkingContent(content).length).toBe(1)
+      expect(content!.endsWith('Done.')).toBe(true)
+    }
   })
 })


### PR DESCRIPTION
## What

This PR adds a fallback for OpenAI wire conversion when assistant messages contain `reasoning` blocks in framework IR.

In `toOpenAIAssistantMessage`, `reasoning` blocks are now downgraded to inline `<thinking>...</thinking>` text and prepended to the next assistant text block. If no text block exists, the fallback text is still emitted as assistant content. For redacted reasoning (`redactedData`), the fallback emits `<thinking>[redacted]</thinking>`.

## Why

Cross-provider or non-native reasoning content could previously be dropped silently when converting assistant IR messages for OpenAI-compatible payloads. This keeps reasoning context visible instead of disappearing.

Refs #223

## Checklist

- [ ] `npm run lint` passes
- [x] `npm run test -- tests/openai-common.test.ts tests/openai-fallback.test.ts` passes
- [x] Added/updated tests for changed behavior
- [x] No new runtime dependencies