### PR TITLE
chore: release 1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-multi-agent/core",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "TypeScript multi-agent framework — one runTeam() call from goal to result. Auto task decomposition, parallel execution. 3 dependencies, deploys anywhere Node.js runs.",
   "files": [
     "dist",


### PR DESCRIPTION
Cuts the v1.4.2 release. Patch covering three opt-in additions (#245, #234, #243), three new examples/cookbook (#232, #231, #235), and docs cleanup (#233).

Full release notes will go in the GitHub Release body after tag push. Walking through PR per #238 precedent (branch protection on main).