### PR TITLE
docs(examples): add Bilig WorkPaper MCP integration

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 Runnable scripts demonstrating `open-multi-agent`. Organized by category — pick one that matches what you're trying to do.
 
-All scripts run with `npx tsx examples/<category>/<name>.ts` and require the corresponding API key in your environment.
+All scripts run with `npx tsx examples/<category>/<name>.ts`. Scripts that call a model require the corresponding API key in your environment.
 
 ---
 
@@ -71,6 +71,7 @@ Hooking the framework up to outside-the-box tooling.
 |---------|-----------------|
 | [`integrations/trace-observability`](integrations/trace-observability.ts) | `onTrace` spans for LLM calls, tools, and tasks. |
 | [`integrations/mcp-github`](integrations/mcp-github.ts) | An MCP server's tools exposed to an agent via `connectMCPTools()`. |
+| [`integrations/mcp-bilig-workpaper`](integrations/mcp-bilig-workpaper.ts) | Bilig WorkPaper MCP tools for formula readback, recalculation, and persisted workbook JSON. |
 | [`integrations/with-vercel-ai-sdk/`](integrations/with-vercel-ai-sdk/) | Next.js app — OMA `runTeam()` + AI SDK `useChat` streaming. |
 | [`integrations/express-customer-support/`](integrations/express-customer-support/) | Express REST API — `runTasks()` behind POST /tickets with per-agent Zod output schemas, mix-and-match provider env vars, and HTTP error mapping (400/502/504). |
 

--- a/examples/integrations/mcp-bilig-workpaper.ts
+++ b/examples/integrations/mcp-bilig-workpaper.ts
@@ -1,39 +1,32 @@
 /**
  * MCP Bilig WorkPaper Tools
  *
- * Connect Bilig's file-backed WorkPaper MCP server over stdio, register its
- * tools with open-multi-agent, and run a no-key proof of spreadsheet formula
- * readback and JSON persistence.
+ * Connect Bilig's file-backed WorkPaper MCP server over stdio and give an
+ * open-multi-agent Agent the workbook tools for formula readback.
  *
  * Run:
  *   npx tsx examples/integrations/mcp-bilig-workpaper.ts
  *
  * Prerequisites:
+ *   - GEMINI_API_KEY or GOOGLE_API_KEY
  *   - @modelcontextprotocol/sdk installed
- *   - npm can execute @bilig/workpaper from the public registry
+ *   - npm can execute @bilig/workpaper@0.96.0 from the public registry
  */
 
 import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { ToolExecutor, ToolRegistry } from '../../src/index.js'
-import type { ToolResult, ToolUseContext } from '../../src/index.js'
+import { Agent, ToolExecutor, ToolRegistry, registerBuiltInTools } from '../../src/index.js'
 import { connectMCPTools } from '../../src/mcp.js'
 
-type JsonRecord = Record<string, unknown>
+if (!process.env.GEMINI_API_KEY?.trim() && !process.env.GOOGLE_API_KEY?.trim()) {
+  console.error('Missing GEMINI_API_KEY or GOOGLE_API_KEY: set a Gemini API key in the environment.')
+  process.exit(1)
+}
 
-const biligPackage = process.env.BILIG_WORKPAPER_PACKAGE ?? '@bilig/workpaper@latest'
+const biligPackage = '@bilig/workpaper@0.96.0'
 const workDir = await mkdtemp(join(tmpdir(), 'oma-bilig-workpaper-'))
 const workpaperPath = join(workDir, 'pricing.workpaper.json')
