### PR TITLE
feat(llm): add ReasoningBlock.provenance + LLMAdapter.capabilities scaffolding (#223 Phase 1)

### DIFF
--- a/src/llm/ai-sdk.ts
+++ b/src/llm/ai-sdk.ts
@@ -152,7 +152,7 @@ function buildLlmResponseFromGenerateText(result: {
 }): LLMResponse {
   const content: ContentBlock[] = []
   if (result.reasoningText !== undefined && result.reasoningText.length > 0) {
-    content.push({ type: 'reasoning', text: result.reasoningText })
+    content.push({ type: 'reasoning', text: result.reasoningText, provenance: 'ai-sdk' })
   }
   if (result.text.length > 0) {
     content.push({ type: 'text', text: result.text } satisfies TextBlock)
@@ -190,6 +190,16 @@ function buildLlmResponseFromGenerateText(result: {
  */
 export class AISdkAdapter implements LLMAdapter {
   readonly name = 'ai-sdk'
+
+  readonly capabilities = {
+    // Conservative default: the AI SDK proxies many providers and the
+    // adapter cannot introspect at IR-conversion time which underlying
+    // provider would natively accept reasoning input. `'never'` keeps the
+    // outbound path safe (always falls back via Phase 2 helper) without
+    // risking signature-mismatch errors. Phase 2 may refine this if a
+    // per-call provider hint becomes available on the AI SDK surface.
+    echoesReasoning: 'never' as const,
+  }
 
   readonly #model: LanguageModel
 
@@ -321,7 +331,7 @@ export class AISdkAdapter implements LLMAdapter {
       }
 
       const doneContent: ContentBlock[] = []
-      if (fullReasoning.length > 0) doneContent.push({ type: 'reasoning', text: fullReasoning })
+      if (fullReasoning.length > 0) doneContent.push({ type: 'reasoning', text: fullReasoning, provenance: 'ai-sdk' })
       if (fullText.length > 0) doneContent.push({ type: 'text', text: fullText })
       doneContent.push(...toolBlocks)
 

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -195,6 +195,7 @@ function fromAnthropicContentBlock(
         type: 'reasoning',
         text: block.thinking,
         signature: block.signature,
+        provenance: 'anthropic',
       }
       return reasoning
     }
@@ -207,6 +208,7 @@ function fromAnthropicContentBlock(
         type: 'reasoning',
         text: '',
         redactedData: block.data,
+        provenance: 'anthropic',
       }
       return reasoning
     }
@@ -297,6 +299,10 @@ function toAnthropicThinkingParam(
  */
 export class AnthropicAdapter implements LLMAdapter {
   readonly name = 'anthropic'
+
+  readonly capabilities = {
+    echoesReasoning: 'own-issued' as const,
+  }
 
   readonly #client: Anthropic
 

--- a/src/llm/azure-openai.ts
+++ b/src/llm/azure-openai.ts
@@ -91,6 +91,12 @@ function resolveAzureDeploymentName(model: string): string {
 export class AzureOpenAIAdapter implements LLMAdapter {
   readonly name: string = 'azure-openai'
 
+  readonly capabilities = {
+    // Azure OpenAI Chat Completions follows the OpenAI wire contract: no
+    // reasoning input accepted. Falls back via shared helper in Phase 2.
+    echoesReasoning: 'never' as const,
+  }
+
   readonly #client: AzureOpenAI
 
   /**
@@ -147,7 +153,7 @@ export class AzureOpenAIAdapter implements LLMAdapter {
     )
 
     const toolNames = options.tools?.map(t => t.name)
-    return fromOpenAICompletion(completion, toolNames)
+    return fromOpenAICompletion(completion, toolNames, this.name)
   }
 
   // -------------------------------------------------------------------------

--- a/src/llm/bedrock.ts
+++ b/src/llm/bedrock.ts
@@ -189,6 +189,7 @@ function fromBedrockContentBlock(block: BedrockContentBlock): ContentBlock | nul
     const reasoning: ReasoningBlock = {
       type: 'reasoning',
       text: r.reasoningText?.text ?? '',
+      provenance: 'bedrock',
     }
     return reasoning
   }
@@ -214,6 +215,20 @@ function buildInferenceConfig(options: LLMChatOptions): InferenceConfiguration |
  */
 export class BedrockAdapter implements LLMAdapter {
   readonly name = 'bedrock'
+
+  readonly capabilities = {
+    // Held at 'never' until BOTH legs of the round-trip carry Bedrock's
+    // `reasoningContent.reasoningText.signature`:
+    //   1. inbound (toBedrockContentBlock 'reasoning' case): does not
+    //      extract the signature into the IR today, so even after the
+    //      outbound TODO lands there'd be no signature to send back.
+    //   2. outbound (toBedrockContentBlock 'reasoning' case TODO): does
+    //      not write the signature onto the wire format.
+    // Upgrading this field to 'own-issued' requires both follow-ups; doing
+    // only one would still silently break Bedrock's multi-turn extended
+    // thinking protocol.
+    echoesReasoning: 'never' as const,
+  }
 
   readonly #client: BedrockRuntimeClient
 
@@ -339,7 +354,11 @@ export class BedrockAdapter implements LLMAdapter {
           const index = event.contentBlockStop.contentBlockIndex ?? 0
           const reasoningBuf = reasoningBuffers.get(index)
           if (reasoningBuf) {
-            const reasoningBlock: ReasoningBlock = { type: 'reasoning', text: reasoningBuf.text }
+            const reasoningBlock: ReasoningBlock = {
+              type: 'reasoning',
+              text: reasoningBuf.text,
+              provenance: 'bedrock',
+            }
             accumulatedContent.push(reasoningBlock)
             reasoningBuffers.delete(index)
           }
@@ -381,7 +400,7 @@ export class BedrockAdapter implements LLMAdapter {
       // block, flush whatever we buffered so the done payload still matches
       // what chat() would have returned for the same response.
       for (const [, buf] of reasoningBuffers) {
-        accumulatedContent.push({ type: 'reasoning', text: buf.text })
+        accumulatedContent.push({ type: 'reasoning', text: buf.text, provenance: 'bedrock' })
       }
       reasoningBuffers.clear()
 

--- a/src/llm/copilot.ts
+++ b/src/llm/copilot.ts
@@ -228,6 +228,12 @@ export interface CopilotAdapterOptions {
 export class CopilotAdapter implements LLMAdapter {
   readonly name = 'copilot'
 
+  readonly capabilities = {
+    // GitHub Copilot proxies OpenAI Chat Completions; no reasoning input
+    // is accepted. Falls back via shared helper in Phase 2.
+    echoesReasoning: 'never' as const,
+  }
+
   #githubToken: string | null
   #cachedToken: string | null = null
   #tokenExpiresAt = 0
@@ -318,7 +324,7 @@ export class CopilotAdapter implements LLMAdapter {
     )
 
     const toolNames = options.tools?.map(t => t.name)
-    return fromOpenAICompletion(completion, toolNames)
+    return fromOpenAICompletion(completion, toolNames, this.name)
   }
 
   // -------------------------------------------------------------------------

--- a/src/llm/gemini.ts
+++ b/src/llm/gemini.ts
@@ -293,7 +293,11 @@ function fromGeminiPart(part: Part): ContentBlock | null {
   }
   if (part.text !== undefined && part.text !== '') {
     if ((part as { thought?: boolean }).thought === true) {
-      const reasoning: ReasoningBlock = { type: 'reasoning', text: part.text }
+      const reasoning: ReasoningBlock = {
+        type: 'reasoning',
+        text: part.text,
+        provenance: 'gemini',
+      }
       // Gemini 3 may attach thoughtSignature to thought-summary parts too.
       // Preserve it on the framework block so the next turn can echo it
       // back — see toGeminiContents reasoning case for the round-trip.
@@ -361,6 +365,10 @@ function fromGeminiResponse(
  */
 export class GeminiAdapter implements LLMAdapter {
   readonly name = 'gemini'
+
+  readonly capabilities = {
+    echoesReasoning: 'own-issued' as const,
+  }
 
   readonly #client: GoogleGenAI
 

--- a/src/llm/openai-common.ts
+++ b/src/llm/openai-common.ts
@@ -289,10 +289,17 @@ function toOpenAIAssistantMessage(
  *                          that looks like a tool call, the fallback extractor
  *                          uses this list to validate matches. Pass the names
  *                          of tools sent in the request for best results.
+ * @param provenance      - Optional adapter-name string stamped onto any
+ *                          extracted {@link ReasoningBlock}, so downstream
+ *                          outbound paths can distinguish native-echo eligible
+ *                          blocks from foreign ones (see #223). Each
+ *                          OpenAI-family adapter should pass its own
+ *                          {@link LLMAdapter.name}.
  */
 export function fromOpenAICompletion(
   completion: ChatCompletion,
   knownToolNames?: string[],
+  provenance?: string,
 ): LLMResponse {
   const choice = completion.choices?.[0]
   if (choice === undefined) {
@@ -304,7 +311,9 @@ export function fromOpenAICompletion(
 
   const reasoningText = getOpenAIReasoningText(message)
   if (reasoningText.length > 0) {
-    const reasoningBlock: ReasoningBlock = { type: 'reasoning', text: reasoningText }
+    const reasoningBlock: ReasoningBlock = provenance !== undefined
+      ? { type: 'reasoning', text: reasoningText, provenance }
+      : { type: 'reasoning', text: reasoningText }
     content.push(reasoningBlock)
   }
 

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -71,6 +71,13 @@ import { extractToolCallsFromText } from '../tool/text-tool-extractor.js'
 export class OpenAIAdapter implements LLMAdapter {
   readonly name: string = 'openai'
 
+  readonly capabilities = {
+    // OpenAI Chat Completions does not accept `reasoning_content` on input;
+    // any reasoning replay must go through the `<thinking>` text fallback
+    // already shipped in #234 (see openai-common.ts replay options).
+    echoesReasoning: 'never' as const,
+  }
+
   readonly #client: OpenAI
 
   constructor(apiKey?: string, baseURL?: string) {
@@ -123,7 +130,7 @@ export class OpenAIAdapter implements LLMAdapter {
     )
 
     const toolNames = options.tools?.map(t => t.name)
-    return fromOpenAICompletion(completion, toolNames)
+    return fromOpenAICompletion(completion, toolNames, this.name)
   }
 
   // -------------------------------------------------------------------------
@@ -274,7 +281,7 @@ export class OpenAIAdapter implements LLMAdapter {
       // Build the complete content array for the done response.
       const doneContent: ContentBlock[] = []
       if (fullReasoning.length > 0) {
-        doneContent.push({ type: 'reasoning', text: fullReasoning })
+        doneContent.push({ type: 'reasoning', text: fullReasoning, provenance: this.name })
       }
       if (fullText.length > 0) {
         const textBlock: TextBlock = { type: 'text', text: fullText }

--- a/src/llm/reasoning-fallback.ts
+++ b/src/llm/reasoning-fallback.ts
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview Shared `<thinking>` text fallback for {@link ReasoningBlock}
+ * round-tripping across adapter boundaries.
+ *
+ * When an outbound IR-to-native conversion encounters a {@link ReasoningBlock}
+ * that the target adapter cannot natively echo — either because the wire
+ * protocol does not accept reasoning input at all
+ * ({@link LLMAdapter.capabilities.echoesReasoning} `=== 'never'`) or because
+ * the block's {@link ReasoningBlock.provenance} does not match the target
+ * adapter for an `'own-issued'` adapter — this helper converts the block to
+ * an inline `<thinking>...</thinking>` text snippet that callers prepend to
+ * the next outgoing text part.
+ *
+ * SAFETY CONTRACT (one-way invariant):
+ *   The reverse direction — parsing `<thinking>` text back into a
+ *   {@link ReasoningBlock} — must never happen. A reconstructed block would
+ *   carry no verifiable signature and would be rejected if re-sent to
+ *   Anthropic / Bedrock / Gemini 3. `ReasoningBlock` instances are only ever
+ *   produced from native API extraction (and always stamped with
+ *   `provenance`), never from text parsing.
+ *
+ * PHASE 1 STATUS:
+ *   This helper is exported but not yet wired into any adapter outbound
+ *   path. It is introduced ahead of behaviour wiring so the IR additions
+ *   (`ReasoningBlock.provenance`, `LLMAdapter.capabilities`) can land
+ *   independently and be reviewed in isolation. Phase 2 (#223) will:
+ *     - Add `AgentConfig.preserveReasoningAcrossProviders` opt-in.
+ *     - Wire each `echoesReasoning: 'never'` and `'own-issued'` adapter's
+ *       outbound path to call this helper when appropriate.
+ *     - Fold the OpenAI-family private helper added in #234 into this one
+ *       so there is a single source of truth.
+ */
+
+import type { ReasoningBlock } from '../types.js'
+
+/**
+ * Default maximum character budget per `<thinking>` block after truncation.
+ * Aligned with the value used by the OpenAI-family private replay helper
+ * shipped in #234 (`openai-common.ts:31`) so Phase 2 consolidation is
+ * behaviour-preserving.
+ */
+export const DEFAULT_REASONING_FALLBACK_MAX_CHARS = 1200
+
+/** Marker inserted between head and tail when reasoning text is truncated. */
+const TRUNCATION_MARKER = '...[truncated]...'
+
+/** Placeholder emitted in place of opaque encrypted (redacted) reasoning. */
+const REDACTED_PLACEHOLDER = '<thinking>[redacted]</thinking>'
+
+export interface ReasoningFallbackOptions {
+  /**
+   * Hard upper bound on the inner text length (the `<thinking>` wrapper
+   * itself is not counted). Values below 1 are clamped to 1; non-finite
+   * values are treated as 1. When omitted, defaults to
+   * {@link DEFAULT_REASONING_FALLBACK_MAX_CHARS}.
+   */
+  readonly maxChars?: number
+}
+
+function resolveMaxChars(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_REASONING_FALLBACK_MAX_CHARS
+  if (!Number.isFinite(value)) return 1
+  const floored = Math.floor(value)
+  if (floored < 1) return 1
+  return floored
+}
+
+/**
+ * Truncate `text` to at most `maxChars` characters via a head+tail excerpt
+ * with a `...[truncated]...` marker. The head receives ~70% of the budget
+ * so the model sees more of the leading reasoning steps. When `maxChars` is
+ * smaller than the marker itself, falls back to a simple head slice.
+ */
+function truncate(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text
+  if (TRUNCATION_MARKER.length >= maxChars) return text.slice(0, maxChars)
+  const budget = maxChars - TRUNCATION_MARKER.length
+  const head = Math.ceil(budget * 0.7)
+  const tail = budget - head
+  return `${text.slice(0, head)}${TRUNCATION_MARKER}${text.slice(text.length - tail)}`
+}
+
+/**
+ * Convert a {@link ReasoningBlock} into its `<thinking>...</thinking>` text
+ * representation for outbound replay through adapters that cannot natively
+ * echo reasoning.
+ *
+ * Behaviour:
+ *   - `redactedData` non-empty → returns {@link REDACTED_PLACEHOLDER} exactly.
+ *     Plaintext is unavailable so emitting the original `text` (which is
+ *     conventionally empty for redacted blocks) would yield an empty
+ *     `<thinking></thinking>` and confuse the next model; the placeholder
+ *     signals that reasoning occurred without leaking any content.
+ *   - Empty non-redacted text → returns the empty string. Callers should
+ *     skip emitting an assistant-message slot rather than pushing an empty
+ *     payload.
+ *   - Otherwise → returns `<thinking>${truncate(text)}</thinking>`.
+ */
+export function reasoningBlockToInlineText(
+  block: ReasoningBlock,
+  options?: ReasoningFallbackOptions,
+): string {
+  if (typeof block.redactedData === 'string' && block.redactedData.length > 0) {
+    return REDACTED_PLACEHOLDER
+  }
+  if (block.text.length === 0) return ''
+  const max = resolveMaxChars(options?.maxChars)
+  return `<thinking>${truncate(block.text, max)}</thinking>`
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,23 @@ export interface ReasoningBlock {
    * `thinking`).
    */
   readonly redactedData?: string
+  /**
+   * Name of the {@link LLMAdapter} that produced this block, stamped at
+   * extraction time on the native-to-IR path (both `chat` responses and
+   * streaming final payloads). Consumed by outbound IR-to-native conversion
+   * to decide between native echo and the `<thinking>` text fallback for
+   * adapters whose {@link LLMAdapter.capabilities.echoesReasoning} is
+   * `'own-issued'`.
+   *
+   * Typed as `string` rather than `SupportedProvider` so third-party adapter
+   * implementations can stamp their own adapter name without modifying the
+   * core enum.
+   *
+   * Optional for backwards compatibility with externally constructed IR.
+   * Outbound paths treat `undefined` as "unknown provenance → cannot
+   * native-echo".
+   */
+  readonly provenance?: string
 }
 
 /**
@@ -1049,4 +1066,28 @@ export interface LLMAdapter {
    * or `type === 'error'` on failure.
    */
   stream(messages: LLMMessage[], options: LLMStreamOptions): AsyncIterable<StreamEvent>
+
+  /**
+   * Optional declaration of how this adapter handles {@link ReasoningBlock}
+   * round-tripping. Consumed by the cross-provider reasoning fallback layer
+   * (see #223) to decide whether to native-echo an incoming `ReasoningBlock`
+   * or downgrade it to `<thinking>` text on outbound conversion.
+   *
+   * - `'never'`: This adapter's wire protocol does not accept reasoning input
+   *   under any circumstance (e.g. OpenAI Chat Completions). Outbound paths
+   *   must fall back regardless of {@link ReasoningBlock.provenance}.
+   * - `'own-issued'`: Native echo is only ever attempted when
+   *   `block.provenance === this.name`. Provenance match is **necessary
+   *   but not sufficient** — adapters MAY impose additional preconditions
+   *   (e.g. Anthropic requires the original `signature`; Gemini drops
+   *   unsigned thought summaries to keep context lean). Phase 2
+   *   implementers MUST consult the adapter-specific outbound serializer
+   *   for the full eligibility rule, not just the provenance match.
+   *
+   * Omitted on third-party adapters that pre-date this field; callers treat
+   * `undefined` as `'never'` to preserve today's silent-drop behaviour.
+   */
+  readonly capabilities?: {
+    readonly echoesReasoning: 'never' | 'own-issued'
+  }
 }

--- a/tests/anthropic-adapter.test.ts
+++ b/tests/anthropic-adapter.test.ts
@@ -230,6 +230,7 @@ describe('AnthropicAdapter', () => {
       expect(result.content[0]).toEqual({
         type: 'reasoning',
         text: 'hmm...',
+        provenance: 'anthropic',
       })
     })
 
@@ -300,7 +301,7 @@ describe('AnthropicAdapter', () => {
 
       const done = events.find(e => e.type === 'done')
       expect((done!.data as LLMResponse).content).toEqual([
-        { type: 'reasoning', text: 'step 1 -> step 2' },
+        { type: 'reasoning', text: 'step 1 -> step 2', provenance: 'anthropic' },
         { type: 'text', text: 'Answer' },
       ])
     })
@@ -488,6 +489,7 @@ describe('AnthropicAdapter', () => {
         type: 'reasoning',
         text: 'reasoning text',
         signature: 'sig-abc-123',
+        provenance: 'anthropic',
       })
       expect(result.content[1]).toEqual({ type: 'text', text: 'final answer' })
     })
@@ -506,6 +508,7 @@ describe('AnthropicAdapter', () => {
         type: 'reasoning',
         text: '',
         redactedData: 'opaque-encrypted-payload',
+        provenance: 'anthropic',
       })
     })
 
@@ -530,6 +533,7 @@ describe('AnthropicAdapter', () => {
         type: 'reasoning',
         text: 'step 1',
         signature: 'streamed-sig',
+        provenance: 'anthropic',
       })
     })
 

--- a/tests/azure-openai-adapter.test.ts
+++ b/tests/azure-openai-adapter.test.ts
@@ -522,4 +522,34 @@ describe('AzureOpenAIAdapter', () => {
       expect(sent.stream).toBe(false)
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // Phase 1 of #223 — provenance stamping on extracted ReasoningBlocks
+  // ---------------------------------------------------------------------------
+
+  describe('reasoning provenance (#223 Phase 1)', () => {
+    it('stamps provenance: "azure-openai" on extracted ReasoningBlocks in chat()', async () => {
+      createCompletionMock.mockResolvedValue(makeCompletion({
+        choices: [{
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: 'Answer.',
+            reasoning_content: 'plan first',
+            tool_calls: undefined,
+          },
+          finish_reason: 'stop',
+        }],
+      }))
+      const adapter = new AzureOpenAIAdapter('k', 'https://test.openai.azure.com')
+
+      const result = await adapter.chat([textMsg('user', 'Hi')], chatOpts({ model: 'my-deployment' }))
+
+      expect(result.content[0]).toEqual({
+        type: 'reasoning',
+        text: 'plan first',
+        provenance: 'azure-openai',
+      })
+    })
+  })
 })

--- a/tests/bedrock-adapter.test.ts
+++ b/tests/bedrock-adapter.test.ts
@@ -299,7 +299,7 @@ describe('BedrockAdapter', () => {
       const doneEvent = events.find(e => e.type === 'done')
       const response = doneEvent?.data as LLMResponse
       const reasoningBlocks = response.content.filter(b => b.type === 'reasoning')
-      expect(reasoningBlocks).toEqual([{ type: 'reasoning', text: 'first thought' }])
+      expect(reasoningBlocks).toEqual([{ type: 'reasoning', text: 'first thought', provenance: 'bedrock' }])
     })
 
     it('flushes reasoning buffer into done payload even when contentBlockStop is missing', async () => {
@@ -311,7 +311,7 @@ describe('BedrockAdapter', () => {
 
       const events = await collectEvents(adapter.stream([textMsg('user', 'Hi')], chatOpts()))
       const response = events.find(e => e.type === 'done')?.data as LLMResponse
-      expect(response.content).toContainEqual({ type: 'reasoning', text: 'unterminated' })
+      expect(response.content).toContainEqual({ type: 'reasoning', text: 'unterminated', provenance: 'bedrock' })
     })
 
     it('emits done event with final LLMResponse', async () => {
@@ -365,6 +365,34 @@ describe('BedrockAdapter', () => {
 
       const toolEvents = events.filter(e => e.type === 'tool_use')
       expect((toolEvents[0].data as ToolUseBlock).input).toEqual({})
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Phase 1 of #223 — provenance stamping on extracted ReasoningBlocks
+  // ---------------------------------------------------------------------------
+
+  describe('reasoning provenance (#223 Phase 1)', () => {
+    it('stamps provenance: "bedrock" on extracted ReasoningBlocks in chat()', async () => {
+      mockSend.mockResolvedValue(makeConverseResponse({
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              { reasoningContent: { reasoningText: { text: 'plan first' } } },
+              { text: 'Answer.' },
+            ],
+          },
+        },
+      }))
+
+      const result = await adapter.chat([textMsg('user', 'Hi')], chatOpts())
+
+      expect(result.content[0]).toEqual({
+        type: 'reasoning',
+        text: 'plan first',
+        provenance: 'bedrock',
+      })
     })
   })
 })

--- a/tests/copilot-adapter.test.ts
+++ b/tests/copilot-adapter.test.ts
@@ -581,4 +581,35 @@ describe('CopilotAdapter', () => {
       expect(formatCopilotMultiplier(0.33)).toBe('0.33\u00d7 premium request')
     })
   })
+
+  // ---------------------------------------------------------------------------
+  // Phase 1 of #223 \u2014 provenance stamping on extracted ReasoningBlocks
+  // ---------------------------------------------------------------------------
+
+  describe('reasoning provenance (#223 Phase 1)', () => {
+    it('stamps provenance: "copilot" on extracted ReasoningBlocks in chat()', async () => {
+      globalThis.fetch = mockFetchForToken()
+      const adapter = new CopilotAdapter('gh_token')
+      mockCreate.mockResolvedValue(makeCompletion({
+        choices: [{
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: 'Answer.',
+            reasoning_content: 'plan first',
+            tool_calls: undefined,
+          },
+          finish_reason: 'stop',
+        }],
+      }))
+
+      const result = await adapter.chat([textMsg('user', 'Hi')], chatOpts())
+
+      expect(result.content[0]).toEqual({
+        type: 'reasoning',
+        text: 'plan first',
+        provenance: 'copilot',
+      })
+    })
+  })
 })

--- a/tests/deepseek-adapter.test.ts
+++ b/tests/deepseek-adapter.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { chatOpts, textMsg } from './helpers/llm-fixtures.js'
 
 // ---------------------------------------------------------------------------
 // Mock OpenAI constructor (must be hoisted for Vitest)
 // ---------------------------------------------------------------------------
+const createCompletionMock = vi.hoisted(() => vi.fn())
 const OpenAIMock = vi.hoisted(() => vi.fn())
 
 vi.mock('openai', () => ({
@@ -19,6 +21,10 @@ import { createAdapter } from '../src/llm/adapter.js'
 describe('DeepSeekAdapter', () => {
   beforeEach(() => {
     OpenAIMock.mockClear()
+    createCompletionMock.mockClear()
+    OpenAIMock.mockImplementation(() => ({
+      chat: { completions: { create: createCompletionMock } },
+    }))
   })
 
   it('has name "deepseek"', () => {
@@ -70,5 +76,42 @@ describe('DeepSeekAdapter', () => {
   it('createAdapter("deepseek") returns DeepSeekAdapter instance', async () => {
     const adapter = await createAdapter('deepseek')
     expect(adapter).toBeInstanceOf(DeepSeekAdapter)
+  })
+
+  // ---------------------------------------------------------------------------
+  // Phase 1 of #223 — subclass-of-OpenAIAdapter provenance flow
+  // ---------------------------------------------------------------------------
+  //
+  // OpenAIAdapter.chat() calls fromOpenAICompletion(..., this.name). Subclasses
+  // inherit chat() and override `name`, so `this.name` must resolve to the
+  // subclass value at runtime. This test acts as the canary for the inheritance
+  // mechanism — if it stamps 'deepseek' rather than the parent's 'openai', the
+  // same code path validates grok / qiniu / minimax (which all use the same
+  // inherited chat()).
+  it('stamps provenance: "deepseek" (not parent "openai") on extracted ReasoningBlocks', async () => {
+    createCompletionMock.mockResolvedValue({
+      id: 'chatcmpl-ds',
+      model: 'deepseek-reasoner',
+      choices: [{
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: 'Answer.',
+          reasoning_content: 'plan first',
+          tool_calls: undefined,
+        },
+        finish_reason: 'stop',
+      }],
+      usage: { prompt_tokens: 1, completion_tokens: 1 },
+    })
+
+    const adapter = new DeepSeekAdapter('deepseek-key')
+    const result = await adapter.chat([textMsg('user', 'Hi')], chatOpts())
+
+    expect(result.content[0]).toEqual({
+      type: 'reasoning',
+      text: 'plan first',
+      provenance: 'deepseek',
+    })
   })
 })

--- a/tests/gemini-adapter-contract.test.ts
+++ b/tests/gemini-adapter-contract.test.ts
@@ -448,6 +448,7 @@ describe('GeminiAdapter (contract)', () => {
       expect(result.content[0]).toEqual({
         type: 'reasoning',
         text: 'I should look up the weather first.',
+        provenance: 'gemini',
       })
       expect(result.content[1]).toEqual({ type: 'text', text: 'It is sunny.' })
     })
@@ -465,6 +466,16 @@ describe('GeminiAdapter (contract)', () => {
       const reasoningEvents = events.filter(e => e.type === 'reasoning')
       expect(reasoningEvents).toHaveLength(1)
       expect(reasoningEvents[0].data).toBe('planning...')
+
+      // Phase 1 of #223: stream done payload also stamps provenance.
+      const done = events.find(e => e.type === 'done')
+      const doneContent = (done!.data as LLMResponse).content
+      const reasoningBlock = doneContent.find(b => b.type === 'reasoning')
+      expect(reasoningBlock).toEqual({
+        type: 'reasoning',
+        text: 'planning...',
+        provenance: 'gemini',
+      })
     })
 
     it('streaming preserves thoughtSignature on tool_use events', async () => {
@@ -579,6 +590,7 @@ describe('GeminiAdapter (contract)', () => {
         type: 'reasoning',
         text: 'thought summary text',
         signature: 'thought-sig-001',
+        provenance: 'gemini',
       })
     })
 

--- a/tests/llm-adapter-capabilities.test.ts
+++ b/tests/llm-adapter-capabilities.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Phase 1 (#223): assert that every shipped adapter declares both
+ *   - `name` — used as the value stamped onto inbound `ReasoningBlock.provenance`
+ *   - `capabilities.echoesReasoning` — `'never'` or `'own-issued'`
+ *
+ * No outbound behaviour is asserted here; that is Phase 2 territory.
+ *
+ * The AI SDK adapter is exercised in tests/ai-sdk-adapter.test.ts; it requires
+ * the optional `ai` peer dependency at construction time and is therefore
+ * excluded from this contract suite to avoid coupling Phase 1 verification
+ * to peer-dep installation.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@anthropic-ai/sdk', () => {
+  const ctor = vi.fn(() => ({ messages: { create: vi.fn(), stream: vi.fn() } }))
+  return { default: ctor, Anthropic: ctor }
+})
+
+vi.mock('openai', () => {
+  const OpenAICtor: any = vi.fn(() => ({
+    chat: { completions: { create: vi.fn() } },
+  }))
+  OpenAICtor.AzureOpenAI = vi.fn(() => ({
+    chat: { completions: { create: vi.fn() } },
+  }))
+  return { default: OpenAICtor, OpenAI: OpenAICtor, AzureOpenAI: OpenAICtor.AzureOpenAI }
+})
+
+vi.mock('@google/genai', () => {
+  return { GoogleGenAI: vi.fn(() => ({ models: { generateContent: vi.fn() } })) }
+})
+
+vi.mock('@aws-sdk/client-bedrock-runtime', () => {
+  return {
+    BedrockRuntimeClient: vi.fn(() => ({ send: vi.fn() })),
+    ConverseCommand: vi.fn(),
+    ConverseStreamCommand: vi.fn(),
+  }
+})
+
+import { AnthropicAdapter } from '../src/llm/anthropic.js'
+import { OpenAIAdapter } from '../src/llm/openai.js'
+import { AzureOpenAIAdapter } from '../src/llm/azure-openai.js'
+import { CopilotAdapter } from '../src/llm/copilot.js'
+import { DeepSeekAdapter } from '../src/llm/deepseek.js'
+import { GrokAdapter } from '../src/llm/grok.js'
+import { QiniuAdapter } from '../src/llm/qiniu.js'
+import { MiniMaxAdapter } from '../src/llm/minimax.js'
+import { GeminiAdapter } from '../src/llm/gemini.js'
+import { BedrockAdapter } from '../src/llm/bedrock.js'
+
+describe('LLMAdapter Phase 1 capability contract', () => {
+  it.each([
+    ['anthropic', () => new AnthropicAdapter('dummy-key'), 'own-issued' as const],
+    ['gemini', () => new GeminiAdapter('dummy-key'), 'own-issued' as const],
+    ['openai', () => new OpenAIAdapter('dummy-key'), 'never' as const],
+    ['azure-openai', () => new AzureOpenAIAdapter('dummy-key', 'https://example.openai.azure.com'), 'never' as const],
+    ['copilot', () => new CopilotAdapter('dummy-token'), 'never' as const],
+    ['deepseek', () => new DeepSeekAdapter('dummy-key'), 'never' as const],
+    ['grok', () => new GrokAdapter('dummy-key'), 'never' as const],
+    ['qiniu', () => new QiniuAdapter('dummy-key'), 'never' as const],
+    ['minimax', () => new MiniMaxAdapter('dummy-key'), 'never' as const],
+    ['bedrock', () => new BedrockAdapter('us-east-1'), 'never' as const],
+  ])('%s declares the documented name and capabilities', (expectedName, factory, expectedEcho) => {
+    const adapter = factory()
+    expect(adapter.name).toBe(expectedName)
+    expect(adapter.capabilities).toBeDefined()
+    expect(adapter.capabilities?.echoesReasoning).toBe(expectedEcho)
+  })
+
+  it('OpenAI subclasses inherit `capabilities` from OpenAIAdapter', () => {
+    // Sanity check: the subclasses don't redeclare `capabilities` and rely on
+    // inheritance so any future adjustment to the parent's value propagates.
+    const parent = new OpenAIAdapter('dummy-key').capabilities
+    expect(new DeepSeekAdapter('dummy-key').capabilities).toEqual(parent)
+    expect(new GrokAdapter('dummy-key').capabilities).toEqual(parent)
+    expect(new QiniuAdapter('dummy-key').capabilities).toEqual(parent)
+    expect(new MiniMaxAdapter('dummy-key').capabilities).toEqual(parent)
+  })
+})
+
+describe('fromOpenAICompletion provenance stamping (Phase 1, #223)', () => {
+  it('stamps the provided provenance onto extracted ReasoningBlock', async () => {
+    const { fromOpenAICompletion } = await import('../src/llm/openai-common.js')
+
+    const completion: any = {
+      id: 'cmpl_test',
+      model: 'gpt-test',
+      choices: [
+        {
+          finish_reason: 'stop',
+          message: {
+            role: 'assistant',
+            content: 'final answer',
+            reasoning_content: 'plan first',
+            tool_calls: undefined,
+          },
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }
+
+    const result = fromOpenAICompletion(completion, undefined, 'openai')
+    expect(result.content[0]).toEqual({
+      type: 'reasoning',
+      text: 'plan first',
+      provenance: 'openai',
+    })
+
+    const azureResult = fromOpenAICompletion(completion, undefined, 'azure-openai')
+    expect(azureResult.content[0]).toEqual({
+      type: 'reasoning',
+      text: 'plan first',
+      provenance: 'azure-openai',
+    })
+  })
+
+  it('omits provenance when caller passes undefined (backwards compatibility)', async () => {
+    const { fromOpenAICompletion } = await import('../src/llm/openai-common.js')
+
+    const completion: any = {
+      id: 'cmpl_test',
+      model: 'gpt-test',
+      choices: [
+        {
+          finish_reason: 'stop',
+          message: {
+            role: 'assistant',
+            content: null,
+            reasoning_content: 'plan',
+          },
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }
+
+    const result = fromOpenAICompletion(completion)
+    expect(result.content[0]).toEqual({ type: 'reasoning', text: 'plan' })
+  })
+})

--- a/tests/openai-adapter.test.ts
+++ b/tests/openai-adapter.test.ts
@@ -216,7 +216,7 @@ describe('OpenAIAdapter', () => {
       const result = await adapter.chat([textMsg('user', 'Hi')], chatOpts())
 
       expect(result.content).toEqual([
-        { type: 'reasoning', text: 'step 1 -> step 2' },
+        { type: 'reasoning', text: 'step 1 -> step 2', provenance: 'openai' },
         { type: 'text', text: 'Final answer' },
       ])
     })
@@ -307,7 +307,7 @@ describe('OpenAIAdapter', () => {
 
       const done = events.find(e => e.type === 'done')
       expect((done!.data as LLMResponse).content).toEqual([
-        { type: 'reasoning', text: 'first thought then second thought' },
+        { type: 'reasoning', text: 'first thought then second thought', provenance: 'openai' },
         { type: 'text', text: 'Answer' },
       ])
     })

--- a/tests/reasoning-fallback.test.ts
+++ b/tests/reasoning-fallback.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_REASONING_FALLBACK_MAX_CHARS,
+  reasoningBlockToInlineText,
+} from '../src/llm/reasoning-fallback.js'
+import type { ReasoningBlock } from '../src/types.js'
+
+describe('reasoningBlockToInlineText', () => {
+  it('wraps non-empty text in <thinking> tags', () => {
+    const block: ReasoningBlock = { type: 'reasoning', text: 'plan first' }
+    expect(reasoningBlockToInlineText(block)).toBe('<thinking>plan first</thinking>')
+  })
+
+  it('returns empty string for non-redacted blocks with empty text', () => {
+    const block: ReasoningBlock = { type: 'reasoning', text: '' }
+    expect(reasoningBlockToInlineText(block)).toBe('')
+  })
+
+  it('emits the [redacted] placeholder when redactedData is non-empty', () => {
+    const block: ReasoningBlock = {
+      type: 'reasoning',
+      text: '',
+      redactedData: 'opaque-encrypted-blob',
+    }
+    expect(reasoningBlockToInlineText(block)).toBe('<thinking>[redacted]</thinking>')
+  })
+
+  it('prefers the redacted placeholder over text when both are present', () => {
+    // Anthropic should never emit both, but the behaviour must be deterministic
+    // if a future provider does — never leak text alongside a redacted marker.
+    const block: ReasoningBlock = {
+      type: 'reasoning',
+      text: 'some plaintext',
+      redactedData: 'opaque',
+    }
+    expect(reasoningBlockToInlineText(block)).toBe('<thinking>[redacted]</thinking>')
+  })
+
+  it('treats empty redactedData as absent (falls through to text path)', () => {
+    const block: ReasoningBlock = {
+      type: 'reasoning',
+      text: 'visible',
+      redactedData: '',
+    }
+    expect(reasoningBlockToInlineText(block)).toBe('<thinking>visible</thinking>')
+  })
+
+  describe('truncation', () => {
+    it('leaves text under maxChars unchanged', () => {
+      const block: ReasoningBlock = { type: 'reasoning', text: 'short' }
+      const out = reasoningBlockToInlineText(block, { maxChars: 100 })
+      expect(out).toBe('<thinking>short</thinking>')
+    })
+
+    it('produces a head+tail excerpt with marker when over maxChars', () => {
+      const text = 'A'.repeat(60) + 'M'.repeat(60) + 'Z'.repeat(60)
+      const block: ReasoningBlock = { type: 'reasoning', text }
+      const out = reasoningBlockToInlineText(block, { maxChars: 60 })
+
+      expect(out.startsWith('<thinking>')).toBe(true)
+      expect(out.endsWith('</thinking>')).toBe(true)
+      expect(out).toContain('...[truncated]...')
+      // Head should preserve the leading 'A's; tail should preserve the
+      // trailing 'Z's. Middle 'M's get dropped by definition of head+tail.
+      expect(out).toContain('A')
+      expect(out).toContain('Z')
+      expect(out).not.toContain('M')
+
+      // Inner text length (excluding wrapper) is bounded by maxChars.
+      const inner = out.slice('<thinking>'.length, -'</thinking>'.length)
+      expect(inner.length).toBeLessThanOrEqual(60)
+    })
+
+    it('falls back to a head slice when maxChars is smaller than the marker', () => {
+      const text = 'abcdefghij'
+      const block: ReasoningBlock = { type: 'reasoning', text }
+      // Marker is "...[truncated]..." (17 chars); ask for budget below that.
+      const out = reasoningBlockToInlineText(block, { maxChars: 3 })
+      expect(out).toBe('<thinking>abc</thinking>')
+    })
+
+    it('clamps non-finite maxChars to 1', () => {
+      const block: ReasoningBlock = { type: 'reasoning', text: 'abc' }
+      expect(reasoningBlockToInlineText(block, { maxChars: NaN })).toBe('<thinking>a</thinking>')
+      expect(reasoningBlockToInlineText(block, { maxChars: Infinity })).toBe('<thinking>a</thinking>')
+    })
+
+    it('clamps maxChars below 1 to 1', () => {
+      const block: ReasoningBlock = { type: 'reasoning', text: 'abc' }
+      expect(reasoningBlockToInlineText(block, { maxChars: 0 })).toBe('<thinking>a</thinking>')
+      expect(reasoningBlockToInlineText(block, { maxChars: -10 })).toBe('<thinking>a</thinking>')
+    })
+
+    it('uses DEFAULT_REASONING_FALLBACK_MAX_CHARS when maxChars is omitted', () => {
+      const text = 'X'.repeat(DEFAULT_REASONING_FALLBACK_MAX_CHARS + 100)
+      const block: ReasoningBlock = { type: 'reasoning', text }
+      const out = reasoningBlockToInlineText(block)
+      const inner = out.slice('<thinking>'.length, -'</thinking>'.length)
+      expect(inner.length).toBeLessThanOrEqual(DEFAULT_REASONING_FALLBACK_MAX_CHARS)
+    })
+  })
+
+  describe('one-way invariant', () => {
+    it('always emits a string output (no parsing back to ReasoningBlock)', () => {
+      // This test is a documentation marker rather than a behaviour check:
+      // the helper has no inverse, by design. If a future contributor adds
+      // an `inlineTextToReasoningBlock` function, it would violate the
+      // safety contract documented in src/llm/reasoning-fallback.ts.
+      const block: ReasoningBlock = { type: 'reasoning', text: 'x' }
+      const out = reasoningBlockToInlineText(block)
+      expect(typeof out).toBe('string')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Phase 1 of #223 — additive IR and capability declaration with no behaviour change.

Each adapter now stamps the producing provider name on extracted `ReasoningBlock`s and declares whether it can natively echo reasoning, but **no outbound path is modified**. Phase 2 will introduce the opt-in `AgentConfig` flag, wire the shared helper into each adapter's outbound path, and fold the OpenAI-family private helper added in #234 into the shared implementation.

## What changed

**IR (`src/types.ts`)**
- `ReasoningBlock.provenance?: string` — stamped at extraction time on both `chat()` and `stream()` final-payload paths. Typed as `string` (not `SupportedProvider`) so third-party adapters can extend.
- `LLMAdapter.capabilities?: { echoesReasoning: 'never' | 'own-issued' }`. JSDoc explicitly notes that for `'own-issued'`, provenance match is necessary but not sufficient — adapters MAY impose additional preconditions (e.g. Anthropic signature presence, Gemini unsigned-drop).

**Shared helper (`src/llm/reasoning-fallback.ts`)**
- `reasoningBlockToInlineText(block, options)` — exported but not wired into any adapter outbound path on this PR. Defaults align with the OpenAI-family private replay helper shipped in #234 so Phase 2 can fold it in without behaviour drift.

**Per-adapter values**

| Adapter | `echoesReasoning` |
|---|---|
| anthropic, gemini | `'own-issued'` |
| bedrock | `'never'` (held until BOTH legs of the round-trip carry the Bedrock signature — currently neither inbound extraction nor outbound serialization handle it) |
| openai, azure-openai, copilot, grok, deepseek, qiniu, minimax | `'never'` (Chat Completions does not accept reasoning input) |
| ai-sdk | `'never'` (conservative default; AI SDK proxies many providers and cannot introspect target reasoning support at IR conversion time) |

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — 836 / 841 passing. The 5 failures in `tests/ai-sdk-adapter.test.ts` are pre-existing peer-dep resolution issues that exist on `main` independent of this PR (verified by `git stash && npm test`).
- [x] New `tests/reasoning-fallback.test.ts` (12 tests) — wrapping, redacted placeholder, truncation head+tail with marker, NaN/Infinity/negative `maxChars` clamping, default constant, redacted vs text precedence, one-way invariant marker.
- [x] New `tests/llm-adapter-capabilities.test.ts` (13 tests) — per-adapter `name` + `capabilities.echoesReasoning` contract, OpenAI subclass `capabilities` inheritance, `fromOpenAICompletion` provenance stamping (both stamped and undefined-provenance backwards-compat paths).
- [x] Existing per-adapter assertions updated to include `provenance: '<adapter-name>'` on extracted `ReasoningBlock`s (anthropic, gemini, openai, bedrock).
- [x] Added end-to-end provenance assertions for surfaces that lacked them: Azure-OpenAI chat, Copilot chat, Bedrock chat, Gemini stream done-payload, DeepSeek chat (canary for the OpenAI-subclass `this.name` inheritance mechanism).
- [x] No outbound IR-to-native conversion logic modified or asserted.

Refs #223
