### PR TITLE
feat(orchestrator): optional revealCoordinator to inject team context into worker prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ Preview the coordinator's task DAG without executing agents:
 const plan = await orchestrator.runTeam(team, goal, { planOnly: true })
 ```
 
+Inject team context (goal, roster, this worker's role) into every worker prompt. Helps workers stay aligned with the overall goal and makes multi-step runs easier to debug. Off by default; worker prompts stay byte-identical when omitted.
+
+```ts
+const result = await orchestrator.runTeam(team, goal, { revealCoordinator: true })
+```
+
 For MapReduce-style fan-out without task dependencies, use `AgentPool.runParallel()` directly. See [`patterns/fan-out-aggregate`](examples/patterns/fan-out-aggregate.ts).
 
 For shell and CI, use the JSON-first `oma` binary. See [docs/cli.md](./docs/cli.md).

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -401,6 +401,15 @@ function parseTaskSpecs(raw: string): ParsedTaskSpec[] | null {
 // ---------------------------------------------------------------------------
 
 /**
+ * Team-level context optionally injected into every worker prompt when
+ * `RunTeamOptions.revealCoordinator` is true.
+ */
+interface RevealCoordinatorContext {
+  readonly goal: string
+  readonly rosterNames: readonly string[]
+}
+
+/**
  * Internal execution context assembled once per `runTeam` / `runTasks` call.
  */
 interface RunContext {
@@ -418,6 +427,11 @@ interface RunContext {
   budgetExceededTriggered: boolean
   budgetExceededReason?: string
   readonly taskMetrics: Map<string, TaskExecutionMetrics>
+  /**
+   * Present only when `runTeam` is called with `{ revealCoordinator: true }`.
+   * `runTasks` omits this entirely (no goal concept).
+   */
+  readonly revealCoordinatorContext?: RevealCoordinatorContext
 }
 
 /**
@@ -601,7 +615,7 @@ async function executeQueue(
       } satisfies OrchestratorEvent)
 
       // Build the prompt: task description + dependency-only context by default.
-      const prompt = await buildTaskPrompt(task, team, queue)
+      const prompt = await buildTaskPrompt(task, team, queue, ctx.revealCoordinatorContext)
 
       // Trace + abort + team tool context (delegate_to_agent)
       const traceBase: Partial<RunOptions> = {
@@ -779,17 +793,41 @@ async function executeQueue(
  * Build the agent prompt for a specific task.
  *
  * Injects:
+ *  - Optional team-context block at the top when `revealContext` is provided
+ *    (set via `RunTeamOptions.revealCoordinator`)
  *  - Task title and description
  *  - Direct dependency task results by default (clean slate when none)
  *  - Optional full shared-memory context when `task.memoryScope === 'all'`
  *  - Any messages addressed to this agent from the team bus
  */
-async function buildTaskPrompt(task: Task, team: Team, queue: TaskQueue): Promise<string> {
-  const lines: string[] = [
+async function buildTaskPrompt(
+  task: Task,
+  team: Team,
+  queue: TaskQueue,
+  revealContext?: RevealCoordinatorContext,
+): Promise<string> {
+  const lines: string[] = []
+
+  // `task.assignee` is belt-and-suspenders: `executeQueue` already fails any
+  // task without an assignee before reaching this function (see the assignee
+  // check in the dispatch loop). The guard here documents the precondition and
+  // protects against future refactors that move the call site.
+  if (revealContext && task.assignee) {
+    lines.push(
+      '## Team context',
+      `Goal: ${revealContext.goal}`,
+      `Team: ${revealContext.rosterNames.join(', ')}`,
+      `Your role in this team: ${task.assignee}`,
+      'Coordinator: selected you for this task based on the description below.',
+      '',
+    )
+  }
+
+  lines.push(
     `# Task: ${task.title}`,
     '',
     task.description,
