### PR TITLE
ci: use npm ci instead of removing lockfile and reinstalling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
-      - run: rm -f package-lock.json && npm install
+      - run: npm ci
       - run: npm run lint
       - run: npm test
 
@@ -30,7 +30,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
-      - run: rm -f package-lock.json && npm install
+      - run: npm ci
       - run: npm run test:coverage
       - uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
Use `npm ci` in the test and coverage jobs so installs respect the committed lockfile. Previously the lockfile was deleted before `npm install`, letting transitive deps drift between local and CI.