### PR TITLE
docs(providers): drop Doubao row referencing missing example

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -45,7 +45,6 @@ No bundled shortcut is needed when a server speaks OpenAI Chat Completions. Use 
 | Groq | `provider: 'openai'` + `baseURL: 'https://api.groq.com/openai/v1'` | `GROQ_API_KEY` | `llama-3.3-70b-versatile` | |
 | Mistral | `provider: 'openai'` + `baseURL: 'https://api.mistral.ai/v1'` | `MISTRAL_API_KEY` | `mistral-large-latest` | See [`providers/mistral`](../examples/providers/mistral.ts). |
 | Zhipu GLM | `provider: 'openai'` + `baseURL: 'https://open.bigmodel.cn/api/paas/v4'` | `ZHIPU_API_KEY` | `glm-4-plus` | See [`providers/zhipu`](../examples/providers/zhipu.ts). |
-| Doubao (ByteDance) | `provider: 'openai'` + `baseURL: 'https://ark.cn-beijing.volces.com/api/v3'` | `ARK_API_KEY` | `doubao-pro-32k` | See [`providers/doubao`](../examples/providers/doubao.ts). |
 
 Other services can be connected the same way if they implement the OpenAI Chat Completions API, but they are not listed as verified providers here. For services where the key is not `OPENAI_API_KEY`, pass it explicitly via `apiKey`; otherwise the `openai` adapter falls back to `OPENAI_API_KEY`.
 


### PR DESCRIPTION
## What

Removes the Doubao row from `docs/providers.md` (OpenAI-Compatible Providers table).

## Why

#231 introduced a row pointing to `examples/providers/doubao.ts` and listing `doubao-pro-32k`. Two issues:

1. `examples/providers/doubao.ts` does not exist — it was expected to land via #232, which is still open and has a separate model-ID problem (see review comment on #232).
2. `doubao-pro-32k` was sunset by Volcengine Ark on 2025-05-28 (https://www.volcengine.com/docs/84313/1366813?lang=zh).

Users clicking through from the README currently hit both a 404 on the example link and an invalid model ID. Removing the row restores the docs to a working state.

## Checklist

- [x] `npm run lint` passes
- [x] No source/test changes