### PR TITLE
fix: redact secrets in traces, bash env, and dashboard payloads

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -34,7 +34,7 @@ Runs **`OpenMultiAgent.runTeam(team, goal)`**: coordinator decomposition, task q
 
 When invoked with `--dashboard`, the **`oma` CLI** writes a static post-execution DAG dashboard HTML to `oma-dashboards/runTeam-<timestamp>.html` under the current working directory (the library does not write files itself; if you want this outside the CLI, call `renderTeamRunDashboard(result)` in application code — see `src/dashboard/render-team-run-dashboard.ts`).
 
-The dashboard page loads **Tailwind CSS** (Play CDN), **Google Fonts** (Space Grotesk, Inter, Material Symbols), and **Material Symbols** from the network at view time. Opening the HTML file requires an **online** environment unless you host or inline those assets yourself (a future improvement).
+The dashboard page is self-contained: it does not load remote scripts, stylesheets, or fonts, and sensitive-looking values in the embedded run payload are redacted before rendering.
 
 | Argument | Required | Description |
 |----------|----------|-------------|

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -18,7 +18,7 @@ Common event types include `task_start`, `task_complete`, `task_retry`, `task_sk
 
 ## Trace Spans
 
-Use `onTrace` when you need structured spans for LLM calls, tool executions, and tasks. Each span carries parent IDs, durations, token counts, and tool I/O.
+Use `onTrace` when you need structured spans for LLM calls, tool executions, and tasks. Each span carries parent IDs, durations, token counts, and best-effort-redacted tool I/O.
 
 ```typescript
 const orchestrator = new OpenMultiAgent({
@@ -28,7 +28,7 @@ const orchestrator = new OpenMultiAgent({
 })
 ```
 
-Forward trace spans to OpenTelemetry, Datadog, Honeycomb, Langfuse, or your own run database. See [`integrations/trace-observability`](../examples/integrations/trace-observability.ts) for a runnable example.
+Forward trace spans to OpenTelemetry, Datadog, Honeycomb, Langfuse, or your own run database only after deciding what data is safe for that sink. See [`integrations/trace-observability`](../examples/integrations/trace-observability.ts) for a runnable example.
 
 ## Post-Run Dashboard
 
@@ -44,7 +44,7 @@ writeFileSync('run.html', renderTeamRunDashboard(result))
 
 The library does not write files by itself. The CLI can write dashboard HTML for you with `oma run --dashboard`; see [docs/cli.md](./cli.md).
 
-The dashboard HTML loads Tailwind CSS and Google Fonts from the network at view time. Opening the generated HTML requires an online environment unless you host or inline those assets yourself.
+The generated dashboard is self-contained and does not load remote scripts, stylesheets, or fonts. Sensitive-looking values in the embedded run payload are redacted before rendering.
 
 ## What to Persist
 

--- a/docs/tool-configuration.md
+++ b/docs/tool-configuration.md
@@ -134,8 +134,12 @@ import { connectMCPTools } from '@open-multi-agent/core/mcp'
 
 const { tools, disconnect } = await connectMCPTools({
   command: 'npx',
-  args: ['-y', '@modelcontextprotocol/server-github'],
-  env: { GITHUB_TOKEN: process.env.GITHUB_TOKEN },
+  args: ['--no-install', '@modelcontextprotocol/server-github'],
+  env: {
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+    HOME: process.env.HOME,
+    PATH: process.env.PATH,
+  },
   namePrefix: 'github',
 })
 
@@ -148,5 +152,6 @@ Notes:
 - `@modelcontextprotocol/sdk` is an optional peer dependency, only needed when using MCP.
 - Current transport support is stdio.
 - MCP input validation is delegated to the MCP server (`inputSchema` is `z.any()`).
+- Prefer locally installed or pinned MCP server binaries and pass only the environment variables that server needs. Avoid spreading `process.env` into MCP subprocesses.
 
 See [`integrations/mcp-github`](../examples/integrations/mcp-github.ts) for a full runnable setup.

--- a/examples/integrations/mcp-github.ts
+++ b/examples/integrations/mcp-github.ts
@@ -11,6 +11,7 @@
  *   - GEMINI_API_KEY
  *   - GITHUB_TOKEN
  *   - @modelcontextprotocol/sdk installed
+ *   - @modelcontextprotocol/server-github installed locally
  */
 
 import { Agent, ToolExecutor, ToolRegistry, registerBuiltInTools } from '../../src/index.js'
@@ -23,10 +24,12 @@ if (!process.env.GITHUB_TOKEN?.trim()) {
 
 const { tools, disconnect } = await connectMCPTools({
   command: 'npx',
-  args: ['-y', '@modelcontextprotocol/server-github'],
+  args: ['--no-install', '@modelcontextprotocol/server-github'],
   env: {
-    ...process.env,
     GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+    HOME: process.env.HOME,
+    PATH: process.env.PATH,
+    TMPDIR: process.env.TMPDIR,
   },
   namePrefix: 'github',
 })

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -37,6 +37,7 @@ import { TokenBudgetExceededError } from '../errors.js'
 import { LoopDetector } from './loop-detector.js'
 import { emitTrace } from '../utils/trace.js'
 import { estimateTokens } from '../utils/tokens.js'
+import { redactSensitiveObject, redactSensitiveText } from '../utils/redaction.js'
 import type { ToolRegistry } from '../tool/framework.js'
 import type { ToolExecutor } from '../tool/executor.js'
 
@@ -966,8 +967,8 @@ export class AgentRunner {
               agent: options.traceAgent ?? this.options.agentName ?? 'unknown',
               tool: block.name,
               isError: result.isError ?? false,
-              input: block.input,
-              output: result.data,
+              input: redactSensitiveObject(block.input),
+              output: redactSensitiveText(result.data),
               startMs: startTime,
               endMs: endTime,
               durationMs: duration,

--- a/src/dashboard/render-team-run-dashboard.ts
+++ b/src/dashboard/render-team-run-dashboard.ts
@@ -4,6 +4,7 @@
 
 import type { TeamRunResult } from '../types.js'
 import { layoutTasks } from './layout-tasks.js'
+import { redactSensitiveObject } from '../utils/redaction.js'
 
 /**
  * Escape serialized JSON so it can be embedded in HTML without closing a {@code <script>} tag.
@@ -30,7 +31,7 @@ export function renderTeamRunDashboard(result: TeamRunResult): string {
       nodeH: layout.nodeH,
     },
   }
-  const dataJson = escapeJsonForHtmlScript(JSON.stringify(payload))
+  const dataJson = escapeJsonForHtmlScript(JSON.stringify(redactSensitiveObject(payload)))
 
   return `<!DOCTYPE html>
 <html class="dark" lang="en">
@@ -38,98 +39,190 @@ export function renderTeamRunDashboard(result: TeamRunResult): string {
     <meta charset="utf-8" />
     <meta content="width=device-width, initial-scale=1.0" name="viewport" />
     <title>Open Multi Agent</title>
-    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
-    <link
-        href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&amp;family=Inter:wght@400;500;600&amp;display=swap"
-        rel="stylesheet" />
-    <link
-        href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap"
-        rel="stylesheet" />
-    <script id="tailwind-config">
-        tailwind.config = {
-            darkMode: "class",
-            theme: {
-                extend: {
-                    "colors": {
-                        "inverse-surface": "#faf8ff",
-                        "secondary-dim": "#ecb200",
-                        "on-primary": "#005762",
-                        "on-tertiary-fixed-variant": "#006827",
-                        "primary-fixed-dim": "#00d4ec",
-                        "tertiary-container": "#5cfd80",
-                        "secondary": "#fdc003",
-                        "primary-dim": "#00d4ec",
-                        "surface-container": "#0f1930",
-                        "on-secondary": "#553e00",
-                        "surface": "#060e20",
-                        "on-surface": "#dee5ff",
-                        "surface-container-highest": "#192540",
-                        "on-secondary-fixed-variant": "#674c00",
-                        "on-tertiary-container": "#005d22",
-                        "secondary-fixed-dim": "#f7ba00",
-                        "surface-variant": "#192540",
-                        "surface-container-low": "#091328",
-                        "secondary-container": "#785900",
-                        "tertiary-fixed-dim": "#4bee74",
-                        "on-primary-fixed-variant": "#005762",
-                        "primary-container": "#00e3fd",
-                        "surface-dim": "#060e20",
-                        "error-container": "#9f0519",
-                        "on-error-container": "#ffa8a3",
-                        "primary-fixed": "#00e3fd",
-                        "tertiary-dim": "#4bee74",
-                        "surface-container-high": "#141f38",
-                        "background": "#060e20",
-                        "surface-bright": "#1f2b49",
-                        "error-dim": "#d7383b",
-                        "on-primary-container": "#004d57",
-                        "outline": "#6d758c",
-                        "error": "#ff716c",
-                        "on-secondary-container": "#fff6ec",
-                        "on-primary-fixed": "#003840",
-                        "inverse-on-surface": "#4d556b",
-                        "secondary-fixed": "#ffca4d",
-                        "tertiary-fixed": "#5cfd80",
-                        "on-tertiary-fixed": "#004819",
-                        "surface-tint": "#81ecff",
-                        "tertiary": "#b8ffbb",
-                        "outline-variant": "#40485d",
-                        "on-error": "#490006",
-                        "on-surface-variant": "#a3aac4",
-                        "surface-container-lowest": "#000000",
-                        "on-tertiary": "#006727",
-                        "primary": "#81ecff",
-                        "on-secondary-fixed": "#443100",
-                        "inverse-primary": "#006976",
-                        "on-background": "#dee5ff"
-                    },
-                    "borderRadius": {
-                        "DEFAULT": "0px",
-                        "lg": "0px",
-                        "xl": "0px",
-                        "full": "9999px"
-                    },
-                    "fontFamily": {
-                        "headline": ["Space Grotesk"],
-                        "body": ["Inter"],
-                        "label": ["Space Grotesk"]
-                    }
-                },
-            },
-        }
-    </script>
     <style>
-        .material-symbols-outlined {
-            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+        :root {
+            --surface: #060e20;
+            --surface-container: #0f1930;
+            --surface-container-high: #141f38;
+            --surface-container-low: #091328;
+            --surface-container-lowest: #000000;
+            --surface-variant: #192540;
+            --on-surface: #dee5ff;
+            --on-surface-variant: #a3aac4;
+            --primary: #81ecff;
+            --secondary: #fdc003;
+            --tertiary: #b8ffbb;
+            --error: #ff716c;
+            --outline: #6d758c;
+            --outline-variant: #40485d;
         }
-
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            background: var(--surface);
+            color: var(--on-surface);
+            font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+        p, h2, h3 { margin: 0; }
+        main {
+            display: flex;
+            gap: 1.5rem;
+            min-height: calc(100vh - 64px);
+            padding: 2rem;
+            position: relative;
+            overflow: hidden;
+        }
+        #viewport {
+            flex: 1;
+            min-height: 600px;
+            position: relative;
+            overflow: hidden;
+            cursor: grab;
+        }
+        #viewport.cursor-grabbing { cursor: grabbing; }
+        #canvas {
+            position: absolute;
+            inset: 0;
+            transform-origin: top left;
+        }
+        #edgesLayer {
+            position: absolute;
+            inset: 0;
+            width: 100%;
+            height: 100%;
+            pointer-events: none;
+        }
+        #detailsPanel {
+            position: relative;
+            width: min(400px, 100%);
+            background: var(--surface-container-high);
+            padding: 1.5rem;
+            border-left: 1px solid rgba(64, 72, 93, 0.4);
+            display: flex;
+            flex-direction: column;
+            gap: 2rem;
+        }
+        #closePanel {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            color: var(--on-surface-variant);
+            background: transparent;
+            border: 0;
+            cursor: pointer;
+        }
+        #closePanel:hover { color: var(--primary); }
+        #liveOutput {
+            background: var(--surface-container-lowest);
+            flex: 1;
+            min-height: 160px;
+            padding: 0.75rem;
+            font: 10px/1.45 ui-monospace, SFMono-Regular, Menlo, monospace;
+            overflow-y: auto;
+        }
+        #selectedTokenRatio {
+            height: 100%;
+            width: 0;
+            background: var(--primary);
+        }
+        .hidden { display: none !important; }
+        .material-symbols-outlined {
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            font-size: 0.75rem;
+            line-height: 1;
+        }
         .grid-pattern {
             background-image: radial-gradient(circle, #40485d 1px, transparent 1px);
             background-size: 24px 24px;
         }
-
         .node-active-glow {
             box-shadow: 0 0 15px rgba(129, 236, 255, 0.15);
+        }
+        .node {
+            position: absolute;
+            width: 16rem;
+            border-left: 2px solid var(--outline);
+            padding: 1rem;
+            cursor: pointer;
+            overflow: hidden;
+        }
+        .node h3 {
+            margin: 0.25rem 0;
+            font-size: 0.875rem;
+            font-weight: 700;
+            overflow-wrap: anywhere;
+        }
+        .node span { display: inline-block; }
+        .flex { display: flex; }
+        .flex-1 { flex: 1; }
+        .flex-col { flex-direction: column; }
+        .grid { display: grid; }
+        .grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        .justify-between { justify-content: space-between; }
+        .items-start { align-items: flex-start; }
+        .items-center { align-items: center; }
+        .gap-1 { gap: 0.25rem; }
+        .gap-2 { gap: 0.5rem; }
+        .gap-4 { gap: 1rem; }
+        .gap-8 { gap: 2rem; }
+        .mb-1 { margin-bottom: 0.25rem; }
+        .mb-4 { margin-bottom: 1rem; }
+        .mb-6 { margin-bottom: 1.5rem; }
+        .mt-2 { margin-top: 0.5rem; }
+        .p-2 { padding: 0.5rem; }
+        .p-3 { padding: 0.75rem; }
+        .p-4 { padding: 1rem; }
+        .px-2 { padding-left: 0.5rem; padding-right: 0.5rem; }
+        .py-0\\.5 { padding-top: 0.125rem; padding-bottom: 0.125rem; }
+        .w-full { width: 100%; }
+        .h-1 { height: 0.25rem; }
+        .text-xs { font-size: 0.75rem; }
+        .text-sm { font-size: 0.875rem; }
+        .text-lg { font-size: 1.125rem; }
+        .font-mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+        .font-bold { font-weight: 700; }
+        .font-black { font-weight: 900; }
+        .uppercase { text-transform: uppercase; }
+        .tracking-widest { letter-spacing: 0.08em; }
+        .bg-surface-container { background: var(--surface-container); }
+        .bg-surface-container-low { background: var(--surface-container-low); }
+        .bg-surface-container-lowest { background: var(--surface-container-lowest); }
+        .bg-surface-variant { background: var(--surface-variant); }
+        .text-primary { color: var(--primary); }
+        .text-secondary { color: var(--secondary); }
+        .text-tertiary { color: var(--tertiary); }
+        .text-error { color: var(--error); }
+        .text-outline { color: var(--outline); }
+        .text-on-surface { color: var(--on-surface); }
+        .text-on-surface-variant { color: var(--on-surface-variant); }
+        .border-tertiary { border-color: var(--tertiary); }
+        .border-error { border-color: var(--error); }
+        .border-outline { border-color: var(--outline); }
+        .border-secondary { border-color: var(--secondary); }
+        .opacity-60 { opacity: 0.6; }
+        .grayscale { filter: grayscale(1); }
+        .space-y-1 > * + * { margin-top: 0.25rem; }
+        .space-y-2 > * + * { margin-top: 0.5rem; }
+        .space-y-6 > * + * { margin-top: 1.5rem; }
+        .bg-gradient-to-b {
+            position: fixed;
+            left: 0;
+            top: 0;
+            width: 4px;
+            height: 100vh;
+            background: linear-gradient(to bottom, var(--primary), var(--secondary), var(--tertiary));
+            opacity: 0.3;
+            z-index: 60;
+        }
+        .animate-spin { animation: spin 1s linear infinite; }
+        @keyframes spin { to { transform: rotate(360deg); } }
+        @media (max-width: 1023px) {
+            main { flex-direction: column; padding: 1rem; }
+            #detailsPanel { border-left: 0; border-top: 1px solid rgba(64, 72, 93, 0.4); }
+        }
+        @media (min-width: 1024px) {
+            main { flex-direction: row; }
         }
     </style>
 </head>

--- a/src/llm/ai-sdk.ts
+++ b/src/llm/ai-sdk.ts
@@ -59,7 +59,7 @@ export function llmMessagesToAiSdkModelMessages(messages: readonly LLMMessage[])
         } else if (block.type === 'reasoning') {
           const text =
             block.redactedData !== undefined && block.redactedData.length > 0
-              ? `[redacted_thinking]${block.redactedData}`
+              ? '[redacted_thinking]'
               : block.text
           acc.push({ type: 'reasoning', text })
         } else if (block.type === 'tool_use') {

--- a/src/tool/built-in/bash.ts
+++ b/src/tool/built-in/bash.ts
@@ -8,12 +8,26 @@
 import { spawn } from 'child_process'
 import { z } from 'zod'
 import { defineTool } from '../framework.js'
+import { isSensitiveName, redactSensitiveText } from '../../utils/redaction.js'
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 const DEFAULT_TIMEOUT_MS = 30_000
+const SAFE_ENV_ALLOWLIST = new Set([
+  'HOME',
+  'LANG',
+  'LC_ALL',
+  'LOGNAME',
+  'PATH',
+  'SHELL',
+  'TEMP',
+  'TERM',
+  'TMP',
+  'TMPDIR',
+  'USER',
+])
 
 // ---------------------------------------------------------------------------
 // Tool definition
@@ -52,7 +66,7 @@ export const bashTool = defineTool({
       context.abortSignal,
     )
 
-    const combined = buildOutput(stdout, stderr, exitCode)
+    const combined = redactSensitiveText(buildOutput(stdout, stderr, exitCode))
     const isError = exitCode !== 0
 
     return {
@@ -92,7 +106,7 @@ function runCommand(
 
     const child = spawn('bash', ['-c', command], {
       cwd: options.cwd,
-      env: process.env,
+      env: buildSafeShellEnv(process.env),
       stdio: ['ignore', 'pipe', 'pipe'],
     })
 
@@ -151,6 +165,17 @@ function runCommand(
       }
     })
   })