-
-const context: ToolUseContext = {
-  agent: {
-    name: 'bilig-workpaper-proof',
-    role: 'integration-example',
-    model: 'direct-tool-execution',
-  },
-  cwd: workDir,
-}
 
 const { tools, disconnect } = await connectMCPTools({
   command: 'npm',
@@ -54,216 +47,38 @@ const { tools, disconnect } = await connectMCPTools({
 })
 
 const registry = new ToolRegistry()
+registerBuiltInTools(registry)
 for (const tool of tools) registry.register(tool)
 const executor = new ToolExecutor(registry)
-let initialDisconnected = false
+
+const agent = new Agent(
+  {
+    name: 'bilig-workpaper-agent',
+    model: process.env.AGENT_MODEL ?? 'gemini-2.5-flash',
+    provider: 'gemini',
+    maxTurns: 8,
+    parallelToolCalls: false,
+    tools: tools.map((tool) => tool.name),
+    systemPrompt: [
+      'Use Bilig WorkPaper MCP tools to inspect and edit formula workbooks.',
+      'Always verify a write by reading the recalculated output cell afterward.',
+      'Keep the final answer short and include the before and after values.',
+    ].join(' '),
+  },
+  registry,
+  executor,
+)
 
 try {
-  const expectedTools = [
-    'list_sheets',
-    'read_range',
-    'read_cell',
-    'set_cell_contents',
-    'get_cell_display_value',
-    'export_workpaper_document',
-    'validate_formula',
-  ]
-  const registered = tools.map((tool) => tool.name).sort()
-
-  for (const tool of expectedTools) {
-    const name = `bilig_${tool}`
-    if (!registry.has(name)) {
-      throw new Error(`Expected MCP tool ${name}; got ${registered.join(', ')}`)
-    }
-  }
-
-  const sheets = await executeJson('bilig_list_sheets', {})
-  const before = await executeJson('bilig_read_cell', {
-    sheetName: 'Summary',
-    address: 'B3',
-  })
-  const validation = await executeJson('bilig_validate_formula', {
-    formula: '=SUM(1,2)',
-  })
-  const write = await executeJson('bilig_set_cell_contents', {
-    sheetName: 'Inputs',
-    address: 'B3',
-    value: 0.4,
-  })
-  const after = await executeJson('bilig_read_cell', {
-    sheetName: 'Summary',
-    address: 'B3',
-  })
-  const display = await executeJson('bilig_get_cell_display_value', {
-    sheetName: 'Summary',
-    address: 'B3',
-  })
-  const exported = await executeJson('bilig_export_workpaper_document', {
-    includeConfig: true,
-  })
-
-  const formulaOutputBefore = readCellNumber(before)
-  const formulaOutputAfter = readCellNumber(after)
-
-  assertEqual(formulaOutputBefore, 60_000, 'baseline Summary!B3')
-  assertEqual(formulaOutputAfter, 96_000, 'recalculated Summary!B3')
-  assertEqual(readString(display, 'displayValue'), '96000', 'display value')
-  assertEqual(readBoolean(validation, 'valid'), true, 'formula validation')
-  assertEqual(readNestedBoolean(write, ['checks', 'persisted']), true, 'persisted write')
-  assertEqual(readNestedBoolean(write, ['checks', 'restoredMatchesAfter']), true, 'restored readback')
-
-  if (readNumber(exported, 'serializedBytes') <= 0) {
-    throw new Error('Expected exported WorkPaper JSON bytes to be greater than zero')
-  }
-
-  await disconnectInitial()
-
-  const restarted = await connectMCPTools({
-    command: 'npm',
-    args: [
-      'exec',
-      '--yes',
-      '--package',
-      biligPackage,
-      '--',
-      'bilig-workpaper-mcp',
-      '--workpaper',
-      workpaperPath,
-    ],
-    namePrefix: 'bilig',
-    requestTimeoutMs: 60_000,
-  })
-
-  try {
-    const readCell = restarted.tools.find((tool) => tool.name === 'bilig_read_cell')
-    if (readCell === undefined) {
-      throw new Error('Expected bilig_read_cell after reconnect')
-    }
-    const restored = parseJsonResult(
-      await readCell.execute(
-        {
-          sheetName: 'Summary',
-          address: 'B3',
-        },
-        context,
-      ),
-      'bilig_read_cell after reconnect',
-    )
-
-    assertEqual(readCellNumber(restored), 96_000, 'persisted Summary!B3')
-  } finally {
-    await restarted.disconnect()
-  }
-
-  console.log(JSON.stringify(
-    {
-      ok: true,
-      package: biligPackage,
-      workpaperPath,
-      registeredTools: registered,
-      sheetCount: Array.isArray(sheets.sheets) ? sheets.sheets.length : undefined,
-      formulaOutputBefore,
-      formulaOutputAfter,
-      displayValue: display.displayValue,
-      persisted: readNestedBoolean(write, ['checks', 'persisted']),
-      exportedBytes: exported.serializedBytes,
-    },
-    null,
-    2,
-  ))
-} finally {
-  await disconnectInitial().catch(() => undefined)
-}
-
-async function disconnectInitial(): Promise<void> {
-  if (initialDisconnected) {
-    return
-  }
-  initialDisconnected = true
-  await disconnect()
-}
-
-async function executeJson(toolName: string, input: JsonRecord): Promise<JsonRecord> {
-  return parseJsonResult(
-    await executor.execute(toolName, input, context),
-    toolName,
+  const result = await agent.run(
+    [
+      'Use the Bilig MCP tools on the demo pricing workbook.',
+      'List sheets, read Summary!B3, set Inputs!B3 to 0.4, then read Summary!B3 again.',
+      'Report whether the workbook recalculated and persisted the edit.',
+    ].join(' '),
   )
-}
 
-function parseJsonResult(result: ToolResult, label: string): JsonRecord {
-  if (result.isError === true) {
-    throw new Error(`${label} failed: ${result.data}`)
-  }
-
-  try {
-    const parsed: unknown = JSON.parse(result.data)
-    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as JsonRecord
-    }
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error)
-    throw new Error(`${label} returned non-JSON output: ${detail}\n${result.data}`)
-  }
-
-  throw new Error(`${label} returned JSON that was not an object`)
-}
-
-function readNumber(record: JsonRecord, key: string): number {
-  const value = record[key]
-  if (typeof value !== 'number') {
-    throw new Error(`Expected ${key} to be a number; got ${JSON.stringify(value)}`)
-  }
-  return value
-}
-
-function readCellNumber(record: JsonRecord): number {
-  const value = record.value
-  if (typeof value === 'number') {
-    return value
-  }
-  if (
-    value !== null &&
-    typeof value === 'object' &&
-    !Array.isArray(value) &&
-    typeof (value as JsonRecord).value === 'number'
-  ) {
-    return (value as JsonRecord).value as number
-  }
-  throw new Error(`Expected cell value to be numeric; got ${JSON.stringify(value)}`)
-}
-
-function readString(record: JsonRecord, key: string): string {
-  const value = record[key]
-  if (typeof value !== 'string') {
-    throw new Error(`Expected ${key} to be a string; got ${JSON.stringify(value)}`)
-  }
-  return value
-}
-
-function readBoolean(record: JsonRecord, key: string): boolean {
-  const value = record[key]
-  if (typeof value !== 'boolean') {
-    throw new Error(`Expected ${key} to be a boolean; got ${JSON.stringify(value)}`)
-  }
-  return value
-}
-
-function readNestedBoolean(record: JsonRecord, path: string[]): boolean {
-  let value: unknown = record
-  for (const key of path) {
-    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-      throw new Error(`Expected ${path.join('.')} to exist`)
-    }
-    value = (value as JsonRecord)[key]
-  }
-  if (typeof value !== 'boolean') {
-    throw new Error(`Expected ${path.join('.')} to be a boolean; got ${JSON.stringify(value)}`)
-  }
-  return value
-}
-
-function assertEqual<T>(actual: T, expected: T, label: string): void {
-  if (actual !== expected) {
-    throw new Error(`${label}: expected ${String(expected)}, got ${String(actual)}`)
-  }
+  console.log(result.output)
+} finally {
+  await disconnect()
 }

