### PR TITLE
refactor(llm): extract shared repairToolArgs helper

### DIFF
--- a/src/llm/openai-common.ts
+++ b/src/llm/openai-common.ts
@@ -291,6 +291,28 @@ function toOpenAIAssistantMessage(
 // ---------------------------------------------------------------------------
 
 /**
+ * Repair malformed single-string tool-call arguments after `JSON.parse` fails.
+ * Local models frequently break single-parameter tools with unescaped quotes or
+ * Python-style triple quotes (`"""`/`'''`). Returns the repaired argument object,
+ * or null when the input doesn't match the single-parameter `{"name": value}` shape.
+ */
+export function repairToolArgs(raw: string): Record<string, unknown> | null {
+  const args = raw.trim()
+  const match = args.match(/\{\s*"([^"]+)"\s*:\s*([\s\S]*?)\s*\}$/)
+  if (match) {
+    const paramName = match[1]!
+    let val = match[2]!.trim()
+    if (val.startsWith('"""') && val.endsWith('"""')) val = val.slice(3, -3)
+    else if (val.startsWith("'''") && val.endsWith("'''")) val = val.slice(3, -3)
+    else if (val.startsWith('"') && val.endsWith('"')) {
+      val = val.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\')
+    }
+    return { [paramName]: val }
+  }
+  return null
+}
+
+/**
  * Convert an OpenAI {@link ChatCompletion} into a framework {@link LLMResponse}.
  *
  * Takes only the first choice (index 0), consistent with how the framework
@@ -343,20 +365,8 @@ export function fromOpenAICompletion(
         parsedInput = parsed as Record<string, unknown>
       }
     } catch {
-      // Malformed arguments from the model — attempt fallback for single-string parameter tools
-      // which often fail due to unescaped quotes or Python-style triple quotes.
-      const args = toolCall.function.arguments.trim()
-      const match = args.match(/\{\s*"([^"]+)"\s*:\s*([\s\S]*?)\s*\}$/)
-      if (match) {
-        const paramName = match[1]!
-        let val = match[2]!.trim()
-        if (val.startsWith('"""') && val.endsWith('"""')) val = val.slice(3, -3)
-        else if (val.startsWith("'''") && val.endsWith("'''")) val = val.slice(3, -3)
-        else if (val.startsWith('"') && val.endsWith('"')) {
-          val = val.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\')
-        }
-        parsedInput = { [paramName]: val }
-      }
+      const repaired = repairToolArgs(toolCall.function.arguments)
+      if (repaired) parsedInput = repaired
     }
 
     const toolUseBlock: ToolUseBlock = {

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -56,6 +56,7 @@ import {
   normalizeFinishReason,
   buildOpenAIMessageList,
   getOpenAIReasoningText,
+  repairToolArgs,
 } from './openai-common.js'
 import type { ReasoningOutboundOptions } from './reasoning-fallback.js'
 import { extractToolCallsFromText } from '../tool/text-tool-extractor.js'
@@ -304,20 +305,8 @@ export class OpenAIAdapter implements LLMAdapter {
             parsedInput = parsed as Record<string, unknown>
           }
         } catch {
-          // Malformed JSON — attempt fallback for single-string parameter tools
-          // which often fail due to unescaped quotes or Python-style triple quotes.
-          const args = buf.argsJson.trim()
-          const match = args.match(/\{\s*"([^"]+)"\s*:\s*([\s\S]*?)\s*\}$/)
-          if (match) {
-            const paramName = match[1]!
-            let val = match[2]!.trim()
-            if (val.startsWith('"""') && val.endsWith('"""')) val = val.slice(3, -3)
-            else if (val.startsWith("'''") && val.endsWith("'''")) val = val.slice(3, -3)
-            else if (val.startsWith('"') && val.endsWith('"')) {
-              val = val.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\')
-            }
-            parsedInput = { [paramName]: val }
-          }
+          const repaired = repairToolArgs(buf.argsJson)
+          if (repaired) parsedInput = repaired
         }
 
         const toolUseBlock: ToolUseBlock = {

--- a/tests/openai-adapter.test.ts
+++ b/tests/openai-adapter.test.ts
@@ -377,6 +377,18 @@ describe('OpenAIAdapter', () => {
       expect((toolEvents[0].data as ToolUseBlock).input).toEqual({})
     })
 
+    it('repairs triple-quoted tool arguments through the shared helper', async () => {
+      mockCreate.mockResolvedValue(makeChunks([
+        toolCallChunk(0, 'call_1', 'search', '{"query": """hello"""}', 'tool_calls'),
+        { id: 'chatcmpl-123', model: 'gpt-4o', choices: [], usage: { prompt_tokens: 5, completion_tokens: 3 } },
+      ]))
+
+      const events = await collectEvents(adapter.stream([textMsg('user', 'Hi')], chatOpts()))
+
+      const toolEvents = events.filter(e => e.type === 'tool_use')
+      expect((toolEvents[0].data as ToolUseBlock).input).toEqual({ query: 'hello' })
+    })
+
     it('yields error event on stream failure', async () => {
       mockCreate.mockResolvedValue(
         (async function* () { throw new Error('Stream exploded') })(),


### PR DESCRIPTION
#269 added a regex fallback for malformed single-string tool args (Python triple quotes, unescaped quotes), but the ~13-line repair block landed verbatim in two catch blocks: `fromOpenAICompletion` (openai-common.ts) and `OpenAIAdapter.stream` (openai.ts). This pulls it into one exported `repairToolArgs()` in openai-common.ts.

Pure move, no behavior change: same regex, slice offsets, `.replace()` order. On no match it returns `null` and the caller keeps `parsedInput` as `{}`, exactly as before. No existing assertions touched. Also added one streaming test for the triple-quote path, which only had a no-match case before.

Lint + tests green (`npm test` 972, was 971).