+}
+
+function buildSafeShellEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const safeEnv: NodeJS.ProcessEnv = {}
+  for (const [name, value] of Object.entries(env)) {
+    if (value === undefined) continue
+    if (!SAFE_ENV_ALLOWLIST.has(name)) continue
+    if (isSensitiveName(name)) continue
+    safeEnv[name] = value
+  }
+  return safeEnv
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -919,9 +919,9 @@ export interface ToolCallTrace extends TraceEventBase {
   readonly type: 'tool_call'
   readonly tool: string
   readonly isError: boolean
-  /** The input arguments passed to the tool — mirrors the originating ToolUseBlock.input. */
+  /** The input arguments passed to the tool after best-effort sensitive-field redaction. */
   readonly input: Record<string, unknown>
-  /** The serialised output returned by the tool — mirrors ToolResult.data (truncation, if any, has already been applied by the executor). */
+  /** The serialised output returned by the tool after executor truncation and best-effort sensitive-value redaction. */
   readonly output: string
 }
 

--- a/src/utils/redaction.ts
+++ b/src/utils/redaction.ts
@@ -1,0 +1,95 @@
+const REDACTED = '[redacted]'
+
+const SENSITIVE_NAME_PATTERN =
+  /(?:api[_-]?key|apiKey|secret|password|passwd|pwd|private[_-]?key|privateKey|access[_-]?key|accessKey|accessToken|refreshToken|idToken|githubToken|authorization|auth[_-]?token|authToken|cookie|session|credential|bearer|^token$|[_-]token$|^token[_-])/i
+
+const ASSIGNMENT_PATTERN =
+  /(["']?)([A-Za-z_][A-Za-z0-9_.-]*)(["']?\s*[:=]\s*)(["']?)([^"',\s}\]]+)(["']?)/g
+
+const TOKEN_LITERAL_PATTERNS: readonly RegExp[] = [
+  /\bsk-[A-Za-z0-9_-]{16,}\b/g,
+  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g,
+]
+
+export function isSensitiveName(name: string): boolean {
+  return SENSITIVE_NAME_PATTERN.test(name)
+}
+
+export function redactSensitiveText(text: string): string {
+  if (text.length === 0) return text
+
+  let redacted = text.replace(
+    /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g,
+    REDACTED,
+  )
+
+  redacted = redacted.replace(
+    /\b(Authorization\s*:\s*)(?:Bearer\s+)?[^\n\r,;}]+/gi,
+    `$1${REDACTED}`,
+  )
+
+  redacted = redacted.replace(
+    /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi,
+    `Bearer ${REDACTED}`,
+  )
+
+  redacted = redacted.replace(
+    ASSIGNMENT_PATTERN,
+    (
+      match: string,
+      keyQuote: string,
+      key: string,
+      separator: string,
+      valueQuote: string,
+      value: string,
+      closeQuote: string,
+    ) => {
+      if (!isSensitiveName(key)) return match
+      // Value char class stops at `]`, so an earlier pass that emitted
+      // `[redacted]` (e.g. the Authorization rule) would be re-matched as
+      // `[redacted` and re-emitted, leaving an orphan `]` behind. Bail out
+      // when the value already looks redacted.
+      if (value === '[redacted') return match
+      return `${keyQuote}${key}${separator}${valueQuote}${REDACTED}${closeQuote || valueQuote}`
+    },
+  )
+
+  for (const pattern of TOKEN_LITERAL_PATTERNS) {
+    redacted = redacted.replace(pattern, REDACTED)
+  }
+
+  return redacted
+}
+
+export function redactSensitiveObject<T>(value: T): T {
+  return redactValue(value) as T
+}
+
+function redactValue(value: unknown, key?: string): unknown {
+  if (key !== undefined && isSensitiveName(key)) {
+    return REDACTED
+  }
+
+  if (typeof value === 'string') {
+    return redactSensitiveText(value)
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(item => redactValue(item))
+  }
+
+  if (value !== null && typeof value === 'object') {
+    if (value instanceof Date) return value
+
+    const redacted: Record<string, unknown> = {}
+    for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+      redacted[childKey] = redactValue(childValue, childKey)
+    }
+    return redacted
+  }
+
+  return value
+}

