### PR TITLE
feat(deepseek): migrate defaults to V4 model names

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -25,7 +25,7 @@ The framework ships a wired-in provider name for each of these. Set `provider` a
 | Azure OpenAI | `provider: 'azure-openai'` | `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT` | `gpt-4` | Optional `AZURE_OPENAI_API_VERSION`, `AZURE_OPENAI_DEPLOYMENT`. |
 | GitHub Copilot | `provider: 'copilot'` | `GITHUB_COPILOT_TOKEN` (falls back to `GITHUB_TOKEN`) | `gpt-4o` | Custom token-exchange flow on top of OpenAI protocol. |
 | Grok (xAI) | `provider: 'grok'` | `XAI_API_KEY` | `grok-4` | OpenAI-compatible; endpoint is `api.x.ai/v1`. |
-| DeepSeek | `provider: 'deepseek'` | `DEEPSEEK_API_KEY` | `deepseek-chat` | OpenAI-compatible. `deepseek-chat` (V3, coding) or `deepseek-reasoner` (thinking mode). |
+| DeepSeek | `provider: 'deepseek'` | `DEEPSEEK_API_KEY` | `deepseek-v4-flash` | OpenAI-compatible. `deepseek-v4-flash` (default) or `deepseek-v4-pro` (flagship for coding); both support 1M context and 384K max output. Legacy `deepseek-chat` / `deepseek-reasoner` retire 2026-07-24. |
 | MiniMax (global) | `provider: 'minimax'` | `MINIMAX_API_KEY` | `MiniMax-M2.7` | OpenAI-compatible. |
 | MiniMax (China) | `provider: 'minimax'` + `MINIMAX_BASE_URL` | `MINIMAX_API_KEY` | `MiniMax-M2.7` | Set `MINIMAX_BASE_URL=https://api.minimaxi.com/v1`. |
 | Qiniu | `provider: 'qiniu'` | `QINIU_API_KEY` | `deepseek-v3` | OpenAI-compatible. Endpoint `https://api.qnaigc.com/v1`; multiple model families, see [Qiniu AI docs](https://developer.qiniu.com/aitokenapi/12882/ai-inference-api). |

--- a/examples/integrations/with-engram/research-team.ts
+++ b/examples/integrations/with-engram/research-team.ts
@@ -33,7 +33,7 @@
  *   AGENT_PROVIDER=grok AGENT_MODEL=grok-3 XAI_API_KEY=... ENGRAM_INVITE_KEY=ek_live_... npx tsx examples/integrations/with-engram/research-team.ts
  *
  *   # DeepSeek
- *   AGENT_PROVIDER=deepseek AGENT_MODEL=deepseek-chat DEEPSEEK_API_KEY=... ENGRAM_INVITE_KEY=ek_live_... npx tsx examples/integrations/with-engram/research-team.ts
+ *   AGENT_PROVIDER=deepseek AGENT_MODEL=deepseek-v4-flash DEEPSEEK_API_KEY=... ENGRAM_INVITE_KEY=ek_live_... npx tsx examples/integrations/with-engram/research-team.ts
  *
  * Prerequisites:
  *   - API key env var for your chosen provider

--- a/examples/integrations/with-vercel-ai-sdk/app/api/chat/route.ts
+++ b/examples/integrations/with-vercel-ai-sdk/app/api/chat/route.ts
@@ -7,7 +7,7 @@ export const maxDuration = 120
 
 // --- DeepSeek via OpenAI-compatible API ---
 const DEEPSEEK_BASE_URL = 'https://api.deepseek.com'
-const DEEPSEEK_MODEL = 'deepseek-chat'
+const DEEPSEEK_MODEL = 'deepseek-v4-flash'
 
 const deepseek = createOpenAICompatible({
   name: 'deepseek',

--- a/examples/providers/deepseek.ts
+++ b/examples/providers/deepseek.ts
@@ -11,19 +11,19 @@
  *   DEEPSEEK_API_KEY environment variable must be set.
  *
  * Available models:
- *   deepseek-chat      — DeepSeek-V3 (non-thinking mode, recommended for coding tasks)
- *   deepseek-reasoner  — DeepSeek-V3 (thinking mode, for complex reasoning)
+ *   deepseek-v4-flash  — economical (1M context)
+ *   deepseek-v4-pro    — flagship, best for coding (1M context)
  */
 
 import { OpenMultiAgent } from '../../src/index.js'
 import type { AgentConfig, OrchestratorEvent } from '../../src/types.js'
 
 // ---------------------------------------------------------------------------
-// Agent definitions (all using deepseek-chat)
+// Agent definitions
 // ---------------------------------------------------------------------------
 const architect: AgentConfig = {
   name: 'architect',
-  model: 'deepseek-reasoner',
+  model: 'deepseek-v4-pro',
   provider: 'deepseek',
   systemPrompt: `You are a software architect with deep experience in Node.js and REST API design.
 Your job is to design clear, production-quality API contracts and file/directory structures.
@@ -35,7 +35,7 @@ Output concise plans in markdown — no unnecessary prose.`,
 
 const developer: AgentConfig = {
   name: 'developer',
-  model: 'deepseek-chat',
+  model: 'deepseek-v4-flash',
   provider: 'deepseek',
   systemPrompt: `You are a TypeScript/Node.js developer. You implement what the architect specifies.
 Write clean, runnable code with proper error handling. Use the tools to write files and run tests.`,
@@ -46,7 +46,7 @@ Write clean, runnable code with proper error handling. Use the tools to write fi
 
 const reviewer: AgentConfig = {
   name: 'reviewer',
-  model: 'deepseek-chat',
+  model: 'deepseek-v4-flash',
   provider: 'deepseek',
   systemPrompt: `You are a senior code reviewer. Review code for correctness, security, and clarity.
 Provide a structured review with: LGTM items, suggestions, and any blocking issues.
@@ -93,7 +93,7 @@ function handleProgress(event: OrchestratorEvent): void {
 // Orchestrate
 // ---------------------------------------------------------------------------
 const orchestrator = new OpenMultiAgent({
-  defaultModel: 'deepseek-chat',
+  defaultModel: 'deepseek-v4-flash',
   defaultProvider: 'deepseek',
   maxConcurrency: 1, // sequential for readable output
   onProgress: handleProgress,

--- a/src/cli/oma.ts
+++ b/src/cli/oma.ts
@@ -54,7 +54,7 @@ const PROVIDER_REFERENCE: ReadonlyArray<{
   { id: 'gemini', apiKeyEnv: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'], baseUrlSupported: false },
   { id: 'grok', apiKeyEnv: ['XAI_API_KEY'], baseUrlSupported: true },
   { id: 'minimax', apiKeyEnv: ['MINIMAX_API_KEY'], baseUrlSupported: true, notes: 'Global endpoint: https://api.minimax.io/v1 (default). China endpoint: https://api.minimaxi.com/v1. Set MINIMAX_BASE_URL to choose, or pass baseURL in agent config.' },
-  { id: 'deepseek', apiKeyEnv: ['DEEPSEEK_API_KEY'], baseUrlSupported: true, notes: 'OpenAI-compatible endpoint at https://api.deepseek.com/v1. Models: deepseek-chat (V3), deepseek-reasoner (thinking).' },
+  { id: 'deepseek', apiKeyEnv: ['DEEPSEEK_API_KEY'], baseUrlSupported: true, notes: 'OpenAI-compatible endpoint at https://api.deepseek.com/v1. Models: deepseek-v4-flash (default), deepseek-v4-pro (flagship); both support 1M context. Legacy deepseek-chat/deepseek-reasoner retire 2026-07-24.' },
   { id: 'qiniu', apiKeyEnv: ['QINIU_API_KEY'], baseUrlSupported: true, notes: 'OpenAI-compatible endpoint at https://api.qnaigc.com/v1. Set provider to qiniu and choose a model available to your key.' },
   {
     id: 'copilot',
@@ -287,7 +287,7 @@ const DEFAULT_MODEL_HINT: Record<SupportedProvider, string> = {
   grok: 'grok-2-latest',
   copilot: 'gpt-4o',
   minimax: 'MiniMax-M2.7',
-  deepseek: 'deepseek-chat',
+  deepseek: 'deepseek-v4-flash',
   qiniu: 'deepseek-v3',
   bedrock: 'anthropic.claude-3-5-haiku-20241022-v1:0',
 }

--- a/src/llm/deepseek.ts
+++ b/src/llm/deepseek.ts
@@ -8,13 +8,17 @@
 import { OpenAIAdapter } from './openai.js'
 
 /**
- * LLM adapter for DeepSeek models (deepseek-chat, deepseek-reasoner, and future models).
+ * LLM adapter for DeepSeek V4 models. Both models support a 1M context window.
  *
  * Thread-safe. Can be shared across agents.
  *
  * Usage:
  *   provider: 'deepseek'
- *   model: 'deepseek-chat' (or 'deepseek-reasoner' for the thinking model)
+ *   model: 'deepseek-v4-flash' (economical) or 'deepseek-v4-pro' (flagship)
+ *
+ * Legacy `deepseek-chat` and `deepseek-reasoner` map to the non-thinking and
+ * thinking modes of `deepseek-v4-flash` respectively, and will be fully retired
+ * by DeepSeek on 2026-07-24.
  */
 export class DeepSeekAdapter extends OpenAIAdapter {
   readonly name = 'deepseek'

--- a/tests/deepseek-adapter.test.ts
+++ b/tests/deepseek-adapter.test.ts
@@ -91,7 +91,7 @@ describe('DeepSeekAdapter', () => {
   it('stamps provenance: "deepseek" (not parent "openai") on extracted ReasoningBlocks', async () => {
     createCompletionMock.mockResolvedValue({
       id: 'chatcmpl-ds',
-      model: 'deepseek-reasoner',
+      model: 'deepseek-v4-pro',
       choices: [{
         index: 0,
         message: {


### PR DESCRIPTION
DeepSeek retires `deepseek-chat` / `deepseek-reasoner` on 2026-07-24.
This migrates the shipped default and examples to V4 names ahead of
the cutoff.

New default is `deepseek-v4-flash`. Upstream auto-maps the old
`deepseek-chat` to v4-flash non-thinking, so pinned users see
equivalent behavior at lower pricing. In `examples/providers/deepseek.ts`
the architect goes to `deepseek-v4-pro` rather than v4-flash thinking
mode because v4-pro is the upstream "best for coding" pick: deliberate
upgrade for the reasoning-heavy role, not a 1:1 swap from
`deepseek-reasoner`. Adapter code unchanged; `OpenAIAdapter` already
forwards `reasoning_effort` and `extraBody`. Base URL kept at
`https://api.deepseek.com/v1` (upstream still accepts; canonical is
now `/`).