### PR TITLE
chore: release 1.7.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,7 +32,7 @@ Paste any error messages or logs here
 
 - OS: [e.g. macOS 14, Ubuntu 22.04]
 - Node.js version: [e.g. 20.11]
-- Package version: [e.g. 1.6.0]
+- Package version: [e.g. 1.7.0]
 - LLM provider: [e.g. Anthropic, OpenAI]
 
 ## Additional context

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@open-multi-agent/core",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "TypeScript multi-agent framework — one runTeam() call from goal to result. Auto task decomposition, parallel execution. 3 dependencies, deploys anywhere Node.js runs.",
   "files": [
     "dist",


### PR DESCRIPTION
Release commit for 1.7.0: version + lock bump to 1.7.0, plus the bug_report example version.

Full notes ship on the GitHub release. Headline changes this cycle: built-in tools are now default-deny (breaking), consensus / adversarial verification, deterministic model routing, and MiniMax-M3 as the new default.