--- a/src/utils/redaction.ts
+++ b/src/utils/redaction.ts
@@ -3,8 +3,18 @@ const REDACTED = '[redacted]'
 const SENSITIVE_NAME_PATTERN =
   /(?:api[_-]?key|apiKey|secret|password|passwd|pwd|private[_-]?key|privateKey|access[_-]?key|accessKey|accessToken|refreshToken|idToken|githubToken|authorization|auth[_-]?token|authToken|cookie|session|credential|bearer|^token$|[_-]token$|^token[_-])/i
 
-const ASSIGNMENT_PATTERN =
-  /(["']?)([A-Za-z_][A-Za-z0-9_.-]*)(["']?\s*[:=]\s*)(["']?)([^"',\s}\]]+)(["']?)/g
+// Quoted value: matches `key: "value with spaces"` or `key='value with spaces'`
+// (lazy `[^]*?` + back-referenced closing quote handles spaces and inner quotes
+// of the opposite kind; escaped same-kind quotes are not handled by design.)
+const QUOTED_ASSIGNMENT_PATTERN =
+  /(["']?)([A-Za-z_][A-Za-z0-9_.-]*)(\1?\s*[:=]\s*)(["'])([^]*?)\4/g
+
+// Unquoted value: matches `key=value` where value may include spaces and
+// runs until a structural delimiter (`,`, `;`, `}`, `]`, newline) or EOL.
+// Must run AFTER the quoted pass so already-redacted quoted values
+// (`password="[redacted]"`) aren't matched here.
+const UNQUOTED_ASSIGNMENT_PATTERN =
+  /(["']?)([A-Za-z_][A-Za-z0-9_.-]*)(\1?\s*[:=]\s*)([^"'\s,;}\]\n\r][^,;}\]\n\r]*)/g
 
 const TOKEN_LITERAL_PATTERNS: readonly RegExp[] = [
   /\bsk-[A-Za-z0-9_-]{16,}\b/g,
@@ -36,24 +46,42 @@ export function redactSensitiveText(text: string): string {
     `Bearer ${REDACTED}`,
   )
 
+  // Pass 1: quoted values. Consume to matching closing quote so values
+  // containing spaces (`password="my pass"`) are fully redacted rather than
+  // partially leaked at the first whitespace.
   redacted = redacted.replace(
-    ASSIGNMENT_PATTERN,
+    QUOTED_ASSIGNMENT_PATTERN,
     (
       match: string,
       keyQuote: string,
       key: string,
       separator: string,
       valueQuote: string,
-      value: string,
-      closeQuote: string,
+      _value: string,
     ) => {
       if (!isSensitiveName(key)) return match
-      // Value char class stops at `]`, so an earlier pass that emitted
-      // `[redacted]` (e.g. the Authorization rule) would be re-matched as
-      // `[redacted` and re-emitted, leaving an orphan `]` behind. Bail out
-      // when the value already looks redacted.
-      if (value === '[redacted') return match
-      return `${keyQuote}${key}${separator}${valueQuote}${REDACTED}${closeQuote || valueQuote}`
+      return `${keyQuote}${key}${separator}${valueQuote}${REDACTED}${valueQuote}`
+    },
+  )
+
+  // Pass 2: unquoted values. Consume to the next structural delimiter so
+  // values with internal whitespace (`password=my pass`) are fully redacted.
+  redacted = redacted.replace(
+    UNQUOTED_ASSIGNMENT_PATTERN,
+    (
+      match: string,
+      keyQuote: string,
+      key: string,
+      separator: string,
+      value: string,
+    ) => {
+      if (!isSensitiveName(key)) return match
+      // Skip already-redacted values from an earlier pass (e.g. the
+      // Authorization rule emits `[redacted]`; the value char class stops
+      // at `]`, so we capture `[redacted` and would otherwise re-emit it
+      // and leave an orphan `]` behind).
+      if (value === '[redacted' || value.startsWith('[redacted')) return match
+      return `${keyQuote}${key}${separator}${REDACTED}`
     },
   )
 

--- a/tests/ai-sdk-adapter.test.ts
+++ b/tests/ai-sdk-adapter.test.ts
@@ -69,6 +69,25 @@ describe('llmMessagesToAiSdkModelMessages', () => {
     expect(toolMsg.role).toBe('tool')
     expect(toolMsg.content[0]?.output).toEqual({ type: 'error-text', value: 'boom' })
   })
+
+  it('does not serialize opaque redacted reasoning payloads', () => {
+    const out = llmMessagesToAiSdkModelMessages([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'reasoning',
+            text: '',
+            redactedData: 'opaque-redacted-thinking-payload',
+          },
+        ],
+      },
+    ])
+
+    const assistant = out[0] as { role: string; content: Array<{ type: string; text: string }> }
+    expect(assistant.content[0]).toEqual({ type: 'reasoning', text: '[redacted_thinking]' })
+    expect(JSON.stringify(out)).not.toContain('opaque-redacted-thinking-payload')
+  })
 })
 
 describe('AISdkAdapter', () => {

--- a/tests/built-in-tools.test.ts
+++ b/tests/built-in-tools.test.ts
@@ -317,6 +317,37 @@ describe('bash', () => {
     expect(result.isError).toBe(false)
     expect(result.data).toContain('command completed with no output')
   })
+
+  it('does not pass provider secrets from process.env into the shell', async () => {
+    const original = process.env['OPENAI_API_KEY']
+    process.env['OPENAI_API_KEY'] = 'sk-envsecretvalue1234567890'
+    try {
+      const result = await bashTool.execute(
+        { command: 'printf "%s" "$OPENAI_API_KEY"' },
+        defaultContext,
+      )
+
+      expect(result.isError).toBe(false)
+      expect(result.data).not.toContain('sk-envsecretvalue1234567890')
+    } finally {
+      if (original === undefined) {
+        delete process.env['OPENAI_API_KEY']
+      } else {
+        process.env['OPENAI_API_KEY'] = original
+      }
+    }
+  })
+
+  it('redacts sensitive-looking command output', async () => {
+    const result = await bashTool.execute(
+      { command: 'printf "OPENAI_API_KEY=sk-outputsecretvalue1234567890"' },
+      defaultContext,
+    )
+
+    expect(result.isError).toBe(false)
+    expect(result.data).toContain('[redacted]')
+    expect(result.data).not.toContain('sk-outputsecretvalue1234567890')
+  })
 })
 
 // ===========================================================================

--- a/tests/dashboard-render.test.ts
+++ b/tests/dashboard-render.test.ts
@@ -89,4 +89,52 @@ describe('renderTeamRunDashboard', () => {
     }
     expect(parsed.tasks[0]!.result).toBe(result)
   })
+
+  it('does not reference remote dashboard assets', () => {
+    const html = renderTeamRunDashboard({
+      success: true,
+      goal: 'safe-goal',
+      tasks: [],
+      agentResults: new Map(),
+      totalTokenUsage: { input_tokens: 0, output_tokens: 0 },
+    })
+
+    expect(html).not.toMatch(/<script[^>]+src=/i)
+    expect(html).not.toMatch(/<link[^>]+href=/i)
+    expect(html).not.toContain('cdn.tailwindcss.com')
+    expect(html).not.toContain('fonts.googleapis.com')
+  })
+
+  it('redacts sensitive-looking values from the embedded JSON payload', () => {
+    const secret = 'sk-dashboardsecretvalue1234567890'
+    const html = renderTeamRunDashboard({
+      success: true,
+      goal: 'password=hunter2',
+      tasks: [
+        {
+          id: 't1',
+          title: 'task',
+          description: `OPENAI_API_KEY=${secret}`,
+          result: `Authorization: Bearer ${secret}`,
+          status: 'completed',
+          dependsOn: [],
+        } as { id: string; title: string; description: string; result: string; status: 'completed'; dependsOn: string[] },
+      ],
+      agentResults: new Map(),
+      totalTokenUsage: { input_tokens: 0, output_tokens: 0 },
+    })
+
+    const start = html.indexOf('id="oma-data">')
+    const contentStart = start + 'id="oma-data">'.length
+    const end = html.indexOf('</script>', contentStart)
+    const parsed = JSON.parse(html.slice(contentStart, end)) as {
+      goal: string
+      tasks: Array<{ description?: string; result?: string }>
+    }
+
+    expect(html).not.toContain(secret)
+    expect(parsed.goal).toBe('password=[redacted]')
+    expect(parsed.tasks[0]!.description).toBe('OPENAI_API_KEY=[redacted]')
+    expect(parsed.tasks[0]!.result).toBe('Authorization: [redacted]')
+  })
 })

