### PR TITLE
docs(examples): list existing provider examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,10 @@ One example per supported provider. All follow the same three-agent (architect /
 | [`providers/deepseek`](providers/deepseek.ts) | DeepSeek Chat | `DEEPSEEK_API_KEY` |
 | [`providers/openrouter`](providers/openrouter.ts) | OpenRouter (OpenAI-compatible) | `OPENROUTER_API_KEY` |
 | [`providers/groq`](providers/groq.ts) | Groq (OpenAI-compatible) | `GROQ_API_KEY` |
+| [`providers/mistral`](providers/mistral.ts) | Mistral (OpenAI-compatible) | `MISTRAL_API_KEY` |
+| [`providers/zhipu`](providers/zhipu.ts) | Zhipu GLM (OpenAI-compatible) | `ZHIPU_API_KEY` |
+| [`providers/doubao`](providers/doubao.ts) | Doubao / ByteDance (OpenAI-compatible) | `ARK_API_KEY` |
+| [`providers/qiniu`](providers/qiniu.ts) | Qiniu (OpenAI-compatible) | `QINIU_API_KEY` |
 
 ## patterns — orchestration patterns
 


### PR DESCRIPTION
## Summary

- Add existing provider example scripts to `examples/README.md`.
- Cover Mistral, Zhipu GLM, Doubao, and Qiniu in the provider examples index.

These examples already exist under `examples/providers/`; this only makes the runnable scripts discoverable from the examples index.

## Test plan

- [x] `npm run lint`
- [x] `npm test`
- [x] Verified each linked provider file exists with `test -f`.