### PR TITLE
feat(orchestrator): wire verify hook into runTeam coordinator tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@ oma-dashboards/
 .claude/
 .npmrc
 .env
-analyze-*.md
-tracking.md

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ oma-dashboards/
 .claude/
 .npmrc
 .env
+analyze-*.md
+tracking.md

--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -371,6 +371,19 @@ export async function executeWithRetry(
 // Parsed task spec (result of coordinator decomposition)
 // ---------------------------------------------------------------------------
 
+/**
+ * Partial verify config that the coordinator can emit in task JSON.
+ * Contains only fields that are safe to include in LLM output — `judges`
+ * (full AgentConfig objects) are always supplied by the caller via
+ * {@link RunTeamOptions.verifyJudges} and are never in coordinator JSON.
+ */
+interface CoordinatorVerifySpec {
+  readonly mode?: 'refute' | 'lens'
+  readonly quorum?: number
+  readonly maxRounds?: number
+  readonly onDissent?: 'revise' | 'reject' | 'keep'
+}
+
 interface ParsedTaskSpec {
   title: string
   description: string
@@ -382,7 +395,59 @@ interface ParsedTaskSpec {
   retryBackoff?: number
   role?: string
   priority?: 'low' | 'normal' | 'high' | 'critical'
-  verify?: ConsensusVerifyOptions
+  /**
+   * Full verify options (used by explicit `runTasks` specs that already
+   * include judges) OR a coordinator-emitted partial spec / boolean `true`
+   * (resolved into full options by `loadSpecsIntoQueue` when
+   * `verifyJudges` is available).
+   */
+  verify?: ConsensusVerifyOptions | CoordinatorVerifySpec | true
+}
+
+/**
+ * Resolve a parsed task spec's `verify` field into a full
+ * {@link ConsensusVerifyOptions} (or `undefined` when no verify should run).
+ *
+ * - Full `ConsensusVerifyOptions` (already has `judges`): used as-is.
+ * - `true` or `CoordinatorVerifySpec` (no `judges`): merged with
+ *   `verifyJudges` when provided; ignored when `verifyJudges` is absent.
+ * - `undefined`: no verify.
+ */
+function resolveVerify(
+  spec: ConsensusVerifyOptions | CoordinatorVerifySpec | true | undefined,
+  verifyJudges?: readonly AgentConfig[],
+): ConsensusVerifyOptions | undefined {
+  if (spec === undefined) return undefined
+  if (spec !== true && 'judges' in spec) return spec as ConsensusVerifyOptions
+  if (!verifyJudges || verifyJudges.length === 0) return undefined
+  const partial: CoordinatorVerifySpec = spec === true ? {} : spec
+  return {
+    judges: verifyJudges,
+    ...(partial.mode !== undefined ? { mode: partial.mode } : {}),
+    ...(partial.quorum !== undefined ? { quorum: partial.quorum } : {}),
+    ...(partial.maxRounds !== undefined ? { maxRounds: partial.maxRounds } : {}),
+    ...(partial.onDissent !== undefined ? { onDissent: partial.onDissent } : {}),
+  }
+}
+
+/**
+ * Parse the coordinator-emitted `verify` field on a task JSON object.
+ * Accepts `true` (use all defaults) or a partial object with `mode`,
+ * `quorum`, `maxRounds`, and/or `onDissent`. Returns `undefined` for any
+ * other value so missing / null / unrecognised values are ignored safely.
+ */
+function parseCoordinatorVerify(raw: unknown): CoordinatorVerifySpec | true | undefined {
+  if (raw === true) return true
+  if (typeof raw !== 'object' || raw === null) return undefined
+  const obj = raw as Record<string, unknown>
+  const mode = obj['mode'] === 'refute' || obj['mode'] === 'lens' ? obj['mode'] : undefined
+  const quorum = typeof obj['quorum'] === 'number' && obj['quorum'] >= 1 ? Math.floor(obj['quorum']) : undefined
+  const maxRounds = typeof obj['maxRounds'] === 'number' && obj['maxRounds'] >= 1 ? Math.floor(obj['maxRounds']) : undefined
+  const onDissent = obj['onDissent'] === 'revise' || obj['onDissent'] === 'reject' || obj['onDissent'] === 'keep'
+    ? obj['onDissent']
+    : undefined
+  if (mode === undefined && quorum === undefined && maxRounds === undefined && onDissent === undefined) return true
+  return { mode, quorum, maxRounds, onDissent }
 }
 
 /**
@@ -429,6 +494,7 @@ function parseTaskSpecs(raw: string): ParsedTaskSpec[] | null {
         priority: obj['priority'] === 'low' || obj['priority'] === 'normal' || obj['priority'] === 'high' || obj['priority'] === 'critical'
           ? obj['priority']
           : undefined,
+        verify: parseCoordinatorVerify(obj['verify']),
       })
     }
 
@@ -1637,7 +1703,7 @@ export class OpenMultiAgent {
       provider: coordinatorOverrides?.provider ?? this.config.defaultProvider,
       baseURL: coordinatorOverrides?.baseURL ?? this.config.defaultBaseURL,
       apiKey: coordinatorOverrides?.apiKey ?? this.config.defaultApiKey,
-      systemPrompt: this.buildCoordinatorPrompt(agentConfigs, coordinatorOverrides),
+      systemPrompt: this.buildCoordinatorPrompt(agentConfigs, coordinatorOverrides, (options?.verifyJudges?.length ?? 0) > 0),
       maxTurns: coordinatorOverrides?.maxTurns ?? 3,
       maxTokens: coordinatorOverrides?.maxTokens,
       temperature: coordinatorOverrides?.temperature,
@@ -1709,7 +1775,7 @@ export class OpenMultiAgent {
     if (taskSpecs && taskSpecs.length > 0) {
       // Map title-based dependsOn references to real task IDs so we can
       // build the dependency graph before adding tasks to the queue.
-      this.loadSpecsIntoQueue(taskSpecs, agentConfigs, queue)
+      this.loadSpecsIntoQueue(taskSpecs, agentConfigs, queue, options?.verifyJudges)
     } else {
       // Coordinator failed to produce structured output — fall back to
       // one task per agent using the goal as the description.
@@ -1797,6 +1863,7 @@ export class OpenMultiAgent {
         maxRetries: task.maxRetries,
         retryDelayMs: task.retryDelayMs,
         retryBackoff: task.retryBackoff,
+        verify: task.verify,
         metrics: undefined,
       }))
       this.config.onProgress?.({
@@ -1823,6 +1890,7 @@ export class OpenMultiAgent {
       maxRetries: task.maxRetries,
       retryDelayMs: task.retryDelayMs,
       retryBackoff: task.retryBackoff,
+      verify: task.verify,
       metrics: taskMetrics.get(task.id),
     }))
 
@@ -2138,34 +2206,34 @@ export class OpenMultiAgent {
   // -------------------------------------------------------------------------
 
   /** Build the system prompt given to the coordinator agent. */
-  private buildCoordinatorSystemPrompt(agents: AgentConfig[]): string {
+  private buildCoordinatorSystemPrompt(agents: AgentConfig[], hasVerifyJudges?: boolean): string {
     return [
       'You are a task coordinator responsible for decomposing high-level goals',
       'into concrete, actionable tasks and assigning them to the right team members.',
       '',
       this.buildCoordinatorRosterSection(agents),
       '',
-      this.buildCoordinatorOutputFormatSection(),
+      this.buildCoordinatorOutputFormatSection(hasVerifyJudges),
       '',
       this.buildCoordinatorSynthesisSection(),
     ].join('\n')
   }
 
   /** Build coordinator system prompt with optional caller overrides. */
-  private buildCoordinatorPrompt(agents: AgentConfig[], config?: CoordinatorConfig): string {
+  private buildCoordinatorPrompt(agents: AgentConfig[], config?: CoordinatorConfig, hasVerifyJudges?: boolean): string {
     if (config?.systemPrompt) {
       return [
         config.systemPrompt,
         '',
         this.buildCoordinatorRosterSection(agents),
         '',
-        this.buildCoordinatorOutputFormatSection(),
+        this.buildCoordinatorOutputFormatSection(hasVerifyJudges),
         '',
         this.buildCoordinatorSynthesisSection(),
       ].join('\n')
     }
 
-    const base = this.buildCoordinatorSystemPrompt(agents)
+    const base = this.buildCoordinatorSystemPrompt(agents, hasVerifyJudges)
     if (!config?.instructions) {
       return base
     }
@@ -2194,8 +2262,8 @@ export class OpenMultiAgent {
   }
 
   /** Build the coordinator JSON output-format section. */
-  private buildCoordinatorOutputFormatSection(): string {
-    return [
+  private buildCoordinatorOutputFormatSection(hasVerifyJudges?: boolean): string {
+    const lines = [
       '## Output Format',
       'When asked to decompose a goal, respond ONLY with a JSON array of task objects.',
       'Each task must have:',
@@ -2203,6 +2271,16 @@ export class OpenMultiAgent {
       '  - "description": Full task description with context and expected output (string)',
       '  - "assignee":    One of the agent names listed in the roster (string)',
       '  - "dependsOn":   Array of titles of tasks this task depends on (string[], may be empty).',
+    ]
+    if (hasVerifyJudges) {
+      lines.push(
+        '  - "verify":      (optional) Set to true to apply consensus judge verification on this task\'s result.',
+        '                   Or set to an object with any of: "mode" ("refute"|"lens"), "quorum" (number),',
+        '                   "maxRounds" (number), "onDissent" ("revise"|"reject"|"keep").',
+        '                   Omit for tasks where a single agent\'s answer is sufficient.',
+      )
+    }
+    lines.push(
       '',
       '## Dependency Guidance',
       'Prefer the minimum set of upstream tasks each assignee needs. When deciding dependsOn for agent X:',
@@ -2213,7 +2291,8 @@ export class OpenMultiAgent {
       '',
       'Wrap the JSON in a ```json code fence.',
       'Do not include any text outside the code fence.',
-    ].join('\n')
+    )
+    return lines.join('\n')
   }
 
   /** Build the coordinator synthesis guidance section. */
@@ -2346,6 +2425,7 @@ export class OpenMultiAgent {
       maxRetries: task.maxRetries,
       retryDelayMs: task.retryDelayMs,
       retryBackoff: task.retryBackoff,
+      verify: task.verify,
       metrics: ctx.taskMetrics.get(task.id),
     }))
 
@@ -2369,6 +2449,7 @@ export class OpenMultiAgent {
     }>,
     agentConfigs: AgentConfig[],
     queue: TaskQueue,
+    verifyJudges?: readonly AgentConfig[],
   ): void {
     const agentNames = new Set(agentConfigs.map((a) => a.name))
     const normalizeTitle = (title: string): string => title.toLowerCase().trim()
@@ -2395,7 +2476,7 @@ export class OpenMultiAgent {
         retryBackoff: spec.retryBackoff,
         role: spec.role,
         priority: spec.priority,
-        verify: spec.verify,
+        verify: resolveVerify(spec.verify, verifyJudges),
       })
       const titleKey = normalizeTitle(spec.title)
       if ((titleCounts.get(titleKey) ?? 0) === 1) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -781,6 +781,21 @@ export interface RunTeamOptions extends RunTasksOptions {
    * coordinator model selection is unchanged.
    */
   readonly modelRouting?: ModelRoutingPolicy
+  /**
+   * Judge roster for coordinator-generated task verification.
+   *
+   * When set, the coordinator can opt individual tasks into the `verify` hook
+   * by emitting `"verify": true` (or a partial config with `mode`, `quorum`,
+   * `maxRounds`, or `onDissent`) in the task JSON. The judges provided here
+   * are merged in to form the full {@link ConsensusVerifyOptions}.
+   *
+   * Without this field, coordinator-generated tasks cannot use the verify hook
+   * even if the coordinator emits a `verify` key — the field is ignored.
+   *
+   * Not applicable to `runTasks()` (which accepts full
+   * {@link ConsensusVerifyOptions} with judges per task).
+   */
+  readonly verifyJudges?: readonly AgentConfig[]
 }
 
 /** Aggregated result for a full team run. */
@@ -903,6 +918,8 @@ export interface TaskExecutionRecord {
   readonly maxRetries?: number
   readonly retryDelayMs?: number
   readonly retryBackoff?: number
+  /** Verify config attached to this task, if any. Populated in `planOnly` results for inspection and replay. */
+  readonly verify?: ConsensusVerifyOptions
   readonly metrics?: TaskExecutionMetrics
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -918,7 +918,7 @@ export interface TaskExecutionRecord {
   readonly maxRetries?: number
   readonly retryDelayMs?: number
   readonly retryBackoff?: number
-  /** Verify config attached to this task, if any. Populated in `planOnly` results for inspection and replay. */
+  /** Verify config attached to this task, if any. Populated in `planOnly` results for inspection. */
   readonly verify?: ConsensusVerifyOptions
   readonly metrics?: TaskExecutionMetrics
 }

--- a/tests/runteam-verify.test.ts
+++ b/tests/runteam-verify.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Regression guard: coordinator-generated tasks can opt into the verify hook
+ * when `RunTeamOptions.verifyJudges` is provided.
+ *
+ * Tests cover:
+ *   - `verify: true` in coordinator JSON → full ConsensusVerifyOptions with judges
+ *   - `verify: { mode, quorum }` partial object → merged with verifyJudges
+ *   - No `verify` field → task gets no verify config
+ *   - `verify: true` in coordinator JSON without verifyJudges → ignored (no verify)
+ *   - Coordinator prompt includes verify field docs only when verifyJudges present
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import type { AgentConfig, LLMChatOptions, LLMMessage, LLMResponse, TeamConfig } from '../src/types.js'
+
+// ---------------------------------------------------------------------------
+// Mock adapter
+// ---------------------------------------------------------------------------
+
+let mockAdapterResponses: string[] = []
+
+vi.mock('../src/llm/adapter.js', () => ({
+  createAdapter: async () => {
+    let callIndex = 0
+    return {
+      name: 'mock',
+      async chat(_msgs: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
+        const text = mockAdapterResponses[callIndex] ?? 'default mock response'
+        callIndex++
+        return {
+          id: `resp-${callIndex}`,
+          content: [{ type: 'text', text }],
+          model: options.model ?? 'mock-model',
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 10, output_tokens: 20 },
+        }
+      },
+      async *stream() {
+        yield { type: 'done' as const, data: {} }
+      },
+    }
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function agent(name: string): AgentConfig {
+  return { name, model: 'mock-model', provider: 'openai', systemPrompt: `You are ${name}.` }
+}
+
+function teamCfg(agents: AgentConfig[]): TeamConfig {
+  return { name: 'test-team', agents }
+}
+
+function coordinatorPlan(tasks: object[]): string {
+  return '```json\n' + JSON.stringify(tasks) + '\n```'
+}
+
+// Goal complex enough to bypass the simple-goal short-circuit; planOnly avoids
+// running actual workers so we can inspect the decomposed task graph.
+const GOAL = 'Design and implement a complete secure multi-tier software system architecture'
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('runTeam verify hook integration', () => {
+  beforeEach(() => {
+    mockAdapterResponses = []
+  })
+
+  it('applies verify with judges when coordinator emits verify: true and verifyJudges provided', async () => {
+    const worker = agent('worker')
+    const judge = agent('judge')
+
+    mockAdapterResponses = [
+      coordinatorPlan([{ title: 'Task A', description: 'Do A', assignee: 'worker', dependsOn: [], verify: true }]),
+    ]
+
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('t', teamCfg([worker]))
+
+    const result = await oma.runTeam(team, GOAL, {
+      planOnly: true,
+      verifyJudges: [judge],
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.tasks).toBeDefined()
+    const taskA = result.tasks!.find((t) => t.title === 'Task A')
+    expect(taskA).toBeDefined()
+    expect(taskA!.verify).toBeDefined()
+    expect(taskA!.verify!.judges).toHaveLength(1)
+    expect(taskA!.verify!.judges[0]!.name).toBe('judge')
+  })
+
+  it('merges coordinator partial verify spec with verifyJudges', async () => {
+    const worker = agent('worker')
+    const judge = agent('judge')
+
+    mockAdapterResponses = [
+      coordinatorPlan([{
+        title: 'Task B',
+        description: 'Do B',
+        assignee: 'worker',
+        dependsOn: [],
+        verify: { mode: 'lens', quorum: 1, maxRounds: 3, onDissent: 'reject' },
+      }]),
+    ]
+
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('t', teamCfg([worker]))
+
+    const result = await oma.runTeam(team, GOAL, {
+      planOnly: true,
+      verifyJudges: [judge],
+    })
+
+    expect(result.success).toBe(true)
+    const taskB = result.tasks!.find((t) => t.title === 'Task B')
+    expect(taskB).toBeDefined()
+    expect(taskB!.verify).toBeDefined()
+    expect(taskB!.verify!.judges).toHaveLength(1)
+    expect(taskB!.verify!.mode).toBe('lens')
+    expect(taskB!.verify!.quorum).toBe(1)
+    expect(taskB!.verify!.maxRounds).toBe(3)
+    expect(taskB!.verify!.onDissent).toBe('reject')
+  })
+
+  it('does not apply verify when coordinator emits verify: true but verifyJudges absent', async () => {
+    const worker = agent('worker')
+
+    mockAdapterResponses = [
+      coordinatorPlan([{ title: 'Task C', description: 'Do C', assignee: 'worker', dependsOn: [], verify: true }]),
+    ]
+
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('t', teamCfg([worker]))
+
+    const result = await oma.runTeam(team, GOAL, { planOnly: true })
+
+    expect(result.success).toBe(true)
+    const taskC = result.tasks!.find((t) => t.title === 'Task C')
+    expect(taskC).toBeDefined()
+    expect(taskC!.verify).toBeUndefined()
+  })
+
+  it('does not apply verify to tasks without verify field', async () => {
+    const worker = agent('worker')
+    const judge = agent('judge')
+
+    mockAdapterResponses = [
+      coordinatorPlan([{ title: 'Task D', description: 'Do D', assignee: 'worker', dependsOn: [] }]),
+    ]
+
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('t', teamCfg([worker]))
+
+    const result = await oma.runTeam(team, GOAL, {
+      planOnly: true,
+      verifyJudges: [judge],
+    })
+
+    expect(result.success).toBe(true)
+    const taskD = result.tasks!.find((t) => t.title === 'Task D')
+    expect(taskD).toBeDefined()
+    expect(taskD!.verify).toBeUndefined()
+  })
+
+  it('verify field in coordinator JSON is ignored when invalid (null, number, string)', async () => {
+    const worker = agent('worker')
+    const judge = agent('judge')
+
+    mockAdapterResponses = [
+      coordinatorPlan([
+        { title: 'Task E1', description: 'Do E1', assignee: 'worker', dependsOn: [], verify: null },
+        { title: 'Task E2', description: 'Do E2', assignee: 'worker', dependsOn: [], verify: 42 },
+        { title: 'Task E3', description: 'Do E3', assignee: 'worker', dependsOn: [], verify: 'yes' },
+      ]),
+    ]
+
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('t', teamCfg([worker]))
+
+    const result = await oma.runTeam(team, GOAL, {
+      planOnly: true,
+      verifyJudges: [judge],
+    })
+
+    expect(result.success).toBe(true)
+    for (const task of result.tasks ?? []) {
+      expect(task.verify).toBeUndefined()
+    }
+  })
+})


### PR DESCRIPTION
## What

Closes the gap noted in PR #280: *"Coordinator-generated tasks in `runTeam` can't yet opt in (the coordinator emits task JSON without a `verify` field)."*

**New API**: `RunTeamOptions.verifyJudges`

```ts
const result = await oma.runTeam(team, goal, {
  verifyJudges: [judgeAgentConfig],
})
```

When `verifyJudges` is set, the coordinator prompt gains a `"verify"` field description. The coordinator can opt individual tasks into consensus verification by emitting:
- `"verify": true` — apply with all defaults
- `"verify": { "mode": "refute", "quorum": 1 }` — partial config

`loadSpecsIntoQueue` merges the coordinator's partial spec with the caller-supplied judge roster to form a full `ConsensusVerifyOptions`. Explicit `runTasks` tasks with their own `ConsensusVerifyOptions` (including judges) are unaffected.

**`TaskExecutionRecord.verify`**: also added so `planOnly` snapshots surface the verify config and it can be inspected.

## Why

PR #280 explicitly listed `runTeam` verify integration as a follow-up. The gap was architectural: the coordinator can't emit full `AgentConfig` objects for judges in its JSON output, so it had no way to opt tasks in even if the user passed verify config.

The solution is a judge roster supplied at the call site (`verifyJudges`) that the coordinator JSON references implicitly via `"verify": true` or a partial spec. This keeps coordinator JSON clean while giving users full control over which judges are used.

## Checklist
- [x] `npm run lint` passes
- [x] `npm test` passes (5 new tests in `tests/runteam-verify.test.ts`; pre-existing Windows symlink failures in `fs-walk.test.ts` and `built-in-tools.test.ts` are unrelated)
- [x] Added tests for: `verify: true`, partial spec merge, no-verify-without-judges, tasks without verify field, invalid verify values
- [x] No new runtime dependencies
- [x] Additive change — existing `runTeam` and `runTasks` callers unaffected