--- a/tests/redaction.test.ts
+++ b/tests/redaction.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+import { redactSensitiveText } from '../src/utils/redaction.js'
+
+describe('redactSensitiveText', () => {
+  describe('values containing spaces', () => {
+    it('redacts unquoted env-style value with a space', () => {
+      expect(redactSensitiveText('password=secret value')).toBe('password=[redacted]')
+    })
+
+    it('redacts double-quoted value with a space', () => {
+      expect(redactSensitiveText('password="secret value"')).toBe('password="[redacted]"')
+    })
+
+    it('redacts single-quoted value with a space', () => {
+      expect(redactSensitiveText("password='secret value'")).toBe("password='[redacted]'")
+    })
+
+    it('redacts JSON-style quoted value with a space', () => {
+      expect(redactSensitiveText('apiKey: "abc def"')).toBe('apiKey: "[redacted]"')
+    })
+
+    it('redacts quoted key + quoted value with a space', () => {
+      expect(redactSensitiveText('"apiKey": "abc def"')).toBe('"apiKey": "[redacted]"')
+    })
+
+    it('redacts unquoted value with a tab', () => {
+      expect(redactSensitiveText('password=secret\tvalue')).toBe('password=[redacted]')
+    })
+  })
+
+  describe('multiple assignments on one line', () => {
+    it('redacts each sensitive assignment, leaves non-sensitive', () => {
+      expect(redactSensitiveText('password=hunter2, username=alice')).toBe(
+        'password=[redacted], username=alice',
+      )
+    })
+
+    it('stops space-containing value at the next comma delimiter', () => {
+      expect(redactSensitiveText('password=secret value, username=alice')).toBe(
+        'password=[redacted], username=alice',
+      )
+    })
+  })
+
+  describe('regression: existing behavior', () => {
+    it('redacts Authorization Bearer header without orphan brackets', () => {
+      expect(redactSensitiveText('Authorization: Bearer sk-xxxxxxxxxxxxxxxx')).toBe(
+        'Authorization: [redacted]',
+      )
+    })
+
+    it('leaves non-sensitive assignments untouched', () => {
+      expect(redactSensitiveText('username=alice')).toBe('username=alice')
+    })
+
+    it('redacts simple unquoted sensitive value', () => {
+      expect(redactSensitiveText('password=hunter2')).toBe('password=[redacted]')
+    })
+
+    it('redacts OpenAI-style token literal in free text', () => {
+      const result = redactSensitiveText('the key is sk-abcdefghijklmnop')
+      expect(result).toContain('[redacted]')
+      expect(result).not.toContain('sk-abcdefghijklmnop')
+    })
+
+    it('redacts PEM private key block', () => {
+      const input = '-----BEGIN RSA PRIVATE KEY-----\nMIIEv...\n-----END RSA PRIVATE KEY-----'
+      expect(redactSensitiveText(input)).toBe('[redacted]')
+    })
+  })
+
+  describe('idempotence', () => {
+    it('does not re-process already-redacted values', () => {
+      const once = redactSensitiveText('password="secret value"')
+      const twice = redactSensitiveText(once)
+      expect(twice).toBe(once)
+    })
+  })
+})

