### PR TITLE
feat: checkpoint/resume first slice (per-run checkpoint over MemoryStore)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,13 @@ export { TokenBudgetExceededError, InvalidMessageError } from './errors.js'
 
 export { InMemoryStore } from './memory/store.js'
 export { SharedMemory } from './memory/shared.js'
+export {
+  Checkpoint,
+  CHECKPOINT_KEY_PREFIX,
+  DEFAULT_CHECKPOINT_KEY,
+  checkpointKey,
+  isCheckpointKey,
+} from './memory/checkpoint.js'
 
 // ---------------------------------------------------------------------------
 // Types — all public interfaces re-exported for consumer type-checking
@@ -168,6 +175,8 @@ export type {
   TeamRunResult,
   RunTeamOptions,
   RunTasksOptions,
+  RunTaskSpec,
+  RestoreOptions,
   ModelRouteConfig,
   ModelRoutingMatch,
   ModelRoutingRule,
@@ -192,6 +201,11 @@ export type {
   OrchestratorConfig,
   OrchestratorEvent,
   CoordinatorConfig,
+  CheckpointOptions,
+  CheckpointSnapshot,
+  CompletedTaskCheckpoint,
+  TaskQueueSnapshot,
+  TaskSnapshot,
 
   // Trace
   TraceEventType,
@@ -208,6 +222,8 @@ export type {
   // Memory
   MemoryEntry,
   MemoryStore,
+  MemoryEntrySnapshot,
+  SharedMemorySnapshot,
   SharedMemoryEntry,
   SharedMemoryValue,
   SharedMemoryWriteOptions,

--- a/src/memory/checkpoint.ts
+++ b/src/memory/checkpoint.ts
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview Durable checkpoint persistence over the public MemoryStore API.
+ *
+ * Checkpoints are stored as JSON under a reserved key namespace. The module
+ * intentionally depends only on {@link MemoryStore}, so in-memory, Redis,
+ * SQLite, or any custom backend work without extra hooks.
+ */
+
+import type { CheckpointOptions, CheckpointSnapshot, MemoryStore } from '../types.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const CHECKPOINT_KEY_PREFIX = '__oma_checkpoint__/'
+export const DEFAULT_CHECKPOINT_KEY = `${CHECKPOINT_KEY_PREFIX}latest`
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+export function checkpointKey(runId?: string): string {
+  if (!runId) return DEFAULT_CHECKPOINT_KEY
+  return `${CHECKPOINT_KEY_PREFIX}${runId}/latest`
+}
+
+export function isCheckpointKey(key: string): boolean {
+  return key.startsWith(CHECKPOINT_KEY_PREFIX)
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint
+// ---------------------------------------------------------------------------
+
+export class Checkpoint {
+  readonly key: string
+  private readonly runId: string | undefined
+
+  constructor(
+    private readonly store: MemoryStore,
+    options: Pick<CheckpointOptions, 'key' | 'runId'> = {},
+  ) {
+    this.key = options.key ?? checkpointKey(options.runId)
+    this.runId = options.runId
+  }
+
+  /** Persist `snapshot` as the latest checkpoint. */
+  async save(snapshot: CheckpointSnapshot): Promise<void> {
+    const stored: CheckpointSnapshot = {
+      ...snapshot,
+      ...(snapshot.runId !== undefined || this.runId === undefined
+        ? {}
+        : { runId: this.runId }),
+    }
+    await this.store.set(this.key, JSON.stringify(stored), {
+      namespace: 'checkpoint',
+      version: stored.version,
+      ...(stored.runId !== undefined ? { runId: stored.runId } : {}),
+      createdAt: stored.createdAt,
+    })
+  }
+
+  /** Load the latest checkpoint, or `null` when no checkpoint exists. */
+  async loadLatest(): Promise<CheckpointSnapshot | null> {
+    const entry = await this.store.get(this.key)
+    if (entry === null) return null
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(entry.value)
+    } catch {
+      throw new Error(`Checkpoint: stored value at "${this.key}" is not valid JSON.`)
+    }
+
+    if (!Checkpoint.isSnapshot(parsed)) {
+      throw new Error(`Checkpoint: stored value at "${this.key}" is not a checkpoint snapshot.`)
+    }
+    return parsed
+  }
+
+  /** Alias for {@link loadLatest}. */
+  async load(): Promise<CheckpointSnapshot | null> {
+    return this.loadLatest()
+  }
+
+  /** Delete the persisted checkpoint key. */
+  async delete(): Promise<void> {
+    await this.store.delete(this.key)
+  }
+
+  private static isSnapshot(value: unknown): value is CheckpointSnapshot {
+    if (value === null || typeof value !== 'object') return false
+    const snapshot = value as Record<string, unknown>
+    if (snapshot['version'] !== 1) return false
+    if (snapshot['mode'] !== 'runTeam' && snapshot['mode'] !== 'runTasks') return false
+    if (typeof snapshot['createdAt'] !== 'string') return false
+    if (!Array.isArray(snapshot['completedTaskResults'])) return false
+
+    const queue = snapshot['queue']
+    if (queue === null || typeof queue !== 'object') return false
+    const queueRecord = queue as Record<string, unknown>
+    return queueRecord['version'] === 1 && Array.isArray(queueRecord['tasks'])
+  }
+}

--- a/src/memory/shared.ts
+++ b/src/memory/shared.ts
@@ -8,8 +8,10 @@
  */
 
 import type {
+  MemoryEntrySnapshot,
   MemoryEntry,
   MemoryStore,
+  SharedMemorySnapshot,
   SharedMemoryEntry,
   SharedMemoryValue,
   SharedMemoryWriteOptions,
@@ -23,6 +25,7 @@ import { InMemoryStore } from './store.js'
 const STORE_METHODS = ['get', 'set', 'list', 'delete', 'clear'] as const
 const STRUCTURED_VALUE_ENCODING = 'json'
 const STRUCTURED_VALUE_METADATA_KEY = 'sharedMemoryValueEncoding'
+const RESERVED_STORE_PREFIXES = ['__oma_checkpoint__/'] as const
 
 
 /**
@@ -113,6 +116,62 @@ export class SharedMemory {
   /** Current turn count. Useful for tests and observability. */
   getTurnCount(): number {
     return this.turnCount
+  }
+
+  // ---------------------------------------------------------------------------
+  // Snapshot / restore
+  // ---------------------------------------------------------------------------
+
+  /** Returns a serializable snapshot of all non-expired shared-memory entries. */
+  async snapshot(): Promise<SharedMemorySnapshot> {
+    return {
+      version: 1,
+      turnCount: this.turnCount,
+      entries: this.filterExpired(await this.store.list()).map(SharedMemory.entryToSnapshot),
+    }
+  }
+
+  /**
+   * Rebuilds a {@link SharedMemory} instance from a snapshot.
+   *
+   * Snapshot entry values remain string-only at the {@link MemoryStore}
+   * boundary; structured values are recovered through their metadata when read.
+   */
+  static async fromSnapshot(
+    snapshot: SharedMemorySnapshot,
+    store?: MemoryStore,
+  ): Promise<SharedMemory> {
+    const memory = new SharedMemory(store)
+    await memory.restore(snapshot)
+    return memory
+  }
+
+  /**
+   * Restores this instance from a snapshot. Existing non-checkpoint entries in
+   * the backing store are replaced; reserved checkpoint records are preserved
+   * so the same store can hold both agent memory and checkpoints.
+   */
+  async restore(snapshot: SharedMemorySnapshot): Promise<void> {
+    if (snapshot.version !== 1) {
+      throw new Error(`SharedMemory.restore: unsupported snapshot version ${String(snapshot.version)}.`)
+    }
+
+    const existing = await this.store.list()
+    for (const entry of existing) {
+      if (!SharedMemory.isReservedStoreKey(entry.key)) {
+        await this.store.delete(entry.key)
+      }
+    }
+
+    for (const entry of snapshot.entries) {
+      if (SharedMemory.isReservedStoreKey(entry.key)) continue
+      if (entry.expiresAtTurn !== undefined && typeof this.store.setWithExpiry === 'function') {
+        await this.store.setWithExpiry(entry.key, entry.value, entry.expiresAtTurn, entry.metadata)
+      } else {
+        await this.store.set(entry.key, entry.value, entry.metadata)
+      }
+    }
+    this.turnCount = snapshot.turnCount
   }
 
   // ---------------------------------------------------------------------------
@@ -213,6 +272,7 @@ export class SharedMemory {
    * without the risk of stomping on a fresh write to the same key.
    */
   async read(key: string): Promise<SharedMemoryEntry | null> {
+    if (SharedMemory.isReservedStoreKey(key)) return null
     const entry = await this.store.get(key)
     if (entry === null) return null
     if (this.isExpired(entry)) return null
@@ -330,6 +390,20 @@ export class SharedMemory {
     return `${agentName}/${key}`
   }
 
+  private static isReservedStoreKey(key: string): boolean {
+    return RESERVED_STORE_PREFIXES.some((prefix) => key.startsWith(prefix))
+  }
+
+  private static entryToSnapshot(entry: MemoryEntry): MemoryEntrySnapshot {
+    return {
+      key: entry.key,
+      value: entry.value,
+      ...(entry.metadata !== undefined ? { metadata: { ...entry.metadata } } : {}),
+      createdAt: entry.createdAt.toISOString(),
+      ...(entry.expiresAtTurn !== undefined ? { expiresAtTurn: entry.expiresAtTurn } : {}),
+    }
+  }
+
   private static serializeValue<TValue extends SharedMemoryValue>(
     value: TValue,
     options?: SharedMemoryWriteOptions,
@@ -440,6 +514,6 @@ export class SharedMemory {
    * `expiresAtTurn` are always kept.
    */
   private filterExpired(entries: MemoryEntry[]): MemoryEntry[] {
-    return entries.filter((entry) => !this.isExpired(entry))
+    return entries.filter((entry) => !SharedMemory.isReservedStoreKey(entry.key) && !this.isExpired(entry))
   }
 }

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -44,6 +44,8 @@
 import type {
   AgentConfig,
   AgentRunResult,
+  CheckpointOptions,
+  CheckpointSnapshot,
   ConsensusOptions,
   ConsensusResult,
   ConsensusVerifyOptions,
@@ -54,6 +56,8 @@ import type {
   PlanTaskArtifact,
   OrchestratorConfig,
   OrchestratorEvent,
+  RestoreOptions,
+  RunTaskSpec,
   RunTasksOptions,
   RunTeamOptions,
   StreamEvent,
@@ -77,6 +81,8 @@ import { registerBuiltInTools } from '../tool/built-in/index.js'
 import { defaultWorkspaceDir } from '../tool/built-in/path-safety.js'
 import { Team } from '../team/team.js'
 import { TaskQueue } from '../task/queue.js'
+import { Checkpoint } from '../memory/checkpoint.js'
+import { InMemoryStore } from '../memory/store.js'
 import { createTask, validateTaskDependencies } from '../task/task.js'
 import { extractJSON, validateOutput } from '../agent/structured-output.js'
 import { Scheduler } from './scheduler.js'
@@ -529,6 +535,7 @@ interface RunContext {
   readonly scheduler: Scheduler
   readonly agentResults: Map<string, AgentRunResult>
   readonly config: OrchestratorConfig
+  readonly checkpoint?: ActiveCheckpoint
   /** Trace run ID, present when `onTrace` is configured. */
   readonly runId?: string
   /** AbortSignal for run-level cancellation. Checked between task dispatch rounds. */
@@ -546,6 +553,14 @@ interface RunContext {
   readonly modelRouting?: ModelRoutingPolicy
   readonly taskById: ReadonlyMap<string, Task>
   readonly taskLeafById: ReadonlyMap<string, boolean>
+}
+
+interface ActiveCheckpoint {
+  readonly manager: Checkpoint
+  readonly mode: CheckpointSnapshot['mode']
+  readonly goal?: string
+  readonly runId?: string
+  saveChain: Promise<void>
 }
 
 /**
@@ -642,6 +657,35 @@ function buildTaskAgentTeamInfo(
     delegationChain,
     runDelegatedAgent,
   }
+}
+
+async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Promise<void> {
+  const active = ctx.checkpoint
+  if (!active) return
+
+  const sharedMem = ctx.team.getSharedMemoryInstance()
+  const completedTaskResults = queue.getByStatus('completed').map((task) => ({
+    taskId: task.id,
+    ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
+    ...(task.result !== undefined ? { result: task.result } : {}),
+  }))
+
+  const snapshot: CheckpointSnapshot = {
+    version: 1,
+    mode: active.mode,
+    createdAt: new Date().toISOString(),
+    ...(active.runId !== undefined ? { runId: active.runId } : {}),
+    ...(active.goal !== undefined ? { goal: active.goal } : {}),
+    queue: queue.snapshot(),
+    ...(sharedMem ? { sharedMemory: await sharedMem.snapshot() } : {}),
+    completedTaskResults,
+  }
+
+  const nextSave = active.saveChain
+    .catch(() => undefined)
+    .then(() => active.manager.save(snapshot))
+  active.saveChain = nextSave
+  await nextSave
 }
 
 /**
@@ -904,6 +948,7 @@ async function executeQueue(
 
         const completedTask = queue.complete(task.id, effective.output)
         completedThisRound.push(completedTask)
+        await saveRunCheckpoint(queue, ctx)
 
         config.onProgress?.({
           type: 'task_complete',
@@ -1369,10 +1414,11 @@ async function runTaskVerify(
  */
 export class OpenMultiAgent {
   private readonly config: Required<
-    Omit<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'defaultToolPreset'>
-  > & Pick<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'defaultToolPreset'>
+    Omit<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'defaultToolPreset' | 'checkpoint'>
+  > & Pick<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'defaultToolPreset' | 'checkpoint'>
 
   private readonly teams: Map<string, Team> = new Map()
+  private readonly fallbackCheckpointStore = new InMemoryStore()
   private completedTaskCount = 0
 
   /**
@@ -1398,6 +1444,7 @@ export class OpenMultiAgent {
       defaultCwd: config.defaultCwd === undefined ? defaultWorkspaceDir() : config.defaultCwd,
       maxTokenBudget: config.maxTokenBudget,
       defaultToolPreset: config.defaultToolPreset,
+      checkpoint: config.checkpoint,
       onApproval: config.onApproval,
       onPlanReady: config.onPlanReady,
       onAgentStream: config.onAgentStream,
@@ -1732,12 +1779,19 @@ export class OpenMultiAgent {
     // Step 4: Build pool and execute
     // ------------------------------------------------------------------
     const pool = this.buildPool(agentConfigs)
+    const activeCheckpoint = this.createActiveCheckpoint(
+      team,
+      options?.checkpoint ?? this.config.checkpoint,
+      'runTeam',
+      goal,
+    )
     const ctx: RunContext = {
       team,
       pool,
       scheduler,
       agentResults,
       config: this.config,
+      ...(activeCheckpoint ? { checkpoint: activeCheckpoint } : {}),
       runId,
       abortSignal: options?.abortSignal,
       cumulativeUsage,
@@ -1920,13 +1974,13 @@ export class OpenMultiAgent {
    *
    * Task IDs, dependencies, assignees, titles, and descriptions are used exactly
    * as stored in the artifact. This is intentionally execution-only; it does not
-   * synthesize a coordinator final answer and it does not implement durable
-   * checkpoints.
+   * synthesize a coordinator final answer. Durable checkpoints are available
+   * through the same opt-in `checkpoint` option used by `runTasks`.
    */
   async runFromPlan(
     team: Team,
     plan: PlanArtifact,
-    options?: { abortSignal?: AbortSignal },
+    options?: RunTasksOptions,
   ): Promise<TeamRunResult> {
     if (plan.version !== 1) {
       throw new Error(`Unsupported plan artifact version: ${String(plan.version)}`)
@@ -1943,6 +1997,119 @@ export class OpenMultiAgent {
     return this.executeExplicitTaskQueue(team, queue, options, plan.goal)
   }
 
+  async restore(
+    team: Team,
+    tasks: ReadonlyArray<RunTaskSpec>,
+    options?: RestoreOptions,
+  ): Promise<TeamRunResult>
+  async restore(
+    team: Team,
+    plan: PlanArtifact,
+    options?: RestoreOptions,
+  ): Promise<TeamRunResult>
+  async restore(
+    team: Team,
+    options?: RestoreOptions,
+  ): Promise<TeamRunResult>
+  async restore(
+    team: Team,
+    tasksOrOptions?: ReadonlyArray<RunTaskSpec> | PlanArtifact | RestoreOptions,
+    maybeOptions?: RestoreOptions,
+  ): Promise<TeamRunResult> {
+    const hasTaskSource = Array.isArray(tasksOrOptions) || this.isPlanArtifact(tasksOrOptions)
+    const options = hasTaskSource ? maybeOptions : tasksOrOptions as RestoreOptions | undefined
+    const activeCheckpoint = this.createActiveCheckpoint(
+      team,
+      options?.checkpoint ?? this.config.checkpoint ?? true,
+      'runTasks',
+      options?.goal,
+    )
+
+    const snapshot = activeCheckpoint ? await activeCheckpoint.manager.loadLatest() : null
+    if (!snapshot) {
+      if (Array.isArray(tasksOrOptions)) {
+        const queue = new TaskQueue()
+        this.loadSpecsIntoQueue(
+          tasksOrOptions.map((t) => ({
+            title: t.title,
+            description: t.description,
+            assignee: t.assignee,
+            dependsOn: t.dependsOn,
+            memoryScope: t.memoryScope,
+            maxRetries: t.maxRetries,
+            retryDelayMs: t.retryDelayMs,
+            retryBackoff: t.retryBackoff,
+            role: t.role,
+            priority: t.priority,
+            verify: t.verify,
+          })),
+          team.getAgents(),
+          queue,
+        )
+        return this.executeExplicitTaskQueue(
+          team,
+          queue,
+          options,
+          options?.goal,
+          undefined,
+          activeCheckpoint,
+        )
+      }
+      if (this.isPlanArtifact(tasksOrOptions)) {
+        const queue = new TaskQueue()
+        const tasks = this.tasksFromPlan(tasksOrOptions)
+        const validation = validateTaskDependencies(tasks)
+        if (!validation.valid) {
+          throw new Error(`Invalid plan artifact: ${validation.errors.join(' ')}`)
+        }
+        queue.addBatch(tasks)
+        return this.executeExplicitTaskQueue(
+          team,
+          queue,
+          options,
+          tasksOrOptions.goal ?? options?.goal,
+          undefined,
+          activeCheckpoint,
+        )
+      }
+
+      const queue = new TaskQueue()
+      return this.executeExplicitTaskQueue(
+        team,
+        queue,
+        options,
+        options?.goal,
+        undefined,
+        activeCheckpoint,
+      )
+    }
+
+    const sharedMem = team.getSharedMemoryInstance()
+    if (sharedMem && snapshot.sharedMemory) {
+      await sharedMem.restore(snapshot.sharedMemory)
+    }
+
+    const queue = TaskQueue.fromSnapshot(snapshot.queue, { resetInProgress: true })
+    const agentResults = this.agentResultsFromCheckpoint(snapshot, queue)
+    const checkpointForResume: ActiveCheckpoint | undefined = activeCheckpoint
+      ? {
+          ...activeCheckpoint,
+          mode: snapshot.mode,
+          ...(snapshot.goal !== undefined ? { goal: snapshot.goal } : {}),
+          ...(snapshot.runId !== undefined ? { runId: snapshot.runId } : {}),
+        }
+      : undefined
+
+    return this.executeExplicitTaskQueue(
+      team,
+      queue,
+      options,
+      snapshot.goal ?? options?.goal,
+      agentResults,
+      checkpointForResume,
+    )
+  }
+
   /**
    * Run a team with an explicitly provided task list.
    *
@@ -1955,19 +2122,7 @@ export class OpenMultiAgent {
    */
   async runTasks(
     team: Team,
-    tasks: ReadonlyArray<{
-      title: string
-      description: string
-      assignee?: string
-      dependsOn?: string[]
-      memoryScope?: 'dependencies' | 'all'
-      maxRetries?: number
-      retryDelayMs?: number
-      retryBackoff?: number
-      role?: string
-      priority?: 'low' | 'normal' | 'high' | 'critical'
-      verify?: ConsensusVerifyOptions
-    }>,
+    tasks: ReadonlyArray<RunTaskSpec>,
     options?: RunTasksOptions,
   ): Promise<TeamRunResult> {
     const agentConfigs = team.getAgents()
@@ -2308,19 +2463,28 @@ export class OpenMultiAgent {
     queue: TaskQueue,
     options?: RunTasksOptions,
     goal?: string,
+    initialAgentResults?: Map<string, AgentRunResult>,
+    activeCheckpoint?: ActiveCheckpoint,
   ): Promise<TeamRunResult> {
     const agentConfigs = team.getAgents()
     const scheduler = new Scheduler('dependency-first')
     scheduler.autoAssign(queue, agentConfigs)
 
     const pool = this.buildPool(agentConfigs)
-    const agentResults = new Map<string, AgentRunResult>()
+    const agentResults = initialAgentResults ?? new Map<string, AgentRunResult>()
+    const checkpoint = activeCheckpoint ?? this.createActiveCheckpoint(
+      team,
+      options?.checkpoint ?? this.config.checkpoint,
+      'runTasks',
+      goal,
+    )
     const ctx: RunContext = {
       team,
       pool,
       scheduler,
       agentResults,
       config: this.config,
+      ...(checkpoint ? { checkpoint } : {}),
       runId: this.config.onTrace ? generateRunId() : undefined,
       abortSignal: options?.abortSignal,
       cumulativeUsage: ZERO_USAGE,
@@ -2350,6 +2514,55 @@ export class OpenMultiAgent {
     }))
 
     return this.buildTeamRunResult(agentResults, goal, taskRecords)
+  }
+
+  private createActiveCheckpoint(
+    team: Team,
+    config: boolean | CheckpointOptions | undefined,
+    mode: CheckpointSnapshot['mode'],
+    goal?: string,
+  ): ActiveCheckpoint | undefined {
+    if (config === undefined || config === false) return undefined
+    const options = config === true ? {} : config
+    if (options.enabled === false) return undefined
+
+    const store = options.store ?? team.getSharedMemory() ?? this.fallbackCheckpointStore
+    return {
+      manager: new Checkpoint(store, options),
+      mode,
+      ...(goal !== undefined ? { goal } : {}),
+      ...(options.runId !== undefined ? { runId: options.runId } : {}),
+      saveChain: Promise.resolve(),
+    }
+  }
+
+  private agentResultsFromCheckpoint(
+    snapshot: CheckpointSnapshot,
+    queue: TaskQueue,
+  ): Map<string, AgentRunResult> {
+    const taskById = new Map(queue.list().map((task) => [task.id, task]))
+    const agentResults = new Map<string, AgentRunResult>()
+
+    for (const completed of snapshot.completedTaskResults) {
+      const task = taskById.get(completed.taskId)
+      const assignee = completed.assignee ?? task?.assignee ?? 'unknown'
+      const output = completed.result ?? task?.result ?? ''
+      agentResults.set(`${assignee}:${completed.taskId}`, {
+        success: true,
+        output,
+        messages: [],
+        tokenUsage: ZERO_USAGE,
+        toolCalls: [],
+      })
+    }
+
+    return agentResults
+  }
+
+  private isPlanArtifact(value: unknown): value is PlanArtifact {
+    if (value === null || typeof value !== 'object') return false
+    const artifact = value as Record<string, unknown>
+    return artifact['version'] === 1 && Array.isArray(artifact['tasks'])
   }
 
   /**

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -663,29 +663,44 @@ async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Promise<voi
   const active = ctx.checkpoint
   if (!active) return
 
-  const sharedMem = ctx.team.getSharedMemoryInstance()
-  const completedTaskResults = queue.getByStatus('completed').map((task) => ({
-    taskId: task.id,
-    ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
-    ...(task.result !== undefined ? { result: task.result } : {}),
-  }))
+  // Best-effort: a checkpoint write must never take down the run it protects.
+  // Both snapshot construction and the store write are guarded, so a failing
+  // store (e.g. a transient Redis/SQLite error) is surfaced via `onProgress`
+  // and the run continues — the next completed task retries the write.
+  const save = async (): Promise<void> => {
+    const sharedMem = ctx.team.getSharedMemoryInstance()
+    const completedTaskResults = queue.getByStatus('completed').map((task) => ({
+      taskId: task.id,
+      ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
+      ...(task.result !== undefined ? { result: task.result } : {}),
+    }))
 
-  const snapshot: CheckpointSnapshot = {
-    version: 1,
-    mode: active.mode,
-    createdAt: new Date().toISOString(),
-    ...(active.runId !== undefined ? { runId: active.runId } : {}),
-    ...(active.goal !== undefined ? { goal: active.goal } : {}),
-    queue: queue.snapshot(),
-    ...(sharedMem ? { sharedMemory: await sharedMem.snapshot() } : {}),
-    completedTaskResults,
+    const snapshot: CheckpointSnapshot = {
+      version: 1,
+      mode: active.mode,
+      createdAt: new Date().toISOString(),
+      ...(active.runId !== undefined ? { runId: active.runId } : {}),
+      ...(active.goal !== undefined ? { goal: active.goal } : {}),
+      queue: queue.snapshot(),
+      ...(sharedMem ? { sharedMemory: await sharedMem.snapshot() } : {}),
+      completedTaskResults,
+    }
+
+    await active.manager.save(snapshot)
   }
 
-  const nextSave = active.saveChain
-    .catch(() => undefined)
-    .then(() => active.manager.save(snapshot))
-  active.saveChain = nextSave
-  await nextSave
+  const nextSave = active.saveChain.catch(() => undefined).then(save)
+  // Keep the stored chain non-rejecting so a failed save never leaves an
+  // unhandled rejection or blocks the next checkpoint in the chain.
+  active.saveChain = nextSave.catch(() => undefined)
+  try {
+    await nextSave
+  } catch (error) {
+    ctx.config.onProgress?.({
+      type: 'error',
+      data: { kind: 'checkpoint_save_failed', error },
+    } satisfies OrchestratorEvent)
+  }
 }
 
 /**
@@ -1997,6 +2012,19 @@ export class OpenMultiAgent {
     return this.executeExplicitTaskQueue(team, queue, options, plan.goal)
   }
 
+  /**
+   * Resume a checkpointed run, or start a fresh one when no checkpoint exists.
+   *
+   * Loads the latest checkpoint from the configured {@link MemoryStore}, rebuilds
+   * the task queue and shared memory, skips already-completed tasks, and runs the
+   * remainder. When no checkpoint is found the call falls back to a normal run of
+   * the provided tasks/plan (or a no-op when neither is given).
+   *
+   * Execution always flows through the explicit-task-queue path, so — like
+   * {@link OpenMultiAgent.runFromPlan} — a restored `runTeam` run returns the raw
+   * per-task outputs in `tasks`, not a coordinator-synthesized final answer. Pass
+   * the original tasks/plan to resume a `runTasks`/`runFromPlan` run unchanged.
+   */
   async restore(
     team: Team,
     tasks: ReadonlyArray<RunTaskSpec>,
@@ -2526,7 +2554,19 @@ export class OpenMultiAgent {
     const options = config === true ? {} : config
     if (options.enabled === false) return undefined
 
-    const store = options.store ?? team.getSharedMemory() ?? this.fallbackCheckpointStore
+    // The instance-level fallback store is shared across every run on this
+    // orchestrator, so concurrent runs would overwrite each other at the
+    // default checkpoint key. Require a `runId` (or an explicit `key`/`store`)
+    // before falling back, so each run resolves to a distinct, resumable key.
+    const explicitStore = options.store ?? team.getSharedMemory()
+    if (!explicitStore && options.runId === undefined && options.key === undefined) {
+      throw new Error(
+        'Checkpoint requires a `runId` (or an explicit `store`/`key`) when the team has no ' +
+          'shared-memory store. Without one, concurrent runs would share the fallback store and ' +
+          "overwrite each other's checkpoint at the default key.",
+      )
+    }
+    const store = explicitStore ?? this.fallbackCheckpointStore
     return {
       manager: new Checkpoint(store, options),
       mode,

--- a/src/task/queue.ts
+++ b/src/task/queue.ts
@@ -6,7 +6,7 @@
  * orchestrators can react without polling.
  */
 
-import type { Task, TaskStatus } from '../types.js'
+import type { Task, TaskQueueSnapshot, TaskSnapshot, TaskStatus } from '../types.js'
 import { isTaskReady } from './task.js'
 
 // ---------------------------------------------------------------------------
@@ -91,6 +91,53 @@ export class TaskQueue {
     for (const task of tasks) {
       this.add(task)
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Snapshot / restore
+  // ---------------------------------------------------------------------------
+
+  /** Returns a serializable snapshot of all tasks and their status partitions. */
+  snapshot(): TaskQueueSnapshot {
+    const tasks = this.list()
+    return {
+      version: 1,
+      tasks: tasks.map(TaskQueue.taskToSnapshot),
+      pending: tasks.filter((task) => task.status === 'pending').map((task) => task.id),
+      inProgress: tasks.filter((task) => task.status === 'in_progress').map((task) => task.id),
+      completed: tasks.filter((task) => task.status === 'completed').map((task) => task.id),
+      failed: tasks.filter((task) => task.status === 'failed').map((task) => task.id),
+      blocked: tasks.filter((task) => task.status === 'blocked').map((task) => task.id),
+      skipped: tasks.filter((task) => task.status === 'skipped').map((task) => task.id),
+    }
+  }
+
+  /**
+   * Rebuilds a queue from a snapshot.
+   *
+   * By default this is an exact round-trip, including `'in_progress'` tasks.
+   * Restores that resume execution should pass `{ resetInProgress: true }` so
+   * a task that was running during a crash becomes runnable again once its
+   * dependencies are satisfied.
+   */
+  static fromSnapshot(
+    snapshot: TaskQueueSnapshot,
+    options: { readonly resetInProgress?: boolean } = {},
+  ): TaskQueue {
+    if (snapshot.version !== 1) {
+      throw new Error(`TaskQueue.fromSnapshot: unsupported snapshot version ${String(snapshot.version)}.`)
+    }
+
+    const queue = new TaskQueue()
+    const tasks = snapshot.tasks.map((task) => TaskQueue.taskFromSnapshot(task))
+    const restored = options.resetInProgress
+      ? TaskQueue.resetRestoredInProgress(tasks)
+      : tasks
+
+    for (const task of restored) {
+      queue.tasks.set(task.id, task)
+    }
+    return queue
   }
 
   // ---------------------------------------------------------------------------
@@ -465,5 +512,72 @@ export class TaskQueue {
     const task = this.tasks.get(taskId)
     if (!task) throw new Error(`TaskQueue: task "${taskId}" not found.`)
     return task
+  }
+
+  private static taskToSnapshot(task: Task): TaskSnapshot {
+    return {
+      id: task.id,
+      title: task.title,
+      description: task.description,
+      status: task.status,
+      ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
+      ...(task.dependsOn !== undefined ? { dependsOn: [...task.dependsOn] } : {}),
+      ...(task.memoryScope !== undefined ? { memoryScope: task.memoryScope } : {}),
+      ...(task.role !== undefined ? { role: task.role } : {}),
+      ...(task.priority !== undefined ? { priority: task.priority } : {}),
+      ...(task.result !== undefined ? { result: task.result } : {}),
+      createdAt: task.createdAt.toISOString(),
+      updatedAt: task.updatedAt.toISOString(),
+      ...(task.maxRetries !== undefined ? { maxRetries: task.maxRetries } : {}),
+      ...(task.retryDelayMs !== undefined ? { retryDelayMs: task.retryDelayMs } : {}),
+      ...(task.retryBackoff !== undefined ? { retryBackoff: task.retryBackoff } : {}),
+    }
+  }
+
+  private static taskFromSnapshot(snapshot: TaskSnapshot): Task {
+    return {
+      id: snapshot.id,
+      title: snapshot.title,
+      description: snapshot.description,
+      status: snapshot.status,
+      ...(snapshot.assignee !== undefined ? { assignee: snapshot.assignee } : {}),
+      ...(snapshot.dependsOn !== undefined ? { dependsOn: [...snapshot.dependsOn] } : {}),
+      ...(snapshot.memoryScope !== undefined ? { memoryScope: snapshot.memoryScope } : {}),
+      ...(snapshot.role !== undefined ? { role: snapshot.role } : {}),
+      ...(snapshot.priority !== undefined ? { priority: snapshot.priority } : {}),
+      ...(snapshot.result !== undefined ? { result: snapshot.result } : {}),
+      createdAt: TaskQueue.parseSnapshotDate(snapshot.createdAt),
+      updatedAt: TaskQueue.parseSnapshotDate(snapshot.updatedAt),
+      ...(snapshot.maxRetries !== undefined ? { maxRetries: snapshot.maxRetries } : {}),
+      ...(snapshot.retryDelayMs !== undefined ? { retryDelayMs: snapshot.retryDelayMs } : {}),
+      ...(snapshot.retryBackoff !== undefined ? { retryBackoff: snapshot.retryBackoff } : {}),
+    }
+  }
+
+  private static parseSnapshotDate(value: string): Date {
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? new Date() : date
+  }
+
+  private static resetRestoredInProgress(tasks: Task[]): Task[] {
+    const initial = tasks.map((task): Task =>
+      task.status === 'in_progress'
+        ? { ...task, status: 'pending', updatedAt: new Date() }
+        : task,
+    )
+    const taskById = new Map<string, Task>(initial.map((task) => [task.id, task]))
+
+    return initial.map((task): Task => {
+      if (task.status !== 'pending' && task.status !== 'blocked') return task
+      const pendingTask = { ...task, status: 'pending' as TaskStatus }
+      const ready = isTaskReady(pendingTask, initial, taskById)
+      if (ready && task.status === 'blocked') {
+        return { ...task, status: 'pending', updatedAt: new Date() }
+      }
+      if (!ready && task.status === 'pending') {
+        return { ...task, status: 'blocked', updatedAt: new Date() }
+      }
+      return task
+    })
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -735,9 +735,34 @@ export interface ModelRoutingPolicy {
   readonly rules: readonly ModelRoutingRule[]
 }
 
+/** Input task descriptor accepted by {@link OpenMultiAgent.runTasks}. */
+export interface RunTaskSpec {
+  readonly title: string
+  readonly description: string
+  readonly assignee?: string
+  readonly dependsOn?: string[]
+  readonly memoryScope?: 'dependencies' | 'all'
+  readonly maxRetries?: number
+  readonly retryDelayMs?: number
+  readonly retryBackoff?: number
+  readonly role?: string
+  readonly priority?: 'low' | 'normal' | 'high' | 'critical'
+  readonly verify?: ConsensusVerifyOptions
+}
+
 /** Per-call options for {@link OpenMultiAgent.runTasks}. */
 export interface RunTasksOptions {
   readonly abortSignal?: AbortSignal
+  /**
+   * Opt-in durable task checkpointing. When enabled, the orchestrator writes a
+   * checkpoint after each successfully completed task using the configured
+   * {@link MemoryStore}. Defaults to off.
+   *
+   * `true` uses the team's shared-memory store when available, otherwise a
+   * private in-memory store for the run. Pass an object to provide a durable
+   * store or custom key/run id.
+   */
+  readonly checkpoint?: boolean | CheckpointOptions
   /**
    * Opt-in deterministic model routing. When omitted, existing agent and
    * coordinator model selection is unchanged.
@@ -984,6 +1009,11 @@ export interface OrchestratorConfig {
   readonly defaultBaseURL?: string
   readonly defaultApiKey?: string
   /**
+   * Default checkpoint configuration for `runTeam`, `runTasks`, `runFromPlan`,
+   * and `restore`. Per-call options override this value. Defaults to off.
+   */
+  readonly checkpoint?: boolean | CheckpointOptions
+  /**
    * Fallback tool grant for agents that declare neither {@link AgentConfig.tools}
    * nor {@link AgentConfig.toolPreset}. Built-in tools are opt-in (default-deny):
    * an agent with no grant resolves to zero built-in tools. Set this (e.g.
@@ -1046,6 +1076,97 @@ export interface OrchestratorConfig {
    * Only invoked by runTeam(). Not called for runAgent() or runTasks().
    */
   readonly onAgentStream?: (agentName: string, event: StreamEvent) => void
+}
+
+// ---------------------------------------------------------------------------
+// Checkpoint / restore
+// ---------------------------------------------------------------------------
+
+/** Configuration for opt-in checkpoint persistence. */
+export interface CheckpointOptions {
+  /**
+   * Set to `false` to disable a default checkpoint config for a single run.
+   * Omitted or `true` enables checkpointing.
+   */
+  readonly enabled?: boolean
+  /** Durable store used for checkpoint records. Defaults to the team's shared-memory store. */
+  readonly store?: MemoryStore
+  /** Exact store key for the latest checkpoint. Takes precedence over `runId`. */
+  readonly key?: string
+  /** Logical run id used to derive a checkpoint key when `key` is omitted. */
+  readonly runId?: string
+}
+
+/** Options accepted by {@link OpenMultiAgent.restore}. */
+export interface RestoreOptions extends RunTasksOptions {
+  /** Optional goal attached to the restored result when no checkpoint goal exists. */
+  readonly goal?: string
+}
+
+/** Serializable form of a {@link MemoryEntry}. */
+export interface MemoryEntrySnapshot {
+  readonly key: string
+  readonly value: string
+  readonly metadata?: Readonly<Record<string, unknown>>
+  readonly createdAt: string
+  readonly expiresAtTurn?: number
+}
+
+/** Serializable form of {@link SharedMemory}. */
+export interface SharedMemorySnapshot {
+  readonly version: 1
+  readonly turnCount: number
+  readonly entries: readonly MemoryEntrySnapshot[]
+}
+
+/** Serializable form of a {@link Task}. */
+export interface TaskSnapshot {
+  readonly id: string
+  readonly title: string
+  readonly description: string
+  readonly status: TaskStatus
+  readonly assignee?: string
+  readonly dependsOn?: readonly string[]
+  readonly memoryScope?: 'dependencies' | 'all'
+  readonly role?: string
+  readonly priority?: 'low' | 'normal' | 'high' | 'critical'
+  readonly result?: string
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly maxRetries?: number
+  readonly retryDelayMs?: number
+  readonly retryBackoff?: number
+}
+
+/** Serializable state of a {@link TaskQueue}. */
+export interface TaskQueueSnapshot {
+  readonly version: 1
+  readonly tasks: readonly TaskSnapshot[]
+  readonly pending: readonly string[]
+  readonly inProgress: readonly string[]
+  readonly completed: readonly string[]
+  readonly failed: readonly string[]
+  readonly blocked: readonly string[]
+  readonly skipped: readonly string[]
+}
+
+/** Result recorded for a completed task inside a checkpoint. */
+export interface CompletedTaskCheckpoint {
+  readonly taskId: string
+  readonly assignee?: string
+  readonly result?: string
+}
+
+/** Full persisted checkpoint for a task-based run. */
+export interface CheckpointSnapshot {
+  readonly version: 1
+  readonly mode: 'runTeam' | 'runTasks'
+  readonly createdAt: string
+  readonly runId?: string
+  readonly goal?: string
+  readonly queue: TaskQueueSnapshot
+  readonly sharedMemory?: SharedMemorySnapshot
+  readonly completedTaskResults: readonly CompletedTaskCheckpoint[]
 }
 
 /**

--- a/tests/checkpoint.test.ts
+++ b/tests/checkpoint.test.ts
@@ -14,6 +14,7 @@ import type {
   LLMResponse,
   MemoryEntry,
   MemoryStore,
+  OrchestratorEvent,
   RunTaskSpec,
 } from '../src/types.js'
 
@@ -320,6 +321,110 @@ describe('OpenMultiAgent checkpoint/restore', () => {
       sharedMemoryStore: store,
     })
     const result = await orchestrator.restore(resumedTeam, { checkpoint: { store } })
+
+    expect(scripted.calls()).toBe(2)
+    expect(result.tasks?.map((record) => record.status)).toEqual(['completed', 'completed'])
+  })
+})
+
+/** A store whose writes always reject, to exercise best-effort checkpointing. */
+class FailingSetStore implements MemoryStore {
+  setCalls = 0
+
+  async get(): Promise<MemoryEntry | null> {
+    return null
+  }
+
+  async set(): Promise<void> {
+    this.setCalls++
+    throw new Error('checkpoint store offline')
+  }
+
+  async list(): Promise<MemoryEntry[]> {
+    return []
+  }
+
+  async delete(): Promise<void> {}
+
+  async clear(): Promise<void> {}
+}
+
+describe('checkpoint resilience and key safety', () => {
+  const tasks: RunTaskSpec[] = [
+    { title: 'first', description: 'do first', assignee: 'worker' },
+    { title: 'second', description: 'do second', assignee: 'worker', dependsOn: ['first'] },
+  ]
+
+  it('keeps the run alive when checkpoint writes fail, surfacing them via onProgress', async () => {
+    const store = new InMemoryStore()
+    const checkpointStore = new FailingSetStore()
+    const scripted = scriptedAdapter(['first output', 'second output'])
+    const events: OrchestratorEvent[] = []
+    const orchestrator = new OpenMultiAgent({
+      onProgress(event) {
+        events.push(event)
+      },
+    })
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+      sharedMemoryStore: store,
+    })
+
+    const result = await orchestrator.runTasks(team, tasks, {
+      checkpoint: { store: checkpointStore },
+    })
+
+    // Both tasks ran to completion even though every checkpoint write rejected.
+    expect(scripted.calls()).toBe(2)
+    expect(result.tasks?.map((record) => record.status)).toEqual(['completed', 'completed'])
+    expect(checkpointStore.setCalls).toBeGreaterThan(0)
+
+    // The failure is reported through onProgress, not swallowed.
+    const failures = events.filter(
+      (event) =>
+        event.type === 'error' &&
+        (event.data as { kind?: string } | undefined)?.kind === 'checkpoint_save_failed',
+    )
+    expect(failures.length).toBeGreaterThan(0)
+  })
+
+  it('requires a runId or explicit store when the team has no shared-memory store', async () => {
+    const scripted = scriptedAdapter(['only output'])
+    const team = new Team({ name: 'team', agents: [worker('worker', scripted.adapter)] })
+    const orchestrator = new OpenMultiAgent()
+
+    await expect(
+      orchestrator.runTasks(
+        team,
+        [{ title: 'only', description: 'do it', assignee: 'worker' }],
+        { checkpoint: true },
+      ),
+    ).rejects.toThrow(/runId/)
+    // Rejected before any agent work happened.
+    expect(scripted.calls()).toBe(0)
+  })
+
+  it('accepts a runId without an explicit store and resumes from the fallback store', async () => {
+    const scripted = scriptedAdapter(['first output', 'second output'])
+    const abort = new AbortController()
+    const orchestrator = new OpenMultiAgent({
+      onProgress(event) {
+        if (event.type === 'task_complete') abort.abort()
+      },
+    })
+    const team = new Team({ name: 'team', agents: [worker('worker', scripted.adapter)] })
+
+    await orchestrator.runTasks(team, tasks, {
+      abortSignal: abort.signal,
+      checkpoint: { runId: 'run-1' },
+    })
+    expect(scripted.calls()).toBe(1)
+
+    // Same orchestrator instance, so the in-memory fallback store survives; the
+    // runId-derived key lets the second run find the first run's checkpoint.
+    const resumedTeam = new Team({ name: 'team', agents: [worker('worker', scripted.adapter)] })
+    const result = await orchestrator.restore(resumedTeam, { checkpoint: { runId: 'run-1' } })
 
     expect(scripted.calls()).toBe(2)
     expect(result.tasks?.map((record) => record.status)).toEqual(['completed', 'completed'])

--- a/tests/checkpoint.test.ts
+++ b/tests/checkpoint.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from 'vitest'
+import { Checkpoint, CHECKPOINT_KEY_PREFIX, isCheckpointKey } from '../src/memory/checkpoint.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import { SharedMemory } from '../src/memory/shared.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { TaskQueue } from '../src/task/queue.js'
+import { createTask } from '../src/task/task.js'
+import { Team } from '../src/team/team.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMChatOptions,
+  LLMMessage,
+  LLMResponse,
+  MemoryEntry,
+  MemoryStore,
+  RunTaskSpec,
+} from '../src/types.js'
+
+function textResponse(text: string, model: string): LLMResponse {
+  return {
+    id: `resp-${text}`,
+    content: [{ type: 'text', text }],
+    model,
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function scriptedAdapter(outputs: string[]) {
+  const prompts: string[] = []
+  let callCount = 0
+  const adapter: LLMAdapter = {
+    name: 'checkpoint-test',
+    async chat(messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
+      const prompt = [...messages].reverse()
+        .find((message) => message.role === 'user')
+        ?.content
+        .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+        .map((block) => block.text)
+        .join('\n') ?? ''
+      prompts.push(prompt)
+      const output = outputs[callCount] ?? `output-${callCount}`
+      callCount++
+      return textResponse(output, options.model)
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: textResponse('stream-unused', 'mock-model') }
+    },
+  }
+
+  return {
+    adapter,
+    prompts,
+    calls: () => callCount,
+  }
+}
+
+function worker(name: string, adapter: LLMAdapter): AgentConfig {
+  return { name, model: 'mock-model', adapter, systemPrompt: `You are ${name}.` }
+}
+
+function task(id: string, opts: { dependsOn?: string[]; assignee?: string } = {}) {
+  const created = createTask({ title: id, description: `task ${id}`, assignee: opts.assignee })
+  return { ...created, id, dependsOn: opts.dependsOn } as ReturnType<typeof createTask>
+}
+
+class AsyncMapStore implements MemoryStore {
+  readonly data = new Map<string, MemoryEntry>()
+
+  async get(key: string): Promise<MemoryEntry | null> {
+    return this.data.get(key) ?? null
+  }
+
+  async set(key: string, value: string, metadata?: Record<string, unknown>): Promise<void> {
+    const existing = this.data.get(key)
+    this.data.set(key, {
+      key,
+      value,
+      metadata,
+      createdAt: existing?.createdAt ?? new Date(),
+    })
+  }
+
+  async setWithExpiry(
+    key: string,
+    value: string,
+    expiresAtTurn: number,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    const existing = this.data.get(key)
+    this.data.set(key, {
+      key,
+      value,
+      metadata,
+      createdAt: existing?.createdAt ?? new Date(),
+      expiresAtTurn,
+    })
+  }
+
+  async list(): Promise<MemoryEntry[]> {
+    return Array.from(this.data.values())
+  }
+
+  async delete(key: string): Promise<void> {
+    this.data.delete(key)
+  }
+
+  async clear(): Promise<void> {
+    this.data.clear()
+  }
+}
+
+async function deleteNonCheckpointEntries(store: MemoryStore): Promise<void> {
+  for (const entry of await store.list()) {
+    if (!isCheckpointKey(entry.key)) {
+      await store.delete(entry.key)
+    }
+  }
+}
+
+describe('checkpoint snapshots', () => {
+  it('TaskQueue snapshot round-trips pending, in-progress, and completed partitions', () => {
+    const queue = new TaskQueue()
+    queue.add(task('a'))
+    queue.add(task('b'))
+    queue.add(task('c', { dependsOn: ['a'] }))
+    queue.update('b', { status: 'in_progress' })
+    queue.complete('a', 'done a')
+
+    const snapshot = queue.snapshot()
+    const restored = TaskQueue.fromSnapshot(snapshot)
+
+    expect(restored.snapshot().pending).toEqual(snapshot.pending)
+    expect(restored.snapshot().inProgress).toEqual(snapshot.inProgress)
+    expect(restored.snapshot().completed).toEqual(snapshot.completed)
+    expect(restored.get('a')?.result).toBe('done a')
+  })
+
+  it('TaskQueue restore can make in-progress work runnable again', () => {
+    const queue = new TaskQueue()
+    queue.add(task('a'))
+    queue.update('a', { status: 'in_progress' })
+
+    const restored = TaskQueue.fromSnapshot(queue.snapshot(), { resetInProgress: true })
+    expect(restored.get('a')?.status).toBe('pending')
+  })
+
+  it('SharedMemory snapshot/restore preserves entries and turn count', async () => {
+    const memory = new SharedMemory()
+    await memory.write('agent', 'plain', 'value', { source: 'test' })
+    await memory.write('agent', 'structured', { ok: true, count: 2 })
+    await memory.writeExpiring('agent', 'ttl', 'short', 3)
+    memory.advanceTurn()
+
+    const snapshot = await memory.snapshot()
+    const restored = await SharedMemory.fromSnapshot(snapshot)
+
+    expect(restored.getTurnCount()).toBe(1)
+    expect((await restored.read('agent/plain'))?.value).toBe('value')
+    expect((await restored.read('agent/plain'))?.metadata).toMatchObject({ source: 'test' })
+    expect((await restored.read('agent/structured'))?.value).toEqual({ ok: true, count: 2 })
+    expect((await restored.read('agent/ttl'))?.value).toBe('short')
+  })
+
+  it('Checkpoint persists and loads snapshots through MemoryStore only', async () => {
+    const store = new AsyncMapStore()
+    const checkpoint = new Checkpoint(store, { runId: 'custom' })
+    const queue = new TaskQueue()
+    queue.add(task('a'))
+    queue.complete('a', 'done')
+
+    await checkpoint.save({
+      version: 1,
+      mode: 'runTasks',
+      createdAt: new Date().toISOString(),
+      runId: 'custom',
+      queue: queue.snapshot(),
+      completedTaskResults: [{ taskId: 'a', result: 'done' }],
+    })
+
+    expect((await store.list()).map((entry) => entry.key)).toEqual([
+      `${CHECKPOINT_KEY_PREFIX}custom/latest`,
+    ])
+    expect((await checkpoint.loadLatest())?.queue.completed).toEqual(['a'])
+  })
+})
+
+describe('OpenMultiAgent checkpoint/restore', () => {
+  const tasks: RunTaskSpec[] = [
+    { title: 'first', description: 'do first', assignee: 'worker' },
+    { title: 'second', description: 'do second', assignee: 'worker', dependsOn: ['first'] },
+  ]
+
+  it('does not write checkpoint keys when checkpointing is not enabled', async () => {
+    const store = new InMemoryStore()
+    const scripted = scriptedAdapter(['done'])
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+      sharedMemoryStore: store,
+    })
+    const orchestrator = new OpenMultiAgent()
+
+    await orchestrator.runTasks(team, [
+      { title: 'only', description: 'do it', assignee: 'worker' },
+    ])
+
+    expect((await store.list()).some((entry) => isCheckpointKey(entry.key))).toBe(false)
+  })
+
+  it('restores after an aborted run, skips completed tasks, and rehydrates shared memory', async () => {
+    const store = new InMemoryStore()
+    const scripted = scriptedAdapter(['first output', 'second output'])
+    const abort = new AbortController()
+    const orchestrator = new OpenMultiAgent({
+      onProgress(event) {
+        if (event.type === 'task_complete') {
+          abort.abort()
+        }
+      },
+    })
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+      sharedMemoryStore: store,
+    })
+    await team.getSharedMemoryInstance()!.write('seed', 'note', { keep: true })
+
+    await orchestrator.runTasks(team, tasks, {
+      abortSignal: abort.signal,
+      checkpoint: { store },
+    })
+    expect(scripted.calls()).toBe(1)
+
+    await deleteNonCheckpointEntries(store)
+
+    const resumedTeam = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+      sharedMemoryStore: store,
+    })
+    const restored = await orchestrator.restore(resumedTeam, { checkpoint: { store } })
+
+    expect(scripted.calls()).toBe(2)
+    expect(scripted.prompts[1]).toContain('first output')
+    expect(restored.tasks?.map((record) => [record.title, record.status])).toEqual([
+      ['first', 'completed'],
+      ['second', 'completed'],
+    ])
+    expect((await resumedTeam.getSharedMemoryInstance()!.read('seed/note'))?.value).toEqual({ keep: true })
+  })
+
+  it('restore against an empty store starts a fresh task run', async () => {
+    const store = new InMemoryStore()
+    const scripted = scriptedAdapter(['fresh output'])
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+      sharedMemoryStore: store,
+    })
+    const orchestrator = new OpenMultiAgent()
+
+    const result = await orchestrator.restore(team, [
+      { title: 'fresh', description: 'start fresh', assignee: 'worker' },
+    ], { checkpoint: { store } })
+
+    expect(scripted.calls()).toBe(1)
+    expect(result.tasks?.[0]?.status).toBe('completed')
+    expect((await store.list()).some((entry) => isCheckpointKey(entry.key))).toBe(true)
+  })
+
+  it('checkpoint/restore works with a custom async MemoryStore', async () => {
+    const store = new AsyncMapStore()
+    const scripted = scriptedAdapter(['first output', 'second output'])
+    const abort = new AbortController()
+    const orchestrator = new OpenMultiAgent({
+      onProgress(event) {
+        if (event.type === 'task_complete') abort.abort()
+      },
+    })
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+      sharedMemoryStore: store,
+    })
+
+    await orchestrator.runTasks(team, tasks, {
+      abortSignal: abort.signal,
+      checkpoint: { store },
+    })
+
+    const resumedTeam = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+      sharedMemoryStore: store,
+    })
+    const result = await orchestrator.restore(resumedTeam, { checkpoint: { store } })
+
+    expect(result.tasks?.every((record) => record.status === 'completed')).toBe(true)
+    expect(scripted.calls()).toBe(2)
+  })
+
+  it('restore after the final checkpoint is a no-op', async () => {
+    const store = new InMemoryStore()
+    const scripted = scriptedAdapter(['first output', 'second output'])
+    const orchestrator = new OpenMultiAgent()
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+      sharedMemoryStore: store,
+    })
+
+    await orchestrator.runTasks(team, tasks, { checkpoint: { store } })
+    expect(scripted.calls()).toBe(2)
+
+    const resumedTeam = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+      sharedMemoryStore: store,
+    })
+    const result = await orchestrator.restore(resumedTeam, { checkpoint: { store } })
+
+    expect(scripted.calls()).toBe(2)
+    expect(result.tasks?.map((record) => record.status)).toEqual(['completed', 'completed'])
+  })
+})


### PR DESCRIPTION
## Summary
Adds durable run-level checkpoint/resume so a long-running workflow can be saved and continued, built entirely on the existing `MemoryStore` API.

## Why this matters
Requested in #20 (reopened, bumped to P1): only task-level retry existed, with no way to persist and resume a whole run. This adds a first slice: a `Checkpoint` manager that snapshots run state to the memory store under a reserved key namespace, and orchestrator/queue integration to save on progress and restore on start. Because it depends only on the public `MemoryStore` interface, in-memory, Redis, SQLite, and custom backends all work without extra hooks.

## Changes
- New `memory/checkpoint.ts`: `Checkpoint` class, namespaced keys, snapshot save/load.
- `types.ts`: `CheckpointOptions`, `CheckpointSnapshot`, `RestoreOptions`.
- Orchestrator + task queue: save a checkpoint as tasks complete; restore from a snapshot on resume.

## Scope
This is the first slice: per-run snapshot/restore over `MemoryStore`. Backend-specific durability guarantees and finer-grained mid-task checkpointing are intentionally left for follow-ups so the core API can be reviewed first.

Refs #20

AI was used for assistance.
