### PR TITLE
chore: release 1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,6 @@
 
 `open-multi-agent` is a multi-agent orchestration framework for TypeScript backends. Give it a goal; a coordinator agent decomposes it into a task DAG, parallelizes independents, and synthesizes the result. Three runtime dependencies, drops into any Node.js backend.
 
-> **Package update:** the official npm package is now `@open-multi-agent/core`.
-> The previous package, `@jackchen_me/open-multi-agent`, remains supported during the migration window.
-
 > **Your engineers describe the goal, not the graph.**
 
 ## Quick Start
@@ -56,6 +53,8 @@ Requires Node.js >= 18.
 ```bash
 npm install @open-multi-agent/core
 ```
+
+*Migrating from `@jackchen_me/open-multi-agent`? That package is deprecated; install `@open-multi-agent/core` instead.*
 
 ```typescript
 import { OpenMultiAgent, type AgentConfig } from '@open-multi-agent/core'

--- a/README_zh.md
+++ b/README_zh.md
@@ -42,9 +42,6 @@
 
 `open-multi-agent` 是面向 TypeScript 后端的多智能体编排框架。给定一个目标，协调者 agent 会将其拆解为任务 DAG，并行执行独立任务，合成最终结果。仅 3 个运行时依赖，可直接嵌入任意现有 Node.js 后端。
 
-> **包名更新：** 官方 npm 包已迁移到 `@open-multi-agent/core`。
-> 旧包 `@jackchen_me/open-multi-agent` 在迁移窗口内继续支持。
-
 > **工程师只描述目标，不画任务图。**
 
 ## 快速开始
@@ -56,6 +53,8 @@
 ```bash
 npm install @open-multi-agent/core
 ```
+
+*正在从 `@jackchen_me/open-multi-agent` 迁移？该包已弃用，请改用 `@open-multi-agent/core`。*
 
 ```typescript
 import { OpenMultiAgent, type AgentConfig } from '@open-multi-agent/core'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-multi-agent/core",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "TypeScript multi-agent framework — one runTeam() call from goal to result. Auto task decomposition, parallel execution. 3 dependencies, deploys anywhere Node.js runs.",
   "files": [
     "dist",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { configDefaults, defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
@@ -7,8 +7,10 @@ export default defineConfig({
       reporter: ['text', 'html', 'lcov', 'json'],
     },
     exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
+      ...configDefaults.exclude,
+      // Local agent worktrees can contain stale test copies and should never
+      // affect the repository's test result.
+      '**/.claude/**',
       // E2E tests require API keys — run with: npm run test:e2e
       ...(process.env['RUN_E2E'] ? [] : ['tests/e2e/**']),
     ],


### PR DESCRIPTION
Brings the v1.4.1 release into main. The release commit was originally pushed direct to main (per project convention) but blocked by the new branch protection ruleset, so we're walking it through a PR.

**Already shipped:**
- `v1.4.1` tag (pointing to `4d5a42d`)
- `@open-multi-agent/core@1.4.1` on npm registry

**What's in this PR:**
- `chore: release 1.4.1` (4d5a42d): version bump, README deprecation note, migration callout repositioned
- `test: exclude local agent worktrees from vitest` (df41d3f): earlier local commit that hadn't been pushed

After merge, no further action needed; `git tag --points-at v1.4.1` will resolve correctly.