--- a/examples/integrations/mcp-bilig-workpaper.ts
+++ b/examples/integrations/mcp-bilig-workpaper.ts
@@ -1,0 +1,269 @@
+/**
+ * MCP Bilig WorkPaper Tools
+ *
+ * Connect Bilig's file-backed WorkPaper MCP server over stdio, register its
+ * tools with open-multi-agent, and run a no-key proof of spreadsheet formula
+ * readback and JSON persistence.
+ *
+ * Run:
+ *   npx tsx examples/integrations/mcp-bilig-workpaper.ts
+ *
+ * Prerequisites:
+ *   - @modelcontextprotocol/sdk installed
+ *   - npm can execute @bilig/workpaper from the public registry
+ */
+
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ToolExecutor, ToolRegistry } from '../../src/index.js'
+import type { ToolResult, ToolUseContext } from '../../src/index.js'
+import { connectMCPTools } from '../../src/mcp.js'
+
+type JsonRecord = Record<string, unknown>
+
+const biligPackage = process.env.BILIG_WORKPAPER_PACKAGE ?? '@bilig/workpaper@latest'
+const workDir = await mkdtemp(join(tmpdir(), 'oma-bilig-workpaper-'))
+const workpaperPath = join(workDir, 'pricing.workpaper.json')
+
+const context: ToolUseContext = {
+  agent: {
+    name: 'bilig-workpaper-proof',
+    role: 'integration-example',
+    model: 'direct-tool-execution',
+  },
+  cwd: workDir,
+}
+
+const { tools, disconnect } = await connectMCPTools({
+  command: 'npm',
+  args: [
+    'exec',
+    '--yes',
+    '--package',
+    biligPackage,
+    '--',
+    'bilig-workpaper-mcp',
+    '--workpaper',
+    workpaperPath,
+    '--init-demo-workpaper',
+    '--writable',
+  ],
+  namePrefix: 'bilig',
+  requestTimeoutMs: 60_000,
+})
+
+const registry = new ToolRegistry()
+for (const tool of tools) registry.register(tool)
+const executor = new ToolExecutor(registry)
+let initialDisconnected = false
+
+try {
+  const expectedTools = [
+    'list_sheets',
+    'read_range',
+    'read_cell',
+    'set_cell_contents',
+    'get_cell_display_value',
+    'export_workpaper_document',
+    'validate_formula',
+  ]
+  const registered = tools.map((tool) => tool.name).sort()
+
+  for (const tool of expectedTools) {
+    const name = `bilig_${tool}`
+    if (!registry.has(name)) {
+      throw new Error(`Expected MCP tool ${name}; got ${registered.join(', ')}`)
+    }
+  }
+
+  const sheets = await executeJson('bilig_list_sheets', {})
+  const before = await executeJson('bilig_read_cell', {
+    sheetName: 'Summary',
+    address: 'B3',
+  })
+  const validation = await executeJson('bilig_validate_formula', {
+    formula: '=SUM(1,2)',
+  })
+  const write = await executeJson('bilig_set_cell_contents', {
+    sheetName: 'Inputs',
+    address: 'B3',
+    value: 0.4,
+  })
+  const after = await executeJson('bilig_read_cell', {
+    sheetName: 'Summary',
+    address: 'B3',
+  })
+  const display = await executeJson('bilig_get_cell_display_value', {
+    sheetName: 'Summary',
+    address: 'B3',
+  })
+  const exported = await executeJson('bilig_export_workpaper_document', {
+    includeConfig: true,
+  })
+
+  const formulaOutputBefore = readCellNumber(before)
+  const formulaOutputAfter = readCellNumber(after)
+
+  assertEqual(formulaOutputBefore, 60_000, 'baseline Summary!B3')
+  assertEqual(formulaOutputAfter, 96_000, 'recalculated Summary!B3')
+  assertEqual(readString(display, 'displayValue'), '96000', 'display value')
+  assertEqual(readBoolean(validation, 'valid'), true, 'formula validation')
+  assertEqual(readNestedBoolean(write, ['checks', 'persisted']), true, 'persisted write')
+  assertEqual(readNestedBoolean(write, ['checks', 'restoredMatchesAfter']), true, 'restored readback')
+
+  if (readNumber(exported, 'serializedBytes') <= 0) {
+    throw new Error('Expected exported WorkPaper JSON bytes to be greater than zero')
+  }
+
+  await disconnectInitial()
+
+  const restarted = await connectMCPTools({
+    command: 'npm',
+    args: [
+      'exec',
+      '--yes',
+      '--package',
+      biligPackage,
+      '--',
+      'bilig-workpaper-mcp',
+      '--workpaper',
+      workpaperPath,
+    ],
+    namePrefix: 'bilig',
+    requestTimeoutMs: 60_000,
+  })
+
+  try {
+    const readCell = restarted.tools.find((tool) => tool.name === 'bilig_read_cell')
+    if (readCell === undefined) {
+      throw new Error('Expected bilig_read_cell after reconnect')
+    }
+    const restored = parseJsonResult(
+      await readCell.execute(
+        {
+          sheetName: 'Summary',
+          address: 'B3',
+        },
+        context,
+      ),
+      'bilig_read_cell after reconnect',
+    )
+
+    assertEqual(readCellNumber(restored), 96_000, 'persisted Summary!B3')
+  } finally {
+    await restarted.disconnect()
+  }
+
+  console.log(JSON.stringify(
+    {
+      ok: true,
+      package: biligPackage,
+      workpaperPath,
+      registeredTools: registered,
+      sheetCount: Array.isArray(sheets.sheets) ? sheets.sheets.length : undefined,
+      formulaOutputBefore,
+      formulaOutputAfter,
+      displayValue: display.displayValue,
+      persisted: readNestedBoolean(write, ['checks', 'persisted']),
+      exportedBytes: exported.serializedBytes,
+    },
+    null,
+    2,
+  ))
+} finally {
+  await disconnectInitial().catch(() => undefined)
+}
+
+async function disconnectInitial(): Promise<void> {
+  if (initialDisconnected) {
+    return
+  }
+  initialDisconnected = true
+  await disconnect()
+}
+
+async function executeJson(toolName: string, input: JsonRecord): Promise<JsonRecord> {
+  return parseJsonResult(
+    await executor.execute(toolName, input, context),
+    toolName,
+  )
+}
+
+function parseJsonResult(result: ToolResult, label: string): JsonRecord {
+  if (result.isError === true) {
+    throw new Error(`${label} failed: ${result.data}`)
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(result.data)
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as JsonRecord
+    }
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error(`${label} returned non-JSON output: ${detail}\n${result.data}`)
+  }
+
+  throw new Error(`${label} returned JSON that was not an object`)
+}
+
+function readNumber(record: JsonRecord, key: string): number {
+  const value = record[key]
+  if (typeof value !== 'number') {
+    throw new Error(`Expected ${key} to be a number; got ${JSON.stringify(value)}`)
+  }
+  return value
+}
+
+function readCellNumber(record: JsonRecord): number {
+  const value = record.value
+  if (typeof value === 'number') {
+    return value
+  }
+  if (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    typeof (value as JsonRecord).value === 'number'
+  ) {
+    return (value as JsonRecord).value as number
+  }
+  throw new Error(`Expected cell value to be numeric; got ${JSON.stringify(value)}`)
+}
+
+function readString(record: JsonRecord, key: string): string {
+  const value = record[key]
+  if (typeof value !== 'string') {
+    throw new Error(`Expected ${key} to be a string; got ${JSON.stringify(value)}`)
+  }
+  return value
+}
+
+function readBoolean(record: JsonRecord, key: string): boolean {
+  const value = record[key]
+  if (typeof value !== 'boolean') {
+    throw new Error(`Expected ${key} to be a boolean; got ${JSON.stringify(value)}`)
+  }
+  return value
+}
+
+function readNestedBoolean(record: JsonRecord, path: string[]): boolean {
+  let value: unknown = record
+  for (const key of path) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error(`Expected ${path.join('.')} to exist`)
+    }
+    value = (value as JsonRecord)[key]
+  }
+  if (typeof value !== 'boolean') {
+    throw new Error(`Expected ${path.join('.')} to be a boolean; got ${JSON.stringify(value)}`)
+  }
+  return value
+}
+
+function assertEqual<T>(actual: T, expected: T, label: string): void {
+  if (actual !== expected) {
+    throw new Error(`${label}: expected ${String(expected)}, got ${String(actual)}`)
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Bilig WorkPaper MCP integration example that follows the existing `mcp-github.ts` pattern: connect an MCP stdio server with `connectMCPTools()`, register the tools, and let an `Agent` use them.

The example pins `@bilig/workpaper@0.96.0`, initializes a demo pricing WorkPaper, asks the agent to read `Summary!B3`, write `Inputs!B3 = 0.4`, and verify the recalculated `Summary!B3` result.

## Validation

- `npm run build`
- `npm test -- tests/mcp-tools.test.ts`
- `AGENT_MODEL=gemini-2.5-flash npx tsx examples/integrations/mcp-bilig-workpaper.ts`
- `git diff --check`

The local agent run reported `Summary!B3` changed from `60000` to `96000` and that the workbook recalculated and persisted the edit.