--- a/tests/tool-filtering.test.ts
+++ b/tests/tool-filtering.test.ts
@@ -362,4 +362,3 @@ describe('Tool filtering', () => {
     })
   })
 })
-

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -251,6 +251,41 @@ describe('AgentRunner trace events', () => {
     expect(tool.durationMs).toBeGreaterThanOrEqual(0)
   })
 
+  it('redacts sensitive-looking tool trace input and output', async () => {
+    const traces: TraceEvent[] = []
+    const registry = new ToolRegistry()
+    registry.register(
+      defineTool({
+        name: 'leaky',
+        description: 'returns a sensitive-looking value',
+        inputSchema: z.object({ apiKey: z.string(), query: z.string() }),
+        execute: async () => ({ data: 'Authorization: Bearer sk-tracesecretvalue1234567890' }),
+      }),
+    )
+    const executor = new ToolExecutor(registry)
+    const adapter = mockAdapter([
+      toolUseResponse('leaky', { apiKey: 'sk-inputsecretvalue1234567890', query: 'hello' }),
+      textResponse('Done'),
+    ])
+
+    const runner = new AgentRunner(adapter, registry, executor, {
+      model: 'test-model',
+      agentName: 'tooler',
+      allowedTools: ['leaky'],
+    })
+
+    await runner.run(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+      { onTrace: (e) => { traces.push(e) }, runId: 'run-redact', traceAgent: 'tooler' },
+    )
+
+    const tool = traces.find((t): t is Extract<TraceEvent, { type: 'tool_call' }> => t.type === 'tool_call')!
+    expect(tool.input).toEqual({ apiKey: '[redacted]', query: 'hello' })
+    expect(tool.output).toContain('[redacted]')
+    expect(tool.output).not.toContain('sk-inputsecretvalue1234567890')
+    expect(tool.output).not.toContain('sk-tracesecretvalue1234567890')
+  })
+
   it('tool_call trace has isError: true on tool failure', async () => {
     const traces: TraceEvent[] = []
     const registry = new ToolRegistry()
@@ -499,4 +534,3 @@ describe('Agent trace events', () => {
     expect(llmTraces[1]!.turn).toBe(2)
   })
 })
