### PR TITLE
test(openai-adapter): strengthen fallback text extraction assertion

### DIFF
--- a/tests/openai-adapter.test.ts
+++ b/tests/openai-adapter.test.ts
@@ -221,7 +221,7 @@ describe('OpenAIAdapter', () => {
       ])
     })
 
-    it('passes tool names for fallback text extraction', async () => {
+    it('extracts fallback text tool calls using the requested tool names', async () => {
       // When native tool_calls is empty but text contains tool JSON, the adapter
       // should invoke extractToolCallsFromText with known tool names.
       // We test this indirectly: the completion has text containing tool JSON
@@ -243,9 +243,15 @@ describe('OpenAIAdapter', () => {
         chatOpts({ tools: [toolDef('search')] }),
       )
 
-      // The fromOpenAICompletion + extractToolCallsFromText pipeline should find the tool
-      const toolBlocks = result.content.filter(b => b.type === 'tool_use')
-      expect(toolBlocks.length).toBeGreaterThanOrEqual(0) // may or may not extract depending on format
+      const toolBlocks = result.content.filter((b): b is ToolUseBlock => b.type === 'tool_use')
+      expect(toolBlocks).toHaveLength(1)
+      expect(toolBlocks[0]).toEqual({
+        type: 'tool_use',
+        id: expect.any(String),
+        name: 'search',
+        input: { q: 'test' },
+      })
+      expect(result.stop_reason).toBe('tool_use')
     })
 
     it('propagates SDK errors', async () => {


### PR DESCRIPTION
## Problem

`tests/openai-adapter.test.ts` had:

```ts
expect(toolBlocks.length).toBeGreaterThanOrEqual(0) // may or may not extract depending on format
```

which always passes. If the fallback text-extraction pipeline broke, this test wouldn't catch it.

## Change

- Assert a single `tool_use` block is extracted with `name: 'search'`, `input: { q: 'test' }`, and `stop_reason: 'tool_use'`.
- Rename the test to describe what it actually checks.

## Verification

- `npm test -- tests/openai-adapter.test.ts` passes (25 tests).
- Full suite: 852 tests pass.