### PR TITLE
docs: restructure README, surface built-in capabilities, sync zh

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ Issues, feature requests, and PRs are welcome. Some areas where contributions wo
 ## Contributors
 
 <a href="https://github.com/open-multi-agent/open-multi-agent/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=open-multi-agent/open-multi-agent&max=100&v=20260507" />
+  <img src="https://contrib.rocks/image?repo=open-multi-agent/open-multi-agent&max=100&v=20260529" />
 </a>
 
 <details>
@@ -405,6 +405,8 @@ Issues, feature requests, and PRs are welcome. Some areas where contributions wo
 - [@NamelessNATM](https://github.com/NamelessNATM) (agent delegation base implementation)
 - [@MyPrototypeWhat](https://github.com/MyPrototypeWhat) (reasoning blocks, reasoning_effort, sampling parity, trace input/output)
 - [@SiMinus](https://github.com/SiMinus) (streaming reasoning events)
+- [@matthewYang08](https://github.com/matthewYang08) (OpenAI reasoning-to-text fallback)
+- [@dvirarad](https://github.com/dvirarad) (OpenAI-family adapter hardening)
 
 **Provider integrations**
 
@@ -415,6 +417,7 @@ Issues, feature requests, and PRs are welcome. Some areas where contributions wo
 - [@Deathwing](https://github.com/Deathwing) (GitHub Copilot)
 - [@JackChiang233](https://github.com/JackChiang233) (Qiniu)
 - [@CodingBangboo](https://github.com/CodingBangboo) (AWS Bedrock)
+- [@kidoom](https://github.com/kidoom) (MiMo, Doubao)
 
 **Examples & cookbook**
 
@@ -431,24 +434,20 @@ Issues, feature requests, and PRs are welcome. Some areas where contributions wo
 - [@DaiMao-UT](https://github.com/DaiMao-UT) (paper replication triage)
 - [@oooooowoooooo](https://github.com/oooooowoooooo) (rare disease information triage)
 - [@CodingBangboo](https://github.com/CodingBangboo) (Express customer support pipeline)
+- [@nuthalapativarun](https://github.com/nuthalapativarun) (Doubao and Zhipu provider examples)
+- [@goodneamtakenbydogs](https://github.com/goodneamtakenbydogs) (Moonshot and Qwen provider examples)
+- [@suans4746-del](https://github.com/suans4746-del) (narrative puzzle hint arbitration)
+- [@gregkonush](https://github.com/gregkonush) (Bilig WorkPaper MCP integration)
 
 **Docs & tests**
 
 - [@tmchow](https://github.com/tmchow) (llama.cpp docs)
 - [@kenrogers](https://github.com/kenrogers) (OpenRouter docs)
 - [@jadegold55](https://github.com/jadegold55) (LLM adapter test coverage)
+- [@btroops](https://github.com/btroops) (DeepSeek tool-calling tests)
+- [@nuthalapativarun](https://github.com/nuthalapativarun) (context-management docs)
 
 </details>
-
-## Star History
-
-<a href="https://star-history.com/#open-multi-agent/open-multi-agent&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=open-multi-agent/open-multi-agent&type=Date&theme=dark&v=20260425" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=open-multi-agent/open-multi-agent&type=Date&v=20260425" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=open-multi-agent/open-multi-agent&type=Date&v=20260425" />
- </picture>
-</a>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,15 @@
 
 > **Your engineers describe the goal, not the graph.**
 
+Graph-first frameworks make you enumerate every node and edge up front. `open-multi-agent` is goal-first: you describe the outcome and the coordinator builds the task DAG at runtime, so the orchestration adapts to the goal instead of being hand-wired for one.
+
+## Contents
+
+[Quick Start](#quick-start) · [Three Ways to Run](#three-ways-to-run) · [Features](#features) · [Orchestration Controls](#orchestration-controls) · [Examples](#examples) · [How Is This Different?](#how-is-this-different-from-x) · [Ecosystem](#ecosystem) · [Architecture](#architecture) · [Supported Providers](#supported-providers) · [Production Checklist](#production-checklist) · [Documentation](#documentation) · [Contributing](#contributing)
+
 ## Quick Start
 
 Requires Node.js >= 18.
-
-### Use it in your project
 
 ```bash
 npm install @open-multi-agent/core
@@ -110,7 +114,7 @@ Tokens: 12847 output tokens
 
 Local models via Ollama need no API key, see [`providers/ollama`](examples/providers/ollama.ts). For hosted providers (`OPENAI_API_KEY`, `GEMINI_API_KEY`, etc.), see [Supported Providers](#supported-providers).
 
-### Three Ways to Run
+## Three Ways to Run
 
 | Mode | Method | When to use | Example |
 |------|--------|-------------|---------|
@@ -124,33 +128,66 @@ Preview the coordinator's task DAG without executing agents:
 const plan = await orchestrator.runTeam(team, goal, { planOnly: true })
 ```
 
-Inject team context (goal, roster, this worker's role) into every worker prompt. Helps workers stay aligned with the overall goal and makes multi-step runs easier to debug. Off by default; worker prompts stay byte-identical when omitted.
-
-```ts
-const result = await orchestrator.runTeam(team, goal, { revealCoordinator: true })
-```
-
-For MapReduce-style fan-out without task dependencies, use `AgentPool.runParallel()` directly. See [`patterns/fan-out-aggregate`](examples/patterns/fan-out-aggregate.ts).
-
-For shell and CI, use the JSON-first `oma` binary. See [docs/cli.md](./docs/cli.md).
-
 ## Features
 
 | Capability | What you get |
 |------------|--------------|
-| **Goal-driven coordinator** | One `runTeam(team, goal)` call. The coordinator decomposes the goal into a task DAG, parallelizes independents, and synthesizes the result. |
-| **Mix providers in one team** | 12 built-in: Anthropic, OpenAI, Azure, Bedrock, Gemini, Grok, DeepSeek, Doubao, MiniMax, MiMo, Qiniu, Copilot. Ollama / vLLM / LM Studio / OpenRouter / Groq via OpenAI-compatible. ([full setup](./docs/providers.md)) |
-| **Tools + MCP** | 6 built-in (`bash`, `file_*`, `grep`, `glob`), opt-in `delegate_to_agent`, custom tools via `defineTool()` + Zod, stdio MCP servers via `connectMCPTools()`. ([tool config](./docs/tool-configuration.md)) |
-| **Streaming + structured output** | Token-by-token streaming on every adapter; Zod-validated final answer with auto-retry on parse failure. ([`structured-output`](examples/patterns/structured-output.ts)) |
-| **Observability** | `onProgress` events, `onTrace` spans, post-run HTML dashboard rendering the executed task DAG. ([observability guide](./docs/observability.md)) |
+| **Goal-driven coordinator** | One `runTeam(team, goal)` call decomposes the goal into a task DAG, parallelizes independents, and synthesizes the result. Unassigned tasks are auto-scheduled — `dependency-first` (default), `round-robin`, `least-busy`, or `capability-match`. |
+| **Mix providers in one team** | 12 built-in providers plus any OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, OpenRouter, Groq), mixed freely in one team. Local servers that emit tool calls as plain text are recovered by a fallback parser. ([full list](#supported-providers) · [setup](./docs/providers.md)) |
+| **Extended thinking / reasoning** | One `thinking` config maps to Anthropic thinking, Gemini `thinkingConfig`, and OpenAI `reasoning_effort`; reasoning is streamed as events, with opt-in preservation across a provider switch. ([`cross-provider-reasoning`](examples/patterns/cross-provider-reasoning.ts)) |
+| **Tools + MCP** | 6 built-in (`bash`, `file_*`, `grep`, `glob`), opt-in `delegate_to_agent` (cycle + depth guards), custom tools via `defineTool()` + Zod, stdio MCP servers via `connectMCPTools()`. ([tool config](./docs/tool-configuration.md)) |
+| **Streaming + structured output** | Token-by-token streaming on every adapter (per-agent during team runs via `onAgentStream`); Zod-validated final answer with auto-retry on parse failure. ([`structured-output`](examples/patterns/structured-output.ts)) |
+| **Human-in-the-loop** | Gate execution with `onPlanReady` (approve the plan before any agent runs) and `onApproval` (approve between task rounds), or inspect first with `planOnly`. |
+| **Lifecycle hooks + cancellation** | `beforeRun` rewrites the prompt, `afterRun` post-processes or rejects the result; pass an `AbortSignal` to cancel a run in flight. |
+| **Configurable coordinator** | Override the coordinator's model, provider, adapter, system prompt, or tools via `runTeam(team, goal, { coordinator })`. |
+| **Observability** | `onProgress` events, `onTrace` spans, post-run HTML dashboard rendering the executed task DAG. API keys and tokens are redacted from traces, bash env, and dashboard output. ([observability guide](./docs/observability.md)) |
 | **Pluggable shared memory** | Default in-process KV; swap in Redis / Postgres / your own backend by implementing `MemoryStore`. ([shared memory](./docs/shared-memory.md)) |
 | **Sandboxed filesystem workspace** | Built-in filesystem tools are sandboxed to `<cwd>/.agent-workspace` by default; agents sharing the default configuration share this root. For per-agent isolation, set `AgentConfig.cwd`; for a different shared root, set `OrchestratorConfig.defaultCwd`; pass `null` to disable. ([sandbox config](./docs/tool-configuration.md)) |
 
-Production controls (context strategies, task retry with backoff, loop detection, tool output truncation/compression) are covered in the [Production Checklist](#production-checklist).
+Production controls ([context strategies](./docs/context-management.md), task retry with backoff, loop detection, tool output truncation/compression) are covered in the [Production Checklist](#production-checklist).
+
+## Orchestration Controls
+
+Fine-grained control over a `runTeam` run. All optional; defaults keep behavior unchanged.
+
+**Inject team context.** Prepend the goal, roster, and this worker's role to every worker prompt — helps workers stay aligned and makes multi-step runs easier to debug. Off by default; worker prompts stay byte-identical when omitted.
+
+```ts
+await orchestrator.runTeam(team, goal, { revealCoordinator: true })
+```
+
+**Approve before running.** Inspect the coordinator's plan before any agent executes, and again between task rounds. These live on the orchestrator. Returning `false` aborts; remaining tasks are marked `skipped`.
+
+```ts
+const orchestrator = new OpenMultiAgent({
+  onPlanReady: async (tasks) => tasks.length <= 10,        // gate the whole plan
+  onApproval:  async (completed, next) => next.length > 0, // gate each round
+})
+```
+
+**Cancel a run.** Pass an `AbortSignal`; aborting stops the run in flight.
+
+```ts
+const controller = new AbortController()
+const run = orchestrator.runTeam(team, goal, { abortSignal: controller.signal })
+// controller.abort() from elsewhere to cancel
+```
+
+**Configure the coordinator.** Give the planner its own model, adapter, or extra instructions without touching the worker agents.
+
+```ts
+await orchestrator.runTeam(team, goal, {
+  coordinator: { model: 'claude-opus-4-6', instructions: 'Prefer fewer, larger tasks.' },
+})
+```
+
+**Fan-out without dependencies.** For MapReduce-style parallelism, use `AgentPool.runParallel()` directly. See [`patterns/fan-out-aggregate`](examples/patterns/fan-out-aggregate.ts).
+
+**Shell & CI.** Use the JSON-first `oma` binary. See [docs/cli.md](./docs/cli.md).
 
 ## Examples
 
-[`examples/`](./examples/) is organized by category: basics, cookbook, patterns, providers, integrations, and production. See [`examples/README.md`](./examples/README.md) for the full index.
+[`examples/`](./examples/) is organized by category: basics, cookbook, patterns, providers, and integrations. See [`examples/README.md`](./examples/README.md) for the full index. ([`production/`](./examples/production/README.md) is open for contributions — see the acceptance criteria.)
 
 ### Real-world workflows ([`cookbook/`](./examples/cookbook/))
 
@@ -160,11 +197,16 @@ End-to-end scenarios you can run today. Each one is a complete, opinionated work
 - [`meeting-summarizer`](examples/cookbook/meeting-summarizer.ts): three specialised agents fan out on a transcript, an aggregator merges them into one Markdown report with action items and sentiment.
 - [`competitive-monitoring`](examples/cookbook/competitive-monitoring.ts): three parallel source agents extract claims from feeds; an aggregator cross-checks them and flags contradictions.
 - [`translation-backtranslation`](examples/cookbook/translation-backtranslation.ts): translate EN to target with one provider, back-translate with another, flag semantic drift.
+- [`incident-postmortem-dag`](examples/cookbook/incident-postmortem-dag.ts): three independent root tasks fan out at t=0, then a root-cause hypothesizer and postmortem writer synthesize them into one document.
+- [`personalized-interview-simulator`](examples/cookbook/personalized-interview-simulator.ts): a stateful interviewer (`Agent.prompt()` across turns) plus a transcript-reading observer, with `readline` human input and a Zod-validated debrief.
 
 ### Patterns and integrations
 
 - [`basics/team-collaboration`](examples/basics/team-collaboration.ts): `runTeam()` coordinator pattern.
 - [`patterns/structured-output`](examples/patterns/structured-output.ts): any agent returns Zod-validated JSON.
+- [`patterns/multi-perspective-code-review`](examples/patterns/multi-perspective-code-review.ts): a generator feeds security, performance, and style reviewers running in parallel, then a synthesizer returns Zod-validated findings.
+- [`patterns/cross-provider-reasoning`](examples/patterns/cross-provider-reasoning.ts): preserve a reasoning model's thought stream across a provider switch via `preserveReasoningAsText`.
+- [`patterns/cost-tiered-pipeline`](examples/patterns/cost-tiered-pipeline.ts): assign a different model per stage and estimate per-model USD cost from `onTrace` token counts.
 - [`patterns/fan-out-aggregate`](examples/patterns/fan-out-aggregate.ts): MapReduce-style fan-out via `AgentPool.runParallel()`.
 - [`patterns/agent-handoff`](examples/patterns/agent-handoff.ts): synchronous sub-agent delegation via `delegate_to_agent`.
 - [`integrations/trace-observability`](examples/integrations/trace-observability.ts): `onTrace` spans for LLM calls, tools, and tasks.
@@ -209,7 +251,7 @@ Using `open-multi-agent` in production or a side project? [Open a discussion](ht
 - **[Engram](https://www.engram-memory.com)** — "Git for AI memory." Syncs knowledge across agents instantly and flags conflicts. ([repo](https://github.com/Agentscreator/engram-memory))
 - **[@agentsonar/oma](https://github.com/agentsonar/agentsonar-oma)** — Sidecar detecting cross-run delegation cycles, repetition, and rate bursts.
 
-Built an integration? [Open a discussion](https://github.com/open-multi-agent/open-multi-agent/discussions) to get listed.
+Built an integration? See the [integration guide](examples/integrations/README.md) for how to submit a reference or vendor example and get your product listed.
 
 ### Provider community offers
 
@@ -250,18 +292,10 @@ For products and platforms with a deep `open-multi-agent` integration. See the [
 │  Agent            │
 │  - run()          │    ┌────────────────────────┐
 │  - prompt()       │───►│  LLMAdapter            │
-│  - stream()       │    │  - AnthropicAdapter    │
-└────────┬──────────┘    │  - OpenAIAdapter       │
-         │               │  - AzureOpenAIAdapter  │
-         │               │  - BedrockAdapter      │
-         │               │  - CopilotAdapter      │
-         │               │  - GeminiAdapter       │
-         │               │  - GrokAdapter         │
-         │               │  - MiniMaxAdapter      │
-         │               │  - MiMoAdapter         │
-         │               │  - DeepSeekAdapter     │
-         │               │  - DoubaoAdapter       │
-         │               │  - QiniuAdapter        │
+│  - stream()       │    │  - 12 built-in         │
+└────────┬──────────┘    │    providers           │
+         │               │  - OpenAI-compatible   │
+         │               │  - AI SDK bridge       │
          │               └────────────────────────┘
 ┌────────▼──────────┐
 │  AgentRunner      │    ┌──────────────────────┐
@@ -271,13 +305,6 @@ For products and platforms with a deep `open-multi-agent` integration. See the [
 └───────────────────┘    │  + delegate (opt-in) │
                          └──────────────────────┘
 ```
-
-## Core Concepts
-
-- **Tools + MCP.** Built-ins cover `bash`, `file_read`, `file_write`, `file_edit`, `grep`, and `glob`; custom tools use `defineTool()` + Zod; stdio MCP servers connect through `connectMCPTools()`. See [tool configuration](./docs/tool-configuration.md).
-- **Observability.** Wire `onProgress` for live lifecycle events, `onTrace` for structured spans, and `renderTeamRunDashboard(result)` for a static DAG dashboard. See [observability](./docs/observability.md).
-- **Shared memory.** Use the default in-process KV or bring Redis, Postgres, Engram, or any `MemoryStore`. See [shared memory](./docs/shared-memory.md).
-- **Context management.** Use sliding windows, summarization, rule-based compaction, or a custom compressor for long-running agents. See [context management](./docs/context-management.md).
 
 ## Supported Providers
 
@@ -295,7 +322,7 @@ const agent: AgentConfig = {
 | Kind | How to configure | Services |
 |------|------------------|----------|
 | Built-in shortcuts | Set `provider` to `anthropic`, `gemini`, `openai`, `azure-openai`, `copilot`, `grok`, `deepseek`, `doubao`, `minimax`, `mimo`, `qiniu`, or `bedrock`; the framework supplies the endpoint. | Anthropic, Gemini, OpenAI, Azure OpenAI, GitHub Copilot, xAI Grok, DeepSeek, Doubao (Volcengine), MiniMax, MiMo, Qiniu, AWS Bedrock |
-| OpenAI-compatible endpoints | Set `provider: 'openai'` plus `baseURL` and, when needed, `apiKey`. | Ollama, vLLM, LM Studio, llama.cpp server, OpenRouter, Groq, Mistral |
+| OpenAI-compatible endpoints | Set `provider: 'openai'` plus `baseURL` and, when needed, `apiKey`. | Ollama, vLLM, LM Studio, llama.cpp server, OpenRouter, Groq, Mistral, Moonshot (Kimi), Qwen, Zhipu |
 | Vercel AI SDK | Import `AISdkAdapter` from `@open-multi-agent/core/ai-sdk`; install optional peer `ai` plus an `@ai-sdk/*` provider. | [Any AI SDK provider](https://ai-sdk.dev/providers) (60+ models and hosts) |
 
 See [docs/providers.md](./docs/providers.md) for env vars, model examples, local tool-calling, timeouts, and troubleshooting.
@@ -330,12 +357,23 @@ Before going live, wire up the controls that protect token spend, recover from f
 | Concern | Knob | Where it lives |
 |---------|------|----------------|
 | Bound the conversation | `maxTurns` per agent + `contextStrategy` (`sliding-window` / `summarize` / `compact` / `custom`) | `AgentConfig` |
+| Bound wall-clock time | `timeoutMs` per agent (aborts a run that hangs, common with local models) | `AgentConfig` |
 | Cap tool output | `maxToolOutputChars` (or per-tool `maxOutputChars`) + `compressToolResults: true` | `AgentConfig` and `defineTool()` |
 | Recover from failure | Per-task `maxRetries`, `retryDelayMs`, `retryBackoff` (exponential multiplier) | Task config used via `runTasks()` |
 | Hard-cap spend | `maxTokenBudget` on the orchestrator | `OrchestratorConfig` |
 | Catch stuck agents | `loopDetection` with `onLoopDetected: 'terminate'` (or a custom handler) | `AgentConfig` |
 | Trace and audit | `onTrace` to your tracing backend; persist `renderTeamRunDashboard(result)` | `OrchestratorConfig` |
+| Redact secrets | Automatic — API keys, tokens, and Authorization headers stripped from traces, bash env, and dashboard payloads | built-in (on by default) |
 | Bound filesystem reach | `cwd` / `defaultCwd` (default `.agent-workspace` subdir; widen with `process.cwd()`, disable with `null`) | `AgentConfig` / `OrchestratorConfig` |
+
+## Documentation
+
+- [Providers](./docs/providers.md) — env vars, model examples, local tool-calling, timeouts, troubleshooting.
+- [Tool configuration](./docs/tool-configuration.md) — tool presets, custom tools, the filesystem sandbox, and MCP.
+- [Observability](./docs/observability.md) — `onProgress` events, `onTrace` spans, and the post-run dashboard.
+- [Shared memory](./docs/shared-memory.md) — the default store and custom `MemoryStore` backends.
+- [Context management](./docs/context-management.md) — sliding window, summarization, compaction, and custom compressors.
+- [CLI](./docs/cli.md) — the JSON-first `oma` binary for shell and CI.
 
 ## Contributing
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -44,11 +44,15 @@
 
 > **工程师只描述目标，不画任务图。**
 
+图优先的框架要求你预先列出每个节点和每条边。`open-multi-agent` 是目标优先：你描述想要的结果，协调者在运行时构建任务 DAG，编排随目标自适应，而不必为某一个流程硬接线。
+
+## 目录
+
+[快速开始](#快速开始) · [三种运行模式](#三种运行模式) · [功能一览](#功能一览) · [编排控制](#编排控制) · [示例](#示例) · [与其他框架对比](#与其他框架对比) · [生态](#生态) · [架构](#架构) · [支持的 Provider](#支持的-provider) · [生产级检查清单](#生产级检查清单) · [文档](#文档) · [参与贡献](#参与贡献)
+
 ## 快速开始
 
 要求 Node.js >= 18。
-
-### 在你的项目里使用
 
 ```bash
 npm install @open-multi-agent/core
@@ -110,7 +114,7 @@ Tokens: 12847 output tokens
 
 通过 Ollama 运行本地模型不需要 API key，见 [`providers/ollama`](examples/providers/ollama.ts)。其他 provider（`OPENAI_API_KEY`、`GEMINI_API_KEY` 等）见[支持的 Provider](#支持的-provider)。
 
-### 三种运行模式
+## 三种运行模式
 
 | 模式 | 方法 | 适用场景 | 示例 |
 |------|------|----------|------|
@@ -124,27 +128,66 @@ Tokens: 12847 output tokens
 const plan = await orchestrator.runTeam(team, goal, { planOnly: true })
 ```
 
-要 MapReduce 风格的 fan-out 但不需要任务依赖，直接用 `AgentPool.runParallel()`。例子见 [`patterns/fan-out-aggregate`](examples/patterns/fan-out-aggregate.ts)。
-
-Shell 和 CI 场景使用 JSON-first 的 `oma` 命令行工具。详见 [docs/cli.md](./docs/cli.md)。
-
 ## 功能一览
 
 | 能力 | 说明 |
 |------|------|
-| **目标驱动协调者** | 一个 `runTeam(team, goal)` 调用，协调者把目标拆成任务 DAG，并行执行独立任务，合成最终结果。 |
-| **同队混用 provider** | 10 家原生：Anthropic、OpenAI、Azure、Bedrock、Gemini、Grok、DeepSeek、MiniMax、Qiniu、Copilot；Ollama / vLLM / LM Studio / OpenRouter / Groq 走 OpenAI 兼容协议。([完整说明](./docs/providers.md)) |
-| **工具 + MCP** | 6 个内置（`bash`、`file_*`、`grep`、`glob`），可选启用 `delegate_to_agent`，用 `defineTool()` + Zod 自定义，任意 MCP server 通过 `connectMCPTools()` 接入。([工具配置](./docs/tool-configuration.md)) |
-| **流式 + 结构化输出** | 每个 adapter 都支持 token 级流式输出；用 Zod schema 校验最终答复，解析失败自动重试。([`structured-output`](examples/patterns/structured-output.ts)) |
-| **可观测性** | `onProgress` 事件、`onTrace` span，运行结束后渲染任务 DAG 的 HTML dashboard。([可观测性指南](./docs/observability.md)) |
+| **目标驱动协调者** | 一个 `runTeam(team, goal)` 调用，把目标拆成任务 DAG，并行执行独立任务，合成最终结果。未分配的任务自动调度——`dependency-first`（默认）、`round-robin`、`least-busy` 或 `capability-match`。 |
+| **同队混用 provider** | 12 家内置 provider，外加任意 OpenAI 兼容端点（Ollama、vLLM、LM Studio、OpenRouter、Groq），同队可自由混用。把 tool call 当纯文本输出的本地 server 会由 fallback 解析器兜底。([完整清单](#支持的-provider) · [配置](./docs/providers.md)) |
+| **扩展思考 / 推理** | 一份 `thinking` 配置映射到 Anthropic thinking、Gemini `thinkingConfig` 和 OpenAI `reasoning_effort`；推理以事件流式输出，并可选在切换 provider 时保留。([`cross-provider-reasoning`](examples/patterns/cross-provider-reasoning.ts)) |
+| **工具 + MCP** | 6 个内置（`bash`、`file_*`、`grep`、`glob`），可选启用 `delegate_to_agent`（带 cycle + depth 护栏），用 `defineTool()` + Zod 自定义，任意 MCP server 通过 `connectMCPTools()` 接入。([工具配置](./docs/tool-configuration.md)) |
+| **流式 + 结构化输出** | 每个 adapter 都支持 token 级流式输出（团队运行时通过 `onAgentStream` 拿到每个 agent 的流）；用 Zod schema 校验最终答复，解析失败自动重试。([`structured-output`](examples/patterns/structured-output.ts)) |
+| **人工介入（Human-in-the-loop）** | 用 `onPlanReady`（任何 agent 执行前审批整个计划）和 `onApproval`（每轮任务之间审批）卡点，或用 `planOnly` 先预览。 |
+| **生命周期钩子 + 取消** | `beforeRun` 改写 prompt，`afterRun` 后处理或拒绝结果；传入 `AbortSignal` 即可中途取消运行。 |
+| **可配置协调者** | 通过 `runTeam(team, goal, { coordinator })` 覆盖协调者的 model、provider、adapter、system prompt 或工具。 |
+| **可观测性** | `onProgress` 事件、`onTrace` span，运行结束后渲染任务 DAG 的 HTML dashboard。API key 和 token 会从 trace、bash 环境变量和 dashboard 输出中自动脱敏。([可观测性指南](./docs/observability.md)) |
 | **可插拔共享记忆** | 默认进程内 KV；实现 `MemoryStore` 接口即可换 Redis / Postgres / 自家后端。([共享记忆](./docs/shared-memory.md)) |
 | **沙箱化文件系统工作目录** | 内置文件系统工具默认沙箱化在 `<cwd>/.agent-workspace`；继承默认配置的 agent 共享同一根目录。需要 per-agent 隔离时显式设置 `AgentConfig.cwd`；改换共享根目录用 `OrchestratorConfig.defaultCwd`；传 `null` 关闭沙箱。([沙箱配置](./docs/tool-configuration.md)) |
 
-生产级控制（上下文策略、任务重试退避、循环检测、工具输出截断/压缩）见 [生产级检查清单](#生产级检查清单)。
+生产级控制（[上下文策略](./docs/context-management.md)、任务重试退避、循环检测、工具输出截断/压缩）见 [生产级检查清单](#生产级检查清单)。
+
+## 编排控制
+
+对一次 `runTeam` 运行的精细控制。全部可选；默认行为不变。
+
+**注入团队上下文。** 把目标、roster、当前 worker 的角色注入每个 worker 的 prompt——帮助 worker 与整体目标保持一致，也让多步运行更易调试。默认关闭；省略时 worker prompt 保持逐字节不变。
+
+```ts
+await orchestrator.runTeam(team, goal, { revealCoordinator: true })
+```
+
+**执行前审批。** 在任何 agent 执行前检查协调者的计划，并在每轮任务之间再次审批。这两个钩子在 orchestrator 上。返回 `false` 即中止，剩余任务标记为 `skipped`。
+
+```ts
+const orchestrator = new OpenMultiAgent({
+  onPlanReady: async (tasks) => tasks.length <= 10,        // 审批整个计划
+  onApproval:  async (completed, next) => next.length > 0, // 审批每一轮
+})
+```
+
+**取消运行。** 传入 `AbortSignal`；触发 abort 即中止运行。
+
+```ts
+const controller = new AbortController()
+const run = orchestrator.runTeam(team, goal, { abortSignal: controller.signal })
+// 在别处调用 controller.abort() 取消
+```
+
+**配置协调者。** 给规划者单独指定 model、adapter 或额外指令，不影响 worker agent。
+
+```ts
+await orchestrator.runTeam(team, goal, {
+  coordinator: { model: 'claude-opus-4-6', instructions: 'Prefer fewer, larger tasks.' },
+})
+```
+
+**无依赖 fan-out。** 要 MapReduce 风格的并行，直接用 `AgentPool.runParallel()`。见 [`patterns/fan-out-aggregate`](examples/patterns/fan-out-aggregate.ts)。
+
+**Shell 和 CI。** 使用 JSON-first 的 `oma` 命令行工具。详见 [docs/cli.md](./docs/cli.md)。
 
 ## 示例
 
-[`examples/`](./examples/) 按类别分为 basics、cookbook、patterns、providers、integrations、production。完整索引见 [`examples/README.md`](./examples/README.md)。
+[`examples/`](./examples/) 按类别分为 basics、cookbook、patterns、providers、integrations。完整索引见 [`examples/README.md`](./examples/README.md)。（[`production/`](./examples/production/README.md) 正在征集贡献——见收录标准。）
 
 ### 真实业务流程（[`cookbook/`](./examples/cookbook/)）
 
@@ -154,11 +197,16 @@ Shell 和 CI 场景使用 JSON-first 的 `oma` 命令行工具。详见 [docs/cl
 - [`meeting-summarizer`](examples/cookbook/meeting-summarizer.ts)：三个专精 agent 并行处理会议转录稿，聚合 agent 合成含行动项和情绪分析的 Markdown 报告。
 - [`competitive-monitoring`](examples/cookbook/competitive-monitoring.ts)：三个来源 agent 并行从信息流抽取声明，聚合 agent 跨源校对、标记矛盾。
 - [`translation-backtranslation`](examples/cookbook/translation-backtranslation.ts)：用一个 provider 翻译 EN 到目标语言，另一个 provider 回译，标记语义漂移。
+- [`incident-postmortem-dag`](examples/cookbook/incident-postmortem-dag.ts)：三个独立根任务在 t=0 并行展开，再由 root-cause 假设器和复盘撰写器合成为一份文档。
+- [`personalized-interview-simulator`](examples/cookbook/personalized-interview-simulator.ts)：有状态的面试官（跨轮次用 `Agent.prompt()`）加一个读取完整转录的观察者，用 `readline` 接入人工输入，结束时产出 Zod 校验的复盘。
 
 ### 模式与集成
 
 - [`basics/team-collaboration`](examples/basics/team-collaboration.ts)：`runTeam()` 协调者模式。
 - [`patterns/structured-output`](examples/patterns/structured-output.ts)：任意 agent 产出 Zod 校验过的 JSON。
+- [`patterns/multi-perspective-code-review`](examples/patterns/multi-perspective-code-review.ts)：生成器产出代码，安全、性能、风格三个评审并行，再由合成器返回 Zod 校验的发现列表。
+- [`patterns/cross-provider-reasoning`](examples/patterns/cross-provider-reasoning.ts)：通过 `preserveReasoningAsText` 在切换 provider 时保留推理模型的思考流。
+- [`patterns/cost-tiered-pipeline`](examples/patterns/cost-tiered-pipeline.ts)：每个阶段分配不同 model，用 `onTrace` 的 token 计数估算各 model 的 USD 成本。
 - [`patterns/fan-out-aggregate`](examples/patterns/fan-out-aggregate.ts)：`AgentPool.runParallel()` 做 MapReduce 风格 fan-out。
 - [`patterns/agent-handoff`](examples/patterns/agent-handoff.ts)：`delegate_to_agent` 同步子智能体委派。
 - [`integrations/trace-observability`](examples/integrations/trace-observability.ts)：`onTrace` 回调，给 LLM 调用、工具、任务发结构化 span。
@@ -200,10 +248,10 @@ Shell 和 CI 场景使用 JSON-first 的 `oma` 命令行工具。详见 [docs/cl
 
 ### 集成
 
-- **[Engram](https://www.engram-memory.com)** — "Git for AI memory." Syncs knowledge across agents instantly and flags conflicts. ([repo](https://github.com/Agentscreator/engram-memory))
-- **[@agentsonar/oma](https://github.com/agentsonar/agentsonar-oma)** — Sidecar detecting cross-run delegation cycles, repetition, and rate bursts.
+- **[Engram](https://www.engram-memory.com)** — "AI 记忆的 Git"。在 agent 之间即时同步知识并标记冲突。([repo](https://github.com/Agentscreator/engram-memory))
+- **[@agentsonar/oma](https://github.com/agentsonar/agentsonar-oma)** — Sidecar，检测跨运行的委派环、重复和速率突增。
 
-做了 `open-multi-agent` 集成？[开个 Discussion](https://github.com/open-multi-agent/open-multi-agent/discussions)，我们会将其列在这里。
+做了 `open-multi-agent` 集成？见[集成提交指南](examples/integrations/README.md)：如何提交 reference / vendor 示例，以及如何被列入这里。
 
 ### Provider 社区优惠
 
@@ -244,16 +292,10 @@ Shell 和 CI 场景使用 JSON-first 的 `oma` 命令行工具。详见 [docs/cl
 │  Agent            │
 │  - run()          │    ┌────────────────────────┐
 │  - prompt()       │───►│  LLMAdapter            │
-│  - stream()       │    │  - AnthropicAdapter    │
-└────────┬──────────┘    │  - OpenAIAdapter       │
-         │               │  - AzureOpenAIAdapter  │
-         │               │  - BedrockAdapter      │
-         │               │  - CopilotAdapter      │
-         │               │  - GeminiAdapter       │
-         │               │  - GrokAdapter         │
-         │               │  - MiniMaxAdapter      │
-         │               │  - DeepSeekAdapter     │
-         │               │  - QiniuAdapter        │
+│  - stream()       │    │  - 12 built-in         │
+└────────┬──────────┘    │    providers           │
+         │               │  - OpenAI-compatible   │
+         │               │  - AI SDK bridge       │
          │               └────────────────────────┘
 ┌────────▼──────────┐
 │  AgentRunner      │    ┌──────────────────────┐
@@ -263,13 +305,6 @@ Shell 和 CI 场景使用 JSON-first 的 `oma` 命令行工具。详见 [docs/cl
 └───────────────────┘    │  + delegate (opt-in) │
                          └──────────────────────┘
 ```
-
-## 核心概念
-
-- **工具 + MCP。** 内置工具涵盖 `bash`、`file_read`、`file_write`、`file_edit`、`grep`、`glob`；自定义工具用 `defineTool()` + Zod；stdio MCP 服务器通过 `connectMCPTools()` 接入。详见 [工具配置](./docs/tool-configuration.md)。
-- **可观测性。** 通过 `onProgress` 获取实时生命周期事件，通过 `onTrace` 获取结构化 span，调用 `renderTeamRunDashboard(result)` 生成静态 DAG dashboard。详见 [可观测性](./docs/observability.md)。
-- **共享记忆。** 用默认的进程内 KV，或换 Redis、Postgres、Engram，或任何实现了 `MemoryStore` 的后端。详见 [共享记忆](./docs/shared-memory.md)。
-- **上下文管理。** 对长时间运行的 agent 用滑动窗口、摘要、规则压缩或自定义压缩器。详见 [上下文管理](./docs/context-management.md)。
 
 ## 支持的 Provider
 
@@ -286,11 +321,34 @@ const agent: AgentConfig = {
 
 | 类型 | 配置方式 | 服务 |
 |------|--------|------|
-| 内置快捷方式 | 设 `provider` 为 `anthropic`、`gemini`、`openai`、`azure-openai`、`copilot`、`grok`、`deepseek`、`minimax`、`qiniu`、`bedrock`；框架自带 endpoint。 | Anthropic、Gemini、OpenAI、Azure OpenAI、GitHub Copilot、xAI Grok、DeepSeek、MiniMax、Qiniu、AWS Bedrock |
-| OpenAI 兼容端点 | 设 `provider: 'openai'` + `baseURL`，必要时加 `apiKey`。 | Ollama、vLLM、LM Studio、llama.cpp server、OpenRouter、Groq、Mistral |
-
+| 内置快捷方式 | 设 `provider` 为 `anthropic`、`gemini`、`openai`、`azure-openai`、`copilot`、`grok`、`deepseek`、`doubao`、`minimax`、`mimo`、`qiniu`、`bedrock`；框架自带 endpoint。 | Anthropic、Gemini、OpenAI、Azure OpenAI、GitHub Copilot、xAI Grok、DeepSeek、Doubao（火山引擎）、MiniMax、MiMo、Qiniu、AWS Bedrock |
+| OpenAI 兼容端点 | 设 `provider: 'openai'` + `baseURL`，必要时加 `apiKey`。 | Ollama、vLLM、LM Studio、llama.cpp server、OpenRouter、Groq、Mistral、Moonshot（Kimi）、Qwen、Zhipu（智谱） |
+| Vercel AI SDK | 从 `@open-multi-agent/core/ai-sdk` 导入 `AISdkAdapter`；安装可选 peer `ai` 加一个 `@ai-sdk/*` provider。 | [任意 AI SDK provider](https://ai-sdk.dev/providers)（60+ 模型与平台） |
 
 详见 [docs/providers.md](./docs/providers.md)，含环境变量、模型示例、本地模型工具调用、超时设置、常见问题。
+
+### Vercel AI SDK（可选）
+
+安装可选 peer [`ai`](https://www.npmjs.com/package/ai) 以及你需要的任意 [`@ai-sdk` provider](https://ai-sdk.dev/providers)（例如 [`@ai-sdk/openai`](https://www.npmjs.com/package/@ai-sdk/openai)）。在 `AgentConfig` 上传入 `adapter: new AISdkAdapter(model)`，即可让该 agent 走 AI SDK，而不是内置的 `provider` 工厂。设置了 `adapter` 时，`provider`、`apiKey`、`baseURL`、`region` 都会被忽略。混合团队照常工作：只有带 `adapter` 的 agent 才走 AI SDK。
+
+```typescript
+import { openai } from '@ai-sdk/openai'
+import { AISdkAdapter } from '@open-multi-agent/core/ai-sdk'
+import { OpenMultiAgent } from '@open-multi-agent/core'
+
+const oma = new OpenMultiAgent()
+await oma.runAgent(
+  {
+    name: 'researcher',
+    model: 'gpt-4o',
+    adapter: new AISdkAdapter(openai('gpt-4o')),
+    systemPrompt: 'You are a researcher.',
+  },
+  'What are the latest AI trends?',
+)
+```
+
+协调者也支持同样的钩子：`runTeam(team, goal, { coordinator: { adapter: new AISdkAdapter(...) } })`。
 
 ## 生产级检查清单
 
@@ -299,12 +357,23 @@ const agent: AgentConfig = {
 | 关注点 | 配置项 | 作用域 |
 |--------|--------|--------|
 | 控制对话长度 | `maxTurns`（每个 agent）+ `contextStrategy`（`sliding-window` / `summarize` / `compact` / `custom`） | `AgentConfig` |
+| 控制运行时长 | `timeoutMs`（每个 agent，运行挂起时中止；本地模型常见） | `AgentConfig` |
 | 限制工具输出 | `maxToolOutputChars`（或单工具 `maxOutputChars`）+ `compressToolResults: true` | `AgentConfig` 和 `defineTool()` |
 | 失败重试 | 任务级 `maxRetries`、`retryDelayMs`、`retryBackoff`（指数退避倍率） | 通过 `runTasks()` 用的任务配置 |
 | 总额封顶 | orchestrator 上设 `maxTokenBudget` | `OrchestratorConfig` |
 | 卡死检测 | `loopDetection` + `onLoopDetected: 'terminate'`（或自定义 handler） | `AgentConfig` |
 | 追踪与审计 | `onTrace` 接你的 tracing 后端；落盘 `renderTeamRunDashboard(result)` | `OrchestratorConfig` |
+| 脱敏密钥 | 自动——API key、token、Authorization header 从 trace、bash 环境变量、dashboard payload 中剥除 | 内置（默认开启） |
 | 限定 agent 文件操作范围 | `cwd` / `defaultCwd`（默认 `.agent-workspace` 子目录；用 `process.cwd()` 放宽、`null` 关闭） | `AgentConfig` / `OrchestratorConfig` |
+
+## 文档
+
+- [Provider](./docs/providers.md) — 环境变量、模型示例、本地模型工具调用、超时、常见问题。
+- [工具配置](./docs/tool-configuration.md) — 工具预设、自定义工具、文件系统沙箱、MCP。
+- [可观测性](./docs/observability.md) — `onProgress` 事件、`onTrace` span、运行后 dashboard。
+- [共享记忆](./docs/shared-memory.md) — 默认存储与自定义 `MemoryStore` 后端。
+- [上下文管理](./docs/context-management.md) — 滑动窗口、摘要、压缩、自定义压缩器。
+- [CLI](./docs/cli.md) — 面向 shell 和 CI 的 JSON-first `oma` 命令行。
 
 ## 参与贡献
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -386,7 +386,7 @@ Issue、feature request、PR 都欢迎。特别欢迎以下方面的贡献：
 ## 贡献者
 
 <a href="https://github.com/open-multi-agent/open-multi-agent/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=open-multi-agent/open-multi-agent&max=100&v=20260507" />
+  <img src="https://contrib.rocks/image?repo=open-multi-agent/open-multi-agent&max=100&v=20260529" />
 </a>
 
 <details>
@@ -405,6 +405,8 @@ Issue、feature request、PR 都欢迎。特别欢迎以下方面的贡献：
 - [@NamelessNATM](https://github.com/NamelessNATM)（agent 委派基础实现）
 - [@MyPrototypeWhat](https://github.com/MyPrototypeWhat)（reasoning blocks、reasoning_effort、采样参数对齐、trace 输入输出）
 - [@SiMinus](https://github.com/SiMinus)（流式 reasoning 事件）
+- [@matthewYang08](https://github.com/matthewYang08)（OpenAI reasoning 转文本回退）
+- [@dvirarad](https://github.com/dvirarad)（OpenAI 系列 adapter 健壮性）
 
 **Provider 集成**
 
@@ -415,6 +417,7 @@ Issue、feature request、PR 都欢迎。特别欢迎以下方面的贡献：
 - [@Deathwing](https://github.com/Deathwing)（GitHub Copilot）
 - [@JackChiang233](https://github.com/JackChiang233)（Qiniu）
 - [@CodingBangboo](https://github.com/CodingBangboo)（AWS Bedrock）
+- [@kidoom](https://github.com/kidoom)（MiMo、Doubao）
 
 **示例与 Cookbook**
 
@@ -431,24 +434,20 @@ Issue、feature request、PR 都欢迎。特别欢迎以下方面的贡献：
 - [@DaiMao-UT](https://github.com/DaiMao-UT)（论文复现分诊）
 - [@oooooowoooooo](https://github.com/oooooowoooooo)（罕见病信息分诊）
 - [@CodingBangboo](https://github.com/CodingBangboo)（Express 客服流水线）
+- [@nuthalapativarun](https://github.com/nuthalapativarun)（Doubao、Zhipu provider 示例）
+- [@goodneamtakenbydogs](https://github.com/goodneamtakenbydogs)（Moonshot、Qwen provider 示例）
+- [@suans4746-del](https://github.com/suans4746-del)（叙事谜题提示仲裁）
+- [@gregkonush](https://github.com/gregkonush)（Bilig WorkPaper MCP 集成）
 
 **文档与测试**
 
 - [@tmchow](https://github.com/tmchow)（llama.cpp 文档）
 - [@kenrogers](https://github.com/kenrogers)（OpenRouter 文档）
 - [@jadegold55](https://github.com/jadegold55)（LLM adapter 测试覆盖）
+- [@btroops](https://github.com/btroops)（DeepSeek 工具调用测试）
+- [@nuthalapativarun](https://github.com/nuthalapativarun)（上下文管理文档）
 
 </details>
-
-## Star 趋势
-
-<a href="https://star-history.com/#open-multi-agent/open-multi-agent&Date">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=open-multi-agent/open-multi-agent&type=Date&theme=dark&v=20260425" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=open-multi-agent/open-multi-agent&type=Date&v=20260425" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=open-multi-agent/open-multi-agent&type=Date&v=20260425" />
- </picture>
-</a>
 
 ## 许可证
 


### PR DESCRIPTION
## Summary

The README had drifted behind the code: the zh translation lagged en, several shipped capabilities had zero README visibility, and provider listings were duplicated across four places. This rewrites both README.md and README_zh.md. Docs-only, no code changes.

## Sync (zh ← en)
Added to zh, which had fallen behind: Doubao/MiMo, revealCoordinator, the full Vercel AI SDK section, and translated integration entries.

## De-duplicate
- Features provider row points to the canonical Supported Providers table instead of re-listing 12 names.
- Architecture diagram no longer hardcodes adapter names, so adding a provider no longer means editing the diagram.
- Removed the Core Concepts section (overlapped the Features table); its docs links moved into Features, nothing lost.

## Restructure
- Added a TOC and a Documentation nav section.
- Quick Start trimmed to install + minimal runTeam + one example. Advanced knobs moved to a new Orchestration Controls section (planOnly, revealCoordinator, approval, cancellation, coordinator config, fan-out, CLI).
- Added a short goal-first vs graph-first rationale.

## Surface built-in capabilities (previously no README mention)
- Extended thinking / reasoning (Anthropic / Gemini / OpenAI)
- Human-in-the-loop: `onPlanReady` / `onApproval`
- Cancellation via `AbortSignal`
- Lifecycle hooks: `beforeRun` / `afterRun`
- Configurable coordinator
- Secret redaction in traces, bash env, and dashboard payloads
- Local-model tool-call text fallback
- `delegate_to_agent` cycle + depth guards
- Named popular OpenAI-compatible providers: Moonshot (Kimi), Qwen, Zhipu

## Ecosystem
- Integrations CTA points to the integration submission guide.
- Fixed the Examples section listing `production/` as an existing category when it's empty.

## Out of scope
Low-value config (sampling params, per-tool schema, MessageBus, memory TTL) stays in docs. Dedicated docs pages for reasoning / HITL / redaction are a follow-up.