### PR TITLE
chore: release 1.6.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,7 +32,7 @@ Paste any error messages or logs here
 
 - OS: [e.g. macOS 14, Ubuntu 22.04]
 - Node.js version: [e.g. 20.11]
-- Package version: [e.g. 0.1.0]
+- Package version: [e.g. 1.6.0]
 - LLM provider: [e.g. Anthropic, OpenAI]
 
 ## Additional context

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ oma-dashboards/
 .github/brand/frames/
 .claude/
 .npmrc
+.env

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -186,6 +186,16 @@ Every invocation prints **one JSON document** to stdout, followed by a newline.
 {
   "command": "run",
   "success": true,
+  "goal": "Build a REST API with token auth",
+  "tasks": [
+    {
+      "id": "task-1",
+      "title": "Design the database schema",
+      "assignee": "architect",
+      "status": "completed",
+      "dependsOn": []
+    }
+  ],
   "totalTokenUsage": { "input_tokens": 0, "output_tokens": 0 },
   "agentResults": {
     "architect": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-multi-agent/core",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "TypeScript multi-agent framework — one runTeam() call from goal to result. Auto task decomposition, parallel execution. 3 dependencies, deploys anywhere Node.js runs.",
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "./ai-sdk": {
       "types": "./dist/ai-sdk.d.ts",
       "import": "./dist/ai-sdk.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "build": "tsc",
@@ -52,7 +53,10 @@
     "tool-use",
     "agent-framework"
   ],
-  "author": "",
+  "author": {
+    "name": "open-multi-agent",
+    "url": "https://github.com/open-multi-agent"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Release 1.6.0.

Bundles the deferred post-1.5.0 docs/config cleanup ahead of the version bump:
- package.json author set to the org
- exports map now exposes ./package.json
- cli.md run/task output example includes goal and tasks
- bug_report template version example bumped
- .gitignore now covers .env

Changes since 1.5.0: features #285 #281 #269; fixes #288 #287 #284; refactor #282; tests and provider docs #290; readme #277.

Full release notes go in the GitHub Release.
