### PR TITLE
fix(orchestrator): preserve memoryScope and retry config on plan replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,17 @@ Local models via Ollama need no API key, see [`providers/ollama`](examples/provi
 | Auto-orchestrated team | `runTeam()` | Give a goal, let the coordinator plan and execute | [`basics/team-collaboration`](examples/basics/team-collaboration.ts) |
 | Explicit pipeline | `runTasks()` | You define the task graph and assignments | [`basics/task-pipeline`](examples/basics/task-pipeline.ts) |
 
-Preview the coordinator's task DAG without executing agents:
+Preview the coordinator's task DAG without executing it, or pin that plan and replay the same graph later without another coordinator call:
 
 ```ts
-const plan = await orchestrator.runTeam(team, goal, { planOnly: true })
+// Decompose once and review the plan
+const preview = await orchestrator.runTeam(team, goal, { planOnly: true })
+
+// Turn it into a diffable, version-controllable artifact (plain JSON)
+const plan = orchestrator.createPlanArtifact(preview)
+
+// Later: replay the exact graph (same task ids, deps, assignees), no coordinator
+const result = await orchestrator.runFromPlan(team, plan)
 ```
 
 ## Features
@@ -138,6 +145,7 @@ const plan = await orchestrator.runTeam(team, goal, { planOnly: true })
 | **Tools + MCP** | 6 built-in (`bash`, `file_*`, `grep`, `glob`), opt-in `delegate_to_agent` (cycle + depth guards), custom tools via `defineTool()` + Zod, stdio MCP servers via `connectMCPTools()`. ([tool config](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md)) |
 | **Streaming + structured output** | Token-by-token streaming on every adapter (per-agent during team runs via `onAgentStream`); Zod-validated final answer with auto-retry on parse failure. ([`structured-output`](examples/patterns/structured-output.ts)) |
 | **Human-in-the-loop** | Gate execution with `onPlanReady` (approve the plan before any agent runs) and `onApproval` (approve between task rounds), or inspect first with `planOnly`. |
+| **Pin and replay plans** | Serialize a `planOnly` decomposition with `createPlanArtifact`, then `runFromPlan` replays the exact task graph without re-invoking the coordinator. ([`patterns/plan-replay`](examples/patterns/plan-replay.ts)) |
 | **Lifecycle hooks + cancellation** | `beforeRun` rewrites the prompt, `afterRun` post-processes or rejects the result; pass an `AbortSignal` to cancel a run in flight. |
 | **Configurable coordinator** | Override the coordinator's model, provider, adapter, system prompt, or tools via `runTeam(team, goal, { coordinator })`. |
 | **Observability** | `onProgress` events, `onTrace` spans, post-run HTML dashboard rendering the executed task DAG. API keys and tokens are redacted from traces, bash output, and the dashboard. ([observability guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)) |
@@ -236,6 +244,7 @@ End-to-end scenarios you can run today. Each one is a complete, opinionated work
 - [`patterns/cost-tiered-pipeline`](examples/patterns/cost-tiered-pipeline.ts): assign a different model per stage and estimate per-model USD cost from `onTrace` token counts.
 - [`patterns/fan-out-aggregate`](examples/patterns/fan-out-aggregate.ts): MapReduce-style fan-out via `AgentPool.runParallel()`.
 - [`patterns/agent-handoff`](examples/patterns/agent-handoff.ts): synchronous sub-agent delegation via `delegate_to_agent`.
+- [`patterns/plan-replay`](examples/patterns/plan-replay.ts): decompose a goal once with `planOnly`, serialize it with `createPlanArtifact`, then replay the same DAG via `runFromPlan` without re-running the coordinator.
 - [`integrations/trace-observability`](examples/integrations/trace-observability.ts): `onTrace` spans for LLM calls, tools, and tasks.
 - [`integrations/mcp-github`](examples/integrations/mcp-github.ts): expose an MCP server's tools to an agent via `connectMCPTools()`.
 - [`integrations/with-vercel-ai-sdk`](examples/integrations/with-vercel-ai-sdk/): Next.js app combining OMA `runTeam()` with AI SDK `useChat` streaming.

--- a/README_zh.md
+++ b/README_zh.md
@@ -122,10 +122,17 @@ Tokens: 12847 output tokens
 | 自动编排团队 | `runTeam()` | 给一个目标，框架自动规划和执行 | [`basics/team-collaboration`](examples/basics/team-collaboration.ts) |
 | 显式任务管线 | `runTasks()` | 你自己定义任务图和分配 | [`basics/task-pipeline`](examples/basics/task-pipeline.ts) |
 
-不执行 agent，只预览协调者拆出的任务 DAG：
+不执行 agent，只预览协调者拆出的任务 DAG；也可以把这份计划固定下来，之后无需再次调用协调者就重放同一张图：
 
 ```ts
-const plan = await orchestrator.runTeam(team, goal, { planOnly: true })
+// 先拆解一次，审阅计划
+const preview = await orchestrator.runTeam(team, goal, { planOnly: true })
+
+// 转成可 diff、可纳入版本控制的产物（纯 JSON）
+const plan = orchestrator.createPlanArtifact(preview)
+
+// 之后：重放完全相同的图（task id、依赖、assignee 都不变），不经过协调者
+const result = await orchestrator.runFromPlan(team, plan)
 ```
 
 ## 功能一览
@@ -138,6 +145,7 @@ const plan = await orchestrator.runTeam(team, goal, { planOnly: true })
 | **工具 + MCP** | 6 个内置（`bash`、`file_*`、`grep`、`glob`），可选启用 `delegate_to_agent`（带 cycle + depth 护栏），用 `defineTool()` + Zod 自定义，任意 MCP server 通过 `connectMCPTools()` 接入。([工具配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md)) |
 | **流式 + 结构化输出** | 每个 adapter 都支持 token 级流式输出（团队运行时通过 `onAgentStream` 拿到每个 agent 的流）；用 Zod schema 校验最终答复，解析失败自动重试。([`structured-output`](examples/patterns/structured-output.ts)) |
 | **人工介入（Human-in-the-loop）** | 用 `onPlanReady`（任何 agent 执行前审批整个计划）和 `onApproval`（每轮任务之间审批）卡点，或用 `planOnly` 先预览。 |
+| **固定并重放计划** | 用 `createPlanArtifact` 把 `planOnly` 的拆解结果序列化，之后 `runFromPlan` 不再调用协调者，直接重放完全相同的任务图。（[`patterns/plan-replay`](examples/patterns/plan-replay.ts)） |
 | **生命周期钩子 + 取消** | `beforeRun` 改写 prompt，`afterRun` 后处理或拒绝结果；传入 `AbortSignal` 即可中途取消运行。 |
 | **可配置协调者** | 通过 `runTeam(team, goal, { coordinator })` 覆盖协调者的 model、provider、adapter、system prompt 或工具。 |
 | **可观测性** | `onProgress` 事件、`onTrace` span，运行结束后渲染任务 DAG 的 HTML dashboard。API key 和 token 会从 trace、bash 输出和 dashboard 中自动脱敏。([可观测性指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)) |
@@ -236,6 +244,7 @@ await orchestrator.runTeam(team, goal, {
 - [`patterns/cost-tiered-pipeline`](examples/patterns/cost-tiered-pipeline.ts)：每个阶段分配不同 model，用 `onTrace` 的 token 计数估算各 model 的 USD 成本。
 - [`patterns/fan-out-aggregate`](examples/patterns/fan-out-aggregate.ts)：`AgentPool.runParallel()` 做 MapReduce 风格 fan-out。
 - [`patterns/agent-handoff`](examples/patterns/agent-handoff.ts)：`delegate_to_agent` 同步子智能体委派。
+- [`patterns/plan-replay`](examples/patterns/plan-replay.ts)：用 `planOnly` 把目标拆解一次，用 `createPlanArtifact` 序列化，再用 `runFromPlan` 重放同一张 DAG，不重跑协调者。
 - [`integrations/trace-observability`](examples/integrations/trace-observability.ts)：`onTrace` 回调，给 LLM 调用、工具、任务发结构化 span。
 - [`integrations/mcp-github`](examples/integrations/mcp-github.ts)：用 `connectMCPTools()` 把 MCP 服务器的工具暴露给 agent。
 - [`integrations/with-vercel-ai-sdk`](examples/integrations/with-vercel-ai-sdk/)：Next.js 应用，OMA `runTeam()` 配合 AI SDK `useChat` 流式输出。

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,6 +57,8 @@ Reusable shapes for common multi-agent problems.
 | [`patterns/research-aggregation`](patterns/research-aggregation.ts) | Multi-source research collated by a synthesis agent. |
 | [`patterns/cost-tiered-pipeline`](patterns/cost-tiered-pipeline.ts) | Run the same four-stage pipeline twice to compare flagship vs tiered model cost. |
 | [`patterns/agent-handoff`](patterns/agent-handoff.ts) | Synchronous sub-agent delegation via `delegate_to_agent`. |
+| [`patterns/plan-replay`](patterns/plan-replay.ts) | Pin a coordinator plan with `createPlanArtifact`, then replay it with `runFromPlan`, no coordinator re-run. |
+
 ## cookbook — use-case recipes
 
 End-to-end examples framed around a concrete problem (meeting summarization, translation QA, competitive monitoring, etc.) rather than a single orchestration primitive. Lighter bar than `production/`: no tests or pinned model versions required. Good entry point if you want to see how the patterns compose on a real task.

--- a/examples/patterns/plan-replay.ts
+++ b/examples/patterns/plan-replay.ts
@@ -1,0 +1,108 @@
+/**
+ * Pin and Replay a Coordinator Plan
+ *
+ * Demonstrates `planOnly` + `createPlanArtifact` + `runFromPlan`: let the
+ * coordinator decompose a goal once, serialize that plan to a diffable JSON
+ * artifact, then replay the exact same task graph later WITHOUT invoking the
+ * coordinator again. Task ids, dependencies, assignees, descriptions, and
+ * execution config (memoryScope, retry settings) are preserved, so the replayed
+ * graph matches the reviewed one instead of being re-decomposed by an LLM.
+ *
+ * Scenario: a research + writing team. We decompose the goal once, persist the
+ * plan to disk, then rebuild it from the saved file and replay it.
+ *
+ * Run:
+ *   npx tsx examples/patterns/plan-replay.ts
+ *
+ * Prerequisites:
+ *   ANTHROPIC_API_KEY env var must be set.
+ */
+
+import { writeFileSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { OpenMultiAgent } from '../../src/index.js'
+import type { AgentConfig, PlanArtifact } from '../../src/types.js'
+
+// ---------------------------------------------------------------------------
+// Agents
+// ---------------------------------------------------------------------------
+
+const researcher: AgentConfig = {
+  name: 'researcher',
+  model: 'claude-sonnet-4-6',
+  systemPrompt: 'You research a topic and produce a concise, factual brief.',
+  maxTurns: 2,
+}
+
+const writer: AgentConfig = {
+  name: 'writer',
+  model: 'claude-sonnet-4-6',
+  systemPrompt: 'You turn a research brief into a short, well-structured guide.',
+  maxTurns: 2,
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator + team
+// ---------------------------------------------------------------------------
+
+const orchestrator = new OpenMultiAgent({ defaultModel: 'claude-sonnet-4-6' })
+
+const team = orchestrator.createTeam('research-team', {
+  name: 'research-team',
+  agents: [researcher, writer],
+  sharedMemory: true,
+})
+
+const goal =
+  'First research the benefits of TypeScript strict mode, then write a short adoption guide based on the findings.'
+
+// ---------------------------------------------------------------------------
+// Step 1 — decompose once (planOnly: coordinator runs, no agents execute yet)
+// ---------------------------------------------------------------------------
+
+console.log('Plan Replay Example')
+console.log('='.repeat(60))
+console.log('Step 1: decompose the goal (planOnly — coordinator only)')
+
+const preview = await orchestrator.runTeam(team, goal, { planOnly: true })
+
+// ---------------------------------------------------------------------------
+// Step 2 — serialize to a diffable artifact and persist it
+//
+// `createPlanArtifact` returns a plain JSON-serializable object. Persist it
+// however you like (here: a temp file; in practice, commit it to version
+// control so the plan is reviewable and diffable).
+// ---------------------------------------------------------------------------
+
+const plan = orchestrator.createPlanArtifact(preview)
+const planPath = join(tmpdir(), 'oma-plan.json')
+writeFileSync(planPath, JSON.stringify(plan, null, 2))
+
+console.log(`\nStep 2: saved a ${plan.tasks.length}-task plan to ${planPath}`)
+for (const task of plan.tasks) {
+  const deps = task.dependsOn?.length ? ` (after: ${task.dependsOn.join(', ')})` : ''
+  console.log(`  - ${task.title} -> ${task.assignee ?? 'auto-assigned'}${deps}`)
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — replay the saved plan WITHOUT the coordinator
+// ---------------------------------------------------------------------------
+
+console.log('\nStep 3: replay from the saved artifact (no coordinator call)')
+
+const saved = JSON.parse(readFileSync(planPath, 'utf8')) as PlanArtifact
+const result = await orchestrator.runFromPlan(team, saved)
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+
+console.log('\n' + '='.repeat(60))
+console.log(`Replay success:      ${result.success}`)
+console.log(`Coordinator invoked: ${result.agentResults.has('coordinator')}`) // false (plan replayed as-is)
+console.log(`Tokens — input: ${result.totalTokenUsage.input_tokens}, output: ${result.totalTokenUsage.output_tokens}`)
+
+for (const task of result.tasks ?? []) {
+  console.log(`  [${task.status}] ${task.title} (${task.assignee ?? 'unassigned'})`)
+}

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -1319,6 +1319,10 @@ export class OpenMultiAgent {
         status: task.status,
         dependsOn: task.dependsOn ?? [],
         description: task.description,
+        memoryScope: task.memoryScope,
+        maxRetries: task.maxRetries,
+        retryDelayMs: task.retryDelayMs,
+        retryBackoff: task.retryBackoff,
         metrics: undefined,
       }))
       this.config.onProgress?.({
@@ -1341,6 +1345,10 @@ export class OpenMultiAgent {
       status: task.status,
       dependsOn: task.dependsOn ?? [],
       description: task.description,
+      memoryScope: task.memoryScope,
+      maxRetries: task.maxRetries,
+      retryDelayMs: task.retryDelayMs,
+      retryBackoff: task.retryBackoff,
       metrics: taskMetrics.get(task.id),
     }))
 
@@ -1420,6 +1428,10 @@ export class OpenMultiAgent {
           description: task.description,
           ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
           ...(task.dependsOn.length > 0 ? { dependsOn: task.dependsOn } : {}),
+          ...(task.memoryScope !== undefined ? { memoryScope: task.memoryScope } : {}),
+          ...(task.maxRetries !== undefined ? { maxRetries: task.maxRetries } : {}),
+          ...(task.retryDelayMs !== undefined ? { retryDelayMs: task.retryDelayMs } : {}),
+          ...(task.retryBackoff !== undefined ? { retryBackoff: task.retryBackoff } : {}),
         }
       }),
     }
@@ -1742,6 +1754,10 @@ export class OpenMultiAgent {
       status: task.status,
       dependsOn: task.dependsOn ?? [],
       description: task.description,
+      memoryScope: task.memoryScope,
+      maxRetries: task.maxRetries,
+      retryDelayMs: task.retryDelayMs,
+      retryBackoff: task.retryBackoff,
       metrics: ctx.taskMetrics.get(task.id),
     }))
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -794,6 +794,15 @@ export interface TaskExecutionRecord {
   readonly status: TaskStatus
   readonly dependsOn: readonly string[]
   readonly description?: string
+  /**
+   * Execution config, carried so a `planOnly` snapshot can be serialized into a
+   * lossless replay artifact (see {@link PlanTaskArtifact}). Populated from the
+   * task; `undefined` when the task did not set them.
+   */
+  readonly memoryScope?: 'dependencies' | 'all'
+  readonly maxRetries?: number
+  readonly retryDelayMs?: number
+  readonly retryBackoff?: number
   readonly metrics?: TaskExecutionMetrics
 }
 

