### PR TITLE
docs(examples): add TencentDB-Agent-Memory integration cookbook

### DIFF
--- a/examples/integrations/README.md
+++ b/examples/integrations/README.md
@@ -21,6 +21,8 @@ the contributor. Current:
 
 - `with-engram/`: Engram memory backend. Contributed by
   [@Agentscreator](https://github.com/Agentscreator) via #160.
+- `with-tencentdb-memory/`: TencentDB-Agent-Memory long-term memory (L0→L3
+  pipeline) via its Hermes Gateway sidecar.
 
 ## Submitting a reference integration
 

--- a/examples/integrations/with-tencentdb-memory/README.md
+++ b/examples/integrations/with-tencentdb-memory/README.md
@@ -1,0 +1,255 @@
+# OMA + TencentDB-Agent-Memory
+
+Long-term memory for OMA teams, backed by
+[TencentDB-Agent-Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory)
+(TDAM) — Tencent Cloud's open-source agent memory system. TDAM distills raw
+conversations through a layered pipeline (L0 conversations → L1 atomic facts →
+L2 scenes → L3 persona), stores everything locally in SQLite + sqlite-vec, and
+retrieves with BM25 + vector hybrid search.
+
+TDAM has no general-purpose SDK; third-party frameworks integrate through its
+**Hermes Gateway** — an HTTP sidecar (default `127.0.0.1:8420`) exposing
+capture / search / recall endpoints. This example wires OMA to that Gateway:
+
+| File | What it does |
+|------|--------------|
+| [`tdam-store.ts`](tdam-store.ts) | `MemoryStore` implementation for `TeamConfig.sharedMemoryStore`. Task results written to shared memory are auto-captured into TDAM; recall/search/flush helpers pull long-term memory back. |
+| [`tdam-toolkit.ts`](tdam-toolkit.ts) | Two `defineTool()` tools (`tdam_search_memories`, `tdam_search_conversations`) so agents can query long-term memory mid-task. |
+| [`team-with-memory.ts`](team-with-memory.ts) | Runnable demo: recall → `runTeam()` with auto-capture → flush extraction → search distilled memories. Run it twice to see cross-run persistence. |
+
+## How the mapping works
+
+OMA's `MemoryStore` is a key-value contract; the TDAM Gateway is a
+distillation pipeline with **no read-a-value-back-by-key endpoint** (its
+`/search/*` and `/recall` return formatted text, not raw records). Forcing KV
+reads through search would corrupt the orchestrator's shared-memory plumbing,
+so the store splits responsibilities:
+
+- **Within a run** — `get` / `list` / `delete` / `clear` are served from a
+  local in-process map, exactly like the default `InMemoryStore`. Task-result
+  injection and team summaries behave identically.
+- **Write-through capture** — every `set()` also `POST /capture`s the entry as
+  a conversation turn, with the stored value spoken **user-side** by the
+  writing agent. That phrasing matters: TDAM's L1 extractor is user-centric
+  by design (it distills persona / episodic / instruction memories about the
+  user and explicitly ignores assistant output), so team results reported as
+  user content are what survive as long-term memories.
+- **Across runs** — a fresh process starts with an empty local map, then
+  `recall(topic)` pulls the distilled memories from previous runs and the
+  example injects them into agent system prompts (the same prefetch pattern
+  TDAM's own Hermes plugin uses).
+
+Two consequences worth knowing before you build on it:
+
+- Capture → searchable is **asynchronous**: TDAM records L0 immediately but
+  extracts L1 facts on a schedule — every `memory.pipeline.everyNConversations`
+  captures (default 5, with warm-up) or a 600s idle timer, whichever fires
+  first. In TDAM v0.3.6, `POST /session/end` drains extraction already in
+  flight but does **not** force extraction of turns still below the count
+  threshold. This example therefore runs the Gateway with
+  `everyNConversations: 1` (see below) so every capture extracts immediately
+  and `endSession()` reliably means "everything captured is now searchable".
+  Budget real LLM latency for it — extraction calls the Gateway's configured
+  model.
+- `delete()` / `clear()` only affect the local map. The Gateway has no delete
+  endpoint; captured history stays in TDAM as pipeline raw material.
+
+## Start the Gateway
+
+The Gateway needs an LLM for its extraction pipeline — any OpenAI-compatible
+endpoint works. This example is **verified against TDAM v0.3.6**
+(`@tencentdb-agent-memory/memory-tencentdb@0.3.6`; endpoint schemas from its
+`src/gateway/types.ts`).
+
+### Option A — npm package, version-pinned (what this example is verified with)
+
+The npm package ships the Gateway source; run it with `tsx` (Node ≥ 22):
+
+```bash
+mkdir tdam-gateway && cd tdam-gateway
+npm install @tencentdb-agent-memory/memory-tencentdb@0.3.6 tsx
+
+# Demo pipeline config: distill after every capture instead of batching
+# every 5 conversations, so endSession() deterministically covers all writes.
+cat > tdai-gateway.yaml << 'EOF'
+memory:
+  pipeline:
+    everyNConversations: 1
+EOF
+
+# LLM used by TDAM's extraction pipeline (any OpenAI-compatible endpoint).
+export TDAI_LLM_BASE_URL="https://api.deepseek.com/v1"
+export TDAI_LLM_API_KEY="sk-..."
+export TDAI_LLM_MODEL="deepseek-v4-flash"
+export TDAI_DATA_DIR="$PWD/tdai-data"     # where SQLite memories live
+
+npx tsx node_modules/@tencentdb-agent-memory/memory-tencentdb/src/gateway/server.ts
+```
+
+The Gateway picks up `tdai-gateway.yaml` from the directory it starts in (or
+from `TDAI_DATA_DIR`, or an explicit `TDAI_GATEWAY_CONFIG` path). Any
+OpenAI-compatible `TDAI_LLM_*` endpoint works — `https://api.openai.com/v1`
+with `gpt-4o`, a local Ollama server, etc. Note the Anthropic API is not
+OpenAI-compatible, so an Anthropic key can drive your OMA agents but not the
+Gateway's extraction pipeline.
+
+Verify: `curl http://127.0.0.1:8420/health`. With the default SQLite backend
+and no embedding service this returns
+`{"status":"ok",...,"stores":{"vectorStore":true,"embeddingService":false}}` —
+retrieval then runs on BM25 keyword search, which is enough for this example.
+(`status:"degraded"` means the store failed to initialize; check the Gateway
+log.)
+
+### Option B — Docker (upstream's official image)
+
+Upstream ships a combined Hermes-agent + Gateway image. From a clone of
+[TencentCloud/TencentDB-Agent-Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory)
+at tag `v0.3.6`:
+
+```bash
+git clone --branch v0.3.6 --depth 1 \
+  https://github.com/TencentCloud/TencentDB-Agent-Memory
+cd TencentDB-Agent-Memory/docker/opensource
+
+docker build -f Dockerfile.hermes -t hermes-memory .
+
+docker run -d \
+  --name hermes-memory \
+  --restart unless-stopped \
+  -p 8420:8420 \
+  -e MODEL_API_KEY="your-api-key" \
+  -e MODEL_BASE_URL="https://api.lkeap.cloud.tencent.com/v1" \
+  -e MODEL_NAME="deepseek-v3.2" \
+  -e MODEL_PROVIDER="custom" \
+  -v hermes_data:/opt/data \
+  hermes-memory
+
+curl http://localhost:8420/health
+```
+
+`MODEL_*` is the LLM the Gateway extracts memories with — the defaults point
+at Tencent Cloud's DeepSeek endpoint; any OpenAI-compatible
+`MODEL_BASE_URL`/`MODEL_NAME` works. For the per-capture extraction this
+example expects, drop the same `tdai-gateway.yaml` from Option A into the
+volume's data directory (`/opt/data/tdai-memory/` — the image's
+`TDAI_DATA_DIR`, one of the locations the Gateway's config loader checks).
+
+Two caveats. The upstream Dockerfile installs the Gateway from npm `@latest`
+at **build** time, so the image tracks whatever is newest even on a `v0.3.6`
+checkout — for a strictly pinned Gateway, use Option A. And this example was
+verified against the Option A Gateway (the image runs the same npm-package
+server source, but the image build itself was not exercised here).
+
+## Authentication
+
+Gateway auth is opt-in Bearer token, off by default:
+
+- **Gateway side** — set `TDAI_GATEWAY_API_KEY=<secret>` in the Gateway's
+  environment (or `server.apiKey` in `tdai-gateway.yaml`). Every route except
+  `GET /health` then requires `Authorization: Bearer <secret>` and returns
+  `401` otherwise.
+- **OMA side** — export the same `TDAI_GATEWAY_API_KEY` before running the
+  example; `TdamMemoryStore` and `TdamToolkit` pick it up automatically (or
+  pass `apiKey` to their constructors). When unset, no auth header is sent,
+  matching the Gateway's open default.
+
+Leave auth off only while the Gateway binds to `127.0.0.1` (its default).
+Bind to anything wider and the Gateway itself logs a warning until a key is
+set.
+
+## Run the example
+
+```bash
+# Hosted provider (default: anthropic / claude-sonnet-4-6)
+ANTHROPIC_API_KEY=sk-... npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+
+# Fully local (agents + Gateway extraction all on Ollama)
+AGENT_PROVIDER=openai AGENT_MODEL=qwen3.5:9b-mlx AGENT_BASE_URL=http://localhost:11434/v1 \
+  npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+```
+
+| Env var | Default | Purpose |
+|---------|---------|---------|
+| `AGENT_PROVIDER` / `AGENT_MODEL` | `anthropic` / `claude-sonnet-4-6` | Provider + model for the agents and coordinator |
+| `AGENT_BASE_URL` / `AGENT_API_KEY` | — / `local` | OpenAI-compatible server (Ollama, vLLM, …) with `AGENT_PROVIDER=openai` |
+| `TDAM_GATEWAY_URL` | `http://127.0.0.1:8420` | Hermes Gateway address |
+| `TDAM_SESSION_KEY` | `oma-memory-demo` | TDAM session the captures land in |
+| `TDAI_GATEWAY_API_KEY` | unset | Bearer token, when the Gateway has auth enabled |
+
+**Run it twice.** The first run starts with no long-term memory, captures the
+team's task results, and flushes extraction. The second run recalls the
+distilled facts and injects them into the agents' prompts.
+
+### Verified run
+
+Real output from the verification setup: TDAM v0.3.6 Gateway (npm package,
+`everyNConversations: 1`, Bearer auth enabled end-to-end), agents and
+extraction both on `deepseek-v4-flash`.
+
+First run — no memories yet; captures distill into one episodic memory:
+
+```text
+[1/4] Recalling long-term memory for the topic...
+  No long-term memories yet (first run against this Gateway).
+
+[2/4] Running the team (shared-memory writes auto-capture into TDAM)...
+  Team run succeeded.
+  [... recommendation memo ...]
+
+[3/4] Captured 2/2 shared-memory writes into TDAM (4 L0 records). Flushing L1 extraction...
+  Flush complete in 0.0s.
+
+[4/4] Searching distilled L1 memories...
+  1 memories match (strategy: fts).
+
+- **[episodic]** (priority: 80) [scene: Receiving analyst's completed work report on SQLite vs PostgreSQL comparison]
+  The user (analyst) reported completed work comparing SQLite and PostgreSQL
+  for agent memory stores, concluding that SQLite is preferable for real-time
+  latency and simplicity, while PostgreSQL is better for multi-agent
+  concurrency and scalability.
+```
+
+Second run — recall feeds the distilled memory forward, and TDAM merges the
+new run's results into an upgraded memory:
+
+```text
+[1/4] Recalling long-term memory for the topic...
+  Recalled 1 memories (strategy: hybrid) — injecting into agent prompts.
+
+[2/4] Running the team (shared-memory writes auto-capture into TDAM)...
+  Team run succeeded.
+  [... memo now builds on the recalled findings instead of repeating them ...]
+
+[3/4] Captured 2/2 shared-memory writes into TDAM (4 L0 records). Flushing L1 extraction...
+  Flush complete in 49.9s.
+
+[4/4] Searching distilled L1 memories...
+  1 memories match (strategy: fts).
+
+- **[episodic]** (priority: 85) [scene: Receiving writer's completed memorandum on storage choice for AI agent memory]
+  The open-multi-agent team completed work on storage choice for AI agent
+  memory: the analyst completed an analysis comparing SQLite and PostgreSQL
+  [...] the writer completed a memorandum recommending SQLite for
+  single-agent local workloads and PostgreSQL for multi-agent concurrent
+  systems.
+```
+
+Timings and exact memory text vary by model. Note the flush asymmetry: in run
+one extraction had already completed inline before `endSession()` (hence
+0.0s); in run two the captures were still queued and the call genuinely
+waited for the extraction LLM (49.9s).
+
+## Troubleshooting
+
+- **`Cannot reach the TDAM Gateway`** — the Gateway isn't running, or
+  `TDAM_GATEWAY_URL` points elsewhere. `curl <url>/health` to check; the
+  health route never needs auth.
+- **`401 Unauthorized`** — the Gateway has `TDAI_GATEWAY_API_KEY` set but the
+  example doesn't (or the values differ). Export the same secret on both ends.
+- **`[4/4]` finds 0 memories** — extraction quality depends on the Gateway's
+  `TDAI_LLM_MODEL`; very small local models occasionally produce no
+  extractable facts from a single session. Re-run, or point the Gateway at a
+  stronger model.
+- **Flush is slow** — `endSession()` waits for real LLM extraction calls.
+  On local models budget minutes, not seconds (`flushTimeoutMs` defaults to
+  300s).

--- a/examples/integrations/with-tencentdb-memory/tdam-store.ts
+++ b/examples/integrations/with-tencentdb-memory/tdam-store.ts
@@ -1,0 +1,319 @@
+/**
+ * TencentDB-Agent-Memory (TDAM) Memory Store
+ *
+ * A {@link MemoryStore} implementation that pairs the team's shared memory
+ * with TencentDB-Agent-Memory's Hermes Gateway — an HTTP sidecar in front of
+ * TDAM's layered memory pipeline (L0 raw conversations → L1 atomic facts →
+ * L2 scenes → L3 persona, SQLite + sqlite-vec, BM25 + vector hybrid search).
+ *
+ * The Gateway is a distillation pipeline, not a key-value database: it has no
+ * endpoint that reads a stored value back by key (`/search/*` and `/recall`
+ * return formatted text, not raw records). So this store keeps exact KV
+ * semantics in a local in-process map and treats TDAM as the durable
+ * long-term layer:
+ *
+ *   - `get` / `list` / `delete` / `clear` — served from the local map, so the
+ *     orchestrator's shared-memory plumbing (task-result injection, summaries)
+ *     behaves exactly like the default {@link InMemoryStore}.
+ *   - `set` — writes the local map **and** captures the entry into TDAM via
+ *     `POST /capture`. TDAM's background pipeline distills captured turns
+ *     into searchable long-term memories.
+ *   - `recall` / `searchMemories` / `searchConversations` / `endSession` —
+ *     TDAM-specific helpers for pulling long-term memory back into a new run
+ *     and for flushing extraction at the end of one.
+ *
+ * Within a single run the local map is the source of truth; across runs the
+ * distilled TDAM memories are what persist.
+ *
+ * Run:
+ *   npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+ *
+ * Prerequisites:
+ *   - TDAM Hermes Gateway running at http://127.0.0.1:8420 (see README.md)
+ *   - TDAI_GATEWAY_API_KEY env var if the Gateway has Bearer auth enabled
+ *
+ * Verified against TencentDB-Agent-Memory v0.3.6
+ * (`@tencentdb-agent-memory/memory-tencentdb@0.3.6`, gateway schema from
+ * `src/gateway/types.ts`).
+ */
+
+import type { MemoryEntry, MemoryStore } from '../../../src/types.js'
+
+// ---------------------------------------------------------------------------
+// Gateway wire types (mirror src/gateway/types.ts @ v0.3.6)
+// ---------------------------------------------------------------------------
+
+export interface TdamHealth {
+  status: 'ok' | 'degraded'
+  version: string
+  uptime: number
+  stores: { vectorStore: boolean; embeddingService: boolean }
+}
+
+interface CaptureResponse {
+  l0_recorded: number
+  scheduler_notified: boolean
+}
+
+export interface TdamRecallResult {
+  /** Pre-formatted context block, designed for system-prompt injection. */
+  context: string
+  strategy?: string
+  memory_count?: number
+}
+
+export interface TdamMemorySearchResult {
+  /** Pre-formatted text of matching L1 memories (not raw records). */
+  results: string
+  total: number
+  strategy: string
+}
+
+export interface TdamConversationSearchResult {
+  /** Pre-formatted text of matching L0 conversation turns. */
+  results: string
+  total: number
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface TdamStoreOptions {
+  /** Hermes Gateway URL. Defaults to `http://127.0.0.1:8420`. */
+  baseUrl?: string
+  /**
+   * Bearer token, required only when the Gateway sets `TDAI_GATEWAY_API_KEY`.
+   * Falls back to the same `TDAI_GATEWAY_API_KEY` env var so one variable can
+   * configure both ends. When empty, no Authorization header is sent (the
+   * Gateway's open default).
+   */
+  apiKey?: string
+  /**
+   * TDAM session key. All captures from this store land in one Gateway
+   * session; `endSession()` flushes exactly this session's extraction.
+   */
+  sessionKey?: string
+  /** Timeout for capture/recall/search calls. Defaults to 60s. */
+  requestTimeoutMs?: number
+  /**
+   * Timeout for `endSession()`. The Gateway drains L1 extraction (real LLM
+   * calls) before responding, so this is generous by default: 300s.
+   */
+  flushTimeoutMs?: number
+}
+
+// ---------------------------------------------------------------------------
+// TdamMemoryStore
+// ---------------------------------------------------------------------------
+
+export class TdamMemoryStore implements MemoryStore {
+  private readonly baseUrl: string
+  private readonly apiKey: string
+  private readonly sessionKey: string
+  private readonly requestTimeoutMs: number
+  private readonly flushTimeoutMs: number
+
+  private readonly entries = new Map<string, MemoryEntry>()
+  private captureAttempted = 0
+  private captureSucceeded = 0
+  private l0Recorded = 0
+
+  constructor(options: TdamStoreOptions = {}) {
+    this.baseUrl = (options.baseUrl ?? 'http://127.0.0.1:8420').replace(/\/+$/, '')
+    this.apiKey = options.apiKey ?? process.env.TDAI_GATEWAY_API_KEY ?? ''
+    this.sessionKey = options.sessionKey ?? 'oma-shared-memory'
+    this.requestTimeoutMs = options.requestTimeoutMs ?? 60_000
+    this.flushTimeoutMs = options.flushTimeoutMs ?? 300_000
+  }
+
+  // ---------------------------------------------------------------------------
+  // MemoryStore interface
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Store the value locally and capture it into TDAM as a conversation turn.
+   *
+   * The capture is phrased as a user/assistant exchange because that is the
+   * Gateway's input unit (`user_content` + `assistant_content`). The value —
+   * typically a task result written by the orchestrator — goes in the **user**
+   * slot, spoken by the agent: TDAM's L1 extractor is user-centric by design
+   * (it distills persona / episodic / instruction memories about the user and
+   * explicitly ignores assistant output), so results reported user-side are
+   * what become long-term memories.
+   *
+   * A Gateway failure degrades to local-only storage with a console warning;
+   * it never fails the team run.
+   */
+  async set(key: string, value: string, metadata?: Record<string, unknown>): Promise<void> {
+    this.storeLocal(key, value, metadata)
+    await this.capture(key, value, metadata)
+  }
+
+  /** Like {@link set}, with the turn-count expiry kept on the local entry. */
+  async setWithExpiry(
+    key: string,
+    value: string,
+    expiresAtTurn: number,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    this.storeLocal(key, value, metadata, expiresAtTurn)
+    await this.capture(key, value, metadata)
+  }
+
+  /** Exact read-back from the local map (the Gateway has no KV read API). */
+  async get(key: string): Promise<MemoryEntry | null> {
+    return this.entries.get(key) ?? null
+  }
+
+  /** All entries written during this run, in insertion order. */
+  async list(): Promise<MemoryEntry[]> {
+    return [...this.entries.values()]
+  }
+
+  /**
+   * Remove the local entry. Already-captured turns stay in TDAM — the
+   * Gateway exposes no delete endpoint, and TDAM treats captured history
+   * as the raw material for its memory pipeline.
+   */
+  async delete(key: string): Promise<void> {
+    this.entries.delete(key)
+  }
+
+  /** Clear the local map. TDAM keeps its captured history (see {@link delete}). */
+  async clear(): Promise<void> {
+    this.entries.clear()
+  }
+
+  // ---------------------------------------------------------------------------
+  // TDAM-specific operations
+  // ---------------------------------------------------------------------------
+
+  /** `GET /health` — never requires auth. Throws when the Gateway is down. */
+  async health(): Promise<TdamHealth> {
+    const res = await fetch(`${this.baseUrl}/health`, {
+      signal: AbortSignal.timeout(this.requestTimeoutMs),
+    })
+    if (!res.ok) throw new Error(`TDAM /health failed (${res.status})`)
+    return (await res.json()) as TdamHealth
+  }
+
+  /**
+   * `POST /recall` — fetch long-term context for a query, scoped to this
+   * store's session key. The returned `context` is pre-formatted for direct
+   * injection into an agent system prompt; it is empty when TDAM has no
+   * relevant memories yet (e.g. on the very first run).
+   */
+  async recall(query: string): Promise<TdamRecallResult> {
+    return await this.post<TdamRecallResult>('/recall', {
+      query,
+      session_key: this.sessionKey,
+    })
+  }
+
+  /** `POST /search/memories` — hybrid search over distilled L1 memories. */
+  async searchMemories(query: string, limit = 5): Promise<TdamMemorySearchResult> {
+    return await this.post<TdamMemorySearchResult>('/search/memories', { query, limit })
+  }
+
+  /** `POST /search/conversations` — search raw L0 conversation history. */
+  async searchConversations(query: string, limit = 5): Promise<TdamConversationSearchResult> {
+    return await this.post<TdamConversationSearchResult>('/search/conversations', {
+      query,
+      limit,
+      session_key: this.sessionKey,
+    })
+  }
+
+  /**
+   * `POST /session/end` — wait for this session's pending L1 extraction to
+   * drain (real LLM calls), then resolve.
+   *
+   * Caveat (TDAM v0.3.6): captures arriving over the Gateway's HTTP API are
+   * scheduled by **conversation count** (`memory.pipeline.everyNConversations`,
+   * default 5, with warm-up) or by a 600s idle timer — `/session/end` drains
+   * extraction already in flight but does not force extraction of turns below
+   * the count threshold. Run the Gateway with `everyNConversations: 1` (see
+   * README) to extract every capture immediately; then this call reliably
+   * means "all captures are distilled and searchable".
+   */
+  async endSession(): Promise<void> {
+    await this.post<{ flushed: boolean }>(
+      '/session/end',
+      { session_key: this.sessionKey },
+      this.flushTimeoutMs,
+    )
+  }
+
+  /** Capture accounting for observability (printed by the example). */
+  get captureStats(): { attempted: number; succeeded: number; l0Recorded: number } {
+    return {
+      attempted: this.captureAttempted,
+      succeeded: this.captureSucceeded,
+      l0Recorded: this.l0Recorded,
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private storeLocal(
+    key: string,
+    value: string,
+    metadata?: Record<string, unknown>,
+    expiresAtTurn?: number,
+  ): void {
+    this.entries.set(key, {
+      key,
+      value,
+      metadata,
+      createdAt: new Date(),
+      ...(expiresAtTurn !== undefined ? { expiresAtTurn } : {}),
+    })
+  }
+
+  private async capture(
+    key: string,
+    value: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    const agent = typeof metadata?.agent === 'string' ? metadata.agent : 'unknown-agent'
+    this.captureAttempted++
+    try {
+      const res = await this.post<CaptureResponse>('/capture', {
+        user_content:
+          `I'm "${agent}" from the open-multi-agent team. ` +
+          `Reporting my completed work:\n\n${value}`,
+        assistant_content: `Noted. I've recorded ${agent}'s results in the team's long-term memory.`,
+        session_key: this.sessionKey,
+      })
+      this.captureSucceeded++
+      this.l0Recorded += res.l0_recorded
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.warn(`[tdam-store] capture failed for "${key}" (local copy kept): ${msg}`)
+    }
+  }
+
+  private headers(): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`
+    return headers
+  }
+
+  private async post<T>(path: string, body: Record<string, unknown>, timeoutMs?: number): Promise<T> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: this.headers(),
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs ?? this.requestTimeoutMs),
+    })
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => '<no body>')
+      throw new Error(`TDAM ${path} failed (${res.status}): ${text}`)
+    }
+    return (await res.json()) as T
+  }
+}

--- a/examples/integrations/with-tencentdb-memory/tdam-toolkit.ts
+++ b/examples/integrations/with-tencentdb-memory/tdam-toolkit.ts
@@ -1,0 +1,127 @@
+/**
+ * TencentDB-Agent-Memory (TDAM) Toolkit
+ *
+ * Registers two TDAM search tools so agents can query the team's long-term
+ * memory on demand:
+ *
+ *   - `tdam_search_memories`      — distilled L1 facts (BM25 + vector hybrid)
+ *   - `tdam_search_conversations` — raw L0 conversation history
+ *
+ * Automatic capture and recall are handled by {@link TdamMemoryStore}; these
+ * tools cover the "agent decides mid-task that it needs to look something up"
+ * path.
+ *
+ * Run:
+ *   npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+ *
+ * Prerequisites:
+ *   - TDAM Hermes Gateway running at http://127.0.0.1:8420 (see README.md)
+ *   - TDAI_GATEWAY_API_KEY env var if the Gateway has Bearer auth enabled
+ *
+ * Verified against TencentDB-Agent-Memory v0.3.6.
+ */
+
+import { z } from 'zod'
+import { defineTool, ToolRegistry } from '../../../src/index.js'
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface TdamToolkitOptions {
+  /** Hermes Gateway URL. Defaults to `http://127.0.0.1:8420`. */
+  baseUrl?: string
+  /** Bearer token. Falls back to `TDAI_GATEWAY_API_KEY` env var. */
+  apiKey?: string
+}
+
+// ---------------------------------------------------------------------------
+// TdamToolkit
+// ---------------------------------------------------------------------------
+
+export class TdamToolkit {
+  private readonly baseUrl: string
+  private readonly apiKey: string
+
+  constructor(options: TdamToolkitOptions = {}) {
+    this.baseUrl = (options.baseUrl ?? 'http://127.0.0.1:8420').replace(/\/+$/, '')
+    this.apiKey = options.apiKey ?? process.env.TDAI_GATEWAY_API_KEY ?? ''
+  }
+
+  /** Register both TDAM tools with the given registry. */
+  registerAll(registry: ToolRegistry): void {
+    for (const tool of this.getTools()) {
+      registry.register(tool)
+    }
+  }
+
+  /**
+   * Returns both TDAM tool definitions as an array.
+   * Use this with `AgentConfig.customTools` so the orchestrator's per-agent
+   * registry picks them up automatically.
+   */
+  getTools() {
+    return [this.searchMemoriesTool(), this.searchConversationsTool()]
+  }
+
+  // ---------------------------------------------------------------------------
+  // Tool definitions
+  // ---------------------------------------------------------------------------
+
+  private searchMemoriesTool() {
+    return defineTool({
+      name: 'tdam_search_memories',
+      description:
+        'Search the team\'s long-term memory for distilled facts from previous ' +
+        'sessions. Use this when you need background the current conversation ' +
+        'does not contain — prior findings, decisions, or user preferences.',
+      inputSchema: z.object({
+        query: z.string().describe('What to search for'),
+        limit: z.number().int().min(1).max(20).optional().describe('Max results (default 5)'),
+      }),
+      execute: async (input) => {
+        const res = await fetch(`${this.baseUrl}/search/memories`, {
+          method: 'POST',
+          headers: this.headers(),
+          body: JSON.stringify({ query: input.query, limit: input.limit ?? 5 }),
+          signal: AbortSignal.timeout(60_000),
+        })
+        const data = await res.text()
+        return { data, isError: !res.ok }
+      },
+    })
+  }
+
+  private searchConversationsTool() {
+    return defineTool({
+      name: 'tdam_search_conversations',
+      description:
+        'Search the raw conversation history captured in long-term memory. ' +
+        'Use this to quote or verify exactly what was said in a previous session.',
+      inputSchema: z.object({
+        query: z.string().describe('What to search for'),
+        limit: z.number().int().min(1).max(20).optional().describe('Max results (default 5)'),
+      }),
+      execute: async (input) => {
+        const res = await fetch(`${this.baseUrl}/search/conversations`, {
+          method: 'POST',
+          headers: this.headers(),
+          body: JSON.stringify({ query: input.query, limit: input.limit ?? 5 }),
+          signal: AbortSignal.timeout(60_000),
+        })
+        const data = await res.text()
+        return { data, isError: !res.ok }
+      },
+    })
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private headers(): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    if (this.apiKey) headers.Authorization = `Bearer ${this.apiKey}`
+    return headers
+  }
+}

--- a/examples/integrations/with-tencentdb-memory/team-with-memory.ts
+++ b/examples/integrations/with-tencentdb-memory/team-with-memory.ts
@@ -1,0 +1,273 @@
+/**
+ * Team with TencentDB-Agent-Memory (orchestrated)
+ *
+ * A two-agent team runs via `runTeam()` with {@link TdamMemoryStore} plugged
+ * in as the team's `sharedMemoryStore`. One process run demonstrates the full
+ * memory loop; running the script a second time demonstrates persistence:
+ *
+ *   1. **Recall** — pull long-term context for the topic from previous runs
+ *      and inject it into both agents' system prompts (empty on the first run)
+ *   2. **Run** — the orchestrator's shared-memory writes (task results,
+ *      coordinator summaries) are captured into TDAM automatically
+ *   3. **Flush** — `endSession()` drains TDAM's L0 → L1 extraction so the
+ *      captured material becomes searchable
+ *   4. **Verify** — search distilled memories and print what TDAM extracted
+ *
+ * Works with every provider the framework supports. Set the provider and model
+ * via environment variables:
+ *
+ *   AGENT_PROVIDER  — anthropic | openai | gemini | grok | copilot | deepseek | minimax | azure-openai
+ *   AGENT_MODEL     — model name for the chosen provider
+ *   AGENT_BASE_URL  — optional; OpenAI-compatible server URL (Ollama, vLLM, …),
+ *                     use with AGENT_PROVIDER=openai
+ *   AGENT_API_KEY   — optional; key for AGENT_BASE_URL servers (default "local")
+ *
+ * Defaults to anthropic / claude-sonnet-4-6 when unset.
+ *
+ * Run:
+ *   npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+ *
+ * Examples:
+ *   # Anthropic (default)
+ *   ANTHROPIC_API_KEY=sk-... npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+ *
+ *   # Fully local: agents on Ollama, Gateway extraction also on Ollama
+ *   AGENT_PROVIDER=openai AGENT_MODEL=qwen3 AGENT_BASE_URL=http://localhost:11434/v1 \
+ *     npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+ *
+ * Prerequisites:
+ *   - TDAM Hermes Gateway running at http://127.0.0.1:8420 (see README.md)
+ *   - API key env var for your chosen provider (not needed for local servers)
+ *   - TDAI_GATEWAY_API_KEY env var if the Gateway has Bearer auth enabled
+ */
+
+import { OpenMultiAgent } from '../../../src/index.js'
+import type {
+  AgentConfig,
+  OrchestratorEvent,
+  SupportedProvider,
+} from '../../../src/index.js'
+import { TdamMemoryStore } from './tdam-store.js'
+import { TdamToolkit } from './tdam-toolkit.js'
+
+// ---------------------------------------------------------------------------
+// Provider / model configuration
+// ---------------------------------------------------------------------------
+
+const PROVIDER = (process.env.AGENT_PROVIDER ?? 'anthropic') as SupportedProvider
+const MODEL = process.env.AGENT_MODEL ?? 'claude-sonnet-4-6'
+const BASE_URL = process.env.AGENT_BASE_URL?.trim() || undefined
+const API_KEY = BASE_URL ? (process.env.AGENT_API_KEY?.trim() || 'local') : undefined
+
+const PROVIDER_ENV_KEYS: Record<string, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  openai: 'OPENAI_API_KEY',
+  gemini: 'GEMINI_API_KEY',
+  grok: 'XAI_API_KEY',
+  copilot: 'GITHUB_TOKEN',
+  deepseek: 'DEEPSEEK_API_KEY',
+  minimax: 'MINIMAX_API_KEY',
+  'azure-openai': 'AZURE_OPENAI_API_KEY',
+}
+
+// Hosted providers need their env key; OpenAI-compatible servers passed via
+// AGENT_BASE_URL authenticate with AGENT_API_KEY (or none at all).
+const envKey = PROVIDER_ENV_KEYS[PROVIDER]
+if (!BASE_URL && envKey && !process.env[envKey]?.trim()) {
+  console.error(`Missing ${envKey}: required for provider "${PROVIDER}".`)
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// TDAM-backed shared memory store
+// ---------------------------------------------------------------------------
+
+const GATEWAY_URL = process.env.TDAM_GATEWAY_URL ?? 'http://127.0.0.1:8420'
+
+const store = new TdamMemoryStore({
+  baseUrl: GATEWAY_URL,
+  sessionKey: process.env.TDAM_SESSION_KEY ?? 'oma-memory-demo',
+})
+
+const tdamTools = new TdamToolkit({ baseUrl: GATEWAY_URL }).getTools()
+
+// ---------------------------------------------------------------------------
+// Gateway health check — fail fast with a pointer to the README
+// ---------------------------------------------------------------------------
+
+const TOPIC = 'trade-offs between SQLite and PostgreSQL as storage for AI agent memory'
+
+console.log('Team with TencentDB-Agent-Memory')
+console.log('='.repeat(60))
+console.log(`Provider: ${PROVIDER}${BASE_URL ? ` (via ${BASE_URL})` : ''}`)
+console.log(`Model:    ${MODEL}`)
+console.log(`Gateway:  ${GATEWAY_URL}`)
+console.log(`Topic:    ${TOPIC}\n`)
+
+try {
+  const health = await store.health()
+  console.log(
+    `Gateway health: ${health.status} (v${health.version}, ` +
+    `vectorStore=${health.stores.vectorStore}, embedding=${health.stores.embeddingService})\n`,
+  )
+} catch {
+  console.error(
+    `Cannot reach the TDAM Gateway at ${GATEWAY_URL}.\n` +
+    'Start it first — see examples/integrations/with-tencentdb-memory/README.md.',
+  )
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: recall long-term memory from previous runs
+// ---------------------------------------------------------------------------
+
+console.log('[1/4] Recalling long-term memory for the topic...')
+const recalled = await store.recall(TOPIC)
+
+let memoryContext = ''
+if (recalled.context.trim()) {
+  memoryContext =
+    '\n\n## Long-term memory (distilled from previous sessions)\n' +
+    recalled.context
+  console.log(
+    `  Recalled ${recalled.memory_count ?? 0} memories ` +
+    `(strategy: ${recalled.strategy ?? 'n/a'}) — injecting into agent prompts.\n`,
+  )
+} else {
+  console.log('  No long-term memories yet (first run against this Gateway).\n')
+}
+
+// ---------------------------------------------------------------------------
+// Agent configs
+// ---------------------------------------------------------------------------
+
+const analyst: AgentConfig = {
+  name: 'analyst',
+  model: MODEL,
+  provider: PROVIDER,
+  baseURL: BASE_URL,
+  apiKey: API_KEY,
+  systemPrompt:
+    `You are a storage systems analyst investigating: "${TOPIC}".\n\n` +
+    'State 4-6 concrete, specific findings (latency characteristics, ' +
+    'operational overhead, concurrency behavior, deployment fit for agent ' +
+    'workloads). Number each finding and keep it to one or two sentences.' +
+    memoryContext,
+  maxTurns: 6,
+  timeoutMs: 300_000,
+}
+
+const writer: AgentConfig = {
+  name: 'writer',
+  model: MODEL,
+  provider: PROVIDER,
+  baseURL: BASE_URL,
+  apiKey: API_KEY,
+  systemPrompt:
+    'You are a technical writer. Produce a concise recommendation memo ' +
+    `(150-250 words) on "${TOPIC}", grounded in the analyst's findings from ` +
+    'shared memory. If long-term memory or the tdam_search_memories tool ' +
+    'reveals findings from previous sessions, build on them instead of ' +
+    'repeating them.' +
+    memoryContext,
+  customTools: tdamTools,
+  maxTurns: 6,
+  timeoutMs: 300_000,
+}
+
+// ---------------------------------------------------------------------------
+// Progress tracking
+// ---------------------------------------------------------------------------
+
+function handleProgress(event: OrchestratorEvent): void {
+  const ts = new Date().toISOString().slice(11, 23)
+  switch (event.type) {
+    case 'task_start':
+      console.log(`  [${ts}] TASK START ↓ ${event.task}`)
+      break
+    case 'task_complete':
+      console.log(`  [${ts}] TASK DONE  ↑ ${event.task}`)
+      break
+    case 'error':
+      console.error(`  [${ts}] ERROR      ✗ agent=${event.agent} task=${event.task}`)
+      break
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: run the team — shared-memory writes are captured into TDAM
+// ---------------------------------------------------------------------------
+
+console.log('[2/4] Running the team (shared-memory writes auto-capture into TDAM)...')
+
+const orchestrator = new OpenMultiAgent({
+  defaultModel: MODEL,
+  defaultProvider: PROVIDER,
+  defaultBaseURL: BASE_URL,
+  defaultApiKey: API_KEY,
+  maxConcurrency: 1,
+  onProgress: handleProgress,
+})
+
+const team = orchestrator.createTeam('tdam-memory-demo', {
+  name: 'tdam-memory-demo',
+  agents: [analyst, writer],
+  sharedMemory: true,
+  sharedMemoryStore: store,
+  maxConcurrency: 1,
+})
+
+const result = await orchestrator.runTeam(
+  team,
+  `Research "${TOPIC}". The analyst produces concrete findings, then the ` +
+  'writer turns the findings into a short recommendation memo for an AI ' +
+  'agent framework that needs persistent memory storage.',
+)
+
+console.log(`\n  Team run ${result.success ? 'succeeded' : 'FAILED'}.`)
+const writerResult = result.agentResults.get('writer')
+if (writerResult?.success) {
+  console.log('\n' + '='.repeat(60))
+  console.log('RECOMMENDATION MEMO')
+  console.log('='.repeat(60))
+  console.log()
+  console.log(writerResult.output)
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: flush extraction so captures become searchable
+// ---------------------------------------------------------------------------
+
+const stats = store.captureStats
+console.log('\n' + '-'.repeat(60))
+console.log(
+  `[3/4] Captured ${stats.succeeded}/${stats.attempted} shared-memory writes ` +
+  `into TDAM (${stats.l0Recorded} L0 records). Flushing L1 extraction...`,
+)
+const flushStart = Date.now()
+await store.endSession()
+console.log(`  Flush complete in ${((Date.now() - flushStart) / 1000).toFixed(1)}s.`)
+
+// ---------------------------------------------------------------------------
+// Step 4: verify — search the distilled long-term memories
+// ---------------------------------------------------------------------------
+
+console.log('\n[4/4] Searching distilled L1 memories...')
+const memories = await store.searchMemories(TOPIC, 5)
+console.log(`  ${memories.total} memories match (strategy: ${memories.strategy}).\n`)
+if (memories.results.trim()) {
+  console.log(memories.results)
+}
+
+console.log('\n' + '-'.repeat(60))
+console.log('Token Usage:')
+console.log(
+  `  Total — input: ${result.totalTokenUsage.input_tokens}, ` +
+  `output: ${result.totalTokenUsage.output_tokens}`,
+)
+
+console.log(
+  '\nRun this script again: step 1 will recall what TDAM just distilled, ' +
+  'and the agents will start from it.',
+)


### PR DESCRIPTION
## Summary

Vendor integration example pairing OMA teams with [TencentDB-Agent-Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory) (TDAM), Tencent Cloud's open-source agent memory system (L0 conversations → L1 facts → L2 scenes → L3 persona; SQLite + sqlite-vec; BM25 + vector hybrid retrieval). It wires in through TDAM's Hermes Gateway HTTP sidecar.

New under `examples/integrations/with-tencentdb-memory/`: a `TdamMemoryStore` for `TeamConfig.sharedMemoryStore` (local map for exact KV reads, since the Gateway has no read-by-key endpoint; write-through `/capture` into TDAM; recall/search/flush helpers), a toolkit with two memory-search tools for mid-task lookups, a runnable `runTeam()` demo, and a README. Plus a one-row catalog entry in `examples/integrations/README.md`.

Two upstream behaviors the example works around, since neither is visible from the diff: TDAM's L1 extractor is user-centric and ignores assistant output, so captures put the team result in the user slot of the turn; and `POST /session/end` drains in-flight extraction but won't force turns still under TDAM's batch threshold, so the Gateway runs with `everyNConversations: 1` to keep capture-then-search deterministic.

## Validation

Pinned to TDAM v0.3.6 (`@tencentdb-agent-memory/memory-tencentdb@0.3.6`; endpoint schemas read from its `src/gateway/types.ts`, identical between the v0.3.6 tag and HEAD).

- `npm run lint`
- `npm test` (1033 passing)
- Ran the demo twice with `deepseek-v4-flash` driving both the agents and Gateway extraction, Bearer auth enabled.

Run one captured 2/2 shared-memory writes and distilled one episodic memory; run two recalled it (hybrid strategy), injected it into the agent prompts, and TDAM merged the new results into an upgraded memory. Outputs are in the example README.
