### PR TITLE
docs(readme): remove unverifiable ecosystem entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,6 @@ A quick router. Mechanism breakdown follows.
 ### In production
 
 - **[temodar-agent](https://github.com/xeloxa/temodar-agent)** (~60 stars). WordPress security analysis platform by [Ali Sünbül](https://github.com/xeloxa). Uses our built-in tools (`bash`, `file_*`, `grep`) directly inside a Docker runtime. Confirmed production use.
-- **Cybersecurity SOC (home lab).** A private setup running Qwen 2.5 + DeepSeek Coder entirely offline via Ollama, building an autonomous SOC pipeline on Wazuh + Proxmox. Early user, not yet public.
 
 Using `open-multi-agent` in production or a side project? [Open a discussion](https://github.com/open-multi-agent/open-multi-agent/discussions) and we will list it here.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -188,7 +188,6 @@ Shell 和 CI 场景使用 JSON-first 的 `oma` 命令行工具。详见 [docs/cl
 ### 生产环境在用
 
 - **[temodar-agent](https://github.com/xeloxa/temodar-agent)**（约 60 stars）。WordPress 安全分析平台，作者 [Ali Sünbül](https://github.com/xeloxa)。在 Docker runtime 里直接用我们的内置工具（`bash`、`file_*`、`grep`）。已确认生产环境使用。
-- **家用服务器 Cybersecurity SOC。** 本地完全离线跑 Qwen 2.5 + DeepSeek Coder（通过 Ollama），在 Wazuh + Proxmox 上搭自主 SOC 流水线。早期用户，未公开。
 
 如果在生产或 side project 中使用了 `open-multi-agent`，[请开个 Discussion](https://github.com/open-multi-agent/open-multi-agent/discussions)，我们会将其列在这里。
 


### PR DESCRIPTION
## Summary

Drop the "Cybersecurity SOC (home lab)" line from the "In production" section in both README.md and README_zh.md. The entry was a private, non-public-repo mention with no independently verifiable signal. Keeping it sets a precedent that weakens the bar for future ecosystem listings.

The temodar-agent entry (public repo, ~60 stars, confirmed production use) remains.

## Test plan

- [x] Visual check of README.md and README_zh.md "In production" sections