--- a/tests/orchestrator.test.ts
+++ b/tests/orchestrator.test.ts
@@ -1221,6 +1221,38 @@ describe('OpenMultiAgent', () => {
       expect(replay.tasks?.[1]?.dependsOn).toEqual(['stable-first-id'])
       expect(replay.agentResults.has('coordinator')).toBe(false)
     })
+
+    it('round-trips memoryScope and retry config through the plan artifact', async () => {
+      mockAdapterResponses = [
+        '```json\n[' +
+          '{"title": "Deep dive", "description": "Investigate", "assignee": "worker-a", "memoryScope": "all", "maxRetries": 2, "retryDelayMs": 500, "retryBackoff": 3}' +
+          ']\n```',
+      ]
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg())
+
+      const planOnlyResult = await oma.runTeam(team, complexGoal, { planOnly: true })
+      const plan = oma.createPlanArtifact(planOnlyResult)
+
+      // Execution config survives serialization into the artifact...
+      expect(plan.tasks[0]).toMatchObject({
+        memoryScope: 'all',
+        maxRetries: 2,
+        retryDelayMs: 500,
+        retryBackoff: 3,
+      })
+      expect(JSON.parse(JSON.stringify(plan))).toEqual(plan)
+
+      // ...and replay applies it, surfacing it back on the task record.
+      mockAdapterResponses = ['done']
+      const replay = await oma.runFromPlan(team, plan)
+      expect(replay.tasks?.[0]).toMatchObject({
+        memoryScope: 'all',
+        maxRetries: 2,
+        retryDelayMs: 500,
+        retryBackoff: 3,
+      })
+    })
   })
 
   describe('stream trace events', () => {


### PR DESCRIPTION
## Summary
Follow-up to #285. A saved plan could replay with different agent behavior than the one you reviewed: `memoryScope` (full shared memory vs dependency-only context) and the retry fields were dropped on the way into the artifact. `PlanTaskArtifact` and `tasksFromPlan` already supported them, but `TaskExecutionRecord` didn't carry them, so the `planOnly` snapshot and `createPlanArtifact` dropped them before `runFromPlan` could apply them. A coordinator can emit these (`parseTaskSpecs` accepts them), so the gap was reachable, not theoretical.

Adds the four fields to `TaskExecutionRecord`, populates them wherever records are built, and serializes them in `createPlanArtifact`, so the `planOnly` -> `createPlanArtifact` -> `runFromPlan` round-trip is lossless. Purely additive, no existing field or behavior changes. Also documents the API (`createPlanArtifact` / `runFromPlan`) with a runnable `examples/patterns/plan-replay.ts` and README / README_zh coverage.

## Tests
- `npm run lint`
- `npm test` (980 passing; adds a round-trip test that a plan carrying memoryScope + retry survives `createPlanArtifact` and reappears on the replayed task record)
