### PR TITLE
fix(deepseek): echo reasoning_content on tool-use turns for V4

### DIFF
--- a/src/llm/deepseek.ts
+++ b/src/llm/deepseek.ts
@@ -24,15 +24,17 @@ export class DeepSeekAdapter extends OpenAIAdapter {
   readonly name = 'deepseek'
 
   // DeepSeek V4 in thinking mode requires `reasoning_content` to be echoed
-  // back on every follow-up request that includes a prior tool-use assistant
-  // turn; omitting it returns 400. See:
+  // back on EVERY intermediate assistant message of a tool-calling
+  // conversation, including the final synthesis message that has no
+  // `tool_calls` of its own. Omitting any of them 400s on the next user
+  // turn. See:
   //   https://api-docs.deepseek.com/zh-cn/guides/thinking_mode
   // The `'tool-use-only'` capability tells the OpenAIAdapter base class to
   // pass `nativeReasoningEchoProvider: 'deepseek'` to the message builder,
-  // which attaches `reasoning_content` on outbound assistant messages that
-  // contain `tool_calls` and carry a deepseek-provenance reasoning block.
-  // Non-tool turns drop the reasoning (it would pollute context without
-  // benefit; the spec says it is ignored there anyway).
+  // which attaches `reasoning_content` on every assistant message in a
+  // tool-calling conversation that carries a deepseek-provenance reasoning
+  // block. Non-tool conversations drop reasoning entirely (the spec says
+  // it is ignored there but would still bloat context).
   override readonly capabilities = {
     echoesReasoning: 'tool-use-only' as const,
   }

--- a/src/llm/deepseek.ts
+++ b/src/llm/deepseek.ts
@@ -23,6 +23,20 @@ import { OpenAIAdapter } from './openai.js'
 export class DeepSeekAdapter extends OpenAIAdapter {
   readonly name = 'deepseek'
 
+  // DeepSeek V4 in thinking mode requires `reasoning_content` to be echoed
+  // back on every follow-up request that includes a prior tool-use assistant
+  // turn; omitting it returns 400. See:
+  //   https://api-docs.deepseek.com/zh-cn/guides/thinking_mode
+  // The `'tool-use-only'` capability tells the OpenAIAdapter base class to
+  // pass `nativeReasoningEchoProvider: 'deepseek'` to the message builder,
+  // which attaches `reasoning_content` on outbound assistant messages that
+  // contain `tool_calls` and carry a deepseek-provenance reasoning block.
+  // Non-tool turns drop the reasoning (it would pollute context without
+  // benefit; the spec says it is ignored there anyway).
+  override readonly capabilities = {
+    echoesReasoning: 'tool-use-only' as const,
+  }
+
   constructor(apiKey?: string, baseURL?: string) {
     // Allow override of baseURL (for proxies or future changes) but default to official DeepSeek endpoint.
     super(

--- a/src/llm/openai-common.ts
+++ b/src/llm/openai-common.ts
@@ -46,18 +46,25 @@ export interface OpenAIReasoningReplayOptions {
   readonly maxReasoningReplayChars?: number
   /**
    * Adapter name to use for native `reasoning_content` echo on outbound
-   * assistant messages that contain `tool_calls`.
+   * assistant messages inside a tool-calling conversation.
    *
    * When set, each assistant message is scanned for {@link ReasoningBlock}s
-   * whose {@link ReasoningBlock.provenance} matches this value. If at least
-   * one matching block is found AND the message also has `tool_calls`, the
-   * combined reasoning text is attached as a `reasoning_content` field on the
-   * outbound payload (a non-standard OpenAI field that DeepSeek V4 accepts).
+   * whose {@link ReasoningBlock.provenance} matches this value. The
+   * collected reasoning is attached as a `reasoning_content` field on the
+   * outbound payload (a non-standard OpenAI field that DeepSeek V4 accepts)
+   * if AND ONLY IF the overall conversation contains at least one
+   * `tool_use` block somewhere in its history.
    *
    * Behaviour rules:
-   *   - No `tool_calls` on the message → reasoning is dropped (per DeepSeek
-   *     spec: `reasoning_content` is ignored on non-tool turns and just
-   *     pollutes context).
+   *   - No `tool_use` anywhere in the conversation → all reasoning is
+   *     dropped (per DeepSeek spec: `reasoning_content` is ignored on
+   *     non-tool conversations and just pollutes context).
+   *   - Tool-calling conversation, any assistant message (including the
+   *     final synthesis message with no tool_calls) → matching-provenance
+   *     reasoning is echoed. This matches the spec: "在两个 user 消息之间，
+   *     如果模型进行了工具调用，则中间 assistant 的 reasoning_content 需参与
+   *     上下文拼接". Echoing only on tool-emitting messages would 400 on
+   *     the next user turn after a tool loop ends.
    *   - Provenance mismatch (foreign reasoning) → block is skipped for
    *     native echo. It MAY still fall through to the `<thinking>` text
    *     replay path if {@link enableReasoningTextReplay} is on.
@@ -177,9 +184,22 @@ export function toOpenAIMessages(
 ): ChatCompletionMessageParam[] {
   const result: ChatCompletionMessageParam[] = []
 
+  // Per DeepSeek V4 thinking-mode spec, when a conversation involves any
+  // tool call, ALL intermediate assistant messages must echo
+  // `reasoning_content` — not just the one that emitted the tool_use.
+  // Omitting reasoning on the final synthesis turn (tool_calls=None) 400s
+  // on the next user message. We approximate "tool-calling conversation"
+  // as "any tool_use anywhere in history"; non-tool conversations skip
+  // the echo entirely (per spec, reasoning would be ignored but still
+  // bloat context). See:
+  //   https://api-docs.deepseek.com/zh-cn/guides/thinking_mode
+  const conversationHasToolUse = messages.some((m) =>
+    m.content.some((b) => b.type === 'tool_use'),
+  )
+
   for (const msg of messages) {
     if (msg.role === 'assistant') {
-      const assistantMsg = toOpenAIAssistantMessage(msg, replayOptions)
+      const assistantMsg = toOpenAIAssistantMessage(msg, replayOptions, conversationHasToolUse)
       if (assistantMsg !== null) {
         result.push(assistantMsg)
       }
@@ -247,6 +267,7 @@ function toOpenAIUserMessage(msg: LLMMessage): ChatCompletionUserMessageParam {
 function toOpenAIAssistantMessage(
   msg: LLMMessage,
   replayOptions?: OpenAIReasoningReplayOptions,
+  conversationHasToolUse = false,
 ): ChatCompletionAssistantMessageParam | null {
   const toolCalls: ChatCompletionMessageToolCall[] = []
   const textParts: string[] = []
@@ -255,8 +276,10 @@ function toOpenAIAssistantMessage(
   const enableReasoningReplay = replayOptions?.enableReasoningTextReplay === true
   const maxReasoningChars = resolveReasoningReplayMaxChars(replayOptions?.maxReasoningReplayChars)
   // Collected only when an `echoProvider` is configured. Emitted as a
-  // `reasoning_content` field on the assistant payload below, but only if the
-  // message also has at least one tool_call (DeepSeek V4 rule).
+  // `reasoning_content` field on the assistant payload below, gated by
+  // `conversationHasToolUse` (DeepSeek V4 rule: applies to every assistant
+  // message in a tool-calling conversation, including the final synthesis
+  // message that has no tool_calls of its own).
   const echoEligibleReasoning: string[] = []
 
   for (const block of msg.content) {
@@ -315,15 +338,21 @@ function toOpenAIAssistantMessage(
 
   if (toolCalls.length > 0) {
     assistantMsg.tool_calls = toolCalls
-    // DeepSeek V4 (thinking mode) returns 400 on follow-up requests if a
-    // prior tool-use assistant turn does not carry `reasoning_content` back.
-    // The field is not declared on the upstream SDK type, so we attach it
-    // via an indexed cast; the SDK serialises arbitrary own properties.
-    if (echoEligibleReasoning.length > 0) {
-      const reasoningContent = echoEligibleReasoning.join('')
-      ;(assistantMsg as ChatCompletionAssistantMessageParam & { reasoning_content?: string })
-        .reasoning_content = reasoningContent
-    }
+  }
+
+  // DeepSeek V4 (thinking mode) returns 400 on follow-up requests if any
+  // intermediate assistant message in a tool-calling conversation drops
+  // `reasoning_content` — including the final synthesis message that has
+  // no tool_calls of its own. The gate is on the whole conversation, not
+  // this single message. Non-tool conversations skip the attachment (per
+  // spec, reasoning is ignored there but would still bloat context).
+  //
+  // The field is not declared on the upstream SDK type, so we attach it
+  // via an indexed cast; the SDK serialises arbitrary own properties.
+  if (conversationHasToolUse && echoEligibleReasoning.length > 0) {
+    const reasoningContent = echoEligibleReasoning.join('')
+    ;(assistantMsg as ChatCompletionAssistantMessageParam & { reasoning_content?: string })
+      .reasoning_content = reasoningContent
   }
 
   return assistantMsg

--- a/src/llm/openai-common.ts
+++ b/src/llm/openai-common.ts
@@ -44,6 +44,32 @@ export interface OpenAIReasoningReplayOptions {
    * truncation. Explicit invalid values are clamped to a minimum of 1 char.
    */
   readonly maxReasoningReplayChars?: number
+  /**
+   * Adapter name to use for native `reasoning_content` echo on outbound
+   * assistant messages that contain `tool_calls`.
+   *
+   * When set, each assistant message is scanned for {@link ReasoningBlock}s
+   * whose {@link ReasoningBlock.provenance} matches this value. If at least
+   * one matching block is found AND the message also has `tool_calls`, the
+   * combined reasoning text is attached as a `reasoning_content` field on the
+   * outbound payload (a non-standard OpenAI field that DeepSeek V4 accepts).
+   *
+   * Behaviour rules:
+   *   - No `tool_calls` on the message → reasoning is dropped (per DeepSeek
+   *     spec: `reasoning_content` is ignored on non-tool turns and just
+   *     pollutes context).
+   *   - Provenance mismatch (foreign reasoning) → block is skipped for
+   *     native echo. It MAY still fall through to the `<thinking>` text
+   *     replay path if {@link enableReasoningTextReplay} is on.
+   *   - Redacted blocks (`redactedData` set) → skipped; the placeholder we
+   *     emit on the `<thinking>` path is not appropriate to send as native
+   *     reasoning_content.
+   *
+   * Wired by adapters whose {@link LLMAdapter.capabilities.echoesReasoning}
+   * is `'tool-use-only'` (currently DeepSeek). OpenAI itself sets
+   * `'never'` and does NOT pass this option.
+   */
+  readonly nativeReasoningEchoProvider?: string
 }
 
 // ---------------------------------------------------------------------------
@@ -225,8 +251,13 @@ function toOpenAIAssistantMessage(
   const toolCalls: ChatCompletionMessageToolCall[] = []
   const textParts: string[] = []
   const pendingThinkingParts: string[] = []
+  const echoProvider = replayOptions?.nativeReasoningEchoProvider
   const enableReasoningReplay = replayOptions?.enableReasoningTextReplay === true
   const maxReasoningChars = resolveReasoningReplayMaxChars(replayOptions?.maxReasoningReplayChars)
+  // Collected only when an `echoProvider` is configured. Emitted as a
+  // `reasoning_content` field on the assistant payload below, but only if the
+  // message also has at least one tool_call (DeepSeek V4 rule).
+  const echoEligibleReasoning: string[] = []
 
   for (const block of msg.content) {
     if (block.type === 'tool_use') {
@@ -238,10 +269,26 @@ function toOpenAIAssistantMessage(
           arguments: JSON.stringify(block.input),
         },
       })
-    } else if (block.type === 'reasoning' && enableReasoningReplay) {
-      const serialized = reasoningBlockToThinkingText(block, maxReasoningChars)
-      if (serialized.length > 0) {
-        pendingThinkingParts.push(serialized)
+    } else if (block.type === 'reasoning') {
+      // Path A: native echo (adapter wired with nativeReasoningEchoProvider
+      // and the block's provenance matches). The block is queued for
+      // attachment as `reasoning_content`; gating by tool_use happens after
+      // the loop so we don't emit it on non-tool turns.
+      if (echoProvider !== undefined && block.provenance === echoProvider) {
+        const isRedacted = typeof block.redactedData === 'string' && block.redactedData.length > 0
+        if (!isRedacted && block.text.length > 0) {
+          echoEligibleReasoning.push(block.text)
+        }
+        // Either way, don't double-emit via the text-replay path below.
+        continue
+      }
+      // Path B: legacy <thinking> text replay for foreign-provenance blocks
+      // (or any block when this adapter doesn't support native echo).
+      if (enableReasoningReplay) {
+        const serialized = reasoningBlockToThinkingText(block, maxReasoningChars)
+        if (serialized.length > 0) {
+          pendingThinkingParts.push(serialized)
+        }
       }
     } else if (block.type === 'text') {
       if (pendingThinkingParts.length > 0) {
@@ -268,6 +315,15 @@ function toOpenAIAssistantMessage(
 
   if (toolCalls.length > 0) {
     assistantMsg.tool_calls = toolCalls
+    // DeepSeek V4 (thinking mode) returns 400 on follow-up requests if a
+    // prior tool-use assistant turn does not carry `reasoning_content` back.
+    // The field is not declared on the upstream SDK type, so we attach it
+    // via an indexed cast; the SDK serialises arbitrary own properties.
+    if (echoEligibleReasoning.length > 0) {
+      const reasoningContent = echoEligibleReasoning.join('')
+      ;(assistantMsg as ChatCompletionAssistantMessageParam & { reasoning_content?: string })
+        .reasoning_content = reasoningContent
+    }
   }
 
   return assistantMsg

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -56,6 +56,7 @@ import {
   normalizeFinishReason,
   buildOpenAIMessageList,
   getOpenAIReasoningText,
+  type OpenAIReasoningReplayOptions,
 } from './openai-common.js'
 import { extractToolCallsFromText } from '../tool/text-tool-extractor.js'
 
@@ -71,11 +72,16 @@ import { extractToolCallsFromText } from '../tool/text-tool-extractor.js'
 export class OpenAIAdapter implements LLMAdapter {
   readonly name: string = 'openai'
 
-  readonly capabilities = {
-    // OpenAI Chat Completions does not accept `reasoning_content` on input;
-    // any reasoning replay must go through the `<thinking>` text fallback
-    // already shipped in #234 (see openai-common.ts replay options).
-    echoesReasoning: 'never' as const,
+  // The field type is intentionally widened to the full union (rather than
+  // narrowed to `'never'` via `as const`) so subclasses can override with a
+  // different value — DeepSeek currently uses `'tool-use-only'` for native
+  // `reasoning_content` echo on tool-use turns. The parent's own runtime
+  // value remains `'never'` for OpenAI Chat Completions, which does not
+  // accept `reasoning_content` on input under any circumstance (the
+  // `<thinking>` text fallback shipped in #234 handles cross-provider
+  // reasoning replay for OpenAI proper).
+  readonly capabilities: { readonly echoesReasoning: 'never' | 'own-issued' | 'tool-use-only' } = {
+    echoesReasoning: 'never',
   }
 
   readonly #client: OpenAI
@@ -85,6 +91,21 @@ export class OpenAIAdapter implements LLMAdapter {
       apiKey: apiKey ?? process.env['OPENAI_API_KEY'],
       baseURL,
     })
+  }
+
+  /**
+   * Build the per-call options forwarded to {@link buildOpenAIMessageList}.
+   *
+   * Subclasses overriding `capabilities.echoesReasoning` to `'tool-use-only'`
+   * (e.g. {@link DeepSeekAdapter}) automatically opt into native
+   * `reasoning_content` echo on tool-use turns; no subclass override of
+   * `chat()` / `stream()` is required.
+   */
+  protected buildMessageOptions(): OpenAIReasoningReplayOptions | undefined {
+    if (this.capabilities.echoesReasoning === 'tool-use-only') {
+      return { nativeReasoningEchoProvider: this.name }
+    }
+    return undefined
   }
 
   // -------------------------------------------------------------------------
@@ -99,7 +120,7 @@ export class OpenAIAdapter implements LLMAdapter {
    * handle these (e.g. rate limits, context length exceeded).
    */
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
-    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt)
+    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, this.buildMessageOptions())
 
     const completion = await this.#client.chat.completions.create(
       {
@@ -151,7 +172,7 @@ export class OpenAIAdapter implements LLMAdapter {
     messages: LLMMessage[],
     options: LLMStreamOptions,
   ): AsyncIterable<StreamEvent> {
-    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt)
+    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, this.buildMessageOptions())
 
     // We request usage in the final chunk so we can include it in the `done` event.
     const streamResponse = await this.#client.chat.completions.create(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1095,13 +1095,14 @@ export interface LLMAdapter {
    *   unsigned thought summaries to keep context lean). Phase 2
    *   implementers MUST consult the adapter-specific outbound serializer
    *   for the full eligibility rule, not just the provenance match.
-   * - `'tool-use-only'`: Native echo is attempted **only** on assistant
-   *   messages that also contained `tool_use` blocks, and only when
-   *   `block.provenance === this.name`. On non-tool-use turns the block is
-   *   silently dropped (echoing it would pollute context without provider
-   *   benefit). Used by DeepSeek V4 in thinking mode, whose API returns 400
-   *   when a follow-up request omits `reasoning_content` from a prior
-   *   tool-use turn but ignores `reasoning_content` on plain-text turns.
+   * - `'tool-use-only'`: Native echo is attempted on every assistant
+   *   message inside a tool-calling conversation (one that contains at
+   *   least one `tool_use` block anywhere in its history), gated by
+   *   `block.provenance === this.name`. This includes the final synthesis
+   *   message that has no `tool_use` of its own — omitting it would 400
+   *   the next user turn. Conversations with no `tool_use` anywhere skip
+   *   the echo entirely (per spec, reasoning is ignored there but would
+   *   still bloat context). Used by DeepSeek V4 in thinking mode.
    *
    * Omitted on third-party adapters that pre-date this field; callers treat
    * `undefined` as `'never'` to preserve today's silent-drop behaviour.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1095,11 +1095,18 @@ export interface LLMAdapter {
    *   unsigned thought summaries to keep context lean). Phase 2
    *   implementers MUST consult the adapter-specific outbound serializer
    *   for the full eligibility rule, not just the provenance match.
+   * - `'tool-use-only'`: Native echo is attempted **only** on assistant
+   *   messages that also contained `tool_use` blocks, and only when
+   *   `block.provenance === this.name`. On non-tool-use turns the block is
+   *   silently dropped (echoing it would pollute context without provider
+   *   benefit). Used by DeepSeek V4 in thinking mode, whose API returns 400
+   *   when a follow-up request omits `reasoning_content` from a prior
+   *   tool-use turn but ignores `reasoning_content` on plain-text turns.
    *
    * Omitted on third-party adapters that pre-date this field; callers treat
    * `undefined` as `'never'` to preserve today's silent-drop behaviour.
    */
   readonly capabilities?: {
-    readonly echoesReasoning: 'never' | 'own-issued'
+    readonly echoesReasoning: 'never' | 'own-issued' | 'tool-use-only'
   }
 }

--- a/tests/deepseek-adapter.test.ts
+++ b/tests/deepseek-adapter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { chatOpts, textMsg } from './helpers/llm-fixtures.js'
+import { chatOpts, textMsg, toolDef } from './helpers/llm-fixtures.js'
+import type { LLMMessage } from '../src/types.js'
 
 // ---------------------------------------------------------------------------
 // Mock OpenAI constructor (must be hoisted for Vitest)
@@ -112,6 +113,261 @@ describe('DeepSeekAdapter', () => {
       type: 'reasoning',
       text: 'plan first',
       provenance: 'deepseek',
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // reasoning_content passback (DeepSeek V4 thinking mode)
+  //
+  // Per https://api-docs.deepseek.com/zh-cn/guides/thinking_mode, follow-up
+  // requests that include a prior tool-use assistant turn MUST echo
+  // `reasoning_content` back. Omitting it returns 400.
+  // ---------------------------------------------------------------------------
+  describe('reasoning_content echo on tool-use turns', () => {
+    function getAssistantMessage(callIndex = 0): Record<string, unknown> {
+      const call = createCompletionMock.mock.calls[callIndex]
+      if (call === undefined) throw new Error(`no mock call at index ${callIndex}`)
+      const messages = call[0].messages as Array<Record<string, unknown>>
+      const assistant = messages.find((m) => m['role'] === 'assistant')
+      if (assistant === undefined) throw new Error('no assistant message found in request')
+      return assistant
+    }
+
+    it('echoes reasoning_content on assistant messages that contain tool_calls', async () => {
+      // The agent runner's typical flow: turn 1 yields reasoning + tool_use;
+      // tools execute; turn 2 sends back the assistant + tool_result and the
+      // model returns its final answer.
+      createCompletionMock.mockResolvedValueOnce({
+        id: 'chatcmpl-ds-2',
+        model: 'deepseek-v4-pro',
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: 'Answer.', tool_calls: undefined },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 5, completion_tokens: 3 },
+      })
+
+      const messages: LLMMessage[] = [
+        textMsg('user', 'Search for foo'),
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'I will use the search tool.', provenance: 'deepseek' },
+            { type: 'tool_use', id: 'call_1', name: 'search', input: { q: 'foo' } },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call_1', content: '[results]' }],
+        },
+      ]
+
+      const adapter = new DeepSeekAdapter('deepseek-key')
+      await adapter.chat(messages, chatOpts({ tools: [toolDef('search')] }))
+
+      const assistant = getAssistantMessage()
+      expect(assistant['tool_calls']).toBeDefined()
+      expect(assistant['reasoning_content']).toBe('I will use the search tool.')
+    })
+
+    it('does NOT echo reasoning_content on assistant messages without tool_calls', async () => {
+      // Per spec, `reasoning_content` is ignored on non-tool turns and would
+      // just pollute context. We drop it.
+      createCompletionMock.mockResolvedValueOnce({
+        id: 'chatcmpl-ds-3',
+        model: 'deepseek-v4-pro',
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: 'Sure.', tool_calls: undefined },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 5, completion_tokens: 3 },
+      })
+
+      const messages: LLMMessage[] = [
+        textMsg('user', 'Hi'),
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'Just acknowledge.', provenance: 'deepseek' },
+            { type: 'text', text: 'Hello!' },
+          ],
+        },
+        textMsg('user', 'Now respond again.'),
+      ]
+
+      const adapter = new DeepSeekAdapter('deepseek-key')
+      await adapter.chat(messages, chatOpts())
+
+      const assistant = getAssistantMessage()
+      expect(assistant['tool_calls']).toBeUndefined()
+      expect(assistant['reasoning_content']).toBeUndefined()
+      expect(assistant['content']).toBe('Hello!')
+    })
+
+    it('does NOT echo reasoning blocks from a foreign provenance', async () => {
+      // Cross-provider reasoning (e.g. an upstream Anthropic block carried
+      // through to a DeepSeek adapter) is not eligible for native echo —
+      // DeepSeek did not produce it and would not recognise its signature.
+      createCompletionMock.mockResolvedValueOnce({
+        id: 'chatcmpl-ds-4',
+        model: 'deepseek-v4-pro',
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: 'Done.', tool_calls: undefined },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 5, completion_tokens: 3 },
+      })
+
+      const messages: LLMMessage[] = [
+        textMsg('user', 'Search for bar'),
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'Foreign reasoning.', provenance: 'anthropic' },
+            { type: 'tool_use', id: 'call_1', name: 'search', input: { q: 'bar' } },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call_1', content: '[results]' }],
+        },
+      ]
+
+      const adapter = new DeepSeekAdapter('deepseek-key')
+      await adapter.chat(messages, chatOpts({ tools: [toolDef('search')] }))
+
+      const assistant = getAssistantMessage()
+      expect(assistant['tool_calls']).toBeDefined()
+      expect(assistant['reasoning_content']).toBeUndefined()
+    })
+
+    it('drops a reasoning block with no provenance (treated as foreign)', async () => {
+      // Older clients or third-party IR constructors may produce reasoning
+      // blocks without `provenance`. Treat the same as foreign — silent drop.
+      createCompletionMock.mockResolvedValueOnce({
+        id: 'chatcmpl-ds-5',
+        model: 'deepseek-v4-pro',
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: 'OK.', tool_calls: undefined },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 5, completion_tokens: 3 },
+      })
+
+      const messages: LLMMessage[] = [
+        textMsg('user', 'Search'),
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'No provenance.' },
+            { type: 'tool_use', id: 'call_2', name: 'search', input: { q: 'x' } },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call_2', content: '[]' }],
+        },
+      ]
+
+      const adapter = new DeepSeekAdapter('deepseek-key')
+      await adapter.chat(messages, chatOpts({ tools: [toolDef('search')] }))
+
+      const assistant = getAssistantMessage()
+      expect(assistant['reasoning_content']).toBeUndefined()
+    })
+
+    it('preserves reasoning_content across multiple historical tool-use turns', async () => {
+      // Each prior tool-use turn carries its own reasoning. The spec requires
+      // every such turn to keep its reasoning_content on subsequent requests,
+      // not just the most recent one.
+      createCompletionMock.mockResolvedValueOnce({
+        id: 'chatcmpl-ds-6',
+        model: 'deepseek-v4-pro',
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: 'Final.', tool_calls: undefined },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 5, completion_tokens: 3 },
+      })
+
+      const messages: LLMMessage[] = [
+        textMsg('user', 'Multi-step research.'),
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'Plan A.', provenance: 'deepseek' },
+            { type: 'tool_use', id: 'call_1', name: 'search', input: { q: 'a' } },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call_1', content: '[a]' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'Plan B.', provenance: 'deepseek' },
+            { type: 'tool_use', id: 'call_2', name: 'search', input: { q: 'b' } },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call_2', content: '[b]' }],
+        },
+      ]
+
+      const adapter = new DeepSeekAdapter('deepseek-key')
+      await adapter.chat(messages, chatOpts({ tools: [toolDef('search')] }))
+
+      const sentMessages = createCompletionMock.mock.calls[0][0].messages as Array<Record<string, unknown>>
+      const assistants = sentMessages.filter((m) => m['role'] === 'assistant')
+      expect(assistants).toHaveLength(2)
+      expect(assistants[0]['reasoning_content']).toBe('Plan A.')
+      expect(assistants[1]['reasoning_content']).toBe('Plan B.')
+    })
+
+    it('does NOT echo reasoning_content from OpenAIAdapter (capability remains `never`)', async () => {
+      // Verifies the capability gate, not just the DeepSeek subclass:
+      // OpenAIAdapter itself must NOT attach reasoning_content even when
+      // matching-provenance reasoning is present in the message history.
+      const { OpenAIAdapter } = await import('../src/llm/openai.js')
+      createCompletionMock.mockResolvedValueOnce({
+        id: 'chatcmpl-oai',
+        model: 'gpt-4o',
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: 'Final.', tool_calls: undefined },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 5, completion_tokens: 3 },
+      })
+
+      const messages: LLMMessage[] = [
+        textMsg('user', 'Search'),
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'thinking', provenance: 'openai' },
+            { type: 'tool_use', id: 'call_1', name: 'search', input: { q: 'x' } },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call_1', content: '[]' }],
+        },
+      ]
+
+      const openaiAdapter = new OpenAIAdapter('openai-key')
+      await openaiAdapter.chat(messages, chatOpts({ tools: [toolDef('search')] }))
+
+      const sentMessages = createCompletionMock.mock.calls[0][0].messages as Array<Record<string, unknown>>
+      const assistant = sentMessages.find((m) => m['role'] === 'assistant')
+      expect(assistant!['reasoning_content']).toBeUndefined()
     })
   })
 })

