### PR TITLE
fix(llm): validate message content at adapter entry

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,3 +17,18 @@ export class TokenBudgetExceededError extends Error {
     this.name = 'TokenBudgetExceededError'
   }
 }
+
+/**
+ * Raised when a message list passed to an adapter violates the
+ * {@link LLMMessage}[] contract (e.g. a `content` that isn't a `ContentBlock[]`).
+ * Surfaced at the adapter entry so the violation fails loudly instead of
+ * crashing deep in provider-specific message conversion.
+ */
+export class InvalidMessageError extends Error {
+  readonly code = 'INVALID_MESSAGE'
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'InvalidMessageError'
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,7 +113,7 @@ export type { RegisterBuiltInToolsOptions } from './tool/built-in/index.js'
 
 export { createAdapter } from './llm/adapter.js'
 export type { SupportedProvider } from './llm/adapter.js'
-export { TokenBudgetExceededError } from './errors.js'
+export { TokenBudgetExceededError, InvalidMessageError } from './errors.js'
 
 // ---------------------------------------------------------------------------
 // Memory

--- a/src/llm/ai-sdk.ts
+++ b/src/llm/ai-sdk.ts
@@ -22,6 +22,7 @@ import type {
   ToolUseBlock,
 } from '../types.js'
 import { normalizeFinishReason } from './openai-common.js'
+import { assertValidMessages } from './validate.js'
 import {
   reasoningBlockToInlineText,
   resolveReasoningOutboundMaxChars,
@@ -245,6 +246,7 @@ export class AISdkAdapter implements LLMAdapter {
   }
 
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
+    assertValidMessages(messages)
     const { generateText, tool, jsonSchema } = await import('ai')
     const aiMessages = llmMessagesToAiSdkModelMessages(messages, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 
@@ -285,6 +287,7 @@ export class AISdkAdapter implements LLMAdapter {
   }
 
   async *stream(messages: LLMMessage[], options: LLMStreamOptions): AsyncIterable<StreamEvent> {
+    assertValidMessages(messages)
     const { streamText, tool, jsonSchema } = await import('ai')
     const aiMessages = llmMessagesToAiSdkModelMessages(messages, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -58,6 +58,7 @@ import {
   resolveReasoningOutboundMaxChars,
   type ReasoningOutboundOptions,
 } from './reasoning-fallback.js'
+import { assertValidMessages } from './validate.js'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -344,6 +345,7 @@ export class AnthropicAdapter implements LLMAdapter {
    * and handle these (e.g. rate limits, context window exceeded).
    */
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
+    assertValidMessages(messages)
     const anthropicMessages = toAnthropicMessages(messages, options)
     const effectiveMaxTokens = options.maxTokens ?? 4096
 
@@ -403,6 +405,7 @@ export class AnthropicAdapter implements LLMAdapter {
     messages: LLMMessage[],
     options: LLMStreamOptions,
   ): AsyncIterable<StreamEvent> {
+    assertValidMessages(messages)
     const anthropicMessages = toAnthropicMessages(messages, options)
     const effectiveMaxTokens = options.maxTokens ?? 4096
 

--- a/src/llm/azure-openai.ts
+++ b/src/llm/azure-openai.ts
@@ -61,6 +61,7 @@ import {
   normalizeFinishReason,
   buildOpenAIMessageList,
 } from './openai-common.js'
+import { assertValidMessages } from './validate.js'
 import { extractToolCallsFromText } from '../tool/text-tool-extractor.js'
 
 // ---------------------------------------------------------------------------
@@ -124,6 +125,7 @@ export class AzureOpenAIAdapter implements LLMAdapter {
    * handle these (e.g. rate limits, context length exceeded, deployment not found).
    */
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
+    assertValidMessages(messages)
     const deploymentName = resolveAzureDeploymentName(options.model)
     const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 
@@ -173,6 +175,7 @@ export class AzureOpenAIAdapter implements LLMAdapter {
     messages: LLMMessage[],
     options: LLMStreamOptions,
   ): AsyncIterable<StreamEvent> {
+    assertValidMessages(messages)
     const deploymentName = resolveAzureDeploymentName(options.model)
     const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 

--- a/src/llm/bedrock.ts
+++ b/src/llm/bedrock.ts
@@ -58,6 +58,7 @@ import {
   resolveReasoningOutboundMaxChars,
   type ReasoningOutboundOptions,
 } from './reasoning-fallback.js'
+import { assertValidMessages } from './validate.js'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -260,6 +261,7 @@ export class BedrockAdapter implements LLMAdapter {
   // -------------------------------------------------------------------------
 
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
+    assertValidMessages(messages)
     const bedrockMessages = toBedrockMessages(messages, options)
     const system = options.systemPrompt ? [{ text: options.systemPrompt }] : undefined
 
@@ -304,6 +306,7 @@ export class BedrockAdapter implements LLMAdapter {
   // -------------------------------------------------------------------------
 
   async *stream(messages: LLMMessage[], options: LLMStreamOptions): AsyncIterable<StreamEvent> {
+    assertValidMessages(messages)
     const bedrockMessages = toBedrockMessages(messages, options)
     const system = options.systemPrompt ? [{ text: options.systemPrompt }] : undefined
 

--- a/src/llm/copilot.ts
+++ b/src/llm/copilot.ts
@@ -48,6 +48,7 @@ import {
   normalizeFinishReason,
   buildOpenAIMessageList,
 } from './openai-common.js'
+import { assertValidMessages } from './validate.js'
 
 // ---------------------------------------------------------------------------
 // Copilot auth — OAuth2 device flow + token exchange
@@ -302,6 +303,7 @@ export class CopilotAdapter implements LLMAdapter {
   // -------------------------------------------------------------------------
 
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
+    assertValidMessages(messages)
     const client = await this.#createClient()
     const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 
@@ -335,6 +337,7 @@ export class CopilotAdapter implements LLMAdapter {
     messages: LLMMessage[],
     options: LLMStreamOptions,
   ): AsyncIterable<StreamEvent> {
+    assertValidMessages(messages)
     const client = await this.#createClient()
     const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, { preserveReasoningAsText: options.preserveReasoningAsText, compressReasoningText: options.compressReasoningText })
 

--- a/src/llm/gemini.ts
+++ b/src/llm/gemini.ts
@@ -55,6 +55,7 @@ import {
   resolveReasoningOutboundMaxChars,
   type ReasoningOutboundOptions,
 } from './reasoning-fallback.js'
+import { assertValidMessages } from './validate.js'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -410,6 +411,7 @@ export class GeminiAdapter implements LLMAdapter {
    * which is the idiomatic pattern for `@google/genai`.
    */
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
+    assertValidMessages(messages)
     const id = generateId()
     const contents = toGeminiContents(messages, options)
 
@@ -447,6 +449,7 @@ export class GeminiAdapter implements LLMAdapter {
     messages: LLMMessage[],
     options: LLMStreamOptions,
   ): AsyncIterable<StreamEvent> {
+    assertValidMessages(messages)
     const id = generateId()
     const contents = toGeminiContents(messages, options)
 

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -58,6 +58,7 @@ import {
   getOpenAIReasoningText,
   repairToolArgs,
 } from './openai-common.js'
+import { assertValidMessages } from './validate.js'
 import type { ReasoningOutboundOptions } from './reasoning-fallback.js'
 import { extractToolCallsFromText } from '../tool/text-tool-extractor.js'
 
@@ -140,6 +141,7 @@ export class OpenAIAdapter implements LLMAdapter {
    * handle these (e.g. rate limits, context length exceeded).
    */
   async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
+    assertValidMessages(messages)
     const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, this.buildMessageOptions(options))
 
     const completion = await this.#client.chat.completions.create(
@@ -192,6 +194,7 @@ export class OpenAIAdapter implements LLMAdapter {
     messages: LLMMessage[],
     options: LLMStreamOptions,
   ): AsyncIterable<StreamEvent> {
+    assertValidMessages(messages)
     const openAIMessages = buildOpenAIMessageList(messages, options.systemPrompt, this.buildMessageOptions(options))
 
     // We request usage in the final chunk so we can include it in the `done` event.

--- a/src/llm/validate.ts
+++ b/src/llm/validate.ts
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Entry-point validation for adapter message lists.
+ *
+ * `LLMMessage.content` is typed as `ContentBlock[]`, but JS callers, deserialized
+ * history, or custom integrations can break that contract at runtime. Without a
+ * guard a non-array `content` fails deep in provider-specific conversion with a
+ * cryptic `TypeError: <x>.content.some is not a function`.
+ *
+ * {@link assertValidMessages} is called at the entry of every adapter's
+ * `chat()`/`stream()` so a broken contract surfaces as a clear
+ * {@link InvalidMessageError} at the boundary instead.
+ */
+
+import type { LLMMessage } from '../types.js'
+import { InvalidMessageError } from '../errors.js'
+
+function describeType(value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'array'
+  return typeof value
+}
+
+/**
+ * Assert that `messages` satisfies the {@link LLMMessage}[] contract every
+ * adapter relies on: an array of `{ role, content }` objects whose `content` is
+ * an array of content blocks (objects carrying a string `type`). Throws
+ * {@link InvalidMessageError} naming the offending index on the first violation.
+ *
+ * Intentionally narrow: it validates only the array/shape invariants that
+ * otherwise crash opaquely during conversion, not `role` or block-internal
+ * fields. It rejects invalid input rather than coercing it, so the caller's bug
+ * stays visible instead of being silently reshaped.
+ */
+export function assertValidMessages(messages: LLMMessage[]): void {
+  if (!Array.isArray(messages)) {
+    throw new InvalidMessageError(`messages must be an array, got ${describeType(messages)}`)
+  }
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i] as unknown
+    if (msg === null || typeof msg !== 'object') {
+      throw new InvalidMessageError(`messages[${i}] must be an object, got ${describeType(msg)}`)
+    }
+
+    const content = (msg as { content?: unknown }).content
+    if (!Array.isArray(content)) {
+      throw new InvalidMessageError(
+        `messages[${i}].content must be a ContentBlock[], got ${describeType(content)}`,
+      )
+    }
+
+    for (let j = 0; j < content.length; j++) {
+      const block = content[j] as unknown
+      if (
+        block === null ||
+        typeof block !== 'object' ||
+        typeof (block as { type?: unknown }).type !== 'string'
+      ) {
+        throw new InvalidMessageError(
+          `messages[${i}].content[${j}] must be a content block with a string "type"`,
+        )
+      }
+    }
+  }
+}

--- a/tests/llm-message-validation.test.ts
+++ b/tests/llm-message-validation.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { textMsg, chatOpts, collectEvents } from './helpers/llm-fixtures.js'
+import type { LLMMessage } from '../src/types.js'
+import { assertValidMessages } from '../src/llm/validate.js'
+import { InvalidMessageError } from '../src/errors.js'
+
+// ---------------------------------------------------------------------------
+// Mock the SDKs. The adapters instantiate a client in their constructor, but
+// the guard fires on the first line of chat()/stream() — before any SDK call —
+// so the mocked methods are never reached in these tests.
+// ---------------------------------------------------------------------------
+
+vi.mock('openai', () => {
+  const OpenAIMock = vi.fn(() => ({ chat: { completions: { create: vi.fn() } } }))
+  return { default: OpenAIMock, OpenAI: OpenAIMock }
+})
+
+vi.mock('@anthropic-ai/sdk', () => {
+  const AnthropicMock = vi.fn(() => ({ messages: { create: vi.fn(), stream: vi.fn() } }))
+  return { default: AnthropicMock, Anthropic: AnthropicMock }
+})
+
+import { OpenAIAdapter } from '../src/llm/openai.js'
+import { AnthropicAdapter } from '../src/llm/anthropic.js'
+
+// The reported crash: content is a raw string instead of a ContentBlock[].
+const stringContent = [{ role: 'user', content: 'oops' }] as unknown as LLMMessage[]
+
+// ---------------------------------------------------------------------------
+// Unit: the shared guard
+// ---------------------------------------------------------------------------
+
+describe('assertValidMessages', () => {
+  it('accepts valid message shapes', () => {
+    expect(() => assertValidMessages([textMsg('user', 'hi')])).not.toThrow()
+    expect(() => assertValidMessages([
+      { role: 'assistant', content: [{ type: 'text', text: 'a' }, { type: 'tool_use', id: '1', name: 'x', input: {} }] },
+    ] as LLMMessage[])).not.toThrow()
+    // An empty content array is a valid ContentBlock[] — the guard must not over-reject.
+    expect(() => assertValidMessages([{ role: 'user', content: [] }] as LLMMessage[])).not.toThrow()
+  })
+
+  it('rejects a non-array messages list', () => {
+    expect(() => assertValidMessages('nope' as unknown as LLMMessage[])).toThrow(InvalidMessageError)
+    expect(() => assertValidMessages(null as unknown as LLMMessage[])).toThrow(/messages must be an array, got null/)
+  })
+
+  it('rejects a non-object message', () => {
+    expect(() => assertValidMessages(['x'] as unknown as LLMMessage[])).toThrow(/messages\[0\] must be an object, got string/)
+  })
+
+  it('rejects string content and names the offending index', () => {
+    expect(() => assertValidMessages(stringContent)).toThrow(InvalidMessageError)
+    expect(() => assertValidMessages(
+      [textMsg('user', 'ok'), { role: 'user', content: 'oops' }] as unknown as LLMMessage[],
+    )).toThrow(/messages\[1\]\.content must be a ContentBlock\[\], got string/)
+  })
+
+  it('rejects null or object content', () => {
+    expect(() => assertValidMessages([{ role: 'user', content: null }] as unknown as LLMMessage[])).toThrow(/content must be a ContentBlock\[\], got null/)
+    expect(() => assertValidMessages([{ role: 'user', content: {} }] as unknown as LLMMessage[])).toThrow(/content must be a ContentBlock\[\], got object/)
+  })
+
+  it('rejects a content block without a string type', () => {
+    expect(() => assertValidMessages([{ role: 'user', content: [null] }] as unknown as LLMMessage[]))
+      .toThrow(/messages\[0\]\.content\[0\] must be a content block with a string "type"/)
+    expect(() => assertValidMessages([{ role: 'user', content: [{ text: 'no type' }] }] as unknown as LLMMessage[]))
+      .toThrow(InvalidMessageError)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Wiring: the guard is invoked at each adapter entry (openai-common family +
+// independent family), for both chat() and stream().
+// ---------------------------------------------------------------------------
+
+describe('adapter entry validation', () => {
+  let openai: OpenAIAdapter
+  let anthropic: AnthropicAdapter
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    openai = new OpenAIAdapter('test-key')
+    anthropic = new AnthropicAdapter('test-key')
+  })
+
+  it('OpenAI chat() rejects string content', async () => {
+    await expect(openai.chat(stringContent, chatOpts())).rejects.toThrow(InvalidMessageError)
+  })
+
+  it('OpenAI stream() rejects string content on iteration', async () => {
+    await expect(collectEvents(openai.stream(stringContent, chatOpts()))).rejects.toThrow(InvalidMessageError)
+  })
+
+  it('Anthropic chat() rejects string content', async () => {
+    await expect(anthropic.chat(stringContent, chatOpts())).rejects.toThrow(InvalidMessageError)
+  })
+
+  it('Anthropic stream() rejects string content on iteration', async () => {
+    await expect(collectEvents(anthropic.stream(stringContent, chatOpts()))).rejects.toThrow(InvalidMessageError)
+  })
+})


### PR DESCRIPTION
## What
Adds a shared `assertValidMessages()` guard at the entry of `chat()` and `stream()` on all 7 LLM adapters. When `message.content` isn't a `ContentBlock[]`, it throws `InvalidMessageError` naming the offending index, instead of crashing deep in provider conversion with `TypeError: m.content.some is not a function`.

## Why
`LLMMessage.content` is typed as `ContentBlock[]`, and the framework never produces a string content itself. A non-array content only shows up when the contract is broken upstream of the adapter: a direct `adapter.chat()` call with a raw string (bypassing the `Agent` class), deserialized history, or a custom integration. Today it fails opaquely several call sites deep; this surfaces it at the boundary. It rejects invalid input rather than coercing it, so the caller's bug stays visible instead of being reshaped into `[object Object]`.

Implements the entry-point fail-fast suggested by apollo-mg in #268, extended across all adapters.

## Checklist
- [x] `npm run lint` passes
- [x] `npm test` passes (990 tests)
- [x] Added/updated tests for changed behavior
- [x] No new runtime dependencies
