### PR TITLE
docs(providers): add Gemini setup guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ oma-dashboards/
 .claude/
 .npmrc
 .env
+analyze-*.md
+tracking.md

--- a/docs/providers/gemini.md
+++ b/docs/providers/gemini.md
@@ -1,0 +1,68 @@
+# Gemini setup guide
+
+Google Gemini is OMA's only non-OpenAI-compatible first-class adapter — it uses the official `@google/genai` SDK directly so native features (Gemini 2.5 thinking blocks, `thoughtSignature` round-tripping, grounding) work without transcoding through OpenAI's wire format.
+
+## Setup
+
+### Prerequisites
+
+Gemini is an optional peer dependency. Install the SDK before use:
+
+```bash
+npm install @google/genai
+```
+
+### Environment variables
+
+```bash
+export GEMINI_API_KEY=your-api-key
+```
+
+Get an API key at [Google AI Studio](https://aistudio.google.com/apikey).
+
+### Agent config
+
+```typescript
+const agent: AgentConfig = {
+  name: 'my-agent',
+  provider: 'gemini',
+  model: 'gemini-2.5-flash',
+  systemPrompt: 'You are a helpful assistant.',
+}
+```
+
+### Full example
+
+```typescript
+import { OpenMultiAgent, type AgentConfig } from '@open-multi-agent/core'
+
+const agent: AgentConfig = {
+  name: 'analyst',
+  provider: 'gemini',
+  model: 'gemini-2.5-flash',
+  systemPrompt: 'Analyze data and produce concise reports.',
+}
+
+const orchestrator = new OpenMultiAgent({
+  defaultProvider: 'gemini',
+  defaultModel: 'gemini-2.5-flash',
+})
+
+const result = await orchestrator.runAgent(agent, 'Explain the tradeoffs between Gemini 2.5 Pro and Flash.')
+console.log(result.output)
+```
+
+Runnable three-agent example: [`examples/providers/gemini.ts`](../../examples/providers/gemini.ts)
+
+## Available models
+
+| Model | Notes |
+|-------|-------|
+| `gemini-2.5-flash` | Fast and cost-efficient; recommended default |
+| `gemini-2.5-pro` | More capable; higher latency and cost; larger context |
+
+See the [Gemini API model catalog](https://ai.google.dev/gemini-api/docs/models) for the full list including experimental and multimodal variants.
+
+## Reasoning (thinking) support
+
+Gemini 2.5 models support native thinking blocks. OMA round-trips `thoughtSignature` fields across multi-turn conversations so reasoning state is preserved within the same provider. Cross-provider reasoning preservation requires `AgentConfig.preserveReasoningAsText: true` (see [context-management.md](../context-management.md)).


### PR DESCRIPTION
## What

Adds `docs/providers/gemini.md` — a setup guide for Google Gemini following the `minimax.md` pattern.

Covers:
- `@google/genai` peer dependency install step (Gemini is the only first-class adapter that isn't OpenAI-compatible)
- `GEMINI_API_KEY` setup with link to Google AI Studio
- Agent config and inline full example
- Link to `examples/providers/gemini.ts`
- Model table (`gemini-2.5-flash` / `gemini-2.5-pro`) with notes
- Brief note on native thinking block / `thoughtSignature` support and cross-provider reasoning opt-in

## Why

`docs/providers/minimax.md` established a per-provider doc pattern. Gemini is the second most-referenced provider in the README after Anthropic and has unique setup requirements (non-OpenAI-compatible SDK, optional peer dep install step) that aren't captured in the main `docs/providers.md` table row.

## Checklist
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] No new runtime dependencies
- [x] Follows `minimax.md` structure