### PR TITLE
feat: replay persisted team plans

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,8 @@ export type {
   TeamConfig,
   TeamRunResult,
   RunTeamOptions,
+  PlanArtifact,
+  PlanTaskArtifact,
 
   // Dashboard (static HTML)
   TaskExecutionMetrics,

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -46,6 +46,8 @@ import type {
   AgentRunResult,
   CoordinatorConfig,
   RunTeamOptions,
+  PlanArtifact,
+  PlanTaskArtifact,
   OrchestratorConfig,
   OrchestratorEvent,
   Task,
@@ -67,7 +69,7 @@ import { registerBuiltInTools } from '../tool/built-in/index.js'
 import { defaultWorkspaceDir } from '../tool/built-in/path-safety.js'
 import { Team } from '../team/team.js'
 import { TaskQueue } from '../task/queue.js'
-import { createTask } from '../task/task.js'
+import { createTask, validateTaskDependencies } from '../task/task.js'
 import { Scheduler } from './scheduler.js'
 import { TokenBudgetExceededError } from '../errors.js'
 import { extractKeywords, keywordScore } from '../utils/keywords.js'
@@ -1316,6 +1318,7 @@ export class OpenMultiAgent {
         assignee: task.assignee,
         status: task.status,
         dependsOn: task.dependsOn ?? [],
+        description: task.description,
         metrics: undefined,
       }))
       this.config.onProgress?.({
@@ -1337,6 +1340,7 @@ export class OpenMultiAgent {
       assignee: task.assignee,
       status: task.status,
       dependsOn: task.dependsOn ?? [],
+      description: task.description,
       metrics: taskMetrics.get(task.id),
     }))
 
@@ -1388,8 +1392,66 @@ export class OpenMultiAgent {
   }
 
   // -------------------------------------------------------------------------
-  // Explicit-task team run
+  // Explicit-task and plan replay team runs
   // -------------------------------------------------------------------------
