### PR TITLE
Add Doubao provider shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For shell and CI, use the JSON-first `oma` binary. See [docs/cli.md](./docs/cli.
 | Capability | What you get |
 |------------|--------------|
 | **Goal-driven coordinator** | One `runTeam(team, goal)` call. The coordinator decomposes the goal into a task DAG, parallelizes independents, and synthesizes the result. |
-| **Mix providers in one team** | 10 built-in: Anthropic, OpenAI, Azure, Bedrock, Gemini, Grok, DeepSeek, MiniMax, Qiniu, Copilot. Ollama / vLLM / LM Studio / OpenRouter / Groq via OpenAI-compatible. ([full setup](./docs/providers.md)) |
+| **Mix providers in one team** | 11 built-in: Anthropic, OpenAI, Azure, Bedrock, Gemini, Grok, DeepSeek, Doubao, MiniMax, Qiniu, Copilot. Ollama / vLLM / LM Studio / OpenRouter / Groq via OpenAI-compatible. ([full setup](./docs/providers.md)) |
 | **Tools + MCP** | 6 built-in (`bash`, `file_*`, `grep`, `glob`), opt-in `delegate_to_agent`, custom tools via `defineTool()` + Zod, stdio MCP servers via `connectMCPTools()`. ([tool config](./docs/tool-configuration.md)) |
 | **Streaming + structured output** | Token-by-token streaming on every adapter; Zod-validated final answer with auto-retry on parse failure. ([`structured-output`](examples/patterns/structured-output.ts)) |
 | **Observability** | `onProgress` events, `onTrace` spans, post-run HTML dashboard rendering the executed task DAG. ([observability guide](./docs/observability.md)) |
@@ -252,6 +252,7 @@ For products and platforms with a deep `open-multi-agent` integration. See the [
          │               │  - GrokAdapter         │
          │               │  - MiniMaxAdapter      │
          │               │  - DeepSeekAdapter     │
+         │               │  - DoubaoAdapter       │
          │               │  - QiniuAdapter        │
          │               └────────────────────────┘
 ┌────────▼──────────┐
@@ -285,7 +286,7 @@ const agent: AgentConfig = {
 
 | Kind | How to configure | Services |
 |------|------------------|----------|
-| Built-in shortcuts | Set `provider` to `anthropic`, `gemini`, `openai`, `azure-openai`, `copilot`, `grok`, `deepseek`, `minimax`, `qiniu`, or `bedrock`; the framework supplies the endpoint. | Anthropic, Gemini, OpenAI, Azure OpenAI, GitHub Copilot, xAI Grok, DeepSeek, MiniMax, Qiniu, AWS Bedrock |
+| Built-in shortcuts | Set `provider` to `anthropic`, `gemini`, `openai`, `azure-openai`, `copilot`, `grok`, `deepseek`, `doubao`, `minimax`, `qiniu`, or `bedrock`; the framework supplies the endpoint. | Anthropic, Gemini, OpenAI, Azure OpenAI, GitHub Copilot, xAI Grok, DeepSeek, Doubao (Volcengine), MiniMax, Qiniu, AWS Bedrock |
 | OpenAI-compatible endpoints | Set `provider: 'openai'` plus `baseURL` and, when needed, `apiKey`. | Ollama, vLLM, LM Studio, llama.cpp server, OpenRouter, Groq, Mistral |
 | Vercel AI SDK | Import `AISdkAdapter` from `@open-multi-agent/core/ai-sdk`; install optional peer `ai` plus an `@ai-sdk/*` provider. | [Any AI SDK provider](https://ai-sdk.dev/providers) (60+ models and hosts) |
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,7 +62,7 @@ Global flags: [`--pretty`](#output-flags), [`--include-messages`](#output-flags)
 Read-only helper for wiring JSON configs and env vars.
 
 - **`oma provider`** or **`oma provider list`** — Prints JSON: built-in provider ids, API key environment variable names, whether `baseURL` is supported, and short notes (e.g. OpenAI-compatible servers, Copilot in CI).
-- **`oma provider template <provider>`** — Prints a JSON object with example `orchestrator` and `agent` fields plus placeholder `env` entries. `<provider>` is one of: `anthropic`, `openai`, `gemini`, `grok`, `minimax`, `deepseek`, `qiniu`, `copilot`.
+- **`oma provider template <provider>`** — Prints a JSON object with example `orchestrator` and `agent` fields plus placeholder `env` entries. `<provider>` is one of: `anthropic`, `azure-openai`, `openai`, `gemini`, `grok`, `minimax`, `deepseek`, `doubao`, `qiniu`, `copilot`, `bedrock`.
 
 For OpenRouter, use the `openai` provider template, set `baseURL` to `https://openrouter.ai/api/v1`, and set `apiKey` from `OPENROUTER_API_KEY` in your JSON config.
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -26,6 +26,7 @@ The framework ships a wired-in provider name for each of these. Set `provider` a
 | GitHub Copilot | `provider: 'copilot'` | `GITHUB_COPILOT_TOKEN` (falls back to `GITHUB_TOKEN`) | `gpt-4o` | Custom token-exchange flow on top of OpenAI protocol. |
 | Grok (xAI) | `provider: 'grok'` | `XAI_API_KEY` | `grok-4` | OpenAI-compatible; endpoint is `api.x.ai/v1`. |
 | DeepSeek | `provider: 'deepseek'` | `DEEPSEEK_API_KEY` | `deepseek-v4-flash` | OpenAI-compatible. `deepseek-v4-flash` (default) or `deepseek-v4-pro` (flagship for coding); both support 1M context and 384K max output. Legacy `deepseek-chat` / `deepseek-reasoner` retire 2026-07-24. |
+| Doubao (Volcengine) | `provider: 'doubao'` | `ARK_API_KEY` | `doubao-seed-1-8-251228` | OpenAI-compatible. ByteDance Volcengine Ark endpoint `https://ark.cn-beijing.volces.com/api/v3`. See [`providers/doubao`](../examples/providers/doubao.ts). |
 | MiniMax (global) | `provider: 'minimax'` | `MINIMAX_API_KEY` | `MiniMax-M2.7` | OpenAI-compatible. |
 | MiniMax (China) | `provider: 'minimax'` + `MINIMAX_BASE_URL` | `MINIMAX_API_KEY` | `MiniMax-M2.7` | Set `MINIMAX_BASE_URL=https://api.minimaxi.com/v1`. |
 | Qiniu | `provider: 'qiniu'` | `QINIU_API_KEY` | `deepseek-v3` | OpenAI-compatible. Endpoint `https://api.qnaigc.com/v1`; multiple model families, see [Qiniu AI docs](https://developer.qiniu.com/aitokenapi/12882/ai-inference-api). |
@@ -47,7 +48,6 @@ No bundled shortcut is needed when a server speaks OpenAI Chat Completions. Use 
 | Zhipu GLM | `provider: 'openai'` + `baseURL: 'https://open.bigmodel.cn/api/paas/v4'` | `ZHIPU_API_KEY` | `glm-4-plus` | See [`providers/zhipu`](../examples/providers/zhipu.ts). |
 | Qwen (DashScope) | `provider: 'openai'` + `baseURL: 'https://dashscope.aliyuncs.com/compatible-mode/v1'` | `DASHSCOPE_API_KEY` | `qwen-plus` | See [`providers/qwen`](../examples/providers/qwen.ts). |
 | Moonshot AI (Kimi) | `provider: 'openai'` + `baseURL: 'https://api.moonshot.ai/v1'` | `MOONSHOT_API_KEY` | `kimi-k2.5` | See [`providers/moonshot`](../examples/providers/moonshot.ts). |
-| Doubao (ByteDance) | `provider: 'openai'` + `baseURL: 'https://ark.cn-beijing.volces.com/api/v3'` | `ARK_API_KEY` | `doubao-1-5-pro-32k-250115` | See [`providers/doubao`](../examples/providers/doubao.ts). |
 
 Other services can be connected the same way if they implement the OpenAI Chat Completions API, but they are not listed as verified providers here. For services where the key is not `OPENAI_API_KEY`, pass it explicitly via `apiKey`; otherwise the `openai` adapter falls back to `OPENAI_API_KEY`.
 

--- a/examples/providers/doubao.ts
+++ b/examples/providers/doubao.ts
@@ -2,7 +2,7 @@
  * Multi-Agent Team Collaboration with Doubao (ByteDance)
  *
  * Three specialized agents (architect, developer, reviewer) collaborate via `runTeam()`
- * to build a minimal Express.js REST API. Every agent uses Doubao via the OpenAI-compatible adapter.
+ * to build a minimal Express.js REST API. Every agent uses the built-in Doubao provider shortcut.
  *
  * Run:
  *   npx tsx examples/providers/doubao.ts
@@ -11,14 +11,12 @@
  *   ARK_API_KEY environment variable must be set.
  *
  * Available models:
- *   doubao-1-5-pro-32k-250115  — Doubao 1.5 production model (recommended for coding tasks)
- *   doubao-1-5-lite-32k-250115 — Doubao 1.5 lightweight model (faster, lower cost)
+ *   doubao-seed-1-8-251228 — Doubao Seed 1.8 model
  */
 
 import { OpenMultiAgent } from '../../src/index.js'
 import type { AgentConfig, OrchestratorEvent } from '../../src/types.js'
 
-const DOUBAO_BASE_URL = 'https://ark.cn-beijing.volces.com/api/v3'
 const DOUBAO_API_KEY = process.env.ARK_API_KEY
 
 if (!DOUBAO_API_KEY) {
@@ -26,13 +24,12 @@ if (!DOUBAO_API_KEY) {
 }
 
 // ---------------------------------------------------------------------------
-// Agent definitions (all using Doubao via the OpenAI-compatible adapter)
+// Agent definitions (all using Doubao via the built-in provider shortcut)
 // ---------------------------------------------------------------------------
 const architect: AgentConfig = {
   name: 'architect',
-  model: 'doubao-1-5-pro-32k-250115',
-  provider: 'openai',
-  baseURL: DOUBAO_BASE_URL,
+  model: 'doubao-seed-1-8-251228',
+  provider: 'doubao',
   apiKey: DOUBAO_API_KEY,
   systemPrompt: `You are a software architect with deep experience in Node.js and REST API design.
 Your job is to design clear, production-quality API contracts and file/directory structures.
@@ -44,9 +41,8 @@ Output concise plans in markdown — no unnecessary prose.`,
 
 const developer: AgentConfig = {
   name: 'developer',
-  model: 'doubao-1-5-pro-32k-250115',
-  provider: 'openai',
-  baseURL: DOUBAO_BASE_URL,
+  model: 'doubao-seed-1-8-251228',
+  provider: 'doubao',
   apiKey: DOUBAO_API_KEY,
   systemPrompt: `You are a TypeScript/Node.js developer. You implement what the architect specifies.
 Write clean, runnable code with proper error handling. Use the tools to write files and run tests.`,
@@ -57,9 +53,8 @@ Write clean, runnable code with proper error handling. Use the tools to write fi
 
 const reviewer: AgentConfig = {
   name: 'reviewer',
-  model: 'doubao-1-5-lite-32k-250115',
-  provider: 'openai',
-  baseURL: DOUBAO_BASE_URL,
+  model: 'doubao-seed-1-8-251228',
+  provider: 'doubao',
   apiKey: DOUBAO_API_KEY,
   systemPrompt: `You are a senior code reviewer. Review code for correctness, security, and clarity.
 Provide a structured review with: LGTM items, suggestions, and any blocking issues.
@@ -106,9 +101,8 @@ function handleProgress(event: OrchestratorEvent): void {
 // Orchestrate
 // ---------------------------------------------------------------------------
 const orchestrator = new OpenMultiAgent({
-  defaultModel: 'doubao-1-5-pro-32k-250115',
-  defaultProvider: 'openai',
-  defaultBaseURL: DOUBAO_BASE_URL,
+  defaultModel: 'doubao-seed-1-8-251228',
+  defaultProvider: 'doubao',
   defaultApiKey: DOUBAO_API_KEY,
   maxConcurrency: 1, // sequential for readable output
   onProgress: handleProgress,

--- a/src/cli/oma.ts
+++ b/src/cli/oma.ts
@@ -42,7 +42,7 @@ class OmaValidationError extends Error {
 // Provider helper (static reference data)
 // ---------------------------------------------------------------------------
 
-const PROVIDER_REFERENCE: ReadonlyArray<{
+export const PROVIDER_REFERENCE: ReadonlyArray<{
   id: SupportedProvider
   apiKeyEnv: readonly string[]
   baseUrlSupported: boolean
@@ -55,6 +55,7 @@ const PROVIDER_REFERENCE: ReadonlyArray<{
   { id: 'grok', apiKeyEnv: ['XAI_API_KEY'], baseUrlSupported: true },
   { id: 'minimax', apiKeyEnv: ['MINIMAX_API_KEY'], baseUrlSupported: true, notes: 'Global endpoint: https://api.minimax.io/v1 (default). China endpoint: https://api.minimaxi.com/v1. Set MINIMAX_BASE_URL to choose, or pass baseURL in agent config.' },
   { id: 'deepseek', apiKeyEnv: ['DEEPSEEK_API_KEY'], baseUrlSupported: true, notes: 'OpenAI-compatible endpoint at https://api.deepseek.com/v1. Models: deepseek-v4-flash (default), deepseek-v4-pro (flagship); both support 1M context. Legacy deepseek-chat/deepseek-reasoner retire 2026-07-24.' },
+  { id: 'doubao', apiKeyEnv: ['ARK_API_KEY'], baseUrlSupported: true, notes: 'OpenAI-compatible Volcengine Ark endpoint at https://ark.cn-beijing.volces.com/api/v3. Set provider to doubao and choose a model available to your Ark key.' },
   { id: 'qiniu', apiKeyEnv: ['QINIU_API_KEY'], baseUrlSupported: true, notes: 'OpenAI-compatible endpoint at https://api.qnaigc.com/v1. Set provider to qiniu and choose a model available to your key.' },
   {
     id: 'copilot',
@@ -288,6 +289,7 @@ const DEFAULT_MODEL_HINT: Record<SupportedProvider, string> = {
   copilot: 'gpt-4o',
   minimax: 'MiniMax-M2.7',
   deepseek: 'deepseek-v4-flash',
+  doubao: 'doubao-seed-1-8-251228',
   qiniu: 'deepseek-v3',
   bedrock: 'anthropic.claude-3-5-haiku-20241022-v1:0',
 }

--- a/src/llm/adapter.ts
+++ b/src/llm/adapter.ts
@@ -39,7 +39,7 @@ import type { LLMAdapter } from '../types.js'
  * directly and bypassing this factory, or via {@link AISdkAdapter} from
  * `@open-multi-agent/core/ai-sdk` (optional peer `ai`).
  */
-export type SupportedProvider = 'anthropic' | 'azure-openai' | 'bedrock' | 'copilot' | 'deepseek' | 'grok' | 'minimax' | 'openai' | 'gemini' | 'qiniu'
+export type SupportedProvider = 'anthropic' | 'azure-openai' | 'bedrock' | 'copilot' | 'deepseek' | 'doubao' | 'grok' | 'minimax' | 'openai' | 'gemini' | 'qiniu'
 
 /**
  * Instantiate the appropriate {@link LLMAdapter} for the given provider.
@@ -53,6 +53,7 @@ export type SupportedProvider = 'anthropic' | 'azure-openai' | 'bedrock' | 'copi
  * - `grok`         → `XAI_API_KEY`
  * - `minimax`      → `MINIMAX_API_KEY`
  * - `deepseek`     → `DEEPSEEK_API_KEY`
+ * - `doubao`       → `ARK_API_KEY`
  * - `qiniu`        → `QINIU_API_KEY`
  * - `bedrock`      → no API key; credentials via AWS SDK default provider chain
  *                     (env vars, shared config, IAM role). Pass `region` (4th arg)
@@ -106,6 +107,10 @@ export async function createAdapter(
     case 'deepseek': {
       const { DeepSeekAdapter } = await import('./deepseek.js')
       return new DeepSeekAdapter(apiKey, baseURL)
+    }
+    case 'doubao': {
+      const { DoubaoAdapter } = await import('./doubao.js')
+      return new DoubaoAdapter(apiKey, baseURL)
     }
     case 'qiniu': {
       const { QiniuAdapter } = await import('./qiniu.js')

--- a/src/llm/doubao.ts
+++ b/src/llm/doubao.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Doubao (ByteDance Volcengine) adapter.
+ *
+ * Thin wrapper around OpenAIAdapter that hard-codes the official Volcengine
+ * Ark OpenAI-compatible endpoint and ARK_API_KEY environment variable fallback.
+ */
+
+import { OpenAIAdapter } from './openai.js'
+
+/**
+ * LLM adapter for Doubao (ByteDance Volcengine Ark) models.
+ *
+ * Thread-safe. Can be shared across agents.
+ *
+ * Usage:
+ *   provider: 'doubao'
+ *   model: 'doubao-seed-1-8-251228' (or any model available to your Ark API key)
+ */
+export class DoubaoAdapter extends OpenAIAdapter {
+  readonly name = 'doubao'
+
+  constructor(apiKey?: string, baseURL?: string) {
+    // Allow override of baseURL (for proxies or future changes) but default to official Volcengine Ark endpoint.
+    super(
+      apiKey ?? process.env['ARK_API_KEY'],
+      baseURL ?? 'https://ark.cn-beijing.volces.com/api/v3'
+    )
+  }
+}

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   EXIT,
+  PROVIDER_REFERENCE,
   parseArgs,
   serializeAgentResult,
   serializeTeamRunResult,
@@ -65,5 +66,17 @@ describe('EXIT', () => {
     expect(EXIT.RUN_FAILED).toBe(1)
     expect(EXIT.USAGE).toBe(2)
     expect(EXIT.INTERNAL).toBe(3)
+  })
+})
+
+describe('PROVIDER_REFERENCE', () => {
+  it('includes the Doubao shortcut for provider list/template commands', () => {
+    expect(PROVIDER_REFERENCE).toContainEqual(
+      expect.objectContaining({
+        id: 'doubao',
+        apiKeyEnv: ['ARK_API_KEY'],
+        baseUrlSupported: true,
+      }),
+    )
   })
 })

--- a/tests/doubao-adapter.test.ts
+++ b/tests/doubao-adapter.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock OpenAI constructor (must be hoisted for Vitest)
+// ---------------------------------------------------------------------------
+const OpenAIMock = vi.hoisted(() => vi.fn())
+
+vi.mock('openai', () => ({
+  default: OpenAIMock,
+}))
+
+import { DoubaoAdapter } from '../src/llm/doubao.js'
+import { createAdapter } from '../src/llm/adapter.js'
+
+// ---------------------------------------------------------------------------
+// DoubaoAdapter tests
+// ---------------------------------------------------------------------------
+
+describe('DoubaoAdapter', () => {
+  beforeEach(() => {
+    OpenAIMock.mockClear()
+  })
+
+  it('has name "doubao"', () => {
+    const adapter = new DoubaoAdapter()
+    expect(adapter.name).toBe('doubao')
+  })
+
+  it('uses ARK_API_KEY by default', () => {
+    const original = process.env['ARK_API_KEY']
+    process.env['ARK_API_KEY'] = 'ark-test-key-123'
+
+    try {
+      new DoubaoAdapter()
+      expect(OpenAIMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'ark-test-key-123',
+          baseURL: 'https://ark.cn-beijing.volces.com/api/v3',
+        })
+      )
+    } finally {
+      if (original === undefined) {
+        delete process.env['ARK_API_KEY']
+      } else {
+        process.env['ARK_API_KEY'] = original
+      }
+    }
+  })
+
+  it('uses official Volcengine Ark baseURL by default', () => {
+    new DoubaoAdapter('some-key')
+    expect(OpenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'some-key',
+        baseURL: 'https://ark.cn-beijing.volces.com/api/v3',
+      })
+    )
+  })
+
+  it('allows overriding apiKey and baseURL', () => {
+    new DoubaoAdapter('custom-key', 'https://custom.endpoint/v1')
+    expect(OpenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'custom-key',
+        baseURL: 'https://custom.endpoint/v1',
+      })
+    )
+  })
+
+  it('createAdapter("doubao") returns DoubaoAdapter instance', async () => {
+    const adapter = await createAdapter('doubao')
+    expect(adapter).toBeInstanceOf(DoubaoAdapter)
+  })
+})


### PR DESCRIPTION
## Summary
- add a first-class Doubao provider shortcut backed by the existing OpenAI-compatible adapter
- document the Volcengine Ark endpoint and ARK_API_KEY setup
- update the Doubao provider example and CLI provider template metadata
- add adapter and CLI coverage for the new provider id

## Testing
- npm test -- tests/doubao-adapter.test.ts tests/cli.test.ts
- npm run lint
- npm run build
- Manual: verified Doubao Seed 1.8 tool-calling with file_read using a user-provided Ark API key; no key is included in this PR

Note: full npm test was also attempted locally. It hit existing Windows/WSL-localized failures in tests/built-in-tools.test.ts unrelated to this provider change.