-  ]
+  )
 
   if (task.memoryScope === 'all') {
     // Explicit opt-in for full visibility (legacy/shared-memory behavior).
@@ -1202,6 +1240,14 @@ export class OpenMultiAgent {
       budgetExceededTriggered: false,
       budgetExceededReason: undefined,
       taskMetrics,
+      ...(options?.revealCoordinator
+        ? {
+            revealCoordinatorContext: {
+              goal,
+              rosterNames: agentConfigs.map((a) => a.name),
+            },
+          }
+        : {}),
     }
 
     const planTasks = queue.list()

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -409,6 +409,30 @@ interface RevealCoordinatorContext {
   readonly rosterNames: readonly string[]
 }
 
+function buildRevealCoordinatorLines(
+  revealContext: RevealCoordinatorContext,
+  assignee: string,
+): string[] {
+  return [
+    '## Team context',
+    `Goal: ${revealContext.goal}`,
+    `Team: ${revealContext.rosterNames.join(', ')}`,
+    `Your role in this team: ${assignee}`,
+    'Assignment: You are responsible for the prompt below in this team run.',
+    '',
+  ]
+}
+
+function prependRevealCoordinatorContext(
+  prompt: string,
+  revealContext: RevealCoordinatorContext | undefined,
+  assignee: string,
+): string {
+  return revealContext
+    ? [...buildRevealCoordinatorLines(revealContext, assignee), prompt].join('\n')
+    : prompt
+}
+
 /**
  * Internal execution context assembled once per `runTeam` / `runTasks` call.
  */
@@ -504,7 +528,11 @@ function buildTaskAgentTeamInfo(
       taskId,
       team: nestedTeam,
     }
-    return pool.runEphemeral(tempAgent, prompt, childOpts)
+    return pool.runEphemeral(
+      tempAgent,
+      prependRevealCoordinatorContext(prompt, ctx.revealCoordinatorContext, targetAgent),
+      childOpts,
+    )
   }
 
   return {
@@ -813,14 +841,7 @@ async function buildTaskPrompt(
   // check in the dispatch loop). The guard here documents the precondition and
   // protects against future refactors that move the call site.
   if (revealContext && task.assignee) {
-    lines.push(
-      '## Team context',
-      `Goal: ${revealContext.goal}`,
-      `Team: ${revealContext.rosterNames.join(', ')}`,
-      `Your role in this team: ${task.assignee}`,
-      'Coordinator: selected you for this task based on the description below.',
-      '',
-    )
+    lines.push(...buildRevealCoordinatorLines(revealContext, task.assignee))
   }
 
   lines.push(

--- a/src/types.ts
+++ b/src/types.ts
@@ -642,6 +642,18 @@ export interface RunTeamOptions {
    * the rejection wins: result is `success: false` and `planOnly` is undefined.
    */
   readonly planOnly?: boolean
+  /**
+   * When true, prepends a team-context block (original goal, full roster, and
+   * this worker's assignee identity) to every worker prompt under `runTeam`.
+   * Helps workers stay aligned with the overall goal and makes multi-step runs
+   * easier to debug.
+   *
+   * Default: `false` — worker prompts are byte-identical to today.
+   *
+   * Scope: `runTeam` only. `runTasks` (no goal concept) and the short-circuit
+   * single-agent path (no coordinator) ignore this option.
+   */
+  readonly revealCoordinator?: boolean
 }
 
 /** Aggregated result for a full team run. */

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -38,6 +38,39 @@ function createMockAdapter(responses: string[]): LLMAdapter {
   }
 }
 
+function textResponse(text: string): LLMResponse {
+  return {
+    id: `resp-${text.slice(0, 8)}`,
+    content: [{ type: 'text', text }],
+    model: 'mock-model',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 10, output_tokens: 20 },
+  }
+}
+
+function toolUseResponse(toolName: string, input: Record<string, unknown>): LLMResponse {
+  return {
+    id: `resp-tool-${toolName}`,
+    content: [{
+      type: 'tool_use',
+      id: `tool-${toolName}`,
+      name: toolName,
+      input,
+    }],
+    model: 'mock-model',
+    stop_reason: 'tool_use',
+    usage: { input_tokens: 10, output_tokens: 20 },
+  }
+}
+
+function extractUserPrompt(messages: LLMMessage[]): string {
+  const lastUser = [...messages].reverse().find((m) => m.role === 'user')
+  return (lastUser?.content ?? [])
+    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+    .map((b) => b.text)
+    .join('\n')
+}
+
 /**
  * Mock the createAdapter factory to return our mock adapter.
  * We need to do this at the module level because Agent calls createAdapter internally.
@@ -567,7 +600,8 @@ describe('OpenMultiAgent', () => {
       expect(workerPrompt).toContain(`Goal: ${goal}`)
       expect(workerPrompt).toContain('Team: worker-a, worker-b')
       expect(workerPrompt).toContain('Your role in this team: worker-a')
-      expect(workerPrompt).toContain('Coordinator: selected you')
+      expect(workerPrompt).toContain('Assignment: You are responsible')
+      expect(workerPrompt).not.toContain('Coordinator: selected you')
       // Defensive: the original task block must still be present after the context block.
       expect(workerPrompt).toContain('# Task: Research')
 
@@ -576,6 +610,71 @@ describe('OpenMultiAgent', () => {
       // a future refactor that changes that to break this test.
       expect(capturedPrompts[0]).not.toContain('## Team context')
       expect(capturedPrompts[2]).not.toContain('## Team context')
+    })
+
+    it('injects team-context block into delegated worker prompts when revealCoordinator is true', async () => {
+      const goal = 'First coordinate worker-a, then have worker-a delegate details to worker-b'
+      const delegatedPrompts: string[] = []
+      let coordinatorCalls = 0
+      let workerACalls = 0
+
+      const coordinatorAdapter: LLMAdapter = {
+        name: 'coordinator-mock',
+        async chat(): Promise<LLMResponse> {
+          coordinatorCalls++
+          return coordinatorCalls === 1
+            ? textResponse('```json\n[{"title": "Delegate detail", "description": "Ask worker-b for details", "assignee": "worker-a"}]\n```')
+            : textResponse('final synthesis')
+        },
+        async *stream() { yield { type: 'done' as const, data: {} } },
+      }
+      const workerAAdapter: LLMAdapter = {
+        name: 'worker-a-mock',
+        async chat(): Promise<LLMResponse> {
+          workerACalls++
+          return workerACalls === 1
+            ? toolUseResponse('delegate_to_agent', {
+                target_agent: 'worker-b',
+                prompt: 'Inspect delegated detail',
+              })
+            : textResponse('worker-a done')
+        },
+        async *stream() { yield { type: 'done' as const, data: {} } },
+      }
+      const workerBAdapter: LLMAdapter = {
+        name: 'worker-b-mock',
+        async chat(messages: LLMMessage[]): Promise<LLMResponse> {
+          delegatedPrompts.push(extractUserPrompt(messages))
+          return textResponse('worker-b delegated done')
+        },
+        async *stream() { yield { type: 'done' as const, data: {} } },
+      }
+
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model', maxConcurrency: 3 })
+      const team = oma.createTeam('t', teamCfg([
+        {
+          ...agentConfig('worker-a'),
+          adapter: workerAAdapter,
+          tools: ['delegate_to_agent'],
+          maxTurns: 3,
+        },
+        { ...agentConfig('worker-b'), adapter: workerBAdapter },
+      ]))
+
+      await oma.runTeam(team, goal, {
+        coordinator: { adapter: coordinatorAdapter },
+        revealCoordinator: true,
+      })
+
+      expect(delegatedPrompts).toHaveLength(1)
+      const delegatedPrompt = delegatedPrompts[0] ?? ''
+      expect(delegatedPrompt).toContain('## Team context')
+      expect(delegatedPrompt).toContain(`Goal: ${goal}`)
+      expect(delegatedPrompt).toContain('Team: worker-a, worker-b')
+      expect(delegatedPrompt).toContain('Your role in this team: worker-b')
+      expect(delegatedPrompt).toContain('Assignment: You are responsible')
+      expect(delegatedPrompt).toContain('Inspect delegated detail')
+      expect(delegatedPrompt).not.toContain('Coordinator: selected you')
     })
   })
 

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -527,6 +527,56 @@ describe('OpenMultiAgent', () => {
       expect(coordinatorToolNames).toContain('file_read')
       expect(coordinatorToolNames).not.toContain('bash')
     })
+
+    it('omits team-context block by default (revealCoordinator unset)', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title": "Research", "description": "Research the topic", "assignee": "worker-a"}]\n```',
+        'worker output',
+        'final synthesis',
+      ]
+
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg())
+
+      await oma.runTeam(team, 'First research the topic, then synthesize findings')
+
+      // None of the captured prompts (coordinator decompose, worker run, coordinator synthesis)
+      // should contain the team-context header when the option is unset.
+      for (const prompt of capturedPrompts) {
+        expect(prompt).not.toContain('## Team context')
+      }
+    })
+
+    it('injects team-context block when revealCoordinator is true', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title": "Research", "description": "Research the topic", "assignee": "worker-a"}]\n```',
+        'worker output',
+        'final synthesis',
+      ]
+
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg())
+
+      const goal = 'First research the topic, then synthesize findings'
+      await oma.runTeam(team, goal, { revealCoordinator: true })
+
+      // The worker prompt (second captured prompt) should contain the full context block.
+      // capturedPrompts[0] = coordinator decomposition, [1] = worker run, [2] = coordinator synthesis.
+      const workerPrompt = capturedPrompts[1] ?? ''
+      expect(workerPrompt).toContain('## Team context')
+      expect(workerPrompt).toContain(`Goal: ${goal}`)
+      expect(workerPrompt).toContain('Team: worker-a, worker-b')
+      expect(workerPrompt).toContain('Your role in this team: worker-a')
+      expect(workerPrompt).toContain('Coordinator: selected you')
+      // Defensive: the original task block must still be present after the context block.
+      expect(workerPrompt).toContain('# Task: Research')
+
+      // Defensive: coordinator's own prompts (decompose + synthesis) must NOT carry the
+      // team-context block — they don't go through buildTaskPrompt today, and we want
+      // a future refactor that changes that to break this test.
+      expect(capturedPrompts[0]).not.toContain('## Team context')
+      expect(capturedPrompts[2]).not.toContain('## Team context')
+    })
   })
 
   describe('config defaults', () => {


### PR DESCRIPTION
Implements #244.

Adds opt-in `RunTeamOptions.revealCoordinator`. When `true`, `buildTaskPrompt` prepends a team-context block (goal, full roster, this worker's assignee identity) to every worker prompt under `runTeam`. Default keeps existing prompts byte-identical.

Scope is `runTeam` only. `runTasks` (no goal) and the short-circuit path (no coordinator) ignore it.

## Prior art

[Fukui 2026 (arXiv:2605.13851)](https://arxiv.org/abs/2605.13851): preregistered 3×2 study on visible vs invisible orchestrator structures in multi-agent LLMs. OMA's default worker prompt is closest to the invisible-orchestrator condition. This PR makes that visibility user-controlled rather than reproducing the paper.

## Tests

- 2 new tests: default omits the block; `revealCoordinator: true` injects goal + roster + assignee, with defensive assertions on `# Task:` retention and coordinator prompt non-pollution
- 35 existing orchestrator tests unchanged (proves byte-identical default)
- `npm test`: 843/843

Closes #244