-


### PR DESCRIPTION
Three sinks where sensitive values could leak, plus a reasoning leak and the MCP example.

Adds `src/utils/redaction.ts` for best-effort secret scrubbing. It catches names (`api_key` / `secret` / `password` / `Bearer` / ...), `Authorization:` lines, `Bearer xxx`, OpenAI / GitHub / AWS / Slack token literals, and PEM private key blocks. Applied at:
- `tool_call` trace events (`input`, `output`)
- the `bash` tool's output buffer
- the dashboard's embedded JSON payload

The `bash` tool no longer inherits `process.env`. The child gets a fixed allowlist (HOME, LANG, LC_ALL, LOGNAME, PATH, SHELL, TEMP, TERM, TMP, TMPDIR, USER), so provider keys like `OPENAI_API_KEY` are no longer visible to spawned shells. New tests cover env containment and output redaction.

The post-run dashboard no longer loads Tailwind CDN, Google Fonts, or Material Symbols at view time. CSS is inlined and the page renders without network.

`llmMessagesToAiSdkModelMessages` was emitting `[redacted_thinking]${redactedData}` and forwarding the opaque blob as visible reasoning text to the AI SDK. Now it only emits the marker.

The MCP GitHub example uses `--no-install` instead of `-y` (no auto-install) and passes an explicit env allowlist `{ GITHUB_TOKEN, HOME, PATH, TMPDIR }` instead of spreading `process.env`.