--- a/tests/deepseek-adapter.test.ts
+++ b/tests/deepseek-adapter.test.ts
@@ -171,9 +171,9 @@ describe('DeepSeekAdapter', () => {
       expect(assistant['reasoning_content']).toBe('I will use the search tool.')
     })
 
-    it('does NOT echo reasoning_content on assistant messages without tool_calls', async () => {
-      // Per spec, `reasoning_content` is ignored on non-tool turns and would
-      // just pollute context. We drop it.
+    it('does NOT echo reasoning_content in conversations with no tool_use anywhere (pure text dialog)', async () => {
+      // Per spec, `reasoning_content` on non-tool conversations is ignored
+      // by the API. Echoing it would just bloat context.
       createCompletionMock.mockResolvedValueOnce({
         id: 'chatcmpl-ds-3',
         model: 'deepseek-v4-pro',
@@ -204,6 +204,67 @@ describe('DeepSeekAdapter', () => {
       expect(assistant['tool_calls']).toBeUndefined()
       expect(assistant['reasoning_content']).toBeUndefined()
       expect(assistant['content']).toBe('Hello!')
+    })
+
+    it('echoes reasoning_content on text-only assistant messages within a tool-calling conversation', async () => {
+      // This is the spec-critical case the original fix missed.
+      // Sequence:
+      //   user → assistant#1[reasoning + tool_use] → tool_result →
+      //   assistant#2[reasoning + text final] → user followup
+      // assistant#2 has NO tool_calls of its own, but it is still inside a
+      // tool-calling conversation and so its reasoning_content must be
+      // echoed too. Dropping it 400s on the next user turn.
+      createCompletionMock.mockResolvedValueOnce({
+        id: 'chatcmpl-ds-7',
+        model: 'deepseek-v4-pro',
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: 'Bar follow-up.', tool_calls: undefined },
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 5, completion_tokens: 3 },
+      })
+
+      const messages: LLMMessage[] = [
+        textMsg('user', 'Search for foo'),
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'Need to search.', provenance: 'deepseek' },
+            { type: 'tool_use', id: 'call_1', name: 'search', input: { q: 'foo' } },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'tool_result', tool_use_id: 'call_1', content: '[results]' }],
+        },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'Synthesise the answer.', provenance: 'deepseek' },
+            { type: 'text', text: 'Found foo at example.com' },
+          ],
+        },
+        textMsg('user', 'Now what about bar?'),
+      ]
+
+      const adapter = new DeepSeekAdapter('deepseek-key')
+      await adapter.chat(messages, chatOpts({ tools: [toolDef('search')] }))
+
+      const sentMessages = createCompletionMock.mock.calls[0][0].messages as Array<Record<string, unknown>>
+      const assistants = sentMessages.filter((m) => m['role'] === 'assistant')
+      expect(assistants).toHaveLength(2)
+
+      // assistant#1: tool_use + reasoning, echoed.
+      expect(assistants[0]['tool_calls']).toBeDefined()
+      expect(assistants[0]['reasoning_content']).toBe('Need to search.')
+
+      // assistant#2: text-only (no tool_calls) but in a tool-calling
+      // conversation — reasoning MUST still be echoed. This is the
+      // regression the original PR shipped with.
+      expect(assistants[1]['tool_calls']).toBeUndefined()
+      expect(assistants[1]['content']).toBe('Found foo at example.com')
+      expect(assistants[1]['reasoning_content']).toBe('Synthesise the answer.')
     })
 
     it('does NOT echo reasoning blocks from a foreign provenance', async () => {

--- a/tests/llm-adapter-capabilities.test.ts
+++ b/tests/llm-adapter-capabilities.test.ts
@@ -58,7 +58,7 @@ describe('LLMAdapter Phase 1 capability contract', () => {
     ['openai', () => new OpenAIAdapter('dummy-key'), 'never' as const],
     ['azure-openai', () => new AzureOpenAIAdapter('dummy-key', 'https://example.openai.azure.com'), 'never' as const],
     ['copilot', () => new CopilotAdapter('dummy-token'), 'never' as const],
-    ['deepseek', () => new DeepSeekAdapter('dummy-key'), 'never' as const],
+    ['deepseek', () => new DeepSeekAdapter('dummy-key'), 'tool-use-only' as const],
     ['grok', () => new GrokAdapter('dummy-key'), 'never' as const],
     ['qiniu', () => new QiniuAdapter('dummy-key'), 'never' as const],
     ['minimax', () => new MiniMaxAdapter('dummy-key'), 'never' as const],
@@ -70,14 +70,27 @@ describe('LLMAdapter Phase 1 capability contract', () => {
     expect(adapter.capabilities?.echoesReasoning).toBe(expectedEcho)
   })
 
-  it('OpenAI subclasses inherit `capabilities` from OpenAIAdapter', () => {
-    // Sanity check: the subclasses don't redeclare `capabilities` and rely on
-    // inheritance so any future adjustment to the parent's value propagates.
+  it('OpenAI subclasses inherit `capabilities` from OpenAIAdapter (except DeepSeek)', () => {
+    // Sanity check: most subclasses don't redeclare `capabilities` and rely
+    // on inheritance so any future adjustment to the parent's value
+    // propagates. DeepSeek is the deliberate exception — see the next test.
     const parent = new OpenAIAdapter('dummy-key').capabilities
-    expect(new DeepSeekAdapter('dummy-key').capabilities).toEqual(parent)
     expect(new GrokAdapter('dummy-key').capabilities).toEqual(parent)
     expect(new QiniuAdapter('dummy-key').capabilities).toEqual(parent)
     expect(new MiniMaxAdapter('dummy-key').capabilities).toEqual(parent)
+  })
+
+  it('DeepSeek overrides `capabilities` to `tool-use-only`', () => {
+    // DeepSeek V4 thinking mode requires `reasoning_content` to be echoed
+    // back on follow-up requests with prior tool-use turns; without this
+    // override DeepSeek would inherit OpenAI's `'never'` and hit 400 on the
+    // second turn of any tool-using agent. See deepseek.ts capability docs.
+    expect(new DeepSeekAdapter('dummy-key').capabilities).toEqual({
+      echoesReasoning: 'tool-use-only',
+    })
+    expect(new DeepSeekAdapter('dummy-key').capabilities).not.toEqual(
+      new OpenAIAdapter('dummy-key').capabilities,
+    )
   })
 })
 


### PR DESCRIPTION
## Summary

- DeepSeek V4 thinking mode returns 400 on follow-up requests that omit `reasoning_content` from a tool-calling conversation. `DeepSeekAdapter` was inheriting OpenAI's `echoesReasoning: 'never'` capability, so reasoning was silently dropped on outbound, breaking every tool-using V4 agent on the second turn.
- Adds a third capability value `'tool-use-only'`. `DeepSeekAdapter` overrides to this; the OpenAI-family message builder pre-scans for any `tool_use` in the conversation and, when found, attaches `reasoning_content` on every assistant message that carries a matching-provenance reasoning block, including the final synthesis message with no `tool_calls` of its own (per spec, omitting this would 400 on the next user turn). Non-tool conversations drop reasoning entirely; foreign-provenance blocks are not echoed.
- Other OpenAI-family adapters (OpenAI, Azure, Copilot, Grok, Qiniu, MiniMax) keep `'never'` with no behavior change. Builds on the IR scaffolding from #223 / #243.

Spec: https://api-docs.deepseek.com/zh-cn/guides/thinking_mode

## Test plan

- [x] `npm run lint` clean
- [x] `npm test` 852/852 pass (7 new tests in `tests/deepseek-adapter.test.ts` covering tool-use echo, text-only echo in tool-calling conversation, pure-text-dialog drop, foreign provenance drop, missing provenance drop, multi-historical-turn preservation, and OpenAI parent stays no-echo)
- [x] `npm run build` clean
- [x] End-to-end against live DeepSeek API via `examples/providers/deepseek.ts`: 4 agents, 48 tool calls, no 400s