### PR TITLE
fix(mcp): dedupe normalized tool names and clean up client/transport on connect failure

### DIFF
--- a/src/tool/mcp.ts
+++ b/src/tool/mcp.ts
@@ -105,6 +105,24 @@ function normalizeToolName(rawName: string, namePrefix?: string): string {
   return base.replace(/\//g, '_')
 }
 
+function assertUniqueNormalizedToolNames(
+  tools: readonly MCPToolDescriptor[],
+  namePrefix?: string,
+): void {
+  const seen = new Map<string, string>()
+  for (const tool of tools) {
+    const normalized = normalizeToolName(tool.name, namePrefix)
+    const previous = seen.get(normalized)
+    if (previous !== undefined) {
+      throw new Error(
+        `Duplicate MCP tool name after normalization: "${normalized}" ` +
+          `from "${previous}" and "${tool.name}".`,
+      )
+    }
+    seen.set(normalized, tool.name)
+  }
+}
+
 /** MCP `tools/list` JSON Schema; forwarded to the LLM as-is (runtime validation stays `z.any()`). */
 function mcpLlmInputSchema(
   schema: Record<string, unknown> | undefined,
@@ -251,46 +269,55 @@ export async function connectMCPTools(
     timeout: config.requestTimeoutMs ?? DEFAULT_MCP_REQUEST_TIMEOUT_MS,
   }
 
-  await client.connect(transport, requestOpts)
+  try {
+    await client.connect(transport, requestOpts)
 
-  const mcpTools = await listAllMcpTools(client, requestOpts)
+    const mcpTools = await listAllMcpTools(client, requestOpts)
+    assertUniqueNormalizedToolNames(mcpTools, config.namePrefix)
 
-  const tools: ToolDefinition[] = mcpTools.map((tool) =>
-    defineTool({
-      name: normalizeToolName(tool.name, config.namePrefix),
-      description: tool.description ?? `MCP tool: ${tool.name}`,
-      inputSchema: z.any(),
-      llmInputSchema: mcpLlmInputSchema(tool.inputSchema),
-      execute: async (input: Record<string, unknown>) => {
-        try {
-          const result = await client.callTool(
-            {
-              name: tool.name,
-              arguments: input,
-            },
-            undefined,
-            requestOpts,
-          )
-          return {
-            data: toToolResultData(result),
-            isError: result.isError === true,
+    const tools: ToolDefinition[] = mcpTools.map((tool) =>
+      defineTool({
+        name: normalizeToolName(tool.name, config.namePrefix),
+        description: tool.description ?? `MCP tool: ${tool.name}`,
+        inputSchema: z.any(),
+        llmInputSchema: mcpLlmInputSchema(tool.inputSchema),
+        execute: async (input: Record<string, unknown>) => {
+          try {
+            const result = await client.callTool(
+              {
+                name: tool.name,
+                arguments: input,
+              },
+              undefined,
+              requestOpts,
+            )
+            return {
+              data: toToolResultData(result),
+              isError: result.isError === true,
+            }
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error)
+            return {
+              data: `MCP tool "${tool.name}" failed: ${message}`,
+              isError: true,
+            }
           }
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error)
-          return {
-            data: `MCP tool "${tool.name}" failed: ${message}`,
-            isError: true,
-          }
-        }
+        },
+      }),
+    )
+
+    return {
+      tools,
+      disconnect: async () => {
+        await client.close?.()
       },
-    }),
-  )
-
-  return {
-    tools,
-    disconnect: async () => {
-      await client.close?.()
-    },
+    }
+  } catch (error) {
+    await Promise.allSettled([
+      client.close?.() ?? Promise.resolve(),
+      transport.close?.() ?? Promise.resolve(),
+    ])
+    throw error
   }
 }

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -208,4 +208,65 @@ describe('connectMCPTools', () => {
     expect(result.isError).toBe(true)
     expect(result.data).toContain('permission denied')
   })
+
+  it('cleans up MCP resources when discovery fails after connect', async () => {
+    listToolsMock.mockRejectedValue(new Error('tools/list failed'))
+
+    const { connectMCPTools } = await import('../src/tool/mcp.js')
+
+    await expect(connectMCPTools({
+      command: 'npx',
+      args: ['-y', 'mock-mcp-server'],
+    })).rejects.toThrow('tools/list failed')
+
+    expect(clientCloseMock).toHaveBeenCalledTimes(1)
+    expect(transportCloseMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects duplicate normalized MCP tool names', async () => {
+    listToolsMock.mockResolvedValue({
+      tools: [
+        { name: 'repo/search', description: 'Search slash.', inputSchema: { type: 'object' } },
+        { name: 'repo_search', description: 'Search underscore.', inputSchema: { type: 'object' } },
+      ],
+    })
+
+    const { connectMCPTools } = await import('../src/tool/mcp.js')
+
+    await expect(connectMCPTools({
+      command: 'npx',
+      args: ['-y', 'mock-mcp-server'],
+    })).rejects.toThrow('Duplicate MCP tool name after normalization: "repo_search"')
+
+    expect(clientCloseMock).toHaveBeenCalledTimes(1)
+    expect(transportCloseMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('serializes MCP toolResult first and falls back to structuredContent', async () => {
+    listToolsMock.mockResolvedValue({
+      tools: [{ name: 'structured', description: 'Structured output.', inputSchema: {} }],
+    })
+    callToolMock
+      .mockResolvedValueOnce({
+        toolResult: { ok: true },
+        content: [{ type: 'text', text: 'ignored content' }],
+        structuredContent: { ok: false },
+      })
+      .mockResolvedValueOnce({
+        structuredContent: { count: 2 },
+      })
+
+    const { connectMCPTools } = await import('../src/tool/mcp.js')
+    const connected = await connectMCPTools({
+      command: 'npx',
+      args: ['-y', 'mock-mcp-server'],
+    })
+
+    const toolResult = await connected.tools[0].execute({}, context)
+    expect(toolResult.data).toContain('"ok": true')
+    expect(toolResult.data).not.toContain('ignored content')
+
+    const structured = await connected.tools[0].execute({}, context)
+    expect(structured.data).toContain('"count": 2')
+  })
 })


### PR DESCRIPTION
## Summary

- `normalizeToolName()` replaces `/` with `_`. If an MCP server exposes both `repo/search` and `repo_search`, both normalize to `repo_search` and the later registration silently shadows the earlier one — callers hitting `repo_search` then get unpredictable routing. Added `assertUniqueNormalizedToolNames()`, which runs right after `tools/list` and throws `Duplicate MCP tool name after normalization: "<normalized>"` so the conflict surfaces at connect time instead of at call time.

- `connectMCPTools()` previously executed `client.connect → listAllMcpTools → tools.map(defineTool)` with no error boundary. If `listAllMcpTools` or the dedup check threw, the already-spawned child process and the open transport were leaked. The whole sequence is now wrapped in try/catch; on any failure we `Promise.allSettled([client.close?.(), transport.close?.()])` before rethrowing.

## Test plan

- [x] `npm run lint`
- [x] `npm test` 855/855 (adds 3 tests in `tests/mcp-tools.test.ts`: discovery failure cleans up client + transport, duplicate normalized name rejected, toolResult precedence over structuredContent)