+
+  /**
+   * Convert a plan-only {@link TeamRunResult} into a serializable plan artifact.
+   *
+   * The input must come from `runTeam(team, goal, { planOnly: true })` on a
+   * version that records task descriptions. Executed run results are rejected
+   * because their task records are not a replay contract.
+   */
+  createPlanArtifact(result: TeamRunResult): PlanArtifact {
+    if (result.planOnly !== true || !result.tasks) {
+      throw new Error('createPlanArtifact requires a plan-only TeamRunResult.')
+    }
+
+    return {
+      version: 1,
+      ...(result.goal !== undefined ? { goal: result.goal } : {}),
+      tasks: result.tasks.map((task): PlanTaskArtifact => {
+        if (!task.description) {
+          throw new Error(`Plan task "${task.id}" is missing a description and cannot be replayed.`)
+        }
+        return {
+          id: task.id,
+          title: task.title,
+          description: task.description,
+          ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
+          ...(task.dependsOn.length > 0 ? { dependsOn: task.dependsOn } : {}),
+        }
+      }),
+    }
+  }
+
+  /**
+   * Replay a persisted plan artifact without invoking the coordinator.
+   *
+   * Task IDs, dependencies, assignees, titles, and descriptions are used exactly
+   * as stored in the artifact. This is intentionally execution-only; it does not
+   * synthesize a coordinator final answer and it does not implement durable
+   * checkpoints.
+   */
+  async runFromPlan(
+    team: Team,
+    plan: PlanArtifact,
+    options?: { abortSignal?: AbortSignal },
+  ): Promise<TeamRunResult> {
+    if (plan.version !== 1) {
+      throw new Error(`Unsupported plan artifact version: ${String(plan.version)}`)
+    }
+
+    const queue = new TaskQueue()
+    const tasks = this.tasksFromPlan(plan)
+    const validation = validateTaskDependencies(tasks)
+    if (!validation.valid) {
+      throw new Error(`Invalid plan artifact: ${validation.errors.join(' ')}`)
+    }
+    queue.addBatch(tasks)
+
+    return this.executeExplicitTaskQueue(team, queue, options, plan.goal)
+  }
 
   /**
    * Run a team with an explicitly provided task list.
@@ -1417,7 +1479,6 @@ export class OpenMultiAgent {
   ): Promise<TeamRunResult> {
     const agentConfigs = team.getAgents()
     const queue = new TaskQueue()
-    const scheduler = new Scheduler('dependency-first')
 
     this.loadSpecsIntoQueue(
       tasks.map((t) => ({
@@ -1434,37 +1495,7 @@ export class OpenMultiAgent {
       queue,
     )
 
-    scheduler.autoAssign(queue, agentConfigs)
-
-    const pool = this.buildPool(agentConfigs)
-    const agentResults = new Map<string, AgentRunResult>()
-    const ctx: RunContext = {
-      team,
-      pool,
-      scheduler,
-      agentResults,
-      config: this.config,
-      runId: this.config.onTrace ? generateRunId() : undefined,
-      abortSignal: options?.abortSignal,
-      cumulativeUsage: ZERO_USAGE,
-      maxTokenBudget: this.config.maxTokenBudget,
-      budgetExceededTriggered: false,
-      budgetExceededReason: undefined,
-      taskMetrics: new Map<string, TaskExecutionMetrics>(),
-    }
-
-    await executeQueue(queue, ctx)
-
-    const taskRecords: readonly TaskExecutionRecord[] = queue.list().map((task) => ({
-      id: task.id,
-      title: task.title,
-      assignee: task.assignee,
-      status: task.status,
-      dependsOn: task.dependsOn ?? [],
-      metrics: ctx.taskMetrics.get(task.id),
-    }))
-
-    return this.buildTeamRunResult(agentResults, undefined, taskRecords)
+    return this.executeExplicitTaskQueue(team, queue, options)
   }
 
   // -------------------------------------------------------------------------
@@ -1654,6 +1685,67 @@ export class OpenMultiAgent {
       'Synthesise the above results into a comprehensive final answer that addresses the original goal.',
       'If some tasks failed or were skipped, note any gaps in the result.',
     ].join('\n')
+  }
+
+  private tasksFromPlan(plan: PlanArtifact): Task[] {
+    const now = new Date()
+    return plan.tasks.map((task): Task => ({
+      id: task.id,
+      title: task.title,
+      description: task.description,
+      status: 'pending' as TaskStatus,
+      ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
+      ...(task.dependsOn && task.dependsOn.length > 0 ? { dependsOn: [...task.dependsOn] } : {}),
+      ...(task.memoryScope !== undefined ? { memoryScope: task.memoryScope } : {}),
+      result: undefined,
+      createdAt: now,
+      updatedAt: now,
+      ...(task.maxRetries !== undefined ? { maxRetries: task.maxRetries } : {}),
+      ...(task.retryDelayMs !== undefined ? { retryDelayMs: task.retryDelayMs } : {}),
+      ...(task.retryBackoff !== undefined ? { retryBackoff: task.retryBackoff } : {}),
+    }))
+  }
+
+  private async executeExplicitTaskQueue(
+    team: Team,
+    queue: TaskQueue,
+    options?: { abortSignal?: AbortSignal },
+    goal?: string,
+  ): Promise<TeamRunResult> {
+    const agentConfigs = team.getAgents()
+    const scheduler = new Scheduler('dependency-first')
+    scheduler.autoAssign(queue, agentConfigs)
+
+    const pool = this.buildPool(agentConfigs)
+    const agentResults = new Map<string, AgentRunResult>()
+    const ctx: RunContext = {
+      team,
+      pool,
+      scheduler,
+      agentResults,
+      config: this.config,
+      runId: this.config.onTrace ? generateRunId() : undefined,
+      abortSignal: options?.abortSignal,
+      cumulativeUsage: ZERO_USAGE,
+      maxTokenBudget: this.config.maxTokenBudget,
+      budgetExceededTriggered: false,
+      budgetExceededReason: undefined,
+      taskMetrics: new Map<string, TaskExecutionMetrics>(),
+    }
+
+    await executeQueue(queue, ctx)
+
+    const taskRecords: readonly TaskExecutionRecord[] = queue.list().map((task) => ({
+      id: task.id,
+      title: task.title,
+      assignee: task.assignee,
+      status: task.status,
+      dependsOn: task.dependsOn ?? [],
+      description: task.description,
+      metrics: ctx.taskMetrics.get(task.id),
+    }))
+
+    return this.buildTeamRunResult(agentResults, goal, taskRecords)
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -744,6 +744,29 @@ export interface TeamRunResult {
   readonly totalTokenUsage: TokenUsage
 }
 
+/** A single serializable task in a deterministic replay plan. */
+export interface PlanTaskArtifact {
+  readonly id: string
+  readonly title: string
+  readonly description: string
+  readonly assignee?: string
+  readonly dependsOn?: readonly string[]
+  readonly memoryScope?: 'dependencies' | 'all'
+  readonly maxRetries?: number
+  readonly retryDelayMs?: number
+  readonly retryBackoff?: number
+}
+
+/**
+ * Serializable plan artifact that can be persisted and later replayed without
+ * invoking the coordinator again.
+ */
+export interface PlanArtifact {
+  readonly version: 1
+  readonly goal?: string
+  readonly tasks: readonly PlanTaskArtifact[]
+}
+
 // ---------------------------------------------------------------------------
 // Task
 // ---------------------------------------------------------------------------
