### PR TITLE
fix(orchestrator): respect abortSignal before synthesis and reject ambiguous task deps

### DIFF
--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -1332,6 +1332,9 @@ export class OpenMultiAgent {
     // ------------------------------------------------------------------
     // Step 5: Coordinator synthesises final result
     // ------------------------------------------------------------------
+    if (options?.abortSignal?.aborted) {
+      return this.buildTeamRunResult(agentResults, goal, taskRecords)
+    }
     if (
       maxTokenBudget !== undefined
       && cumulativeUsage.input_tokens + cumulativeUsage.output_tokens > maxTokenBudget
@@ -1659,6 +1662,12 @@ export class OpenMultiAgent {
     queue: TaskQueue,
   ): void {
     const agentNames = new Set(agentConfigs.map((a) => a.name))
+    const normalizeTitle = (title: string): string => title.toLowerCase().trim()
+    const titleCounts = new Map<string, number>()
+    for (const spec of specs) {
+      const key = normalizeTitle(spec.title)
+      titleCounts.set(key, (titleCounts.get(key) ?? 0) + 1)
+    }
 
     // First pass: create tasks (without dependencies) to get stable IDs.
     const titleToId = new Map<string, string>()
@@ -1676,7 +1685,10 @@ export class OpenMultiAgent {
         retryDelayMs: spec.retryDelayMs,
         retryBackoff: spec.retryBackoff,
       })
-      titleToId.set(spec.title.toLowerCase().trim(), task.id)
+      const titleKey = normalizeTitle(spec.title)
+      if ((titleCounts.get(titleKey) ?? 0) === 1) {
+        titleToId.set(titleKey, task.id)
+      }
       createdTasks.push(task)
     }
 
@@ -1691,13 +1703,18 @@ export class OpenMultiAgent {
       }
 
       const resolvedDeps: string[] = []
+      const unresolvedDeps: string[] = []
       for (const depRef of spec.dependsOn) {
         // Accept both raw IDs and title strings
         const byId = createdTasks.find((t) => t.id === depRef)
-        const byTitle = titleToId.get(depRef.toLowerCase().trim())
+        const depTitleKey = normalizeTitle(depRef)
+        const byTitle = titleToId.get(depTitleKey)
         const resolvedId = byId?.id ?? byTitle
         if (resolvedId) {
           resolvedDeps.push(resolvedId)
+        } else {
+          const count = titleCounts.get(depTitleKey) ?? 0
+          unresolvedDeps.push(count > 1 ? `${depRef} (ambiguous duplicate title)` : depRef)
         }
       }
 
@@ -1706,6 +1723,12 @@ export class OpenMultiAgent {
         dependsOn: resolvedDeps.length > 0 ? resolvedDeps : undefined,
       }
       queue.add(taskWithDeps)
+      if (unresolvedDeps.length > 0) {
+        queue.fail(
+          task.id,
+          `Unresolved dependency reference(s): ${unresolvedDeps.join(', ')}`,
+        )
+      }
     }
   }
 

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -676,6 +676,176 @@ describe('OpenMultiAgent', () => {
       expect(delegatedPrompt).toContain('Inspect delegated detail')
       expect(delegatedPrompt).not.toContain('Coordinator: selected you')
     })
