### PR TITLE
feat(orchestrator): add consensus / adversarial verification primitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Local models via Ollama need no API key, see [`providers/ollama`](examples/provi
 | Auto-orchestrated team | `runTeam()` | Give a goal, let the coordinator plan and execute | [`basics/team-collaboration`](examples/basics/team-collaboration.ts) |
 | Explicit pipeline | `runTasks()` | You define the task graph and assignments | [`basics/task-pipeline`](examples/basics/task-pipeline.ts) |
 
+For answers that need scrutiny, `runConsensus()` runs a proposer→judge verification loop (with an opt-in per-task `verify` hook). See [Consensus](./docs/consensus.md).
+
 Preview the coordinator's task DAG without executing agents:
 
 ```ts
@@ -374,6 +376,7 @@ Before going live, wire up the controls that protect token spend, recover from f
 - [Shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — the default store and custom `MemoryStore` backends.
 - [Context management](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — sliding window, summarization, compaction, and custom compressors.
 - [CLI](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/cli.md) — the JSON-first `oma` binary for shell and CI.
+- [Consensus](./docs/consensus.md) — the `runConsensus` proposer→judge primitive, the per-task `verify` hook, and the budget invariant.
 
 ## Contributing
 

--- a/docs/consensus.md
+++ b/docs/consensus.md
@@ -1,0 +1,63 @@
+# Consensus
+
+`runConsensus` adds a proposer→judge verification loop on top of a single prompt: a **proposer** agent emits an answer, then a roster of **judge** agents try to refute it over up to `maxRounds`. The loop exits early once a `quorum` of judges accept.
+
+```ts
+const result = await orchestrator.runConsensus(team, 'Is this proof correct?', {
+  proposer: { name: 'solver', model: 'claude-opus-4-6' },
+  judges: [
+    { name: 'judge-a', model: 'claude-opus-4-6' },
+    { name: 'judge-b', model: 'claude-sonnet-4-6' },
+  ],
+  mode: 'refute',       // identical skeptic framing for every judge
+  quorum: 2,            // default: ceil(judges.length / 2)
+  maxRounds: 2,         // default: 2
+  onDissent: 'revise',  // default: feed dissent back to the proposer
+})
+
+result.answer      // the (possibly revised) answer
+result.verdict     // 'accepted' | 'rejected'
+result.dissent     // critiques recorded across all rounds
+result.rounds      // judging rounds executed
+result.tokenUsage  // proposer + judges + revisions
+```
+
+## Options
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `proposer` | — | One agent, or an array (N-best — all candidates are shown to the judges). |
+| `judges` | — | Verifier roster. Judges run **sequentially** so quorum and budget can stop the rest. |
+| `mode` | `'refute'` | `'refute'`: every judge gets the same skeptic framing. `'lens'`: each judge gets a distinct angle (correctness, completeness, edge cases, …). |
+| `quorum` | `ceil(judges.length / 2)` | Accepting judges required to reach consensus. |
+| `maxRounds` | `2` | Upper bound on proposer↔judge rounds. |
+| `verdictSchema` | — | Optional Zod schema validated against each judge's parsed verdict; a failure counts as dissent. |
+| `onDissent` | `'revise'` | `'revise'`: feed dissent back to the proposer for another round. `'reject'`: stop, verdict `rejected`. `'keep'`: stop but keep the answer, verdict `accepted`. |
+| `judgePrompt` | built-in | Override the verifier prompt — a `string` for all judges, or a `(judge) => string` function for per-judge framing. |
+
+Every judge prompt includes the **original question** alongside the proposed answer, so judges (including lens-mode ones) score the answer against what was actually asked. A judge replies with `{"accept": boolean, "critique": string}`.
+
+## Per-task `verify` hook
+
+Any task in a `runTasks` pipeline can opt into consensus verification of its own result — the task's assignee is the proposer, so you supply everything *except* `proposer`:
+
+```ts
+await orchestrator.runTasks(team, [
+  {
+    title: 'derive-bound',
+    description: 'Prove the O(n log n) bound.',
+    assignee: 'mathematician',
+    verify: { judges: [judgeA, judgeB], mode: 'refute', maxRounds: 2 },
+  },
+])
+```
+
+After the task completes, its result is fed into the same consensus loop. If consensus revises the answer, the revised result replaces the task output for downstream consumers. Tasks **without** `verify` run unchanged and pay nothing — the hook is fully opt-in.
+
+## Budget invariant
+
+Consensus token usage counts against the parent budget exactly like delegation does. Proposer, judge, and revision usage all accumulate into the running total and are checked against `OrchestratorConfig.maxTokenBudget`. Once the cumulative total crosses the budget, consensus **stops issuing further judge calls** — no separate budget knob, no escape hatch. For the per-task `verify` hook, judge usage rolls into the same run-level budget as the rest of the pipeline and trips the same gate.
+
+## Observability
+
+Each dissenting verdict is written to shared memory (under the judge's namespace, key `consensus:round:N:dissent`) and emitted as a `consensus` trace event via `onTrace`, so you can audit which judge objected and why.

--- a/docs/consensus.md
+++ b/docs/consensus.md
@@ -60,4 +60,4 @@ Consensus token usage counts against the parent budget exactly like delegation d
 
 ## Observability
 
-Each dissenting verdict is written to shared memory (under the judge's namespace, key `consensus:round:N:dissent`) and emitted as a `consensus` trace event via `onTrace`, so you can audit which judge objected and why.
+Every judge verdict is emitted as a `consensus` trace event via `onTrace` (with `accepted` set to the judge's decision and `dissent` carrying the critique when it objected), so you can audit each round. Dissenting critiques are additionally written to shared memory (under the judge's namespace, key `consensus:round:N:dissent`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,11 @@ export type {
   TeamRunResult,
   RunTeamOptions,
 
+  // Consensus
+  ConsensusOptions,
+  ConsensusVerifyOptions,
+  ConsensusResult,
+
   // Dashboard (static HTML)
   TaskExecutionMetrics,
   TaskExecutionRecord,
@@ -191,6 +196,7 @@ export type {
   AgentTrace,
   PlanReadyTrace,
   AgentStreamTrace,
+  ConsensusTrace,
 
   // Memory
   MemoryEntry,

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -755,37 +755,44 @@ async function executeQueue(
       }
 
       if (result.success) {
-        // Persist result into shared memory so other agents can read it
         const sharedMem = team.getSharedMemoryInstance()
+
+        // Opt-in consensus verification runs *before* the task is finalised so the
+        // verified outcome (accepted → revised, rejected → original) flows into the
+        // queue, shared memory, progress events, and agentResults as one consistent
+        // result. Judge usage is charged to the same parent budget as the rest of the run.
+        let effective = result
+        if (task.verify && !ctx.budgetExceededTriggered) {
+          effective = await runTaskVerify(task, assignee, result, sharedMem, ctx)
+        }
+
+        // Reflect the verified result in the per-task record the caller receives.
+        ctx.agentResults.set(`${assignee}:${task.id}`, effective)
+
+        // Persist result into shared memory so other agents can read it
         if (sharedMem) {
-          await sharedMem.write(assignee, `task:${task.id}:result`, result.output)
+          await sharedMem.write(assignee, `task:${task.id}:result`, effective.output)
           // Advance the turn counter so any TTL-tagged entries written during
           // this task can be expired by subsequent reads.
           sharedMem.advanceTurn()
         }
 
-        const completedTask = queue.complete(task.id, result.output)
+        const completedTask = queue.complete(task.id, effective.output)
         completedThisRound.push(completedTask)
 
         config.onProgress?.({
           type: 'task_complete',
           task: task.id,
           agent: assignee,
-          data: result,
+          data: effective,
         } satisfies OrchestratorEvent)
 
         config.onProgress?.({
           type: 'agent_complete',
           agent: assignee,
           task: task.id,
-          data: result,
+          data: effective,
         } satisfies OrchestratorEvent)
-
-        // Opt-in consensus verification: judges scrutinise this task's result,
-        // their usage charged to the same parent budget as the rest of the run.
-        if (task.verify && !ctx.budgetExceededTriggered) {
-          await runTaskVerify(task, assignee, result, sharedMem, queue, ctx)
-        }
       } else {
         queue.fail(task.id, result.output)
         config.onProgress?.({
@@ -1142,18 +1149,20 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
 }
 
 /**
- * Run the per-task `verify` hook after a task completes: feed the task result
- * into the consensus loop, fold judge usage into the run's cumulative budget,
- * and replace the task result when consensus revises it.
+ * Run the per-task `verify` hook before a task is finalised: feed the task
+ * result into the consensus loop, fold judge usage into the run's cumulative
+ * budget, surface the verdict, and return the effective result — the accepted
+ * revision when judges revise it, otherwise the original. The caller uses this
+ * to finalise the task so the queue, shared memory, events, and agentResults
+ * all agree on the verified outcome.
  */
 async function runTaskVerify(
   task: Task,
   assignee: string,
   result: AgentRunResult,
   sharedMem: ReturnType<Team['getSharedMemoryInstance']>,
-  queue: TaskQueue,
   ctx: RunContext,
-): Promise<void> {
+): Promise<AgentRunResult> {
   const verify = task.verify!
   const { team, config } = ctx
   const assigneeConfig = team.getAgents().find((a) => a.name === assignee)
@@ -1188,14 +1197,6 @@ async function runTaskVerify(
   })
 
   ctx.cumulativeUsage = addUsage(ctx.cumulativeUsage, consensus.tokenUsage)
-  // Keep the reported per-task usage consistent (mirrors how delegation usage rolls in).
-  const stored = ctx.agentResults.get(`${assignee}:${task.id}`)
-  if (stored) {
-    ctx.agentResults.set(`${assignee}:${task.id}`, {
-      ...stored,
-      tokenUsage: addUsage(stored.tokenUsage, consensus.tokenUsage),
-    })
-  }
 
   // Surface the verdict as a task-level outcome so downstream agents and the
   // final synthesis can see whether the result survived scrutiny.
@@ -1204,13 +1205,6 @@ async function runTaskVerify(
       ? 'accepted'
       : `rejected${consensus.dissent.length ? `: ${consensus.dissent.join('; ')}` : ''}`
     await sharedMem.write(assignee, `task:${task.id}:verdict`, summary)
-  }
-
-  // Only an *accepted* revision supersedes the task result downstream; a rejected
-  // revision is recorded as dissent but never overwrites the original output.
-  if (consensus.verdict === 'accepted' && consensus.answer && consensus.answer !== result.output) {
-    queue.update(task.id, { result: consensus.answer })
-    if (sharedMem) await sharedMem.write(assignee, `task:${task.id}:result`, consensus.answer)
   }
 
   const total = ctx.cumulativeUsage.input_tokens + ctx.cumulativeUsage.output_tokens
@@ -1224,6 +1218,17 @@ async function runTaskVerify(
       task: task.id,
       data: err,
     } satisfies OrchestratorEvent)
+  }
+
+  // Only an *accepted* revision supersedes the task result; a rejected revision is
+  // recorded as dissent but the caller finalises with the original output. Judge
+  // usage rolls into the per-task usage (mirrors how delegation usage rolls in).
+  const useRevision =
+    consensus.verdict === 'accepted' && consensus.answer && consensus.answer !== result.output
+  return {
+    ...result,
+    output: useRevision ? consensus.answer : result.output,
+    tokenUsage: addUsage(result.tokenUsage, consensus.tokenUsage),
   }
 }
 
@@ -1878,6 +1883,12 @@ export class OpenMultiAgent {
           tokenUsage: usage,
         }
       }
+    }
+
+    // Every proposer failed or returned empty output: there is nothing to judge.
+    // Bail with a rejected verdict so an empty answer can never come back accepted.
+    if (candidates.length === 0) {
+      return { answer: '', verdict: 'rejected', dissent: [], rounds: 0, tokenUsage: usage }
     }
 
     return runConsensusCore({

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -1090,6 +1090,23 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
       if (overBudget()) { budgetHit = true; break }
 
       const verdict = parseJudgeVerdict(r.output, verdictSchema)
+
+      // Trace every verdict (accept or dissent); shared memory records dissent only.
+      if (onTrace) {
+        const now = Date.now()
+        emitTrace(onTrace, {
+          type: 'consensus',
+          runId: runId ?? '',
+          agent: judge.name,
+          round,
+          accepted: verdict.accept,
+          ...(verdict.accept ? {} : { dissent: verdict.critique }),
+          startMs: now,
+          endMs: now,
+          durationMs: 0,
+        })
+      }
+
       if (verdict.accept) {
         acceptCount++
         if (acceptCount >= quorum) { accepted = true; break }
@@ -1099,20 +1116,6 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
         dissent.push(labelled)
         if (sharedMem) {
           await sharedMem.write(judge.name, `consensus:round:${round}:dissent`, verdict.critique)
-        }
-        if (onTrace) {
-          const now = Date.now()
-          emitTrace(onTrace, {
-            type: 'consensus',
-            runId: runId ?? '',
-            agent: judge.name,
-            round,
-            accepted: false,
-            dissent: verdict.critique,
-            startMs: now,
-            endMs: now,
-            durationMs: 0,
-          })
         }
       }
     }

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -980,15 +980,18 @@ function buildJudgePrompt(p: {
   ].join('\n')
 }
 
-/** Build the proposer prompt for a revision round, feeding back the dissent. */
-function buildRevisePrompt(prompt: string, dissent: readonly string[]): string {
+/** Build the proposer prompt for a revision round, feeding back the prior answer and the dissent. */
+function buildRevisePrompt(prompt: string, answer: string, dissent: readonly string[]): string {
   return [
     prompt,
+    '',
+    '## Your previous answer',
+    answer,
     '',
     '## Reviewer critiques to address',
     ...dissent.map((d) => `- ${d}`),
     '',
-    'Revise your answer to address every critique above. Respond with the improved answer only.',
+    'Revise the previous answer to address every critique above. Respond with the improved answer only.',
   ].join('\n')
 }
 
@@ -1124,7 +1127,7 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
 
     // Round missed quorum. Revise (if rounds remain) or stop.
     if (onDissent === 'revise' && round < maxRounds && reviseProposer) {
-      const r = await runEphemeral(reviseProposer, buildRevisePrompt(prompt, roundDissent))
+      const r = await runEphemeral(reviseProposer, buildRevisePrompt(prompt, answer, roundDissent))
       usage = addUsage(usage, r.tokenUsage)
       if (r.success && r.output) answer = r.output
       if (overBudget()) { budgetHit = true; break }
@@ -1163,7 +1166,10 @@ async function runTaskVerify(
     budgetBaseTokens: ctx.cumulativeUsage.input_tokens + ctx.cumulativeUsage.output_tokens,
     judges: verify.judges,
     mode: verify.mode ?? 'refute',
-    quorum: Math.max(1, verify.quorum ?? Math.ceil(verify.judges.length / 2)),
+    quorum: Math.min(
+      verify.judges.length,
+      Math.max(1, verify.quorum ?? Math.ceil(verify.judges.length / 2)),
+    ),
     maxRounds: Math.max(1, verify.maxRounds ?? 2),
     verdictSchema: verify.verdictSchema,
     onDissent: verify.onDissent ?? 'revise',
@@ -1191,8 +1197,18 @@ async function runTaskVerify(
     })
   }
 
-  // A revised answer supersedes the task result for downstream consumers.
-  if (consensus.answer && consensus.answer !== result.output) {
+  // Surface the verdict as a task-level outcome so downstream agents and the
+  // final synthesis can see whether the result survived scrutiny.
+  if (sharedMem) {
+    const summary = consensus.verdict === 'accepted'
+      ? 'accepted'
+      : `rejected${consensus.dissent.length ? `: ${consensus.dissent.join('; ')}` : ''}`
+    await sharedMem.write(assignee, `task:${task.id}:verdict`, summary)
+  }
+
+  // Only an *accepted* revision supersedes the task result downstream; a rejected
+  // revision is recorded as dissent but never overwrites the original output.
+  if (consensus.verdict === 'accepted' && consensus.answer && consensus.answer !== result.output) {
     queue.update(task.id, { result: consensus.answer })
     if (sharedMem) await sharedMem.write(assignee, `task:${task.id}:result`, consensus.answer)
   }
@@ -1818,7 +1834,10 @@ export class OpenMultiAgent {
 
     const mode = options.mode ?? 'refute'
     const maxRounds = Math.max(1, options.maxRounds ?? 2)
-    const quorum = Math.max(1, options.quorum ?? Math.ceil(options.judges.length / 2))
+    const quorum = Math.min(
+      options.judges.length,
+      Math.max(1, options.quorum ?? Math.ceil(options.judges.length / 2)),
+    )
     const onDissent = options.onDissent ?? 'revise'
     const budget = this.config.maxTokenBudget
     const defaults: ConsensusAgentDefaults = {

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -44,6 +44,9 @@
 import type {
   AgentConfig,
   AgentRunResult,
+  ConsensusOptions,
+  ConsensusResult,
+  ConsensusVerifyOptions,
   CoordinatorConfig,
   RunTeamOptions,
   OrchestratorConfig,
@@ -57,6 +60,7 @@ import type {
   TeamRunResult,
   TokenUsage,
 } from '../types.js'
+import type { ZodSchema } from 'zod'
 import type { RunOptions } from '../agent/runner.js'
 import { Agent } from '../agent/agent.js'
 import { AgentPool } from '../agent/pool.js'
@@ -68,6 +72,7 @@ import { defaultWorkspaceDir } from '../tool/built-in/path-safety.js'
 import { Team } from '../team/team.js'
 import { TaskQueue } from '../task/queue.js'
 import { createTask } from '../task/task.js'
+import { extractJSON, validateOutput } from '../agent/structured-output.js'
 import { Scheduler } from './scheduler.js'
 import { TokenBudgetExceededError } from '../errors.js'
 import { extractKeywords, keywordScore } from '../utils/keywords.js'
@@ -346,6 +351,7 @@ interface ParsedTaskSpec {
   maxRetries?: number
   retryDelayMs?: number
   retryBackoff?: number
+  verify?: ConsensusVerifyOptions
 }
 
 /**
@@ -774,6 +780,12 @@ async function executeQueue(
           task: task.id,
           data: result,
         } satisfies OrchestratorEvent)
+
+        // Opt-in consensus verification: judges scrutinise this task's result,
+        // their usage charged to the same parent budget as the rest of the run.
+        if (task.verify && !ctx.budgetExceededTriggered) {
+          await runTaskVerify(task, assignee, result, sharedMem, queue, ctx)
+        }
       } else {
         queue.fail(task.id, result.output)
         config.onProgress?.({
@@ -887,6 +899,313 @@ async function buildTaskPrompt(
   }
 
   return lines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
+// Consensus (proposer + judge verification)
+// ---------------------------------------------------------------------------
+
+/** Orchestrator-level defaults applied to ephemeral consensus agents. */
+interface ConsensusAgentDefaults {
+  readonly defaultProvider: OrchestratorConfig['defaultProvider']
+  readonly defaultBaseURL: OrchestratorConfig['defaultBaseURL']
+  readonly defaultApiKey: OrchestratorConfig['defaultApiKey']
+  readonly defaultCwd: OrchestratorConfig['defaultCwd']
+  readonly maxConcurrency: number
+}
+
+/** Skeptic framing applied to every judge (refute mode and lens-mode base). */
+const DEFAULT_VERIFIER_INSTRUCTION =
+  'You are a rigorous skeptic reviewing a proposed answer to the question shown below. ' +
+  'Judge the answer against what that question actually asks: hunt for errors, unsupported ' +
+  'claims, gaps, and faulty reasoning, then decide whether it withstands scrutiny.'
+
+/** Per-judge review angles used in `lens` mode (assigned round-robin by index). */
+const CONSENSUS_LENSES = [
+  'factual correctness and logical soundness',
+  'completeness and coverage of the question',
+  'edge cases, failure modes, and counterexamples',
+  'clarity, precision, and freedom from ambiguity',
+  'hidden assumptions and unstated premises',
+  'evidence, citations, and verifiability',
+] as const
+
+/** Verdict contract appended to every judge prompt. */
+const VERDICT_INSTRUCTION =
+  'Respond ONLY with a JSON object {"accept": <true|false>, "critique": "<concise reason>"}. ' +
+  'Set "accept" to true only if the answer withstands scrutiny; otherwise set it false ' +
+  'and explain the problem in "critique".'
+
+/** Apply orchestrator defaults to a consensus agent config, mirroring buildPool. */
+function applyConsensusDefaults(config: AgentConfig, defaults: ConsensusAgentDefaults): AgentConfig {
+  return {
+    ...config,
+    provider: config.provider ?? defaults.defaultProvider,
+    baseURL: config.baseURL ?? defaults.defaultBaseURL,
+    apiKey: config.apiKey ?? defaults.defaultApiKey,
+    cwd: config.cwd === undefined ? defaults.defaultCwd : config.cwd,
+  }
+}
+
+/** Build the user prompt sent to a single judge, always including the original question. */
+function buildJudgePrompt(p: {
+  judge: string
+  answer: string
+  prompt: string
+  mode: 'refute' | 'lens'
+  judgeIndex: number
+  judgePrompt?: string | ((judge: string) => string)
+}): string {
+  let instruction: string
+  if (p.judgePrompt !== undefined) {
+    instruction = typeof p.judgePrompt === 'function' ? p.judgePrompt(p.judge) : p.judgePrompt
+  } else if (p.mode === 'lens') {
+    const lens = CONSENSUS_LENSES[p.judgeIndex % CONSENSUS_LENSES.length]!
+    instruction = `${DEFAULT_VERIFIER_INSTRUCTION}\nFocus specifically on: ${lens}. ` +
+      'If that angle is irrelevant to this question, accept the answer rather than inventing objections.'
+  } else {
+    instruction = DEFAULT_VERIFIER_INSTRUCTION
+  }
+  return [
+    instruction,
+    '',
+    '## Question',
+    p.prompt,
+    '',
+    '## Proposed answer',
+    p.answer,
+    '',
+    '## Your verdict',
+    VERDICT_INSTRUCTION,
+  ].join('\n')
+}
+
+/** Build the proposer prompt for a revision round, feeding back the dissent. */
+function buildRevisePrompt(prompt: string, dissent: readonly string[]): string {
+  return [
+    prompt,
+    '',
+    '## Reviewer critiques to address',
+    ...dissent.map((d) => `- ${d}`),
+    '',
+    'Revise your answer to address every critique above. Respond with the improved answer only.',
+  ].join('\n')
+}
+
+/** Parse a judge's raw output into an accept/critique decision. */
+function parseJudgeVerdict(
+  output: string,
+  verdictSchema?: ZodSchema,
+): { accept: boolean; critique: string } {
+  let parsed: unknown
+  try {
+    parsed = extractJSON(output)
+  } catch {
+    return { accept: false, critique: 'Judge output was not valid JSON.' }
+  }
+  if (verdictSchema) {
+    try {
+      validateOutput(verdictSchema, parsed)
+    } catch (err) {
+      return { accept: false, critique: `Verdict failed schema validation: ${err instanceof Error ? err.message : String(err)}` }
+    }
+  }
+  const obj = (parsed && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>
+  const accept = typeof obj['accept'] === 'boolean' ? obj['accept'] : false
+  const critique = typeof obj['critique'] === 'string' && obj['critique']
+    ? obj['critique']
+    : accept ? '' : 'No critique provided.'
+  return { accept, critique }
+}
+
+/** Inputs to {@link runConsensusCore} — the judge loop shared by `runConsensus` and the `verify` hook. */
+interface ConsensusCoreParams {
+  readonly team: Team
+  readonly prompt: string
+  /** Proposed answer to scrutinise (proposer output, or the task result). */
+  readonly initialAnswer: string
+  /** Usage attributable so far that should be reported back (proposer usage, or zero for the verify hook). */
+  readonly initialUsage: TokenUsage
+  /** Tokens already spent that count toward the budget but are not re-reported (e.g. prior task usage). */
+  readonly budgetBaseTokens: number
+  readonly judges: readonly AgentConfig[]
+  readonly mode: 'refute' | 'lens'
+  readonly quorum: number
+  readonly maxRounds: number
+  readonly verdictSchema?: ZodSchema
+  readonly onDissent: 'revise' | 'reject' | 'keep'
+  readonly judgePrompt?: string | ((judge: string) => string)
+  readonly budget?: number
+  /** Re-run on a revision round (the proposer, or the task assignee). */
+  readonly reviseProposer?: AgentConfig
+  readonly defaults: ConsensusAgentDefaults
+  readonly onTrace?: OrchestratorConfig['onTrace']
+  readonly runId?: string
+  /** Existing pool to reuse; a fresh one is created when omitted. */
+  readonly pool?: AgentPool
+}
+
+/**
+ * Run the judge/refutation loop over a proposed answer: judges run sequentially
+ * (so quorum and budget can stop the rest), dissent is recorded to shared memory
+ * and trace, and `onDissent` decides whether to revise, reject, or keep.
+ */
+async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusResult> {
+  const {
+    team, prompt, judges, mode, quorum, maxRounds, verdictSchema, onDissent,
+    judgePrompt, budget, budgetBaseTokens, reviseProposer, defaults, onTrace, runId,
+  } = params
+
+  const pool = params.pool ?? new AgentPool(Math.max(1, defaults.maxConcurrency))
+  const sharedMem = team.getSharedMemoryInstance()
+
+  let answer = params.initialAnswer
+  let usage = params.initialUsage
+  const dissent: string[] = []
+  let rounds = 0
+  let accepted = false
+
+  const overBudget = (): boolean =>
+    budget !== undefined && budgetBaseTokens + usage.input_tokens + usage.output_tokens > budget
+
+  const runEphemeral = (config: AgentConfig, text: string): Promise<AgentRunResult> =>
+    pool.runEphemeral(buildAgent(applyConsensusDefaults(config, defaults)), text)
+
+  // Proposer usage was already accumulated by the caller; bail before judging if it blew the budget.
+  if (overBudget()) {
+    return { answer, verdict: 'rejected', dissent, rounds, tokenUsage: usage }
+  }
+
+  let budgetHit = false
+  for (let round = 1; round <= maxRounds; round++) {
+    rounds = round
+    let acceptCount = 0
+    const roundDissent: string[] = []
+
+    for (let j = 0; j < judges.length; j++) {
+      const judge = judges[j]!
+      const judgeText = buildJudgePrompt({ judge: judge.name, answer, prompt, mode, judgeIndex: j, judgePrompt })
+      const r = await runEphemeral(judge, judgeText)
+      usage = addUsage(usage, r.tokenUsage)
+      if (overBudget()) { budgetHit = true; break }
+
+      const verdict = parseJudgeVerdict(r.output, verdictSchema)
+      if (verdict.accept) {
+        acceptCount++
+        if (acceptCount >= quorum) { accepted = true; break }
+      } else {
+        const labelled = `${judge.name}: ${verdict.critique}`
+        roundDissent.push(labelled)
+        dissent.push(labelled)
+        if (sharedMem) {
+          await sharedMem.write(judge.name, `consensus:round:${round}:dissent`, verdict.critique)
+        }
+        if (onTrace) {
+          const now = Date.now()
+          emitTrace(onTrace, {
+            type: 'consensus',
+            runId: runId ?? '',
+            agent: judge.name,
+            round,
+            accepted: false,
+            dissent: verdict.critique,
+            startMs: now,
+            endMs: now,
+            durationMs: 0,
+          })
+        }
+      }
+    }
+
+    if (budgetHit || accepted) break
+
+    // Round missed quorum. Revise (if rounds remain) or stop.
+    if (onDissent === 'revise' && round < maxRounds && reviseProposer) {
+      const r = await runEphemeral(reviseProposer, buildRevisePrompt(prompt, roundDissent))
+      usage = addUsage(usage, r.tokenUsage)
+      if (r.success && r.output) answer = r.output
+      if (overBudget()) { budgetHit = true; break }
+      continue
+    }
+    break
+  }
+
+  const verdict: 'accepted' | 'rejected' =
+    accepted || (!budgetHit && onDissent === 'keep') ? 'accepted' : 'rejected'
+  return { answer, verdict, dissent, rounds, tokenUsage: usage }
+}
+
+/**
+ * Run the per-task `verify` hook after a task completes: feed the task result
+ * into the consensus loop, fold judge usage into the run's cumulative budget,
+ * and replace the task result when consensus revises it.
+ */
+async function runTaskVerify(
+  task: Task,
+  assignee: string,
+  result: AgentRunResult,
+  sharedMem: ReturnType<Team['getSharedMemoryInstance']>,
+  queue: TaskQueue,
+  ctx: RunContext,
+): Promise<void> {
+  const verify = task.verify!
+  const { team, config } = ctx
+  const assigneeConfig = team.getAgents().find((a) => a.name === assignee)
+
+  const consensus = await runConsensusCore({
+    team,
+    prompt: task.description,
+    initialAnswer: result.output,
+    initialUsage: ZERO_USAGE,
+    budgetBaseTokens: ctx.cumulativeUsage.input_tokens + ctx.cumulativeUsage.output_tokens,
+    judges: verify.judges,
+    mode: verify.mode ?? 'refute',
+    quorum: Math.max(1, verify.quorum ?? Math.ceil(verify.judges.length / 2)),
+    maxRounds: Math.max(1, verify.maxRounds ?? 2),
+    verdictSchema: verify.verdictSchema,
+    onDissent: verify.onDissent ?? 'revise',
+    judgePrompt: verify.judgePrompt,
+    budget: ctx.maxTokenBudget,
+    reviseProposer: assigneeConfig,
+    defaults: {
+      defaultProvider: config.defaultProvider,
+      defaultBaseURL: config.defaultBaseURL,
+      defaultApiKey: config.defaultApiKey,
+      defaultCwd: config.defaultCwd,
+      maxConcurrency: config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
+    },
+    onTrace: config.onTrace,
+    ...(ctx.runId ? { runId: ctx.runId } : {}),
+  })
+
+  ctx.cumulativeUsage = addUsage(ctx.cumulativeUsage, consensus.tokenUsage)
+  // Keep the reported per-task usage consistent (mirrors how delegation usage rolls in).
+  const stored = ctx.agentResults.get(`${assignee}:${task.id}`)
+  if (stored) {
+    ctx.agentResults.set(`${assignee}:${task.id}`, {
+      ...stored,
+      tokenUsage: addUsage(stored.tokenUsage, consensus.tokenUsage),
+    })
+  }
+
+  // A revised answer supersedes the task result for downstream consumers.
+  if (consensus.answer && consensus.answer !== result.output) {
+    queue.update(task.id, { result: consensus.answer })
+    if (sharedMem) await sharedMem.write(assignee, `task:${task.id}:result`, consensus.answer)
+  }
+
+  const total = ctx.cumulativeUsage.input_tokens + ctx.cumulativeUsage.output_tokens
+  if (!ctx.budgetExceededTriggered && ctx.maxTokenBudget !== undefined && total > ctx.maxTokenBudget) {
+    ctx.budgetExceededTriggered = true
+    const err = new TokenBudgetExceededError('orchestrator', total, ctx.maxTokenBudget)
+    ctx.budgetExceededReason = err.message
+    config.onProgress?.({
+      type: 'budget_exceeded',
+      agent: assignee,
+      task: task.id,
+      data: err,
+    } satisfies OrchestratorEvent)
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1412,6 +1731,7 @@ export class OpenMultiAgent {
       maxRetries?: number
       retryDelayMs?: number
       retryBackoff?: number
+      verify?: ConsensusVerifyOptions
     }>,
     options?: { abortSignal?: AbortSignal },
   ): Promise<TeamRunResult> {
@@ -1429,6 +1749,7 @@ export class OpenMultiAgent {
         maxRetries: t.maxRetries,
         retryDelayMs: t.retryDelayMs,
         retryBackoff: t.retryBackoff,
+        verify: t.verify,
       })),
       agentConfigs,
       queue,
@@ -1465,6 +1786,98 @@ export class OpenMultiAgent {
     }))
 
     return this.buildTeamRunResult(agentResults, undefined, taskRecords)
+  }
+
+  // -------------------------------------------------------------------------
+  // Consensus
+  // -------------------------------------------------------------------------
+
+  /**
+   * Run a proposer→judge consensus over a single prompt.
+   *
+   * The proposer emits an answer; judges try to refute it over up to
+   * `maxRounds`, exiting early once `quorum` accept. Proposer and judge token
+   * usage all count against the orchestrator's `maxTokenBudget` — crossing it
+   * stops issuing further judge calls, exactly like delegation and `runTasks`.
+   */
+  async runConsensus(
+    team: Team,
+    prompt: string,
+    options: ConsensusOptions,
+  ): Promise<ConsensusResult> {
+    const proposers = Array.isArray(options.proposer) ? options.proposer : [options.proposer]
+    if (proposers.length === 0) {
+      throw new Error('runConsensus: at least one proposer is required.')
+    }
+    if (options.judges.length === 0) {
+      throw new Error('runConsensus: at least one judge is required.')
+    }
+
+    const mode = options.mode ?? 'refute'
+    const maxRounds = Math.max(1, options.maxRounds ?? 2)
+    const quorum = Math.max(1, options.quorum ?? Math.ceil(options.judges.length / 2))
+    const onDissent = options.onDissent ?? 'revise'
+    const budget = this.config.maxTokenBudget
+    const defaults: ConsensusAgentDefaults = {
+      defaultProvider: this.config.defaultProvider,
+      defaultBaseURL: this.config.defaultBaseURL,
+      defaultApiKey: this.config.defaultApiKey,
+      defaultCwd: this.config.defaultCwd,
+      maxConcurrency: this.config.maxConcurrency,
+    }
+
+    const pool = new AgentPool(Math.max(1, this.config.maxConcurrency))
+    let usage: TokenUsage = ZERO_USAGE
+
+    // Step 2: run proposer(s); accumulate usage and honour the budget before judging.
+    const candidates: string[] = []
+    for (const proposerConfig of proposers) {
+      const r = await pool.runEphemeral(
+        buildAgent(applyConsensusDefaults(proposerConfig, defaults)),
+        prompt,
+      )
+      usage = addUsage(usage, r.tokenUsage)
+      if (r.success && r.output) candidates.push(r.output)
+      if (budget !== undefined && usage.input_tokens + usage.output_tokens > budget) {
+        this.config.onProgress?.({
+          type: 'budget_exceeded',
+          agent: proposerConfig.name,
+          data: new TokenBudgetExceededError(
+            proposerConfig.name,
+            usage.input_tokens + usage.output_tokens,
+            budget,
+          ),
+        })
+        return {
+          answer: candidates.join('\n\n---\n\n'),
+          verdict: 'rejected',
+          dissent: [],
+          rounds: 0,
+          tokenUsage: usage,
+        }
+      }
+    }
+
+    return runConsensusCore({
+      team,
+      prompt,
+      initialAnswer: candidates.join('\n\n---\n\n'),
+      initialUsage: usage,
+      budgetBaseTokens: 0,
+      judges: options.judges,
+      mode,
+      quorum,
+      maxRounds,
+      verdictSchema: options.verdictSchema,
+      onDissent,
+      judgePrompt: options.judgePrompt,
+      budget,
+      reviseProposer: proposers[0],
+      defaults,
+      onTrace: this.config.onTrace,
+      runId: this.config.onTrace ? generateRunId() : undefined,
+      pool,
+    })
   }
 
   // -------------------------------------------------------------------------
@@ -1695,6 +2108,7 @@ export class OpenMultiAgent {
         maxRetries: spec.maxRetries,
         retryDelayMs: spec.retryDelayMs,
         retryBackoff: spec.retryBackoff,
+        verify: spec.verify,
       })
       const titleKey = normalizeTitle(spec.title)
       if ((titleCounts.get(titleKey) ?? 0) === 1) {

--- a/src/task/task.ts
+++ b/src/task/task.ts
@@ -7,7 +7,7 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import type { Task, TaskStatus } from '../types.js'
+import type { ConsensusVerifyOptions, Task, TaskStatus } from '../types.js'
 
 // ---------------------------------------------------------------------------
 // Factory
@@ -35,6 +35,7 @@ export function createTask(input: {
   maxRetries?: number
   retryDelayMs?: number
   retryBackoff?: number
+  verify?: ConsensusVerifyOptions
 }): Task {
   const now = new Date()
   return {
@@ -51,6 +52,7 @@ export function createTask(input: {
     maxRetries: input.maxRetries,
     retryDelayMs: input.retryDelayMs,
     retryBackoff: input.retryBackoff,
+    verify: input.verify,
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -745,6 +745,51 @@ export interface TeamRunResult {
 }
 
 // ---------------------------------------------------------------------------
+// Consensus (proposer + judge verification)
+// ---------------------------------------------------------------------------
+
+/**
+ * Judge roster and refutation-loop options shared by
+ * {@link OpenMultiAgent.runConsensus} and the per-task `verify` hook. The
+ * proposer is supplied separately (an agent for `runConsensus`, the task's own
+ * result for the `verify` hook).
+ */
+export interface ConsensusVerifyOptions {
+  /** Verifier roster. Judges run sequentially so quorum/budget can stop the rest. */
+  readonly judges: readonly AgentConfig[]
+  /** `'refute'` (default): identical skeptic framing. `'lens'`: distinct angle per judge. */
+  readonly mode?: 'refute' | 'lens'
+  /** Accepting judges required for consensus. Default `ceil(judges.length / 2)`. */
+  readonly quorum?: number
+  /** Maximum proposer↔judge rounds. Default `2`. */
+  readonly maxRounds?: number
+  /** Zod schema validated against each judge verdict; a failure counts as dissent. */
+  readonly verdictSchema?: ZodSchema
+  /** Action when a round misses quorum. Default `'revise'`. */
+  readonly onDissent?: 'revise' | 'reject' | 'keep'
+  /** Override the default verifier prompt; a function gives per-judge framing. */
+  readonly judgePrompt?: string | ((judge: string) => string)
+}
+
+/** Options for {@link OpenMultiAgent.runConsensus}. */
+export interface ConsensusOptions extends ConsensusVerifyOptions {
+  /** Proposer agent(s). An array runs all (N-best); usage counts against the parent budget. */
+  readonly proposer: AgentConfig | readonly AgentConfig[]
+}
+
+/** Result of a consensus run (or per-task `verify` hook). */
+export interface ConsensusResult {
+  readonly answer: string
+  /** `accepted` when quorum was reached (or `onDissent: 'keep'`); else `rejected`. */
+  readonly verdict: 'accepted' | 'rejected'
+  /** Dissenting critiques across all rounds, prefixed with the judge name. */
+  readonly dissent: string[]
+  readonly rounds: number
+  /** Usage attributable to consensus (proposer + judges + revisions). */
+  readonly tokenUsage: TokenUsage
+}
+
+// ---------------------------------------------------------------------------
 // Task
 // ---------------------------------------------------------------------------
 
@@ -798,6 +843,12 @@ export interface Task {
   readonly retryDelayMs?: number
   /** Exponential backoff multiplier (default: 2). */
   readonly retryBackoff?: number
+  /**
+   * Opt-in consensus verification of this task's result. When set, judges try
+   * to refute the completed task's output; their usage counts against the same
+   * parent `maxTokenBudget`. Tasks without `verify` run unchanged.
+   */
+  readonly verify?: ConsensusVerifyOptions
 }
 
 // ---------------------------------------------------------------------------
@@ -973,6 +1024,7 @@ export type TraceEventType =
   | 'agent'
   | 'plan_ready'
   | 'agent_stream'
+  | 'consensus'
 
 /** Shared fields present on every trace event. */
 export interface TraceEventBase {
@@ -1045,6 +1097,15 @@ export interface AgentStreamTrace extends TraceEventBase {
   readonly streamType: StreamEvent['type']
 }
 
+/** Emitted for each judge verdict during a consensus run. `agent` is the judge name. */
+export interface ConsensusTrace extends TraceEventBase {
+  readonly type: 'consensus'
+  readonly round: number
+  readonly accepted: boolean
+  /** The judge's critique when it dissented. */
+  readonly dissent?: string
+}
+
 /** Discriminated union of all trace event types. */
 export type TraceEvent =
   | LLMCallTrace
@@ -1053,6 +1114,7 @@ export type TraceEvent =
   | AgentTrace
   | PlanReadyTrace
   | AgentStreamTrace
+  | ConsensusTrace
 
 // ---------------------------------------------------------------------------
 // Memory

--- a/tests/consensus.test.ts
+++ b/tests/consensus.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMMessage,
+  LLMResponse,
+  TokenUsage,
+  TraceEvent,
+} from '../src/types.js'
+
+// ---------------------------------------------------------------------------
+// Mock adapter with known per-call usage and prompt capture
+// ---------------------------------------------------------------------------
+
+function extractUserPrompt(messages: LLMMessage[]): string {
+  const lastUser = [...messages].reverse().find((m) => m.role === 'user')
+  return (lastUser?.content ?? [])
+    .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
+    .map((b) => b.text)
+    .join('\n')
+}
+
+interface Capture {
+  readonly adapter: LLMAdapter
+  readonly prompts: string[]
+  readonly calls: () => number
+}
+
+/**
+ * Build an adapter that replies with `reply` (or a per-prompt function),
+ * reporting `usage` per call and recording every user prompt it received.
+ */
+function captureAdapter(
+  reply: string | ((prompt: string) => string),
+  usage: TokenUsage = { input_tokens: 5, output_tokens: 5 },
+): Capture {
+  const prompts: string[] = []
+  const adapter: LLMAdapter = {
+    name: 'mock',
+    async chat(messages: LLMMessage[]): Promise<LLMResponse> {
+      const prompt = extractUserPrompt(messages)
+      prompts.push(prompt)
+      const text = typeof reply === 'function' ? reply(prompt) : reply
+      return {
+        id: `r-${prompts.length}`,
+        content: [{ type: 'text', text }],
+        model: 'mock-model',
+        stop_reason: 'end_turn',
+        usage,
+      }
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: {} }
+    },
+  }
+  return { adapter, prompts, calls: () => prompts.length }
+}
+
+function agent(name: string, adapter: LLMAdapter): AgentConfig {
+  return { name, model: 'mock-model', adapter }
+}
+
+const ACCEPT = '{"accept": true, "critique": ""}'
+const DISSENT = '{"accept": false, "critique": "the answer is wrong"}'
+
+// ---------------------------------------------------------------------------
+// runConsensus — budget accounting (the hard merge gate)
+// ---------------------------------------------------------------------------
+
+describe('runConsensus token accounting', () => {
+  it('accumulates proposer + judge usage into tokenUsage', async () => {
+    const proposer = captureAdapter('Paris.', { input_tokens: 10, output_tokens: 10 })
+    const judge = captureAdapter(ACCEPT, { input_tokens: 3, output_tokens: 3 })
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', { name: 't', agents: [] })
+
+    const res = await orch.runConsensus(team, 'Capital of France?', {
+      proposer: agent('proposer', proposer.adapter),
+      judges: [agent('judge1', judge.adapter)],
+      quorum: 1,
+    })
+
+    expect(res.tokenUsage).toEqual({ input_tokens: 13, output_tokens: 13 })
+    expect(res.verdict).toBe('accepted')
+    expect(res.answer).toBe('Paris.')
+  })
+
+  it('stops issuing judge calls once cumulative usage crosses the parent budget', async () => {
+    // proposer 20, judge1 +10 = 30 > budget 25 → stop before judge2.
+    const proposer = captureAdapter('answer', { input_tokens: 10, output_tokens: 10 })
+    const j1 = captureAdapter(ACCEPT, { input_tokens: 5, output_tokens: 5 })
+    const j2 = captureAdapter(ACCEPT, { input_tokens: 5, output_tokens: 5 })
+    const orch = new OpenMultiAgent({ maxTokenBudget: 25 })
+    const team = orch.createTeam('t', { name: 't', agents: [] })
+
+    const res = await orch.runConsensus(team, 'go', {
+      proposer: agent('proposer', proposer.adapter),
+      judges: [agent('judge1', j1.adapter), agent('judge2', j2.adapter)],
+      quorum: 2, // both needed, so without the budget gate judge2 would run
+    })
+
+    expect(proposer.calls()).toBe(1)
+    expect(j1.calls()).toBe(1)
+    expect(j2.calls()).toBe(0) // budget gate stopped the remaining judge
+    expect(res.verdict).toBe('rejected')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Quorum + rounds
+// ---------------------------------------------------------------------------
+
+describe('runConsensus quorum and rounds', () => {
+  it('exits early once quorum judges accept, leaving the rest unrun', async () => {
+    const proposer = captureAdapter('answer')
+    const j1 = captureAdapter(ACCEPT)
+    const j2 = captureAdapter(ACCEPT)
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', { name: 't', agents: [] })
+
+    const res = await orch.runConsensus(team, 'go', {
+      proposer: agent('proposer', proposer.adapter),
+      judges: [agent('judge1', j1.adapter), agent('judge2', j2.adapter)],
+      quorum: 1,
+    })
+
+    expect(j1.calls()).toBe(1)
+    expect(j2.calls()).toBe(0)
+    expect(res.verdict).toBe('accepted')
+    expect(res.rounds).toBe(1)
+  })
+
+  it('caps the loop at maxRounds (no unbounded revision)', async () => {
+    const proposer = captureAdapter('answer')
+    const judge = captureAdapter(DISSENT)
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', { name: 't', agents: [] })
+
+    const res = await orch.runConsensus(team, 'go', {
+      proposer: agent('proposer', proposer.adapter),
+      judges: [agent('judge', judge.adapter)],
+      quorum: 1,
+      maxRounds: 2,
+      onDissent: 'revise',
+    })
+
+    expect(res.rounds).toBe(2)
+    expect(judge.calls()).toBe(2) // one judge per round
+    expect(proposer.calls()).toBe(2) // initial + one revision
+    expect(res.verdict).toBe('rejected')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Judge prompting (refute vs lens, judgePrompt override)
+// ---------------------------------------------------------------------------
+
+describe('runConsensus judge prompting', () => {
+  async function runTwoJudges(
+    opts: { mode?: 'refute' | 'lens'; judgePrompt?: string | ((j: string) => string) },
+  ): Promise<{ p0: string; p1: string }> {
+    const proposer = captureAdapter('answer')
+    const j0 = captureAdapter(ACCEPT)
+    const j1 = captureAdapter(ACCEPT)
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', { name: 't', agents: [] })
+    await orch.runConsensus(team, 'go', {
+      proposer: agent('proposer', proposer.adapter),
+      judges: [agent('judge0', j0.adapter), agent('judge1', j1.adapter)],
+      quorum: 2, // force both to run
+      ...opts,
+    })
+    return { p0: j0.prompts[0]!, p1: j1.prompts[0]! }
+  }
+
+  it('refute gives every judge the same framing; lens gives distinct angles', async () => {
+    const refute = await runTwoJudges({ mode: 'refute' })
+    expect(refute.p0).toBe(refute.p1)
+
+    const lens = await runTwoJudges({ mode: 'lens' })
+    expect(lens.p0).not.toBe(lens.p1)
+
+    // The two modes themselves differ.
+    expect(refute.p0).not.toBe(lens.p0)
+  })
+
+  it('judgePrompt string overrides the default for all judges', async () => {
+    const { p0, p1 } = await runTwoJudges({ judgePrompt: 'CUSTOM SKEPTIC FRAMING' })
+    expect(p0).toContain('CUSTOM SKEPTIC FRAMING')
+    expect(p0).toBe(p1)
+  })
+
+  it('judgePrompt function applies per-judge framing', async () => {
+    const { p0, p1 } = await runTwoJudges({ judgePrompt: (j) => `Framing for ${j}` })
+    expect(p0).toContain('Framing for judge0')
+    expect(p1).toContain('Framing for judge1')
+    expect(p0).not.toBe(p1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// onDissent branches
+// ---------------------------------------------------------------------------
+
+describe('runConsensus onDissent', () => {
+  async function run(onDissent: 'revise' | 'reject' | 'keep') {
+    const proposer = captureAdapter('answer')
+    const judge = captureAdapter(DISSENT)
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', { name: 't', agents: [] })
+    const res = await orch.runConsensus(team, 'go', {
+      proposer: agent('proposer', proposer.adapter),
+      judges: [agent('judge', judge.adapter)],
+      quorum: 1,
+      maxRounds: 2,
+      onDissent,
+    })
+    return { res, proposerCalls: proposer.calls() }
+  }
+
+  it('revise re-runs the proposer for another round', async () => {
+    const { res, proposerCalls } = await run('revise')
+    expect(proposerCalls).toBe(2)
+    expect(res.rounds).toBe(2)
+    expect(res.verdict).toBe('rejected')
+  })
+
+  it('reject stops after the first round with a rejected verdict', async () => {
+    const { res, proposerCalls } = await run('reject')
+    expect(proposerCalls).toBe(1)
+    expect(res.rounds).toBe(1)
+    expect(res.verdict).toBe('rejected')
+  })
+
+  it('keep stops but keeps the answer (accepted despite dissent)', async () => {
+    const { res, proposerCalls } = await run('keep')
+    expect(proposerCalls).toBe(1)
+    expect(res.rounds).toBe(1)
+    expect(res.verdict).toBe('accepted')
+    expect(res.dissent.length).toBeGreaterThan(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// verdictSchema
+// ---------------------------------------------------------------------------
+
+describe('runConsensus verdictSchema', () => {
+  const schema = z.object({ accept: z.boolean(), confidence: z.number() })
+
+  it('accepts when the judge verdict matches the schema', async () => {
+    const proposer = captureAdapter('answer')
+    const judge = captureAdapter('{"accept": true, "confidence": 0.9}')
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', { name: 't', agents: [] })
+    const res = await orch.runConsensus(team, 'go', {
+      proposer: agent('proposer', proposer.adapter),
+      judges: [agent('judge', judge.adapter)],
+      quorum: 1,
+      verdictSchema: schema,
+    })
+    expect(res.verdict).toBe('accepted')
+  })
+
+  it('treats a schema-invalid verdict as dissent', async () => {
+    const proposer = captureAdapter('answer')
+    const judge = captureAdapter('{"accept": true}') // missing required confidence
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', { name: 't', agents: [] })
+    const res = await orch.runConsensus(team, 'go', {
+      proposer: agent('proposer', proposer.adapter),
+      judges: [agent('judge', judge.adapter)],
+      quorum: 1,
+      maxRounds: 1,
+      onDissent: 'reject',
+      verdictSchema: schema,
+    })
+    expect(res.verdict).toBe('rejected')
+    expect(res.dissent.join(' ')).toMatch(/schema/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Dissent plumbing: result + shared memory + trace
+// ---------------------------------------------------------------------------
+
+describe('runConsensus dissent plumbing', () => {
+  it('records dissent in the result, shared memory, and trace', async () => {
+    const traces: TraceEvent[] = []
+    const proposer = captureAdapter('answer')
+    const judge = captureAdapter(DISSENT)
+    const orch = new OpenMultiAgent({ onTrace: (e) => traces.push(e) })
+    const team = orch.createTeam('t', { name: 't', agents: [], sharedMemory: true })
+
+    const res = await orch.runConsensus(team, 'go', {
+      proposer: agent('proposer', proposer.adapter),
+      judges: [agent('judge', judge.adapter)],
+      quorum: 1,
+      maxRounds: 1,
+      onDissent: 'reject',
+    })
+
+    // result
+    expect(res.dissent.join(' ')).toContain('the answer is wrong')
+
+    // shared memory
+    const mem = team.getSharedMemoryInstance()!
+    const entry = await mem.read('judge/consensus:round:1:dissent')
+    expect(entry?.value).toBe('the answer is wrong')
+
+    // trace
+    const consensusTraces = traces.filter((t) => t.type === 'consensus')
+    expect(consensusTraces.length).toBe(1)
+    expect(consensusTraces[0]).toMatchObject({ accepted: false, round: 1, agent: 'judge' })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Per-task verify hook (composes with runTasks)
+// ---------------------------------------------------------------------------
+
+describe('per-task verify hook', () => {
+  it('runs consensus on a task result only when verify is set', async () => {
+    const worker = captureAdapter('task output', { input_tokens: 5, output_tokens: 5 })
+    const judge = captureAdapter(ACCEPT, { input_tokens: 5, output_tokens: 5 })
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', {
+      name: 't',
+      agents: [agent('worker', worker.adapter)],
+    })
+
+    // No verify → judge never runs.
+    await orch.runTasks(team, [
+      { title: 'plain', description: 'do work', assignee: 'worker' },
+    ])
+    expect(judge.calls()).toBe(0)
+
+    // With verify → judge runs once.
+    await orch.runTasks(team, [
+      {
+        title: 'verified',
+        description: 'do work',
+        assignee: 'worker',
+        verify: { judges: [agent('judge', judge.adapter)], quorum: 1 },
+      },
+    ])
+    expect(judge.calls()).toBe(1)
+  })
+
+  it('rolls hook judge usage into the parent budget and trips the same gate', async () => {
+    // worker 10 (under budget 15), then judge1 +10 = 20 > 15 → budget_exceeded,
+    // judge2 never runs.
+    const worker = captureAdapter('task output', { input_tokens: 5, output_tokens: 5 })
+    const j1 = captureAdapter(ACCEPT, { input_tokens: 5, output_tokens: 5 })
+    const j2 = captureAdapter(ACCEPT, { input_tokens: 5, output_tokens: 5 })
+
+    const budgetEvents: unknown[] = []
+    const orch = new OpenMultiAgent({
+      maxTokenBudget: 15,
+      onProgress: (e) => {
+        if (e.type === 'budget_exceeded') budgetEvents.push(e)
+      },
+    })
+    const team = orch.createTeam('t', {
+      name: 't',
+      agents: [agent('worker', worker.adapter)],
+    })
+
+    await orch.runTasks(team, [
+      {
+        title: 'verified',
+        description: 'do work',
+        assignee: 'worker',
+        verify: { judges: [agent('judge1', j1.adapter), agent('judge2', j2.adapter)], quorum: 2 },
+      },
+    ])
+
+    expect(j1.calls()).toBe(1)
+    expect(j2.calls()).toBe(0) // budget gate stopped the remaining judge
+    expect(budgetEvents.length).toBe(1)
+  })
+})

--- a/tests/consensus.test.ts
+++ b/tests/consensus.test.ts
@@ -87,6 +87,25 @@ describe('runConsensus token accounting', () => {
     expect(res.answer).toBe('Paris.')
   })
 
+  it('rejects (never accepts) when every proposer produces no output', async () => {
+    // A proposer that yields nothing must not come back accepted on an empty answer.
+    const proposer = captureAdapter('', { input_tokens: 4, output_tokens: 0 })
+    const judge = captureAdapter(ACCEPT)
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', { name: 't', agents: [] })
+
+    const res = await orch.runConsensus(team, 'go', {
+      proposer: agent('proposer', proposer.adapter),
+      judges: [agent('judge', judge.adapter)],
+      quorum: 1,
+    })
+
+    expect(res.verdict).toBe('rejected')
+    expect(res.answer).toBe('')
+    expect(judge.calls()).toBe(0) // nothing to judge → judges never run
+    expect(res.tokenUsage).toEqual({ input_tokens: 4, output_tokens: 0 })
+  })
+
   it('stops issuing judge calls once cumulative usage crosses the parent budget', async () => {
     // proposer 20, judge1 +10 = 30 > budget 25 → stop before judge2.
     const proposer = captureAdapter('answer', { input_tokens: 10, output_tokens: 10 })
@@ -428,6 +447,46 @@ describe('per-task verify hook', () => {
     // The verdict is surfaced as a task-level outcome.
     const verdict = await mem.read(`worker/task:${taskId}:verdict`)
     expect(verdict?.value).toMatch(/^rejected/)
+  })
+
+  it('surfaces an accepted revision to the caller, not just downstream', async () => {
+    // Judge dissents on the original, accepts once it sees the revision.
+    const worker = captureAdapter((p) => (p.includes('previous answer') ? 'revised' : 'original'))
+    const judge = captureAdapter((p) => (p.includes('revised') ? ACCEPT : DISSENT))
+    const events: { type: string; output: string }[] = []
+    const orch = new OpenMultiAgent({
+      onProgress: (e) => {
+        if (e.type === 'task_complete' || e.type === 'agent_complete') {
+          events.push({ type: e.type, output: (e.data as { output: string }).output })
+        }
+      },
+    })
+    const team = orch.createTeam('t', {
+      name: 't',
+      agents: [agent('worker', worker.adapter)],
+      sharedMemory: true,
+    })
+
+    const run = await orch.runTasks(team, [
+      {
+        title: 'verified',
+        description: 'do work',
+        assignee: 'worker',
+        verify: { judges: [agent('judge', judge.adapter)], quorum: 1, maxRounds: 2, onDissent: 'revise' },
+      },
+    ])
+    const taskId = run.tasks![0]!.id
+
+    // The accepted revision must reach the returned result, the progress events,
+    // and shared memory — not vanish while only downstream tasks see it.
+    expect(run.agentResults.get('worker')?.output).toBe('revised')
+    expect(events).toEqual([
+      { type: 'task_complete', output: 'revised' },
+      { type: 'agent_complete', output: 'revised' },
+    ])
+    const mem = team.getSharedMemoryInstance()!
+    expect((await mem.read(`worker/task:${taskId}:result`))?.value).toBe('revised')
+    expect((await mem.read(`worker/task:${taskId}:verdict`))?.value).toBe('accepted')
   })
 
   it('feeds the prior answer into the revision prompt', async () => {

--- a/tests/consensus.test.ts
+++ b/tests/consensus.test.ts
@@ -315,6 +315,24 @@ describe('runConsensus dissent plumbing', () => {
     expect(consensusTraces.length).toBe(1)
     expect(consensusTraces[0]).toMatchObject({ accepted: false, round: 1, agent: 'judge' })
   })
+
+  it('emits an accepted trace for a judge that accepts (no dissent)', async () => {
+    const traces: TraceEvent[] = []
+    const orch = new OpenMultiAgent({ onTrace: (e) => traces.push(e) })
+    const team = orch.createTeam('t', { name: 't', agents: [], sharedMemory: true })
+
+    await orch.runConsensus(team, 'go', {
+      proposer: agent('proposer', captureAdapter('answer').adapter),
+      judges: [agent('judge', captureAdapter(ACCEPT).adapter)],
+      quorum: 1,
+      maxRounds: 1,
+    })
+
+    const consensusTraces = traces.filter((t) => t.type === 'consensus')
+    expect(consensusTraces.length).toBe(1)
+    expect(consensusTraces[0]).toMatchObject({ accepted: true, round: 1, agent: 'judge' })
+    expect((consensusTraces[0] as { dissent?: string }).dissent).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/tests/consensus.test.ts
+++ b/tests/consensus.test.ts
@@ -399,4 +399,57 @@ describe('per-task verify hook', () => {
     expect(j2.calls()).toBe(0) // budget gate stopped the remaining judge
     expect(budgetEvents.length).toBe(1)
   })
+
+  it('does not overwrite the task result when the revision is still rejected', async () => {
+    // Worker emits 'original' first, then 'revised' once it sees its prior answer.
+    const worker = captureAdapter((p) => (p.includes('previous answer') ? 'revised' : 'original'))
+    const judge = captureAdapter(DISSENT) // never accepts → verdict stays rejected
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', {
+      name: 't',
+      agents: [agent('worker', worker.adapter)],
+      sharedMemory: true,
+    })
+
+    const run = await orch.runTasks(team, [
+      {
+        title: 'verified',
+        description: 'do work',
+        assignee: 'worker',
+        verify: { judges: [agent('judge', judge.adapter)], quorum: 1, maxRounds: 2, onDissent: 'revise' },
+      },
+    ])
+    const taskId = run.tasks![0]!.id
+
+    const mem = team.getSharedMemoryInstance()!
+    // Rejected revision must not supersede the original task result downstream.
+    const result = await mem.read(`worker/task:${taskId}:result`)
+    expect(result?.value).toBe('original')
+    // The verdict is surfaced as a task-level outcome.
+    const verdict = await mem.read(`worker/task:${taskId}:verdict`)
+    expect(verdict?.value).toMatch(/^rejected/)
+  })
+
+  it('feeds the prior answer into the revision prompt', async () => {
+    const worker = captureAdapter((p) => (p.includes('previous answer') ? 'revised' : 'original'))
+    const judge = captureAdapter(DISSENT)
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', {
+      name: 't',
+      agents: [agent('worker', worker.adapter)],
+    })
+
+    await orch.runTasks(team, [
+      {
+        title: 'verified',
+        description: 'do work',
+        assignee: 'worker',
+        verify: { judges: [agent('judge', judge.adapter)], quorum: 1, maxRounds: 2, onDissent: 'revise' },
+      },
+    ])
+
+    // The revision prompt (worker's 2nd call) must echo the answer being revised.
+    expect(worker.prompts[1]).toContain('## Your previous answer')
+    expect(worker.prompts[1]).toContain('original')
+  })
 })


### PR DESCRIPTION
## What

Adds a built-in **propose → refute → converge** primitive so users get grounded, scrutinised answers without hand-wiring reviewer agents into a task graph.
- **`OpenMultiAgent.runConsensus(team, prompt, options)`** — a proposer emits an answer; a roster of judges tries to refute it over up to `maxRounds`, exiting early once a `quorum` accepts.
- **Per-task `verify` hook** — any `runTasks` task can opt into the same loop on its own result; a revised answer supersedes the task output for downstream consumers.

## Merge Gate Mentioned in the Issue

Proposer/judge/revision usage all accumulate into the run's cumulative usage and are checked against `maxTokenBudget`: crossing it stops further judge calls, mirroring `delegate_to_agent`

## Why

Follows #275 

Just to reiterate the API shape and the opt-in verification of the task mentioned in #275's discussion:
```ts
const result = await orchestrator.runConsensus(team, 'Is this proof correct?', {
  proposer: { name: 'solver', model: 'claude-opus-4-6' },   // or an array (N-best)
  judges: [judgeA, judgeB],
  mode: 'refute',       // 'refute' (identical skeptics) | 'lens' (distinct angles)
  quorum: 2,            // default: ceil(judges.length / 2)
  maxRounds: 2,         // default: 2
  onDissent: 'revise',  // 'revise' | 'reject' | 'keep'
})
```
```
// Opt-in verification of a pipeline task's own result:
await orchestrator.runTasks(team, [
  { title: 'derive-bound', description: '…', assignee: 'mathematician',
    verify: { judges: [judgeA, judgeB], maxRounds: 2 } },
])
```

## Additional design notes
1. Judges run on the existing `AgentPool` via `runEphemeral`, and verdicts reuse the structured-output path (`extractJSON` + `validateOutput`) to parse the `{ accept, critique }` contract.
2. Sequential judges, not parallel
3. The per-task `verify` hook is awaited inside the task's dispatch promise, before the wave's `Promise.all(dispatchPromises)` resolves. A revised answer is written back to the queue (`queue.update(taskId, { result })`) and shared memory before any dependent task is dispatched, so downstream consumers always read the post-verification result, never the pre-revision one.
4. `quorum` defaults to `ceil(judges.length / 2)` and is fully configurable;`maxRounds` defaults to `2`. Nothing about the vote count is baked in.
5. Verification modes
- **`refute`** — every judge receives the same skeptic framing.
- **`lens`** — each judge is assigned a distinct review angle (correctness, completeness, edge cases, clarity, assumptions, evidence) round-robin by index, with a built-in instruction to accept rather than invent objections when the
  angle is irrelevant to the question. 


`judgePrompt` overrides the framing entirely — a `string` for all judges, or a `(judge) => string` function for per-judge prompts. Every judge prompt includes the original question alongside the proposed answer.Users can input their own instructions like this:
```
// Define your judges
const judges = [
  { name: 'security',    model: 'claude-opus-4-6' },
  { name: 'performance', model: 'claude-opus-4-6' },
  { name: 'api-design',  model: 'claude-sonnet-4-6' },
]

// Your own angles, keyed by judge name
const angles: Record<string, string> = {
  security:    'Focus only on security: injection, authz, secret handling, unsafe deserialization.',
  performance: 'Focus only on performance: N+1 queries, allocations in hot paths, blocking I/O.',
  'api-design':'Focus only on API ergonomics: naming, backward compatibility, error contracts.',
}

const result = await orchestrator.runConsensus(team, 'Review this PR diff: …', {
  proposer: { name: 'author', model: 'claude-opus-4-6' },
  judges,
  judgePrompt: (judge) => angles[judge] ?? 'Review the answer for correctness.',
})
```
## Some good follow-up works
1. add `examples/patterns/consensus.ts`
2. `runTeam` integration. The `verify` hook is wired into explicit `runTasks` tasks. Coordinator-generated tasks in `runTeam` can't yet opt in (the coordinator emits task JSON without a verify field)