@@ -770,6 +793,7 @@ export interface TaskExecutionRecord {
   readonly assignee?: string
   readonly status: TaskStatus
   readonly dependsOn: readonly string[]
+  readonly description?: string
   readonly metrics?: TaskExecutionMetrics
 }
 

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -1136,6 +1136,91 @@ describe('OpenMultiAgent', () => {
         types.filter((t) => t === 'agent_complete').length,
       )
     })
+
+    it('creates a serializable artifact from planOnly output and replays without coordinator', async () => {
+      mockAdapterResponses = [
+        '```json\n[' +
+          '{"title": "Research", "description": "Research the topic", "assignee": "worker-a"},' +
+          '{"title": "Write", "description": "Write the guide", "assignee": "worker-b", "dependsOn": ["Research"]}' +
+          ']\n```',
+      ]
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg())
+
+      const planOnlyResult = await oma.runTeam(team, complexGoal, { planOnly: true })
+      const plan = oma.createPlanArtifact(planOnlyResult)
+
+      expect(JSON.parse(JSON.stringify(plan))).toEqual(plan)
+      expect(plan.goal).toBe(complexGoal)
+      expect(plan.tasks).toHaveLength(2)
+      expect(plan.tasks[0]).toMatchObject({ title: 'Research', description: 'Research the topic', assignee: 'worker-a' })
+      expect(plan.tasks[1]?.dependsOn).toEqual([plan.tasks[0]?.id])
+
+      capturedChatOptions = []
+      capturedPrompts = []
+      mockAdapterResponses = ['research done', 'write done', 'coordinator should not be called']
+
+      const replay = await oma.runFromPlan(team, plan)
+
+      expect(replay.success).toBe(true)
+      expect(replay.goal).toBe(complexGoal)
+      expect(capturedChatOptions).toHaveLength(2)
+      expect(replay.agentResults.has('coordinator')).toBe(false)
+      expect(replay.tasks?.map((task) => ({
+        id: task.id,
+        title: task.title,
+        description: task.description,
+        assignee: task.assignee,
+        dependsOn: task.dependsOn,
+      }))).toEqual(plan.tasks.map((task) => ({
+        id: task.id,
+        title: task.title,
+        description: task.description,
+        assignee: task.assignee,
+        dependsOn: task.dependsOn ?? [],
+      })))
+      expect(capturedPrompts[0]).toContain('# Task: Research')
+      expect(capturedPrompts[1]).toContain('# Task: Write')
+      expect(capturedPrompts[1]).toContain('### Research (by worker-a)')
+      expect(capturedPrompts[1]).toContain('research done')
+    })
+
+    it('replays a persisted plan exactly without resolving dependencies by title', async () => {
+      const executionOrder: string[] = []
+      const adapter: LLMAdapter = {
+        name: 'recording',
+        async chat(messages) {
+          const prompt = extractUserPrompt(messages)
+          const title = prompt.includes('# Task: Second') ? 'second' : 'first'
+          executionOrder.push(title)
+          return textResponse(`${title} done`)
+        },
+        async *stream() {
+          yield { type: 'done' as const, data: {} }
+        },
+      }
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg([
+        { ...agentConfig('worker-a'), adapter },
+        { ...agentConfig('worker-b'), adapter },
+      ]))
+      const plan = {
+        version: 1 as const,
+        goal: 'persisted goal',
+        tasks: [
+          { id: 'stable-first-id', title: 'First', description: 'Do first', assignee: 'worker-a' },
+          { id: 'stable-second-id', title: 'Second', description: 'Do second', assignee: 'worker-b', dependsOn: ['stable-first-id'] },
+        ],
+      }
+
+      const replay = await oma.runFromPlan(team, plan)
+
+      expect(replay.success).toBe(true)
+      expect(executionOrder).toEqual(['first', 'second'])
+      expect(replay.tasks?.map((task) => task.id)).toEqual(['stable-first-id', 'stable-second-id'])
+      expect(replay.tasks?.[1]?.dependsOn).toEqual(['stable-first-id'])
+      expect(replay.agentResults.has('coordinator')).toBe(false)
+    })
   })
 
   describe('stream trace events', () => {


### PR DESCRIPTION
## Summary
- add a serializable plan artifact for plan-only team runs
- add replay support that runs a persisted plan without invoking the coordinator again
- preserve task ids, descriptions, assignees, dependencies, and memory scope during replay
- share the existing explicit-task execution path for deterministic behavior

## Tests
- `node ./node_modules/vitest/dist/cli.js --run tests/orchestrator.test.ts`
- `npm run lint`

Fixes #272