+
+    it('does not run final synthesis when abortSignal is aborted after task execution', async () => {
+      const controller = new AbortController()
+      let coordinatorCalls = 0
+      const coordinatorAdapter: LLMAdapter = {
+        name: 'coordinator-mock',
+        async chat(): Promise<LLMResponse> {
+          coordinatorCalls++
+          return coordinatorCalls === 1
+            ? textResponse('```json\n[{"title": "Work", "description": "Do work", "assignee": "worker"}]\n```')
+            : textResponse('unexpected synthesis')
+        },
+        async *stream() { yield { type: 'done' as const, data: {} } },
+      }
+      const workerAdapter: LLMAdapter = {
+        name: 'worker-mock',
+        async chat(): Promise<LLMResponse> {
+          controller.abort()
+          return textResponse('worker output')
+        },
+        async *stream() { yield { type: 'done' as const, data: {} } },
+      }
+
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg([
+        { ...agentConfig('worker'), adapter: workerAdapter },
+      ]))
+
+      const result = await oma.runTeam(team, 'First do the work, then synthesize the result', {
+        coordinator: { adapter: coordinatorAdapter },
+        abortSignal: controller.signal,
+      })
+
+      expect(coordinatorCalls).toBe(1)
+      expect(result.tasks?.[0]?.status).toBe('completed')
+      expect(result.agentResults.get('worker')?.output).toBe('worker output')
+    })
+
+    it('marks tasks with unknown coordinator dependencies as failed instead of dropping them', async () => {
+      let workerCalls = 0
+      let synthesisPrompt = ''
+      const coordinatorAdapter: LLMAdapter = {
+        name: 'coordinator-mock',
+        async chat(messages: LLMMessage[]): Promise<LLMResponse> {
+          const prompt = extractUserPrompt(messages)
+          if (prompt.includes('Task Results')) {
+            synthesisPrompt = prompt
+            return textResponse('final with gap')
+          }
+          return textResponse('```json\n[{"title": "Use missing", "description": "Use a missing result", "assignee": "worker", "dependsOn": ["Missing research"]}]\n```')
+        },
+        async *stream() { yield { type: 'done' as const, data: {} } },
+      }
+      const workerAdapter: LLMAdapter = {
+        name: 'worker-mock',
+        async chat(): Promise<LLMResponse> {
+          workerCalls++
+          return textResponse('should not run')
+        },
+        async *stream() { yield { type: 'done' as const, data: {} } },
+      }
+
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg([
+        { ...agentConfig('worker'), adapter: workerAdapter },
+      ]))
+
+      const result = await oma.runTeam(team, 'First resolve dependencies, then produce output', {
+        coordinator: { adapter: coordinatorAdapter },
+      })
+
+      const task = result.tasks?.find((t) => t.title === 'Use missing')
+      expect(task?.status).toBe('failed')
+      expect(synthesisPrompt).toContain('Unresolved dependency reference(s): Missing research')
+      expect(workerCalls).toBe(0)
+    })
+
+    it('fails ambiguous title dependencies when coordinator emits duplicate task titles', async () => {
+      let synthesisPrompt = ''
+      const coordinatorAdapter: LLMAdapter = {
+        name: 'coordinator-mock',
+        async chat(messages: LLMMessage[]): Promise<LLMResponse> {
+          const prompt = extractUserPrompt(messages)
+          if (prompt.includes('Task Results')) {
+            synthesisPrompt = prompt
+            return textResponse('final with ambiguity')
+          }
+          return textResponse([
+                '```json',
+                '[',
+                '{"title": "Research", "description": "Research A", "assignee": "worker-a"},',
+                '{"title": "Research", "description": "Research B", "assignee": "worker-b"},',
+                '{"title": "Synthesize", "description": "Use research", "assignee": "worker-a", "dependsOn": ["Research"]}',
+                ']',
+                '```',
+              ].join('\n'))
+        },
+        async *stream() { yield { type: 'done' as const, data: {} } },
+      }
+
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg())
+
+      const result = await oma.runTeam(team, 'First research in parallel, then synthesize', {
+        coordinator: { adapter: coordinatorAdapter },
+      })
+
+      const synth = result.tasks?.find((t) => t.title === 'Synthesize')
+      expect(synth?.status).toBe('failed')
+      expect(synthesisPrompt).toContain('Research (ambiguous duplicate title)')
+    })
+
+    it('includes failed and skipped task sections in final synthesis prompt', async () => {
+      let coordinatorCalls = 0
+      let synthesisPrompt = ''
+      const coordinatorAdapter: LLMAdapter = {
+        name: 'coordinator-mock',
+        async chat(messages: LLMMessage[]): Promise<LLMResponse> {
+          coordinatorCalls++
+          if (coordinatorCalls === 1) {
+            return textResponse([
+              '```json',
+              '[',
+              '{"title": "Failing task", "description": "This fails", "assignee": "worker-a"},',
+              '{"title": "Successful task", "description": "This succeeds", "assignee": "worker-b"},',
+              '{"title": "Later task", "description": "Runs after success", "assignee": "worker-b", "dependsOn": ["Successful task"]}',
+              ']',
+              '```',
+            ].join('\n'))
+          }
+          synthesisPrompt = extractUserPrompt(messages)
+          return textResponse('final with caveats')
+        },
+        async *stream() { yield { type: 'done' as const, data: {} } },
+      }
+      const failingAdapter: LLMAdapter = {
+        name: 'failing-worker',
+        async chat(): Promise<LLMResponse> {
+          throw new Error('worker failed')
+        },
+        async *stream() { yield { type: 'done' as const, data: {} } },
+      }
+      const successAdapter: LLMAdapter = {
+        name: 'success-worker',
+        async chat(): Promise<LLMResponse> {
+          return textResponse('success output')
+        },
+        async *stream() { yield { type: 'done' as const, data: {} } },
+      }
+
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onApproval: async () => false,
+      })
+      const team = oma.createTeam('t', teamCfg([
+        { ...agentConfig('worker-a'), adapter: failingAdapter },
+        { ...agentConfig('worker-b'), adapter: successAdapter },
+      ]))
+
+      await oma.runTeam(team, 'First run independent work, then review the remaining step', {
+        coordinator: { adapter: coordinatorAdapter },
+      })
+
+      expect(synthesisPrompt).toContain('## Failed Tasks')
+      expect(synthesisPrompt).toContain('### Failing task (FAILED)')
+      expect(synthesisPrompt).toContain('worker failed')
+      expect(synthesisPrompt).toContain('## Skipped Tasks')
+      expect(synthesisPrompt).toContain('### Later task (SKIPPED)')
+      expect(synthesisPrompt).toContain('Skipped: approval rejected.')
+    })
   })
 
   describe('config defaults', () => {


### PR DESCRIPTION
## Summary

- `runTeam()` checked `abortSignal` while tasks were running but not before the Step 5 coordinator synthesis call. An aborted run still spent one more coordinator round-trip. Now we check the signal first and return `buildTeamRunResult(agentResults, goal, taskRecords)` immediately when aborted.

- `applyTaskSpecs()` resolved `dependsOn` strings by title, but two coordinator-emitted tasks with the same title silently overwrote each other in `titleToId`, leaving dependency references pointing at an unpredictable winner. We now pre-count titles and refuse to register duplicates in `titleToId`; references to a duplicate title are reported as `"<title> (ambiguous duplicate title)"`.

- References to a title or ID that doesn't exist used to be dropped from `dependsOn` without trace — the task ran as if it had no dependency. We now track those as `unresolvedDeps` and explicitly `queue.fail(task.id, ...)` so the failure surfaces in the run result and in the synthesis prompt's Failed Tasks section instead of becoming a silent mis-execution.

## Test plan

- [x] `npm run lint`
- [x] `npm test` 856/856 (adds 4 tests in `tests/orchestrator.test.ts`: abort skips synthesis, unknown dep -> failed, duplicate title -> failed, synthesis prompt includes Failed/Skipped sections)