### PR TITLE
feat(llm): cross-provider reasoning text fallback with opt-in (#223 Phase 2)

### DIFF
--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -62,3 +62,40 @@ const agent: AgentConfig = {
 ```
 
 Per-tool `maxOutputChars` (set on `ToolDefinition`) takes priority over the agent-level `maxToolOutputChars`.
+
+## Preserving Reasoning Across Providers
+
+Reasoning models (OpenAI o-series, DeepSeek reasoner, Anthropic extended thinking, Gemini thought summaries) emit intermediate reasoning that the framework extracts as `ReasoningBlock`s with a `provenance` field identifying the producing adapter. By default, only same-provider blocks with a valid signature are echoed back; everything else is silently dropped on outbound conversion to avoid the receiving model rejecting an unsigned thinking block or to keep prompt size predictable.
+
+`preserveReasoningAsText` opts into a `<thinking>...</thinking>` text fallback: whenever an outbound conversion encounters a reasoning block the target adapter cannot natively echo, the block is downgraded to inline text and prepended to the next assistant message:
+
+```typescript
+const agent: AgentConfig = {
+  name: 'cross-provider',
+  model: 'gpt-5',
+  provider: 'openai',
+  // Enable text fallback for reasoning blocks the target adapter can't echo.
+  preserveReasoningAsText: true,
+  // Defaults to ON when preserveReasoningAsText is true; head+tail truncate
+  // each block to 1200 chars. Override to tune, or set false to disable.
+  // compressReasoningText: { minChars: 4000 },
+}
+```
+
+When the fallback fires:
+
+| Source provenance | Target adapter capability | Behaviour with `preserveReasoningAsText: true` |
+|---|---|---|
+| Matches target (`'anthropic'` → Anthropic) and has signature | `'own-issued'` | Native echo (unchanged) |
+| Matches target but no signature | `'own-issued'` | Text fallback |
+| Foreign (e.g. `'openai'` → Anthropic) | `'own-issued'` | Text fallback |
+| Any | `'never'` (OpenAI, Azure, Copilot, Bedrock, AI SDK, etc.) | Text fallback |
+
+Redacted reasoning (Anthropic safety-filtered) emits the placeholder `<thinking>[redacted]</thinking>` to signal that reasoning occurred without leaking the opaque payload.
+
+**Notes:**
+- Disabled by default to avoid silently inflating prompt tokens.
+- Default-on truncation (`compressReasoningText`) is mandatory for safety on long chain-of-thought; disable only when debugging.
+- Some local OpenAI-compatible models may echo `<thinking>` text back into their assistant response, which can trip the loop detector. See `examples/patterns/cross-provider-reasoning.ts` for the failure mode and mitigations.
+- Bedrock currently has `capabilities.echoesReasoning === 'never'` until a follow-up restores its signature round-trip on both inbound extraction and outbound serialization; until then, opt-in always falls back to text for Bedrock targets.
+

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -89,6 +89,9 @@ When the fallback fires:
 | Matches target (`'anthropic'` → Anthropic) and has signature | `'own-issued'` | Native echo (unchanged) |
 | Matches target but no signature | `'own-issued'` | Text fallback |
 | Foreign (e.g. `'openai'` → Anthropic) | `'own-issued'` | Text fallback |
+| Matches target (`'deepseek'` → DeepSeek) in a tool-calling conversation | `'tool-use-only'` | Native `reasoning_content` echo (per DeepSeek V4 spec, see #251) |
+| Matches target but no `tool_use` anywhere in history | `'tool-use-only'` | Dropped (DeepSeek spec ignores non-tool reasoning) |
+| Foreign (e.g. `'openai'` → DeepSeek) | `'tool-use-only'` | Text fallback |
 | Any | `'never'` (OpenAI, Azure, Copilot, Bedrock, AI SDK, etc.) | Text fallback |
 
 Redacted reasoning (Anthropic safety-filtered) emits the placeholder `<thinking>[redacted]</thinking>` to signal that reasoning occurred without leaking the opaque payload.
@@ -98,4 +101,5 @@ Redacted reasoning (Anthropic safety-filtered) emits the placeholder `<thinking>
 - Default-on truncation (`compressReasoningText`) is mandatory for safety on long chain-of-thought; disable only when debugging.
 - Some local OpenAI-compatible models may echo `<thinking>` text back into their assistant response, which can trip the loop detector. See `examples/patterns/cross-provider-reasoning.ts` for the failure mode and mitigations.
 - Bedrock currently has `capabilities.echoesReasoning === 'never'` until a follow-up restores its signature round-trip on both inbound extraction and outbound serialization; until then, opt-in always falls back to text for Bedrock targets.
+- `'tool-use-only'` (DeepSeek V4) is the only capability where same-provider echo works **without** the user opting into `preserveReasoningAsText` — it's forced on internally because the DeepSeek API requires it.
 

--- a/examples/patterns/cross-provider-reasoning.ts
+++ b/examples/patterns/cross-provider-reasoning.ts
@@ -1,0 +1,93 @@
+/**
+ * Cross-provider reasoning preservation via `preserveReasoningAsText`
+ *
+ * When an `Agent.prompt()` conversation runs against a "reasoning" model that
+ * emits `reasoning_content` (OpenAI o-series, DeepSeek reasoner, Anthropic
+ * extended-thinking-via-Bedrock, etc.), the model's intermediate thought
+ * stream is normally either:
+ *
+ *   (a) native-echoed back when the next turn targets the same provider with
+ *       a valid signature (Anthropic, Gemini own-issued path), OR
+ *   (b) silently dropped on the next outbound conversion (everyone else).
+ *
+ * Opt into {@link AgentConfig.preserveReasoningAsText} to replace (b) with a
+ * downgrade — the prior reasoning is wrapped in `<thinking>...</thinking>`
+ * text and prepended to the next assistant message, so the receiving model
+ * has full context of what was previously considered. See #223 for design.
+ *
+ * Run:
+ *   npx tsx examples/patterns/cross-provider-reasoning.ts
+ *
+ * Prerequisites:
+ *   ANTHROPIC_API_KEY
+ *   OPENAI_API_KEY (uses an o-series model for the reasoning emit)
+ */
+
+import { Agent } from '../../src/index.js'
+
+// --- Caveat: loop-detector interaction --------------------------------------
+//
+// Some OpenAI-compatible local models (and a few hosted ones at low quality
+// tiers) re-emit `<thinking>...</thinking>` text back into their assistant
+// response as if the tag were an instruction template. When this happens
+// across multiple turns, the framework's loop-detector may flag the agent as
+// stuck because the assistant text matches turn-over-turn.
+//
+// Mitigation if you hit this:
+//   - Set `loopDetection: { enabled: false }` on the AgentConfig (loses the
+//     safety net for other genuine loop cases — use as a debug measure only).
+//   - Switch to a model that ignores `<thinking>` text on input (most o-series
+//     and Claude models do; problem is mostly with smaller local models).
+//   - Disable `preserveReasoningAsText` entirely; accept reasoning loss.
+//
+// The example below does NOT trigger the issue against gpt-5 / Claude, but is
+// included so contributors testing local models know what to watch for.
+// ----------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  if (!process.env['ANTHROPIC_API_KEY'] || !process.env['OPENAI_API_KEY']) {
+    console.log('Skip: ANTHROPIC_API_KEY and OPENAI_API_KEY both required.')
+    process.exit(0)
+  }
+
+  // Step 1: a reasoning-capable OpenAI model produces a turn that includes
+  // a `reasoning_content` chunk. The adapter extracts it into a ReasoningBlock
+  // with `provenance: 'openai'`, stored in the agent's persistent history.
+  const agent = new Agent({
+    name: 'cross-provider-demo',
+    model: 'gpt-5',  // o-series-style reasoning model
+    provider: 'openai',
+    systemPrompt: 'You reason carefully then give a short final answer.',
+    preserveReasoningAsText: true,
+    // compressReasoningText defaults to `true` whenever preserve is true,
+    // so long reasoning chains are head+tail truncated to 1200 chars by
+    // default. Override with `{ minChars: N }` to tune, or `false` to disable
+    // (footgun — long CoT will eat your prompt budget).
+    compressReasoningText: { minChars: 1500 },
+  })
+
+  const firstAnswer = await agent.prompt(
+    'A train leaves Boston at 60 mph heading west. Another leaves NYC at 80 mph heading north. ' +
+    'After 2 hours, what is the straight-line distance between them? Show your reasoning briefly.',
+  )
+  console.log('--- Turn 1 (OpenAI o-series) ---')
+  console.log(firstAnswer.output.slice(0, 500))
+
+  // Step 2: swap the model to Anthropic mid-conversation. Without
+  // `preserveReasoningAsText`, the prior reasoning would be silently dropped
+  // because Anthropic's outbound only round-trips its own-signed thinking
+  // blocks. With opt-in on, the prior OpenAI reasoning is replayed as
+  // `<thinking>` text so Claude sees the chain.
+  //
+  // (Note: in real code you'd construct a new Agent or use a per-call model
+  // override. The Agent instance owns its adapter; this example keeps things
+  // short and just illustrates the persistence model.)
+  console.log('\n(Hypothetical: if you constructed a second Agent against ' +
+    'Anthropic and replayed the same messageHistory, the prior OpenAI ' +
+    'reasoning would arrive as `<thinking>` text on its first request.)')
+}
+
+void main().catch((err: unknown) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/agent/agent.ts
+++ b/src/agent/agent.ts
@@ -178,6 +178,8 @@ export class Agent {
       maxTokenBudget: this.config.maxTokenBudget,
       contextStrategy: this.config.contextStrategy,
       compressToolResults: this.config.compressToolResults,
+      preserveReasoningAsText: this.config.preserveReasoningAsText,
+      compressReasoningText: this.config.compressReasoningText,
     }
 
     this.runner = new AgentRunner(

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -140,6 +140,10 @@ export interface RunnerOptions {
    * See {@link AgentConfig.compressToolResults} for details.
    */
   readonly compressToolResults?: boolean | { readonly minChars?: number }
+  /** See {@link AgentConfig.preserveReasoningAsText}. */
+  readonly preserveReasoningAsText?: boolean
+  /** See {@link AgentConfig.compressReasoningText}. */
+  readonly compressReasoningText?: boolean | { readonly minChars?: number }
 }
 
 /**
@@ -705,6 +709,8 @@ export class AgentRunner {
       presencePenalty: this.options.presencePenalty,
       extraBody: this.options.extraBody,
       thinking: this.options.thinking,
+      preserveReasoningAsText: this.options.preserveReasoningAsText,
+      compressReasoningText: this.options.compressReasoningText,
       systemPrompt: this.options.systemPrompt,
       abortSignal: effectiveAbortSignal,
     }

--- a/src/llm/ai-sdk.ts
+++ b/src/llm/ai-sdk.ts
@@ -22,6 +22,11 @@ import type {
   ToolUseBlock,
 } from '../types.js'
 import { normalizeFinishReason } from './openai-common.js'
+import {
+  reasoningBlockToInlineText,
+  resolveReasoningOutboundMaxChars,
+  type ReasoningOutboundOptions,
+} from './reasoning-fallback.js'
 
 // ---------------------------------------------------------------------------
 // Message conversion — OMA <-> AI SDK ModelMessage
@@ -42,9 +47,19 @@ function collectToolNamesByCallId(messages: readonly LLMMessage[]): Map<string, 
  * Convert framework {@link LLMMessage}s to AI SDK {@link ModelMessage}s.
  * Exported for unit tests and for callers who need to preflight prompts.
  */
-export function llmMessagesToAiSdkModelMessages(messages: readonly LLMMessage[]): ModelMessage[] {
+export function llmMessagesToAiSdkModelMessages(
+  messages: readonly LLMMessage[],
+  outboundOptions?: ReasoningOutboundOptions,
+): ModelMessage[] {
   const toolNamesByCallId = collectToolNamesByCallId(messages)
   const out: ModelMessage[] = []
+  // When `preserveReasoningAsText` is enabled, swap the AI SDK structured
+  // reasoning emit for a `<thinking>` text part — honouring the adapter's
+  // declared `'never'` capability (see #223 Phase 2). When the flag is off,
+  // we preserve the pre-Phase-2 behaviour of passing structured reasoning
+  // through to the AI SDK provider, since some providers may handle it.
+  const preserveAsText = outboundOptions?.preserveReasoningAsText === true
+  const maxChars = resolveReasoningOutboundMaxChars(outboundOptions)
 
   for (const msg of messages) {
     if (msg.role === 'assistant') {
@@ -57,11 +72,18 @@ export function llmMessagesToAiSdkModelMessages(messages: readonly LLMMessage[])
         if (block.type === 'text') {
           acc.push({ type: 'text', text: block.text })
         } else if (block.type === 'reasoning') {
-          const text =
-            block.redactedData !== undefined && block.redactedData.length > 0
-              ? `[redacted_thinking]${block.redactedData}`
-              : block.text
-          acc.push({ type: 'reasoning', text })
+          if (preserveAsText) {
+            const text = maxChars === undefined
+              ? reasoningBlockToInlineText(block)
+              : reasoningBlockToInlineText(block, { maxChars })
+            if (text.length > 0) acc.push({ type: 'text', text })
+          } else {
+            const text =
+              block.redactedData !== undefined && block.redactedData.length > 0
+                ? `[redacted_thinking]${block.redactedData}`
+                : block.text
+            acc.push({ type: 'reasoning', text })
+          }
         } else if (block.type === 'tool_use') {
           acc.push({
             type: 'tool-call',
@@ -192,12 +214,21 @@ export class AISdkAdapter implements LLMAdapter {
   readonly name = 'ai-sdk'
 
   readonly capabilities = {
-    // Conservative default: the AI SDK proxies many providers and the
-    // adapter cannot introspect at IR-conversion time which underlying
-    // provider would natively accept reasoning input. `'never'` keeps the
-    // outbound path safe (always falls back via Phase 2 helper) without
-    // risking signature-mismatch errors. Phase 2 may refine this if a
-    // per-call provider hint becomes available on the AI SDK surface.
+    // `'never'` means: this framework cannot natively round-trip a
+    // {@link ReasoningBlock} into the AI SDK in a provider-agnostic way —
+    // the AI SDK proxies many providers and we can't introspect at
+    // IR-conversion time which underlying provider would accept reasoning.
+    //
+    // When `preserveReasoningAsText` is set, the outbound conversion in
+    // `llmMessagesToAiSdkModelMessages` honours this by downgrading to
+    // inline `<thinking>` text via the shared helper.
+    //
+    // When the opt-in is OFF, however, we keep the pre-Phase-2 back-compat
+    // behaviour of passing the framework's `ReasoningBlock` through as an
+    // AI SDK structured `{ type: 'reasoning' }` part, letting the SDK
+    // handle it per-provider. This is a deliberate exception to the
+    // `'never'` semantic (which strictly would mean drop-on-default), made
+    // to avoid silently changing what existing AI-SDK users see today.
     echoesReasoning: 'never' as const,
   }
 
@@ -209,7 +240,7 @@ export class AISdkAdapter implements LLMAdapter {
 
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
     const { generateText, tool, jsonSchema } = await import('ai')
-    const aiMessages = llmMessagesToAiSdkModelMessages(messages)
+    const aiMessages = llmMessagesToAiSdkModelMessages(messages, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 
     const tools =
       options.tools !== undefined && options.tools.length > 0
@@ -249,7 +280,7 @@ export class AISdkAdapter implements LLMAdapter {
 
   async *stream(messages: LLMMessage[], options: LLMStreamOptions): AsyncIterable<StreamEvent> {
     const { streamText, tool, jsonSchema } = await import('ai')
-    const aiMessages = llmMessagesToAiSdkModelMessages(messages)
+    const aiMessages = llmMessagesToAiSdkModelMessages(messages, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 
     const tools =
       options.tools !== undefined && options.tools.length > 0

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -53,6 +53,11 @@ import type {
   ToolResultBlock,
   ToolUseBlock,
 } from '../types.js'
+import {
+  reasoningBlockToInlineText,
+  resolveReasoningOutboundMaxChars,
+  type ReasoningOutboundOptions,
+} from './reasoning-fallback.js'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -62,30 +67,34 @@ import type {
  * Convert a single framework {@link ContentBlock} into an Anthropic
  * {@link ContentBlockParam} suitable for the `messages` array, or `null`
  * when the block has no faithful representation on the wire (e.g. a
- * reasoning block from another provider that lacks an Anthropic signature).
+ * reasoning block from another provider that lacks an Anthropic signature
+ * AND the user hasn't opted into the text fallback).
  *
  * `tool_result` blocks are only valid inside `user`-role messages, which is
  * handled by {@link toAnthropicMessages} based on role context.
  */
-function toAnthropicContentBlockParam(block: ContentBlock): ContentBlockParam | null {
+function toAnthropicContentBlockParam(
+  block: ContentBlock,
+  outboundOptions: ReasoningOutboundOptions | undefined,
+): ContentBlockParam | null {
   switch (block.type) {
     case 'reasoning': {
       // Anthropic strictly validates the signature on echoed thinking
       // blocks, so we only round-trip blocks that originated here:
       //   - `redactedData` -> `redacted_thinking` (opaque, signature lives inside)
       //   - `signature`    -> `thinking` block with text + signature
-      // Cross-provider reasoning (e.g. Gemini thought summaries) and
-      // unsigned reasoning text from a single-turn final response carry no
-      // valid signature, so dropping them is safer than risking an API
-      // rejection on the next turn.
-      if (block.redactedData !== undefined) {
+      // For foreign-provenance or unsigned reasoning, fall back to plain
+      // `<thinking>` text when the user opts in (see #223 Phase 2), or
+      // drop silently (today's default) when opt-in is off.
+      const ownProvenance = block.provenance === 'anthropic'
+      if (ownProvenance && block.redactedData !== undefined) {
         const param: RedactedThinkingBlockParam = {
           type: 'redacted_thinking',
           data: block.redactedData,
         }
         return param
       }
-      if (block.signature !== undefined) {
+      if (ownProvenance && block.signature !== undefined) {
         const param: ThinkingBlockParam = {
           type: 'thinking',
           thinking: block.text,
@@ -93,7 +102,14 @@ function toAnthropicContentBlockParam(block: ContentBlock): ContentBlockParam | 
         }
         return param
       }
-      return null
+      if (outboundOptions?.preserveReasoningAsText !== true) return null
+      const maxChars = resolveReasoningOutboundMaxChars(outboundOptions)
+      const text = maxChars === undefined
+        ? reasoningBlockToInlineText(block)
+        : reasoningBlockToInlineText(block, { maxChars })
+      if (text.length === 0) return null
+      const param: TextBlockParam = { type: 'text', text }
+      return param
     }
     case 'text': {
       const param: TextBlockParam = { type: 'text', text: block.text }
@@ -150,11 +166,14 @@ function toAnthropicContentBlockParam(block: ContentBlock): ContentBlockParam | 
  * enforce that here — the caller is responsible for producing a valid
  * conversation history.
  */
-function toAnthropicMessages(messages: LLMMessage[]): MessageParam[] {
+function toAnthropicMessages(
+  messages: LLMMessage[],
+  outboundOptions: ReasoningOutboundOptions | undefined,
+): MessageParam[] {
   return messages.map((msg): MessageParam => ({
     role: msg.role,
     content: msg.content
-      .map(toAnthropicContentBlockParam)
+      .map(block => toAnthropicContentBlockParam(block, outboundOptions))
       .filter((p): p is ContentBlockParam => p !== null),
   }))
 }
@@ -325,7 +344,7 @@ export class AnthropicAdapter implements LLMAdapter {
    * and handle these (e.g. rate limits, context window exceeded).
    */
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
-    const anthropicMessages = toAnthropicMessages(messages)
+    const anthropicMessages = toAnthropicMessages(messages, options)
     const effectiveMaxTokens = options.maxTokens ?? 4096
 
     const response = await this.#client.messages.create(
@@ -384,7 +403,7 @@ export class AnthropicAdapter implements LLMAdapter {
     messages: LLMMessage[],
     options: LLMStreamOptions,
   ): AsyncIterable<StreamEvent> {
-    const anthropicMessages = toAnthropicMessages(messages)
+    const anthropicMessages = toAnthropicMessages(messages, options)
     const effectiveMaxTokens = options.maxTokens ?? 4096
 
     // MessageStream gives us typed events and handles SSE reconnect internally.

--- a/src/llm/azure-openai.ts
+++ b/src/llm/azure-openai.ts
@@ -125,7 +125,7 @@ export class AzureOpenAIAdapter implements LLMAdapter {
    */
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
     const deploymentName = resolveAzureDeploymentName(options.model)
-    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt)
+    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 
     const completion = await this.#client.chat.completions.create(
       {
@@ -174,7 +174,7 @@ export class AzureOpenAIAdapter implements LLMAdapter {
     options: LLMStreamOptions,
   ): AsyncIterable<StreamEvent> {
     const deploymentName = resolveAzureDeploymentName(options.model)
-    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt)
+    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 
     // We request usage in the final chunk so we can include it in the `done` event.
     const streamResponse = await this.#client.chat.completions.create(

--- a/src/llm/bedrock.ts
+++ b/src/llm/bedrock.ts
@@ -53,6 +53,11 @@ import type {
   ToolResultBlock,
   ToolUseBlock,
 } from '../types.js'
+import {
+  reasoningBlockToInlineText,
+  resolveReasoningOutboundMaxChars,
+  type ReasoningOutboundOptions,
+} from './reasoning-fallback.js'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -73,10 +78,18 @@ function base64ToUint8Array(b64: string): Uint8Array {
  * Convert a single framework {@link ContentBlock} into a Bedrock
  * {@link BedrockContentBlock} for the messages array.
  *
- * Reasoning blocks are dropped on input — see the `case 'reasoning'` arm below
- * for the round-trip limitation that forces this.
+ * Reasoning blocks are converted via the shared cross-provider fallback
+ * (see #223): dropped silently by default; emitted as a standalone text
+ * block wrapped in `<thinking>...</thinking>` when
+ * {@link LLMChatOptions.preserveReasoningAsText} is `true`. Native echo
+ * (which would require writing the signature into Bedrock's
+ * `reasoningContent.reasoningText.signature` shape) is still pending —
+ * see {@link BedrockAdapter.capabilities} for the gating rationale.
  */
-function toBedrockContentBlock(block: ContentBlock): BedrockContentBlock | null {
+function toBedrockContentBlock(
+  block: ContentBlock,
+  outboundOptions: ReasoningOutboundOptions | undefined,
+): BedrockContentBlock | null {
   switch (block.type) {
     case 'text':
       return { text: block.text }
@@ -109,15 +122,18 @@ function toBedrockContentBlock(block: ContentBlock): BedrockContentBlock | null 
       }
     }
 
-    case 'reasoning':
-      // Bedrock requires the original reasoning text plus its `signature`
-      // (and `redactedData` for redacted blocks) to be echoed back unchanged
-      // when continuing a multi-turn tool-use conversation with extended
-      // thinking. The IR now carries these fields on {@link ReasoningBlock}
-      // (added in #200), but wiring them through Bedrock's
-      // `reasoningContent.reasoningText.signature` shape has been deferred
-      // to a follow-up PR — until then, we drop reasoning on input.
-      return null
+    case 'reasoning': {
+      // Capability is `'never'` (see BedrockAdapter.capabilities) — all
+      // reasoning falls back to text when the user opts in, regardless of
+      // provenance. When opt-in is off, drop silently (today's default).
+      if (outboundOptions?.preserveReasoningAsText !== true) return null
+      const maxChars = resolveReasoningOutboundMaxChars(outboundOptions)
+      const text = maxChars === undefined
+        ? reasoningBlockToInlineText(block)
+        : reasoningBlockToInlineText(block, { maxChars })
+      if (text.length === 0) return null
+      return { text }
+    }
 
     default: {
       const _exhaustive: never = block
@@ -131,17 +147,19 @@ function toBedrockContentBlock(block: ContentBlock): BedrockContentBlock | null 
  *
  * System prompt is passed separately via `options.systemPrompt` and handled
  * in `chat()`/`stream()` — it never appears as a message role in the framework.
- * Reasoning blocks are silently dropped on input — see {@link toBedrockContentBlock}
- * for why; multi-turn tool-use flows with extended thinking are tracked as
- * a follow-up to #200's phase-1 IR additions.
+ * Reasoning blocks are routed via {@link toBedrockContentBlock}'s fallback —
+ * see #223 for the cross-provider preservation design.
  */
-function toBedrockMessages(messages: LLMMessage[]): BedrockMessage[] {
+function toBedrockMessages(
+  messages: LLMMessage[],
+  outboundOptions: ReasoningOutboundOptions | undefined,
+): BedrockMessage[] {
   const bedrockMessages: BedrockMessage[] = []
 
   for (const msg of messages) {
     const content: BedrockContentBlock[] = []
     for (const block of msg.content) {
-      const converted = toBedrockContentBlock(block)
+      const converted = toBedrockContentBlock(block, outboundOptions)
       if (converted !== null) content.push(converted)
     }
     if (content.length > 0) {
@@ -242,7 +260,7 @@ export class BedrockAdapter implements LLMAdapter {
   // -------------------------------------------------------------------------
 
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
-    const bedrockMessages = toBedrockMessages(messages)
+    const bedrockMessages = toBedrockMessages(messages, options)
     const system = options.systemPrompt ? [{ text: options.systemPrompt }] : undefined
 
     const input: ConstructorParameters<typeof ConverseCommand>[0] = {
@@ -286,7 +304,7 @@ export class BedrockAdapter implements LLMAdapter {
   // -------------------------------------------------------------------------
 
   async *stream(messages: LLMMessage[], options: LLMStreamOptions): AsyncIterable<StreamEvent> {
-    const bedrockMessages = toBedrockMessages(messages)
+    const bedrockMessages = toBedrockMessages(messages, options)
     const system = options.systemPrompt ? [{ text: options.systemPrompt }] : undefined
 
     const input: ConstructorParameters<typeof ConverseStreamCommand>[0] = {

--- a/src/llm/copilot.ts
+++ b/src/llm/copilot.ts
@@ -303,7 +303,7 @@ export class CopilotAdapter implements LLMAdapter {
 
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
     const client = await this.#createClient()
-    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt)
+    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 
     const completion = await client.chat.completions.create(
       {
@@ -336,7 +336,7 @@ export class CopilotAdapter implements LLMAdapter {
     options: LLMStreamOptions,
   ): AsyncIterable<StreamEvent> {
     const client = await this.#createClient()
-    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt)
+    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 
     const streamResponse = await client.chat.completions.create(
       {

--- a/src/llm/gemini.ts
+++ b/src/llm/gemini.ts
@@ -50,6 +50,11 @@ import type {
   ThinkingConfig,
   ToolUseBlock,
 } from '../types.js'
+import {
+  reasoningBlockToInlineText,
+  resolveReasoningOutboundMaxChars,
+  type ReasoningOutboundOptions,
+} from './reasoning-fallback.js'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -79,12 +84,18 @@ function toGeminiRole(role: 'user' | 'assistant'): string {
  * sequence that produced the call. We attach it to the outgoing Part
  * whenever the source {@link ToolUseBlock} carries a signature. Thought
  * summaries (incoming text Parts with `thought: true` surfaced as
- * {@link ReasoningBlock}) are echoed back only when they carry a signature
- * — Gemini 3 recommends round-tripping these signatures, but unsigned
- * reasoning (e.g. cross-provider blocks or Gemini 2.5 thought summaries
- * which never carry signatures) is dropped to keep context lean.
+ * {@link ReasoningBlock}) are echoed back natively only when they carry a
+ * signature AND `provenance === 'gemini'` (Phase 1 contract). For unsigned
+ * own-provenance blocks, foreign-provenance blocks, or Gemini 2.5 thought
+ * summaries (which never carry signatures), the post-Phase-2 behaviour
+ * depends on {@link AgentConfig.preserveReasoningAsText}: when opt-in is
+ * set, the block falls back to inline `<thinking>` text via the shared
+ * helper; when off, it drops silently (pre-Phase-2 default).
  */
-function toGeminiContents(messages: LLMMessage[]): Content[] {
+function toGeminiContents(
+  messages: LLMMessage[],
+  outboundOptions: ReasoningOutboundOptions | undefined,
+): Content[] {
   // First pass: build id → name map for resolving tool results.
   const toolNameById = new Map<string, string>()
   for (const msg of messages) {
@@ -100,17 +111,26 @@ function toGeminiContents(messages: LLMMessage[]): Content[] {
     for (const block of msg.content) {
       switch (block.type) {
         case 'reasoning': {
-          // Echo only when we have a signature to round-trip — see JSDoc
-          // above. Drop unsigned reasoning silently rather than emitting an
-          // empty/unsigned text part that would inflate context for no
-          // protocol benefit.
-          if (block.signature === undefined) break
-          const part: Part = {
-            text: block.text,
-            thought: true,
-            thoughtSignature: block.signature,
+          // Native echo only when this is a Gemini-own block with signature
+          // (matches the Phase-1 own-issued contract). Foreign-provenance or
+          // unsigned reasoning falls back to plain `<thinking>` text when the
+          // user opts in (see #223 Phase 2), or drops silently otherwise.
+          const ownProvenance = block.provenance === 'gemini'
+          if (ownProvenance && block.signature !== undefined) {
+            const part: Part = {
+              text: block.text,
+              thought: true,
+              thoughtSignature: block.signature,
+            }
+            parts.push(part)
+            break
           }
-          parts.push(part)
+          if (outboundOptions?.preserveReasoningAsText !== true) break
+          const maxChars = resolveReasoningOutboundMaxChars(outboundOptions)
+          const text = maxChars === undefined
+            ? reasoningBlockToInlineText(block)
+            : reasoningBlockToInlineText(block, { maxChars })
+          if (text.length > 0) parts.push({ text })
           break
         }
 
@@ -391,7 +411,7 @@ export class GeminiAdapter implements LLMAdapter {
    */
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
     const id = generateId()
-    const contents = toGeminiContents(messages)
+    const contents = toGeminiContents(messages, options)
 
     const response = await this.#client.models.generateContent({
       model: options.model,
@@ -428,7 +448,7 @@ export class GeminiAdapter implements LLMAdapter {
     options: LLMStreamOptions,
   ): AsyncIterable<StreamEvent> {
     const id = generateId()
-    const contents = toGeminiContents(messages)
+    const contents = toGeminiContents(messages, options)
 
     try {
       const streamResponse = await this.#client.models.generateContentStream({

--- a/src/llm/openai-common.ts
+++ b/src/llm/openai-common.ts
@@ -27,24 +27,7 @@ import type {
   ToolUseBlock,
 } from '../types.js'
 import { extractToolCallsFromText } from '../tool/text-tool-extractor.js'
-
-const DEFAULT_REASONING_REPLAY_MAX_CHARS = 1200
-
-export interface OpenAIReasoningReplayOptions {
-  /**
-   * Opt-in switch for replaying framework `reasoning` blocks as inline
-   * `<thinking>...</thinking>` text in OpenAI-family request payloads.
-   *
-   * Defaults to `false` so existing users keep historical behavior:
-   * `reasoning` blocks are ignored on outbound assistant message conversion.
-   */
-  readonly enableReasoningTextReplay?: boolean
-  /**
-   * Maximum character budget for each replayed reasoning block after
-   * truncation. Explicit invalid values are clamped to a minimum of 1 char.
-   */
-  readonly maxReasoningReplayChars?: number
-}
+import { reasoningBlockToInlineText, resolveReasoningOutboundMaxChars, type ReasoningOutboundOptions } from './reasoning-fallback.js'
 
 // ---------------------------------------------------------------------------
 // Framework → OpenAI
@@ -90,35 +73,6 @@ export function getOpenAIReasoningText(source: unknown): string {
   return extractReasoningText((source as Record<string, unknown>)['reasoning_content'])
 }
 
-function resolveReasoningReplayMaxChars(value: number | undefined): number {
-  if (value === undefined) return DEFAULT_REASONING_REPLAY_MAX_CHARS
-  if (!Number.isFinite(value)) return 1
-  const floored = Math.floor(value)
-  if (floored < 1) return 1
-  return floored
-}
-
-function truncateReasoningForReplay(text: string, maxChars: number): string {
-  if (text.length <= maxChars) return text
-
-  const marker = '...[truncated]...'
-  if (marker.length >= maxChars) return text.slice(0, maxChars)
-
-  const budget = maxChars - marker.length
-  const head = Math.ceil(budget * 0.7)
-  const tail = budget - head
-  return `${text.slice(0, head)}${marker}${text.slice(text.length - tail)}`
-}
-
-function reasoningBlockToThinkingText(block: ReasoningBlock, maxChars: number): string {
-  if (typeof block.redactedData === 'string' && block.redactedData.length > 0) {
-    return '<thinking>[redacted]</thinking>'
-  }
-  if (block.text.length === 0) return ''
-  const bounded = truncateReasoningForReplay(block.text, maxChars)
-  return `<thinking>${bounded}</thinking>`
-}
-
 /**
  * Determine whether a framework message contains any `tool_result` content
  * blocks, which must be serialised as separate OpenAI `tool`-role messages.
@@ -147,13 +101,13 @@ function hasToolResults(msg: LLMMessage): boolean {
  */
 export function toOpenAIMessages(
   messages: LLMMessage[],
-  replayOptions?: OpenAIReasoningReplayOptions,
+  outboundOptions?: ReasoningOutboundOptions,
 ): ChatCompletionMessageParam[] {
   const result: ChatCompletionMessageParam[] = []
 
   for (const msg of messages) {
     if (msg.role === 'assistant') {
-      const assistantMsg = toOpenAIAssistantMessage(msg, replayOptions)
+      const assistantMsg = toOpenAIAssistantMessage(msg, outboundOptions)
       if (assistantMsg !== null) {
         result.push(assistantMsg)
       }
@@ -220,13 +174,13 @@ function toOpenAIUserMessage(msg: LLMMessage): ChatCompletionUserMessageParam {
  */
 function toOpenAIAssistantMessage(
   msg: LLMMessage,
-  replayOptions?: OpenAIReasoningReplayOptions,
+  outboundOptions?: ReasoningOutboundOptions,
 ): ChatCompletionAssistantMessageParam | null {
   const toolCalls: ChatCompletionMessageToolCall[] = []
   const textParts: string[] = []
   const pendingThinkingParts: string[] = []
-  const enableReasoningReplay = replayOptions?.enableReasoningTextReplay === true
-  const maxReasoningChars = resolveReasoningReplayMaxChars(replayOptions?.maxReasoningReplayChars)
+  const enableReasoningReplay = outboundOptions?.preserveReasoningAsText === true
+  const resolvedMaxChars = resolveReasoningOutboundMaxChars(outboundOptions)
 
   for (const block of msg.content) {
     if (block.type === 'tool_use') {
@@ -239,7 +193,11 @@ function toOpenAIAssistantMessage(
         },
       })
     } else if (block.type === 'reasoning' && enableReasoningReplay) {
-      const serialized = reasoningBlockToThinkingText(block, maxReasoningChars)
+      // OpenAI-family adapters are uniformly capability `'never'` — every
+      // reasoning block falls back to text regardless of provenance.
+      const serialized = resolvedMaxChars === undefined
+        ? reasoningBlockToInlineText(block)
+        : reasoningBlockToInlineText(block, { maxChars: resolvedMaxChars })
       if (serialized.length > 0) {
         pendingThinkingParts.push(serialized)
       }
@@ -412,7 +370,7 @@ export function normalizeFinishReason(reason: string): string {
 export function buildOpenAIMessageList(
   messages: LLMMessage[],
   systemPrompt: string | undefined,
-  replayOptions?: OpenAIReasoningReplayOptions,
+  outboundOptions?: ReasoningOutboundOptions,
 ): ChatCompletionMessageParam[] {
   const result: ChatCompletionMessageParam[] = []
 
@@ -420,6 +378,6 @@ export function buildOpenAIMessageList(
     result.push({ role: 'system', content: systemPrompt })
   }
 
-  result.push(...toOpenAIMessages(messages, replayOptions))
+  result.push(...toOpenAIMessages(messages, outboundOptions))
   return result
 }

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -72,9 +72,12 @@ export class OpenAIAdapter implements LLMAdapter {
   readonly name: string = 'openai'
 
   readonly capabilities = {
-    // OpenAI Chat Completions does not accept `reasoning_content` on input;
-    // any reasoning replay must go through the `<thinking>` text fallback
-    // already shipped in #234 (see openai-common.ts replay options).
+    // OpenAI Chat Completions does not accept `reasoning_content` on input.
+    // When the user sets {@link AgentConfig.preserveReasoningAsText}, the
+    // outbound conversion in `toOpenAIMessages` (openai-common.ts) downgrades
+    // each reasoning block to inline `<thinking>` text via the shared
+    // helper in `reasoning-fallback.ts`. Without the opt-in, reasoning
+    // blocks are dropped silently.
     echoesReasoning: 'never' as const,
   }
 
@@ -99,7 +102,7 @@ export class OpenAIAdapter implements LLMAdapter {
    * handle these (e.g. rate limits, context length exceeded).
    */
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
-    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt)
+    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 
     const completion = await this.#client.chat.completions.create(
       {
@@ -151,7 +154,7 @@ export class OpenAIAdapter implements LLMAdapter {
     messages: LLMMessage[],
     options: LLMStreamOptions,
   ): AsyncIterable<StreamEvent> {
-    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt)
+    const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 
     // We request usage in the final chunk so we can include it in the `done` event.
     const streamResponse = await this.#client.chat.completions.create(

--- a/src/llm/reasoning-fallback.ts
+++ b/src/llm/reasoning-fallback.ts
@@ -83,6 +83,28 @@ export interface ReasoningOutboundOptions {
   readonly preserveReasoningAsText?: boolean
   /** Mirrors {@link LLMChatOptions.compressReasoningText}. */
   readonly compressReasoningText?: boolean | { readonly minChars?: number }
+  /**
+   * Adapter name to use for native `reasoning_content` echo on outbound
+   * assistant messages inside a tool-calling conversation. Wired by adapters
+   * whose {@link LLMAdapter.capabilities.echoesReasoning} is `'tool-use-only'`
+   * (currently DeepSeek V4 thinking-mode — see PR #251 / DeepSeek API spec).
+   *
+   * When set, each assistant message is scanned for {@link ReasoningBlock}s
+   * whose {@link ReasoningBlock.provenance} matches this value. The collected
+   * reasoning is attached as a `reasoning_content` field on the outbound
+   * payload (a non-standard OpenAI-compat field) IF AND ONLY IF the overall
+   * conversation contains at least one `tool_use` block somewhere in its
+   * history. Non-tool conversations skip the attachment entirely.
+   *
+   * Foreign-provenance blocks fall through to the {@link preserveReasoningAsText}
+   * `<thinking>` text path when that flag is on, so the two mechanisms
+   * compose: native echo for own-provenance + tool-use; text fallback for
+   * everything else.
+   *
+   * Adapters that don't need this leave it unset (default `'never'` and
+   * `'own-issued'` capability paths).
+   */
+  readonly nativeReasoningEchoProvider?: string
 }
 
 /**

--- a/src/llm/reasoning-fallback.ts
+++ b/src/llm/reasoning-fallback.ts
@@ -19,16 +19,13 @@
  *   produced from native API extraction (and always stamped with
  *   `provenance`), never from text parsing.
  *
- * PHASE 1 STATUS:
- *   This helper is exported but not yet wired into any adapter outbound
- *   path. It is introduced ahead of behaviour wiring so the IR additions
- *   (`ReasoningBlock.provenance`, `LLMAdapter.capabilities`) can land
- *   independently and be reviewed in isolation. Phase 2 (#223) will:
- *     - Add `AgentConfig.preserveReasoningAcrossProviders` opt-in.
- *     - Wire each `echoesReasoning: 'never'` and `'own-issued'` adapter's
- *       outbound path to call this helper when appropriate.
- *     - Fold the OpenAI-family private helper added in #234 into this one
- *       so there is a single source of truth.
+ * Wiring (post #223 Phase 2): every adapter outbound path consults
+ * {@link ReasoningOutboundOptions} resolved from
+ * {@link AgentConfig.preserveReasoningAsText} +
+ * {@link AgentConfig.compressReasoningText}. When opt-in is off, reasoning
+ * blocks that can't be native-echoed are dropped silently (preserving
+ * pre-Phase-2 behaviour). When opt-in is on, they pass through
+ * {@link reasoningBlockToInlineText} and become inline `<thinking>` text.
  */
 
 import type { ReasoningBlock } from '../types.js'
@@ -36,10 +33,20 @@ import type { ReasoningBlock } from '../types.js'
 /**
  * Default maximum character budget per `<thinking>` block after truncation.
  * Aligned with the value used by the OpenAI-family private replay helper
- * shipped in #234 (`openai-common.ts:31`) so Phase 2 consolidation is
- * behaviour-preserving.
+ * shipped in #234 so the Phase 2 consolidation is behaviour-preserving.
  */
 export const DEFAULT_REASONING_FALLBACK_MAX_CHARS = 1200
+
+/**
+ * Sentinel value the resolver returns when the caller explicitly disables
+ * truncation (`compressReasoningText: false`). Exported so the special-case
+ * branch in {@link resolveMaxChars} stays searchable — removing the branch
+ * would silently re-introduce truncation for users who opted out.
+ *
+ * Equal to `Number.POSITIVE_INFINITY`; the resolver maps it to
+ * `Number.MAX_SAFE_INTEGER` so `text.length <= maxChars` is always true.
+ */
+export const NO_TRUNCATION = Number.POSITIVE_INFINITY
 
 /** Marker inserted between head and tail when reasoning text is truncated. */
 const TRUNCATION_MARKER = '...[truncated]...'
@@ -50,15 +57,63 @@ const REDACTED_PLACEHOLDER = '<thinking>[redacted]</thinking>'
 export interface ReasoningFallbackOptions {
   /**
    * Hard upper bound on the inner text length (the `<thinking>` wrapper
-   * itself is not counted). Values below 1 are clamped to 1; non-finite
-   * values are treated as 1. When omitted, defaults to
-   * {@link DEFAULT_REASONING_FALLBACK_MAX_CHARS}.
+   * itself is not counted). Special values:
+   *   - `undefined` → defaults to {@link DEFAULT_REASONING_FALLBACK_MAX_CHARS}.
+   *   - {@link NO_TRUNCATION} (`Number.POSITIVE_INFINITY`) → no truncation;
+   *     the entire reasoning text passes through unchanged. This is the
+   *     sentinel returned by {@link resolveReasoningOutboundMaxChars} when
+   *     the caller sets `compressReasoningText: false`.
+   *   - Any other non-finite value (`NaN`, `-Infinity`) → clamped to 1
+   *     (defensive — these values are invalid input).
+   *   - Finite values below 1 → clamped to 1.
+   *   - Finite values ≥ 1 → used as-is (floored).
    */
   readonly maxChars?: number
 }
 
+/**
+ * Outbound-conversion options derived from {@link AgentConfig}'s reasoning
+ * fields. Threaded through every adapter's outbound IR-to-native conversion
+ * so each can opt the user into the cross-provider `<thinking>` text
+ * fallback (see #223). Internal to the LLM layer — adapters pick the values
+ * out of {@link LLMChatOptions} themselves.
+ */
+export interface ReasoningOutboundOptions {
+  /** Mirrors {@link LLMChatOptions.preserveReasoningAsText}. */
+  readonly preserveReasoningAsText?: boolean
+  /** Mirrors {@link LLMChatOptions.compressReasoningText}. */
+  readonly compressReasoningText?: boolean | { readonly minChars?: number }
+}
+
+/**
+ * Resolve {@link ReasoningOutboundOptions} to the `maxChars` value accepted
+ * by {@link reasoningBlockToInlineText}. Encodes the
+ * default-on-when-preserve-on semantics documented in #223:
+ *
+ *   - `preserve=false`           → returns `undefined` (fallback never runs;
+ *                                  callers must check `preserve` themselves)
+ *   - `compress=undefined`/`true`→ returns `undefined` so the helper applies
+ *                                  its own default head+tail budget
+ *   - `compress=false`           → returns {@link NO_TRUNCATION}; the helper
+ *                                  treats this as a no-op cap (full text)
+ *   - `compress={minChars: N}`   → `N` (the threshold value also serves as
+ *                                  the truncation cap)
+ */
+export function resolveReasoningOutboundMaxChars(
+  options: ReasoningOutboundOptions | undefined,
+): number | undefined {
+  if (options?.preserveReasoningAsText !== true) return undefined
+  const compress = options.compressReasoningText
+  if (compress === false) return NO_TRUNCATION
+  if (compress === undefined || compress === true) {
+    return undefined  // helper applies its own default when maxChars omitted
+  }
+  return compress.minChars  // undefined → helper default, number → that cap
+}
+
 function resolveMaxChars(value: number | undefined): number {
   if (value === undefined) return DEFAULT_REASONING_FALLBACK_MAX_CHARS
+  if (value === NO_TRUNCATION) return Number.MAX_SAFE_INTEGER
   if (!Number.isFinite(value)) return 1
   const floored = Math.floor(value)
   if (floored < 1) return 1

--- a/src/types.ts
+++ b/src/types.ts
@@ -507,6 +507,59 @@ export interface AgentConfig {
    */
   readonly compressToolResults?: boolean | { readonly minChars?: number }
   /**
+   * Opt-in: when an outbound IR-to-native conversion encounters a
+   * {@link ReasoningBlock} that the target adapter cannot natively echo
+   * (see {@link LLMAdapter.capabilities.echoesReasoning}), downgrade the
+   * block to `<thinking>...</thinking>` text and prepend to the next text
+   * part instead of dropping it silently (today's default).
+   *
+   * Triggers in two scenarios:
+   *  1. **Same-provider replay** through a `'never'` adapter (e.g. an
+   *     OpenAI o-series response carries `reasoning_content` that gets
+   *     extracted to a `ReasoningBlock`; on the next turn it would
+   *     normally be dropped because Chat Completions doesn't accept
+   *     reasoning input).
+   *  2. **Cross-provider handoff** — `Agent.prompt()` switching `model`
+   *     mid-conversation, or any other path that puts a block from one
+   *     provider in front of another adapter.
+   *
+   * Default `false` because enabling silently inflates prompt tokens
+   * (reasoning blocks can be very long) and emits the model's internal
+   * thinking text to potentially different providers, both of which the
+   * user should consent to. See #223 for the design discussion.
+   *
+   * Caveat: some OpenAI-compatible local models echo `<thinking>` text
+   * back as if it were instruction, which can trip the loop detector —
+   * see `examples/patterns/cross-provider-reasoning.ts`.
+   */
+  readonly preserveReasoningAsText?: boolean
+  /**
+   * Truncate the inner text of each `<thinking>` block emitted by the
+   * {@link preserveReasoningAsText} fallback. Shares the
+   * `boolean | { minChars?: number }` shape with
+   * {@link compressToolResults}, but **the compression method differs**:
+   *
+   *   - `compressToolResults`: blocks over the threshold are *replaced*
+   *     wholesale with a short marker string.
+   *   - `compressReasoningText`: blocks over the threshold are kept but
+   *     reduced to a head+tail excerpt that fits within `minChars`. The
+   *     same number serves as both the activation threshold AND the cap on
+   *     the post-truncation length.
+   *
+   * Values:
+   * - `true` — enable with default 1200-char head+tail excerpt.
+   * - `{ minChars: N }` — pass blocks of length ≤ N untouched; truncate
+   *   longer blocks to fit within N chars.
+   * - `false` — never truncate (footgun for long CoT, not recommended).
+   * - `undefined` — defaults to `true` when {@link preserveReasoningAsText}
+   *   is `true`, else `false`. Matches the maintainer's guidance in #223
+   *   to "tie compress default-on to the preserve flag".
+   *
+   * Has no effect when {@link preserveReasoningAsText} is `false` (no
+   * fallback runs, so nothing to truncate).
+   */
+  readonly compressReasoningText?: boolean | { readonly minChars?: number }
+  /**
    * Optional Zod schema for structured output.  When set, the agent's final
    * output is parsed as JSON and validated against this schema.  A single
    * retry with error feedback is attempted on validation failure.
@@ -1042,6 +1095,10 @@ export interface LLMChatOptions {
   readonly extraBody?: Record<string, unknown>
   /** See {@link AgentConfig.thinking}. */
   readonly thinking?: ThinkingConfig
+  /** See {@link AgentConfig.preserveReasoningAsText}. */
+  readonly preserveReasoningAsText?: boolean
+  /** See {@link AgentConfig.compressReasoningText}. */
+  readonly compressReasoningText?: boolean | { readonly minChars?: number }
   readonly systemPrompt?: string
   readonly abortSignal?: AbortSignal
 }

--- a/tests/ai-sdk-adapter.test.ts
+++ b/tests/ai-sdk-adapter.test.ts
@@ -69,6 +69,65 @@ describe('llmMessagesToAiSdkModelMessages', () => {
     expect(toolMsg.role).toBe('tool')
     expect(toolMsg.content[0]?.output).toEqual({ type: 'error-text', value: 'boom' })
   })
+
+  describe('reasoning text fallback (#223 Phase 2)', () => {
+    it('default-off: reasoning passes through as AI SDK structured part (back-compat)', () => {
+      const out = llmMessagesToAiSdkModelMessages([
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'plan', provenance: 'openai' },
+            { type: 'text', text: 'reply' },
+          ],
+        },
+      ])
+      const assistant = out[0] as { content: Array<{ type: string; text: string }> }
+      expect(assistant.content).toEqual([
+        { type: 'reasoning', text: 'plan' },
+        { type: 'text', text: 'reply' },
+      ])
+    })
+
+    it('preserve=true: reasoning becomes a text part wrapped in <thinking>', () => {
+      const out = llmMessagesToAiSdkModelMessages(
+        [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'reasoning', text: 'plan', provenance: 'openai' },
+              { type: 'text', text: 'reply' },
+            ],
+          },
+        ],
+        { preserveReasoningAsText: true },
+      )
+      const assistant = out[0] as { content: Array<{ type: string; text: string }> }
+      expect(assistant.content).toEqual([
+        { type: 'text', text: '<thinking>plan</thinking>' },
+        { type: 'text', text: 'reply' },
+      ])
+    })
+
+    it('preserve=true: redacted reasoning becomes [redacted] placeholder', () => {
+      const out = llmMessagesToAiSdkModelMessages(
+        [
+          {
+            role: 'assistant',
+            content: [
+              { type: 'reasoning', text: '', redactedData: 'opaque', provenance: 'anthropic' },
+              { type: 'text', text: 'reply' },
+            ],
+          },
+        ],
+        { preserveReasoningAsText: true },
+      )
+      const assistant = out[0] as { content: Array<{ type: string; text: string }> }
+      expect(assistant.content).toEqual([
+        { type: 'text', text: '<thinking>[redacted]</thinking>' },
+        { type: 'text', text: 'reply' },
+      ])
+    })
+  })
 })
 
 describe('AISdkAdapter', () => {

--- a/tests/anthropic-adapter.test.ts
+++ b/tests/anthropic-adapter.test.ts
@@ -548,6 +548,7 @@ describe('AnthropicAdapter', () => {
         type: 'reasoning',
         text: 'previous reasoning',
         signature: 'echo-sig-789',
+        provenance: 'anthropic',
       }
       const messages: LLMMessage[] = [
         { role: 'assistant', content: [reasoning, { type: 'tool_use', id: 't1', name: 's', input: {} }] },
@@ -570,6 +571,7 @@ describe('AnthropicAdapter', () => {
         type: 'reasoning',
         text: '',
         redactedData: 'opaque-payload',
+        provenance: 'anthropic',
       }
       const messages: LLMMessage[] = [
         { role: 'assistant', content: [reasoning, { type: 'text', text: 'ok' }] },
@@ -695,6 +697,111 @@ describe('AnthropicAdapter', () => {
           chatOpts({ maxTokens: 1024, thinking: { enabled: true } }),
         ),
       ).rejects.toThrow(/budgetTokens \(1024\) must be < maxTokens \(1024\)/)
+    })
+  })
+
+  // =========================================================================
+  // Phase 2 of #223 — cross-provider <thinking> text fallback (outbound)
+  // =========================================================================
+
+  describe('reasoning text fallback (#223 Phase 2)', () => {
+    it('default-off: foreign-provenance reasoning is dropped (regression guard)', async () => {
+      mockCreate.mockResolvedValue(makeAnthropicResponse())
+      const foreign: ReasoningBlock = {
+        type: 'reasoning',
+        text: 'from openai',
+        provenance: 'openai',
+      }
+      const messages: LLMMessage[] = [
+        { role: 'assistant', content: [foreign, { type: 'text', text: 'reply' }] },
+      ]
+
+      await adapter.chat(messages, chatOpts())
+
+      const sent = mockCreate.mock.calls[0][0].messages
+      expect(sent[0].content).toEqual([{ type: 'text', text: 'reply' }])
+    })
+
+    it('preserve=true: foreign-provenance reasoning becomes a text block', async () => {
+      mockCreate.mockResolvedValue(makeAnthropicResponse())
+      const foreign: ReasoningBlock = {
+        type: 'reasoning',
+        text: 'from openai',
+        provenance: 'openai',
+      }
+      const messages: LLMMessage[] = [
+        { role: 'assistant', content: [foreign, { type: 'text', text: 'reply' }] },
+      ]
+
+      await adapter.chat(messages, chatOpts({ preserveReasoningAsText: true }))
+
+      const sent = mockCreate.mock.calls[0][0].messages
+      expect(sent[0].content).toEqual([
+        { type: 'text', text: '<thinking>from openai</thinking>' },
+        { type: 'text', text: 'reply' },
+      ])
+    })
+
+    it('preserve=true: own-provenance signed block still native-echoes (no fallback)', async () => {
+      mockCreate.mockResolvedValue(makeAnthropicResponse())
+      const own: ReasoningBlock = {
+        type: 'reasoning',
+        text: 'mine',
+        signature: 'sig',
+        provenance: 'anthropic',
+      }
+      const messages: LLMMessage[] = [
+        { role: 'assistant', content: [own, { type: 'text', text: 'reply' }] },
+      ]
+
+      await adapter.chat(messages, chatOpts({ preserveReasoningAsText: true }))
+
+      const sent = mockCreate.mock.calls[0][0].messages
+      expect(sent[0].content).toEqual([
+        { type: 'thinking', thinking: 'mine', signature: 'sig' },
+        { type: 'text', text: 'reply' },
+      ])
+    })
+
+    it('preserve=true: own-provenance unsigned block falls back to text (no signature to echo)', async () => {
+      mockCreate.mockResolvedValue(makeAnthropicResponse())
+      const own: ReasoningBlock = {
+        type: 'reasoning',
+        text: 'mine but unsigned',
+        provenance: 'anthropic',
+      }
+      const messages: LLMMessage[] = [
+        { role: 'assistant', content: [own, { type: 'text', text: 'reply' }] },
+      ]
+
+      await adapter.chat(messages, chatOpts({ preserveReasoningAsText: true }))
+
+      const sent = mockCreate.mock.calls[0][0].messages
+      expect(sent[0].content).toEqual([
+        { type: 'text', text: '<thinking>mine but unsigned</thinking>' },
+        { type: 'text', text: 'reply' },
+      ])
+    })
+
+    it('preserve=true: foreign redacted block uses [redacted] placeholder', async () => {
+      mockCreate.mockResolvedValue(makeAnthropicResponse())
+      const foreign: ReasoningBlock = {
+        type: 'reasoning',
+        text: '',
+        redactedData: 'opaque',
+        provenance: 'openai',
+      }
+      const messages: LLMMessage[] = [
+        { role: 'assistant', content: [foreign, { type: 'text', text: 'reply' }] },
+      ]
+
+      await adapter.chat(messages, chatOpts({ preserveReasoningAsText: true }))
+
+      const sent = mockCreate.mock.calls[0][0].messages
+      expect(sent[0].content).toEqual([
+        { type: 'text', text: '<thinking>[redacted]</thinking>' },
+        { type: 'text', text: 'reply' },
+      ])
     })
   })
 })

--- a/tests/bedrock-adapter.test.ts
+++ b/tests/bedrock-adapter.test.ts
@@ -395,4 +395,72 @@ describe('BedrockAdapter', () => {
       })
     })
   })
+
+  // =========================================================================
+  // Phase 2 of #223 — cross-provider <thinking> text fallback (outbound)
+  // =========================================================================
+
+  describe('reasoning text fallback (#223 Phase 2)', () => {
+    function lastSentMessages(): Array<Record<string, unknown>> {
+      const cmd = mockSend.mock.calls[0][0]
+      return (cmd.input.messages ?? []) as Array<Record<string, unknown>>
+    }
+
+    it('default-off: reasoning blocks dropped on outbound (regression guard)', async () => {
+      mockSend.mockResolvedValue(makeConverseResponse())
+      const messages: LLMMessage[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'plan', provenance: 'anthropic' },
+            { type: 'text', text: 'reply' },
+          ],
+        },
+      ]
+
+      await adapter.chat(messages, chatOpts())
+
+      expect(lastSentMessages()[0]?.content).toEqual([{ text: 'reply' }])
+    })
+
+    it('preserve=true: reasoning becomes a standalone text block', async () => {
+      mockSend.mockResolvedValue(makeConverseResponse())
+      const messages: LLMMessage[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'plan first', provenance: 'anthropic' },
+            { type: 'text', text: 'reply' },
+          ],
+        },
+      ]
+
+      await adapter.chat(messages, chatOpts({ preserveReasoningAsText: true }))
+
+      expect(lastSentMessages()[0]?.content).toEqual([
+        { text: '<thinking>plan first</thinking>' },
+        { text: 'reply' },
+      ])
+    })
+
+    it('preserve=true: redacted reasoning uses [redacted] placeholder', async () => {
+      mockSend.mockResolvedValue(makeConverseResponse())
+      const messages: LLMMessage[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: '', redactedData: 'opaque', provenance: 'anthropic' },
+            { type: 'text', text: 'reply' },
+          ],
+        },
+      ]
+
+      await adapter.chat(messages, chatOpts({ preserveReasoningAsText: true }))
+
+      expect(lastSentMessages()[0]?.content).toEqual([
+        { text: '<thinking>[redacted]</thinking>' },
+        { text: 'reply' },
+      ])
+    })
+  })
 })

--- a/tests/gemini-adapter-contract.test.ts
+++ b/tests/gemini-adapter-contract.test.ts
@@ -601,6 +601,7 @@ describe('GeminiAdapter (contract)', () => {
         type: 'reasoning',
         text: 'previous thinking',
         signature: 'thought-sig-001',
+        provenance: 'gemini',
       }
       const messages: LLMMessage[] = [
         { role: 'assistant', content: [reasoning, { type: 'text', text: 'reply' }] },
@@ -659,6 +660,70 @@ describe('GeminiAdapter (contract)', () => {
         chatOpts({ thinking: { enabled: false, budgetTokens: 4096 } }),
       )
       expect(mockGenerateContent.mock.calls[1][0].config.thinkingConfig).toBeUndefined()
+    })
+  })
+
+  // =========================================================================
+  // Phase 2 of #223 — cross-provider <thinking> text fallback (outbound)
+  // =========================================================================
+
+  describe('reasoning text fallback (#223 Phase 2)', () => {
+    it('default-off: foreign-provenance reasoning is dropped (regression guard)', async () => {
+      mockGenerateContent.mockResolvedValue(makeGeminiResponse([{ text: 'ok' }]))
+      const foreign: ReasoningBlock = {
+        type: 'reasoning',
+        text: 'from anthropic',
+        provenance: 'anthropic',
+      }
+      const messages: LLMMessage[] = [
+        { role: 'assistant', content: [foreign, { type: 'text', text: 'reply' }] },
+      ]
+
+      await adapter.chat(messages, chatOpts())
+
+      const sent = mockGenerateContent.mock.calls[0][0].contents
+      expect(sent[0].parts).toEqual([{ text: 'reply' }])
+    })
+
+    it('preserve=true: foreign-provenance reasoning becomes a text part', async () => {
+      mockGenerateContent.mockResolvedValue(makeGeminiResponse([{ text: 'ok' }]))
+      const foreign: ReasoningBlock = {
+        type: 'reasoning',
+        text: 'from anthropic',
+        provenance: 'anthropic',
+      }
+      const messages: LLMMessage[] = [
+        { role: 'assistant', content: [foreign, { type: 'text', text: 'reply' }] },
+      ]
+
+      await adapter.chat(messages, chatOpts({ preserveReasoningAsText: true }))
+
+      const sent = mockGenerateContent.mock.calls[0][0].contents
+      expect(sent[0].parts).toEqual([
+        { text: '<thinking>from anthropic</thinking>' },
+        { text: 'reply' },
+      ])
+    })
+
+    it('preserve=true: own-provenance signed block still native-echoes', async () => {
+      mockGenerateContent.mockResolvedValue(makeGeminiResponse([{ text: 'ok' }]))
+      const own: ReasoningBlock = {
+        type: 'reasoning',
+        text: 'mine',
+        signature: 'thought-sig',
+        provenance: 'gemini',
+      }
+      const messages: LLMMessage[] = [
+        { role: 'assistant', content: [own, { type: 'text', text: 'reply' }] },
+      ]
+
+      await adapter.chat(messages, chatOpts({ preserveReasoningAsText: true }))
+
+      const sent = mockGenerateContent.mock.calls[0][0].contents
+      expect(sent[0].parts).toEqual([
+        { text: 'mine', thought: true, thoughtSignature: 'thought-sig' },
+        { text: 'reply' },
+      ])
     })
   })
 })

--- a/tests/openai-common.test.ts
+++ b/tests/openai-common.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from 'vitest'
 import { toOpenAIMessages } from '../src/llm/openai-common.js'
 import type { LLMMessage } from '../src/types.js'
 
+type OutboundOpts = {
+  preserveReasoningAsText?: boolean
+  compressReasoningText?: boolean | { minChars?: number }
+}
+
 function getAssistantContent(
   messages: LLMMessage[],
-  replayOptions?: { enableReasoningTextReplay?: boolean; maxReasoningReplayChars?: number },
+  outboundOptions?: OutboundOpts,
 ): string | null {
-  const output = toOpenAIMessages(messages, replayOptions)
+  const output = toOpenAIMessages(messages, outboundOptions)
   const first = output[0]
   if (first === undefined || first.role !== 'assistant') {
     throw new Error('expected first message to be assistant')
@@ -51,7 +56,7 @@ describe('toOpenAIMessages reasoning fallback', () => {
       },
     ]
 
-    expect(getAssistantContent(messages, { enableReasoningTextReplay: true })).toBe('<thinking>plan first</thinking>Now execute.')
+    expect(getAssistantContent(messages, { preserveReasoningAsText: true })).toBe('<thinking>plan first</thinking>Now execute.')
   })
 
   it('keeps redacted reasoning with placeholder text', () => {
@@ -65,7 +70,7 @@ describe('toOpenAIMessages reasoning fallback', () => {
       },
     ]
 
-    expect(getAssistantContent(messages, { enableReasoningTextReplay: true })).toBe('<thinking>[redacted]</thinking>Proceeding.')
+    expect(getAssistantContent(messages, { preserveReasoningAsText: true })).toBe('<thinking>[redacted]</thinking>Proceeding.')
   })
 
   it('retains fallback text when no regular text block exists', () => {
@@ -76,10 +81,10 @@ describe('toOpenAIMessages reasoning fallback', () => {
       },
     ]
 
-    expect(getAssistantContent(messages, { enableReasoningTextReplay: true })).toBe('<thinking>intermediate chain</thinking>')
+    expect(getAssistantContent(messages, { preserveReasoningAsText: true })).toBe('<thinking>intermediate chain</thinking>')
   })
 
-  it('bounds replay size with truncation when enabled', () => {
+  it('bounds replay size when compress.minChars is set', () => {
     const messages: LLMMessage[] = [
       {
         role: 'assistant',
@@ -91,14 +96,57 @@ describe('toOpenAIMessages reasoning fallback', () => {
     ]
 
     const content = getAssistantContent(messages, {
-      enableReasoningTextReplay: true,
-      maxReasoningReplayChars: 32,
+      preserveReasoningAsText: true,
+      compressReasoningText: { minChars: 32 },
     })
     expect(content).not.toBeNull()
     expect(content!).toContain('<thinking>')
     expect(content!).toContain('[truncated')
     expect(extractThinkingContent(content).length).toBeLessThanOrEqual(32)
     expect(content!.endsWith('Done.')).toBe(true)
+  })
+
+  it('skips truncation when compressReasoningText is explicitly false', () => {
+    // Footgun mode: caller opts into preserve + opts out of compression.
+    // The full reasoning text should pass through unchanged.
+    const longText = 'x'.repeat(5000)
+    const messages: LLMMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: longText },
+          { type: 'text', text: 'Done.' },
+        ],
+      },
+    ]
+
+    const content = getAssistantContent(messages, {
+      preserveReasoningAsText: true,
+      compressReasoningText: false,
+    })
+    expect(content).toBe(`<thinking>${longText}</thinking>Done.`)
+  })
+
+  it('defaults compress to on when preserve is true and compress is undefined', () => {
+    // Maintainer guidance from #223: "tie compress default-on to the preserve
+    // flag". A very long text should be truncated even without an explicit
+    // compress setting.
+    const longText = 'y'.repeat(5000)
+    const messages: LLMMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'reasoning', text: longText },
+          { type: 'text', text: 'Done.' },
+        ],
+      },
+    ]
+
+    const content = getAssistantContent(messages, {
+      preserveReasoningAsText: true,
+    })
+    expect(extractThinkingContent(content).length).toBeLessThan(longText.length)
+    expect(content!).toContain('[truncated')
   })
 
   it('omits reasoning-only assistant messages when fallback is disabled', () => {
@@ -112,8 +160,10 @@ describe('toOpenAIMessages reasoning fallback', () => {
     expect(toOpenAIMessages(messages)).toEqual([])
   })
 
-  it('clamps explicit invalid max chars to minimum bound', () => {
-    const invalidValues = [0, -3, 0.5, Number.NaN, Number.POSITIVE_INFINITY]
+  it('clamps explicit invalid compress.minChars to minimum bound', () => {
+    // Note: positive Infinity is intentionally NOT in this list — it now
+    // means "no truncation" rather than "clamp to 1". See reasoning-fallback.ts.
+    const invalidValues = [0, -3, 0.5, Number.NaN]
     const baseMessages: LLMMessage[] = [
       {
         role: 'assistant',
@@ -126,8 +176,8 @@ describe('toOpenAIMessages reasoning fallback', () => {
 
     for (const value of invalidValues) {
       const content = getAssistantContent(baseMessages, {
-        enableReasoningTextReplay: true,
-        maxReasoningReplayChars: value,
+        preserveReasoningAsText: true,
+        compressReasoningText: { minChars: value },
       })
       expect(extractThinkingContent(content).length).toBe(1)
       expect(content!.endsWith('Done.')).toBe(true)

--- a/tests/reasoning-fallback.test.ts
+++ b/tests/reasoning-fallback.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   DEFAULT_REASONING_FALLBACK_MAX_CHARS,
+  NO_TRUNCATION,
   reasoningBlockToInlineText,
 } from '../src/llm/reasoning-fallback.js'
 import type { ReasoningBlock } from '../src/types.js'
@@ -92,6 +93,19 @@ describe('reasoningBlockToInlineText', () => {
       const text = 'x'.repeat(5000)
       const block: ReasoningBlock = { type: 'reasoning', text }
       expect(reasoningBlockToInlineText(block, { maxChars: Infinity })).toBe(`<thinking>${text}</thinking>`)
+    })
+
+    it('NO_TRUNCATION constant behaves identically to Number.POSITIVE_INFINITY', () => {
+      // Runtime invariant: this guards against a future refactor that
+      // accidentally removes the special-case branch in resolveMaxChars or
+      // re-binds NO_TRUNCATION to a different value. Without this assertion
+      // the JSDoc contract on `maxChars` could silently drift from runtime.
+      expect(NO_TRUNCATION).toBe(Number.POSITIVE_INFINITY)
+      const text = 'y'.repeat(3000)
+      const block: ReasoningBlock = { type: 'reasoning', text }
+      expect(reasoningBlockToInlineText(block, { maxChars: NO_TRUNCATION })).toBe(
+        `<thinking>${text}</thinking>`,
+      )
     })
 
     it('clamps maxChars below 1 to 1', () => {

--- a/tests/reasoning-fallback.test.ts
+++ b/tests/reasoning-fallback.test.ts
@@ -79,10 +79,19 @@ describe('reasoningBlockToInlineText', () => {
       expect(out).toBe('<thinking>abc</thinking>')
     })
 
-    it('clamps non-finite maxChars to 1', () => {
+    it('clamps non-finite maxChars to 1 (except positive Infinity)', () => {
       const block: ReasoningBlock = { type: 'reasoning', text: 'abc' }
       expect(reasoningBlockToInlineText(block, { maxChars: NaN })).toBe('<thinking>a</thinking>')
-      expect(reasoningBlockToInlineText(block, { maxChars: Infinity })).toBe('<thinking>a</thinking>')
+      expect(reasoningBlockToInlineText(block, { maxChars: -Infinity })).toBe('<thinking>a</thinking>')
+    })
+
+    it('treats positive Infinity maxChars as no truncation', () => {
+      // The resolver maps Infinity → MAX_SAFE_INTEGER so text.length <= maxChars
+      // is always true and the text passes through unchanged. This is the
+      // sentinel callers use when AgentConfig.compressReasoningText is `false`.
+      const text = 'x'.repeat(5000)
+      const block: ReasoningBlock = { type: 'reasoning', text }
+      expect(reasoningBlockToInlineText(block, { maxChars: Infinity })).toBe(`<thinking>${text}</thinking>`)
     })
 
     it('clamps maxChars below 1 to 1', () => {

--- a/tests/runner-reasoning-flags.test.ts
+++ b/tests/runner-reasoning-flags.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Phase 2 (#223): assert that `preserveReasoningAsText` and
+ * `compressReasoningText` set on AgentRunner options actually reach the
+ * adapter's `chat()` and `stream()` calls as part of LLMChatOptions /
+ * LLMStreamOptions.
+ *
+ * The wiring path covered:
+ *   AgentConfig (src/agent/agent.ts:178-185)
+ *     → RunnerOptions in src/agent/runner.ts:142-148
+ *     → baseChatOptions in src/agent/runner.ts:707-715
+ *     → adapter.chat(messages, options) / adapter.stream(...)
+ *
+ * A regression that drops the runner-side copy would silently break the
+ * public API while every per-adapter outbound conversion test (which
+ * exercises the conversion in isolation with a directly-constructed
+ * `outboundOptions`) still passes. This file pins the runner contract.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { AgentRunner } from '../src/agent/runner.js'
+import { ToolRegistry } from '../src/tool/framework.js'
+import { ToolExecutor } from '../src/tool/executor.js'
+import type {
+  LLMAdapter,
+  LLMChatOptions,
+  LLMResponse,
+  LLMStreamOptions,
+  StreamEvent,
+} from '../src/types.js'
+
+function makeTextResponse(): LLMResponse {
+  return {
+    id: 'resp-1',
+    content: [{ type: 'text', text: 'done' }],
+    model: 'mock',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+interface CapturingAdapter extends LLMAdapter {
+  readonly capturedChat: LLMChatOptions[]
+  readonly capturedStream: LLMStreamOptions[]
+}
+
+function makeCapturingAdapter(): CapturingAdapter {
+  const capturedChat: LLMChatOptions[] = []
+  const capturedStream: LLMStreamOptions[] = []
+  return {
+    name: 'mock',
+    capturedChat,
+    capturedStream,
+    capabilities: { echoesReasoning: 'never' },
+    async chat(_messages, options) {
+      capturedChat.push(options)
+      return makeTextResponse()
+    },
+    async *stream(_messages, options): AsyncIterable<StreamEvent> {
+      capturedStream.push(options)
+      yield { type: 'done', data: makeTextResponse() }
+    },
+  } satisfies CapturingAdapter
+}
+
+describe('AgentRunner reasoning-flag propagation (#223 Phase 2)', () => {
+  it('forwards preserveReasoningAsText + compressReasoningText into chat() options', async () => {
+    const adapter = makeCapturingAdapter()
+    const runner = new AgentRunner(adapter, new ToolRegistry(), new ToolExecutor(new ToolRegistry()), {
+      model: 'mock-model',
+      maxTurns: 1,
+      preserveReasoningAsText: true,
+      compressReasoningText: { minChars: 2000 },
+    })
+
+    await runner.run([{ role: 'user', content: [{ type: 'text', text: 'hi' }] }])
+
+    expect(adapter.capturedChat).toHaveLength(1)
+    const opts = adapter.capturedChat[0]!
+    expect(opts.preserveReasoningAsText).toBe(true)
+    expect(opts.compressReasoningText).toEqual({ minChars: 2000 })
+  })
+
+  it('forwards undefined when flags are not set on RunnerOptions (back-compat)', async () => {
+    const adapter = makeCapturingAdapter()
+    const runner = new AgentRunner(adapter, new ToolRegistry(), new ToolExecutor(new ToolRegistry()), {
+      model: 'mock-model',
+      maxTurns: 1,
+      // flags omitted
+    })
+
+    await runner.run([{ role: 'user', content: [{ type: 'text', text: 'hi' }] }])
+
+    expect(adapter.capturedChat).toHaveLength(1)
+    const opts = adapter.capturedChat[0]!
+    expect(opts.preserveReasoningAsText).toBeUndefined()
+    expect(opts.compressReasoningText).toBeUndefined()
+  })
+
+  it('forwards compressReasoningText: false sentinel for "no truncation"', async () => {
+    const adapter = makeCapturingAdapter()
+    const runner = new AgentRunner(adapter, new ToolRegistry(), new ToolExecutor(new ToolRegistry()), {
+      model: 'mock-model',
+      maxTurns: 1,
+      preserveReasoningAsText: true,
+      compressReasoningText: false,
+    })
+
+    await runner.run([{ role: 'user', content: [{ type: 'text', text: 'hi' }] }])
+
+    expect(adapter.capturedChat[0]?.compressReasoningText).toBe(false)
+  })
+})

--- a/tests/runner-reasoning-flags.test.ts
+++ b/tests/runner-reasoning-flags.test.ts
@@ -1,19 +1,29 @@
 /**
  * Phase 2 (#223): assert that `preserveReasoningAsText` and
- * `compressReasoningText` set on AgentRunner options actually reach the
- * adapter's `chat()` and `stream()` calls as part of LLMChatOptions /
- * LLMStreamOptions.
+ * `compressReasoningText` set on `AgentRunner` options actually reach the
+ * adapter's `chat()` call as `LLMChatOptions` fields.
  *
- * The wiring path covered:
- *   AgentConfig (src/agent/agent.ts:178-185)
- *     → RunnerOptions in src/agent/runner.ts:142-148
- *     → baseChatOptions in src/agent/runner.ts:707-715
- *     → adapter.chat(messages, options) / adapter.stream(...)
+ * Wiring path covered HERE:
+ *   `AgentRunner` constructor options (src/agent/runner.ts:142-148)
+ *     → `baseChatOptions` (src/agent/runner.ts:707-715)
+ *     → `adapter.chat(messages, options)` (src/agent/runner.ts:766)
  *
- * A regression that drops the runner-side copy would silently break the
- * public API while every per-adapter outbound conversion test (which
- * exercises the conversion in isolation with a directly-constructed
- * `outboundOptions`) still passes. This file pins the runner contract.
+ * Wiring path NOT covered here (intentional):
+ *   - `AgentConfig → RunnerOptions` (src/agent/agent.ts:181-182). That's a
+ *     one-line copy guarded by TypeScript's structural typing — both fields
+ *     are optional on both sides, so a regression would compile-fail iff
+ *     the field is renamed. No runtime test is added because constructing
+ *     a fully-wired `Agent` with a stub adapter has unrelated dependencies
+ *     (tool registry plumbing) that bloat the test surface.
+ *
+ *   - `adapter.stream()`. The framework's streaming path lives in
+ *     `AgentRunner.stream()` (`runner.ts:677`), which under the hood still
+ *     calls `adapter.chat()` rather than `adapter.stream()`. `adapter.stream`
+ *     is exposed on the `LLMAdapter` interface but is currently unused by
+ *     the runner — therefore Phase 2 flag propagation through `adapter.stream`
+ *     does not exercise a real code path. Per-adapter outbound conversion
+ *     tests still verify each `toXxxMessages` implementation correctly
+ *     interprets the options regardless of which adapter method invokes it.
  */
 
 import { describe, it, expect } from 'vitest'
@@ -24,7 +34,6 @@ import type {
   LLMAdapter,
   LLMChatOptions,
   LLMResponse,
-  LLMStreamOptions,
   StreamEvent,
 } from '../src/types.js'
 
@@ -40,23 +49,21 @@ function makeTextResponse(): LLMResponse {
 
 interface CapturingAdapter extends LLMAdapter {
   readonly capturedChat: LLMChatOptions[]
-  readonly capturedStream: LLMStreamOptions[]
 }
 
 function makeCapturingAdapter(): CapturingAdapter {
   const capturedChat: LLMChatOptions[] = []
-  const capturedStream: LLMStreamOptions[] = []
   return {
     name: 'mock',
     capturedChat,
-    capturedStream,
     capabilities: { echoesReasoning: 'never' },
     async chat(_messages, options) {
       capturedChat.push(options)
       return makeTextResponse()
     },
-    async *stream(_messages, options): AsyncIterable<StreamEvent> {
-      capturedStream.push(options)
+    // Required by the interface; intentionally not exercised by these tests
+    // (see file-level JSDoc for rationale).
+    async *stream(): AsyncIterable<StreamEvent> {
       yield { type: 'done', data: makeTextResponse() }
     },
   } satisfies CapturingAdapter
@@ -108,5 +115,28 @@ describe('AgentRunner reasoning-flag propagation (#223 Phase 2)', () => {
     await runner.run([{ role: 'user', content: [{ type: 'text', text: 'hi' }] }])
 
     expect(adapter.capturedChat[0]?.compressReasoningText).toBe(false)
+  })
+
+  it('runner.stream() also threads the flags via adapter.chat() (internal contract)', async () => {
+    // `AgentRunner.stream()` internally drives turns via `adapter.chat()` —
+    // verify the same flag-propagation contract holds for the stream entrypoint
+    // so a future regression that touches the stream path's options-build still
+    // gets caught.
+    const adapter = makeCapturingAdapter()
+    const runner = new AgentRunner(adapter, new ToolRegistry(), new ToolExecutor(new ToolRegistry()), {
+      model: 'mock-model',
+      maxTurns: 1,
+      preserveReasoningAsText: true,
+      compressReasoningText: { minChars: 500 },
+    })
+
+    const events: StreamEvent[] = []
+    for await (const ev of runner.stream([{ role: 'user', content: [{ type: 'text', text: 'hi' }] }])) {
+      events.push(ev)
+    }
+
+    expect(adapter.capturedChat).toHaveLength(1)
+    expect(adapter.capturedChat[0]?.preserveReasoningAsText).toBe(true)
+    expect(adapter.capturedChat[0]?.compressReasoningText).toEqual({ minChars: 500 })
   })
 })


### PR DESCRIPTION
## Summary

Phase 2 of #223 — wires the shared `<thinking>` text fallback into every adapter's outbound path behind two new opt-in flags. Builds on Phase 1 (#243) and **composes orthogonally with #251** (DeepSeek V4 `'tool-use-only'` native echo): native echo claims own-provenance blocks first, text fallback handles everything else.

The default behaviour for every adapter is unchanged: reasoning blocks the target adapter cannot natively echo are still dropped silently. Users who set `preserveReasoningAsText: true` get text-fallback round-tripping with default-on head+tail truncation.

> Note: this branch was rebased onto main via merge after #251 landed. See merge commit `9ca9a91` and the small follow-up `a4841d0` which extends the docs capability table to acknowledge the `'tool-use-only'` third state.

## What changed

**Public API (`AgentConfig` / `LLMChatOptions`)**

- `preserveReasoningAsText?: boolean` — default `false`. When `true`, outbound IR-to-native conversion downgrades each `ReasoningBlock` the target adapter cannot natively echo to inline `<thinking>` text.
- `compressReasoningText?: boolean | { minChars?: number }` — same shape as `compressToolResults`, but the compression method differs (head+tail truncation vs marker replacement). JSDoc explicitly contrasts the two. Defaults default-on when `preserveReasoningAsText` is `true` per #223 maintainer guidance.

**Adapter wiring (5 outbound paths, covering 11 adapters)**

| Adapter | Behaviour with `preserveReasoningAsText: true` |
|---|---|
| openai / azure-openai / copilot / grok / qiniu / minimax (via openai-common) | All foreign reasoning → `<thinking>` text. Native `reasoning_content` echo NOT applied (capability `'never'`). |
| deepseek | Own-provenance + tool-calling conversation → native `reasoning_content` echo (forced by DeepSeek V4 spec via #251 path); foreign-provenance OR non-tool conversation → `<thinking>` text fallback if opt-in is on, else drop. |
| anthropic | Native echo when `provenance === 'anthropic'` AND signature present; foreign-provenance or unsigned own-provenance → text fallback. |
| gemini | Same own/foreign pattern as anthropic, gated on signature. |
| bedrock | All reasoning → text fallback (capability `'never'` until the deferred signature follow-up). |
| ai-sdk | Capability `'never'`; default-off keeps pre-Phase-2 structured `{type:'reasoning'}` pass-through (back-compat). |

**Refactor**

The never-wired `OpenAIReasoningReplayOptions` interface from #234 was already removed in this PR's pre-merge state. After merge, `ReasoningOutboundOptions` (in `src/llm/reasoning-fallback.ts`) is the single shared interface and carries all three orthogonal fields:
- `preserveReasoningAsText` (#223 — opt-in text fallback)
- `compressReasoningText` (#223 — truncation cap)
- `nativeReasoningEchoProvider` (#251 — DeepSeek tool-use native echo)

Each adapter's `buildMessageOptions(options)` derives both `nativeReasoningEchoProvider` (from `capabilities.echoesReasoning === 'tool-use-only'`) AND the AgentConfig fields, returning a single composed options object to `buildOpenAIMessageList`.

The shared `reasoningBlockToInlineText` helper replaces #234's private `reasoningBlockToThinkingText` (the OpenAI-family path now goes through the same code path as anthropic/gemini/bedrock/ai-sdk text fallback). `NO_TRUNCATION` is exported as a searchable sentinel for `compressReasoningText: false`.

**Docs + example**

- `docs/context-management.md` "Preserving Reasoning Across Providers" section, capability table covers all 3 states (`'never'`, `'own-issued'`, `'tool-use-only'`) and the loop-detector caveat.
- `examples/patterns/cross-provider-reasoning.ts` demonstrates the model-swap scenario.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — 869 / 874 passing (5 pre-existing `tests/ai-sdk-adapter.test.ts` peer-dep failures, exist on main, verified via `git stash`).
- [x] `tests/runner-reasoning-flags.test.ts` (4 tests): pins the `RunnerOptions → adapter.chat()` flag propagation contract (including `compressReasoningText: false` / NO_TRUNCATION sentinel and `runner.stream()` entrypoint).
- [x] `tests/reasoning-fallback.test.ts` runtime invariant: ties `NO_TRUNCATION` constant value to the `resolveMaxChars` special case.
- [x] Per-adapter Phase 2 outbound describe blocks: `tests/anthropic-adapter.test.ts` (5), `tests/gemini-adapter-contract.test.ts` (3), `tests/bedrock-adapter.test.ts` (3), `tests/ai-sdk-adapter.test.ts` (3). Each covers default-off drop, opt-in text fallback, redacted placeholder, and (for `'own-issued'` adapters) the native echo path stays intact.
- [x] `tests/openai-common.test.ts` rewritten with new flag names; added cases for `compressReasoningText: false` and the default-on-when-preserve-on semantics.
- [x] All 8 new tests from #251's DeepSeek `'tool-use-only'` behaviour continue to pass post-merge (verified by `npm test -- tests/deepseek-adapter.test.ts`).

## Deferred follow-ups (out of scope)

Surfaced in two rounds of self-review; deliberately deferred to keep this PR focused:

1. **`AISdkAdapter` capability honesty.** `'never'` is type-dishonest because default-off keeps structured `{type:'reasoning'}` pass-through. A `'unknown'` / `'provider-dependent'` fourth capability state would let consumers branch correctly. Adding a fourth state ripples through every adapter's capability check + docs table; worth its own PR cycle.
2. **`compressReasoningText.minChars` dual-role.** The number serves as both activation threshold AND post-truncation cap. Cleaner shape: `{ minChars?: number; maxChars?: number }`. JSDoc documents the dual-role honestly; a structural fix is better done before users start depending on the current shape.
3. **`adapter.stream()` is unused by the framework.** `AgentRunner.stream()` internally calls `adapter.chat()`; the interface method `adapter.stream()` exists but no framework code path invokes it. Wiring it (and adding propagation tests) is a separable refactor.

## Composition with #251

This PR and #251 are orthogonal — both extend `LLMAdapter.capabilities.echoesReasoning` (now 3-state: `'never' | 'own-issued' | 'tool-use-only'`) but solve different problems:

| | #251 (merged) | This PR |
|---|---|---|
| Problem | DeepSeek V4 protocol compliance | Cross-provider reasoning preservation |
| Mechanism | Native `reasoning_content` echo | `<thinking>` text fallback |
| User control | Auto (forced by API spec) | `AgentConfig.preserveReasoningAsText` opt-in |
| Scope | DeepSeek + openai-common pre-scan | All 5 outbound paths |

The merge resolution composes both paths in `toOpenAIAssistantMessage`: Path A (native echo for own-provenance + tool-use, claims block first) and Path B (text fallback for everything else, runs only on opt-in).

Refs #223, #251
