### PR TITLE
fix(agent): replay history into loop detector and inject warnings for text-only loops

### DIFF
--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -328,6 +328,16 @@ function prependSyntheticPrefixToFirstUser(
   return [...messages.slice(0, userIdx), merged, ...messages.slice(userIdx + 1)]
 }
 
+function loopWarningText(kind: 'tool_repetition' | 'text_repetition'): string {
+  return kind === 'text_repetition'
+    ? 'WARNING: You appear to be generating the same response repeatedly. ' +
+        'This suggests you are stuck in a loop. Please try a different approach ' +
+        'or provide new information.'
+    : 'WARNING: You appear to be repeating the same tool calls with identical arguments. ' +
+        'This suggests you are stuck in a loop. Please try a different approach, use different ' +
+        'parameters, or explain what you are trying to accomplish.'
+}
+
 // ---------------------------------------------------------------------------
 // AgentRunner
 // ---------------------------------------------------------------------------
@@ -713,6 +723,19 @@ export class AgentRunner {
     const detector = this.options.loopDetection
       ? new LoopDetector(this.options.loopDetection)
       : null
+    if (detector !== null) {
+      for (const message of conversationMessages) {
+        if (message.role !== 'assistant') continue
+        const historicalToolUseBlocks = extractToolUseBlocks(message.content)
+        if (historicalToolUseBlocks.length > 0) {
+          detector.recordToolCalls(historicalToolUseBlocks)
+        }
+        const historicalText = extractText(message.content)
+        if (historicalText.length > 0) {
+          detector.recordText(historicalText)
+        }
+      }
+    }
     let loopDetected = false
     let loopWarned = false
     const loopAction = this.options.loopDetection?.onLoopDetected ?? 'warn'
@@ -824,8 +847,10 @@ export class AgentRunner {
         // ------------------------------------------------------------------
         let injectWarning = false
         let injectWarningKind: 'tool_repetition' | 'text_repetition' = 'tool_repetition'
-        if (detector && toolUseBlocks.length > 0) {
-          const toolInfo = detector.recordToolCalls(toolUseBlocks)
+        if (detector) {
+          const toolInfo = toolUseBlocks.length > 0
+            ? detector.recordToolCalls(toolUseBlocks)
+            : null
           const textInfo = turnText.length > 0 ? detector.recordText(turnText) : null
           const info = toolInfo ?? textInfo
 
@@ -865,6 +890,19 @@ export class AgentRunner {
         // Step 3: Decide whether to continue looping.
         // ------------------------------------------------------------------
         if (toolUseBlocks.length === 0) {
+          if (pendingBudgetExceeded) {
+            break
+          }
+          if (injectWarning) {
+            const warningMessage: LLMMessage = {
+              role: 'user',
+              content: [{ type: 'text', text: loopWarningText(injectWarningKind) }],
+            }
+            conversationMessages.push(warningMessage)
+            newMessages.push(warningMessage)
+            options.onMessage?.(warningMessage)
+            continue
+          }
           // Warn on first turn if tools were provided but model didn't use them.
           if (turns === 1 && toolDefs.length > 0 && options.onWarning) {
             const agentName = this.options.agentName ?? 'unknown'
@@ -989,14 +1027,7 @@ export class AgentRunner {
         // the LLM sees it alongside the results (avoids two consecutive user
         // messages which violates the alternating-role constraint).
         if (injectWarning) {
-          const warningText = injectWarningKind === 'text_repetition'
-            ? 'WARNING: You appear to be generating the same response repeatedly. ' +
-              'This suggests you are stuck in a loop. Please try a different approach ' +
-              'or provide new information.'
-            : 'WARNING: You appear to be repeating the same tool calls with identical arguments. ' +
-              'This suggests you are stuck in a loop. Please try a different approach, use different ' +
-              'parameters, or explain what you are trying to accomplish.'
-          toolResultBlocks.push({ type: 'text' as const, text: warningText })
+          toolResultBlocks.push({ type: 'text' as const, text: loopWarningText(injectWarningKind) })
         }
 
         const toolResultMessage: LLMMessage = {

--- a/tests/loop-detection.test.ts
+++ b/tests/loop-detection.test.ts
@@ -256,6 +256,25 @@ describe('AgentRunner loop detection', () => {
     expect(info.repetitions).toBe(3)
   })
 
+  it('terminates on repeated text responses from existing conversation history', async () => {
+    const runner = buildRunner([textResponse('stuck')], {
+      maxRepetitions: 3,
+      onLoopDetected: 'terminate',
+    })
+
+    const result = await runner.run([
+      { role: 'user', content: [{ type: 'text', text: 'first' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'stuck' }] },
+      { role: 'user', content: [{ type: 'text', text: 'second' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'stuck' }] },
+      { role: 'user', content: [{ type: 'text', text: 'third' }] },
+    ])
+
+    expect(result.loopDetected).toBe(true)
+    expect(result.turns).toBe(1)
+    expect(result.output).toBe('stuck')
+  })
+
   it('calls onWarning in terminate mode', async () => {
     const responses = [
       ...Array.from({ length: 5 }, () => toolUseResponse('echo', { message: 'hi' })),


### PR DESCRIPTION
## Summary

- When a multi-turn run resumes with a non-empty `conversationMessages`, the loop detector started recording from scratch, so a loop already visible in history wasn't picked up until it repeated again from turn 0. Now the runner pre-feeds every historical assistant message (tool-use signatures and text) into the detector before the first turn so resumed conversations don't get a free pass.

- Detection was previously gated on `toolUseBlocks.length > 0`, which meant a pure-text repetition (the agent keeps answering the same paragraph without calling a tool) was invisible. Tool-call recording and text recording are now decoupled, and text-only repetition is detected on the same `maxRepetitions` setting.

- If a loop is flagged on a turn that produced no tool calls, the runner used to fall straight through to the end branch. It now injects the warning as a `user` message and continues the loop, giving the model one more turn to break out — matching the behaviour of the tool-using path.

- Refactor: the two copies of the warning text moved into a `loopWarningText(kind)` helper.

## Test plan

- [x] `npm run lint`
- [x] `npm test` 853/853 (adds 1 history-replay test in `tests/loop-detection.test.ts`)