### PR TITLE
feat(bedrock): implement native reasoning round-trip via signature (#223)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,3 @@ oma-dashboards/
 .claude/
 .npmrc
 .env
-analyze-*.md
-tracking.md

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ oma-dashboards/
 .claude/
 .npmrc
 .env
+analyze-*.md
+tracking.md

--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -92,7 +92,8 @@ When the fallback fires:
 | Matches target (`'deepseek'` → DeepSeek) in a tool-calling conversation | `'tool-use-only'` | Native `reasoning_content` echo (per DeepSeek V4 spec, see #251) |
 | Matches target but no `tool_use` anywhere in history | `'tool-use-only'` | Dropped (DeepSeek spec ignores non-tool reasoning) |
 | Foreign (e.g. `'openai'` → DeepSeek) | `'tool-use-only'` | Text fallback |
-| Any | `'never'` (OpenAI, Azure, Copilot, Bedrock, AI SDK, etc.) | Text fallback |
+| Matches target (`'bedrock'` → Bedrock) and has signature or is redacted | `'own-issued'` | Native echo via `reasoningContent.{reasoningText,redactedContent}` (see #223) |
+| Any | `'never'` (OpenAI, Azure, Copilot, AI SDK, etc.) | Text fallback |
 
 Redacted reasoning (Anthropic safety-filtered) emits the placeholder `<thinking>[redacted]</thinking>` to signal that reasoning occurred without leaking the opaque payload.
 
@@ -100,6 +101,6 @@ Redacted reasoning (Anthropic safety-filtered) emits the placeholder `<thinking>
 - Disabled by default to avoid silently inflating prompt tokens.
 - Default-on truncation (`compressReasoningText`) is mandatory for safety on long chain-of-thought; disable only when debugging.
 - Some local OpenAI-compatible models may echo `<thinking>` text back into their assistant response, which can trip the loop detector. See `examples/patterns/cross-provider-reasoning.ts` for the failure mode and mitigations.
-- Bedrock currently has `capabilities.echoesReasoning === 'never'` until a follow-up restores its signature round-trip on both inbound extraction and outbound serialization; until then, opt-in always falls back to text for Bedrock targets.
+- Bedrock has `capabilities.echoesReasoning === 'own-issued'`: signed reasoning blocks (`reasoningContent.reasoningText.signature`) and redacted blocks (`reasoningContent.redactedContent`) round-trip natively on both `chat()` and `stream()`, in both inbound extraction and outbound serialization (see #223).
 - `'tool-use-only'` (DeepSeek V4) is the only capability where same-provider echo works **without** the user opting into `preserveReasoningAsText` — it's forced on internally because the DeepSeek API requires it.
 

--- a/src/llm/bedrock.ts
+++ b/src/llm/bedrock.ts
@@ -79,13 +79,12 @@ function base64ToUint8Array(b64: string): Uint8Array {
  * Convert a single framework {@link ContentBlock} into a Bedrock
  * {@link BedrockContentBlock} for the messages array.
  *
- * Reasoning blocks are converted via the shared cross-provider fallback
- * (see #223): dropped silently by default; emitted as a standalone text
- * block wrapped in `<thinking>...</thinking>` when
- * {@link LLMChatOptions.preserveReasoningAsText} is `true`. Native echo
- * (which would require writing the signature into Bedrock's
- * `reasoningContent.reasoningText.signature` shape) is still pending —
- * see {@link BedrockAdapter.capabilities} for the gating rationale.
+ * Reasoning blocks with Bedrock provenance and a signature are echoed
+ * natively via `reasoningContent.reasoningText.{text,signature}`. Redacted
+ * blocks with Bedrock provenance are echoed via `reasoningContent.redactedContent`.
+ * All other reasoning blocks (foreign provenance, no signature) fall back to
+ * the cross-provider `<thinking>` text path when `preserveReasoningAsText` is
+ * set, or are dropped silently.
  */
 function toBedrockContentBlock(
   block: ContentBlock,
@@ -124,9 +123,18 @@ function toBedrockContentBlock(
     }
 
     case 'reasoning': {
-      // Capability is `'never'` (see BedrockAdapter.capabilities) — all
-      // reasoning falls back to text when the user opts in, regardless of
-      // provenance. When opt-in is off, drop silently (today's default).
+      if (block.provenance === 'bedrock') {
+        if (block.redactedData !== undefined) {
+          return {
+            reasoningContent: { redactedContent: base64ToUint8Array(block.redactedData) },
+          } as unknown as BedrockContentBlock
+        }
+        if (block.signature !== undefined) {
+          return {
+            reasoningContent: { reasoningText: { text: block.text, signature: block.signature } },
+          } as unknown as BedrockContentBlock
+        }
+      }
       if (outboundOptions?.preserveReasoningAsText !== true) return null
       const maxChars = resolveReasoningOutboundMaxChars(outboundOptions)
       const text = maxChars === undefined
@@ -204,10 +212,20 @@ function fromBedrockContentBlock(block: BedrockContentBlock): ContentBlock | nul
     return toolUse
   }
   if (block.reasoningContent !== undefined) {
-    const r = block.reasoningContent as { reasoningText?: { text?: string } }
+    const r = block.reasoningContent as { reasoningText?: { text?: string; signature?: string }; redactedContent?: Uint8Array }
+    if (r.redactedContent !== undefined) {
+      const reasoning: ReasoningBlock = {
+        type: 'reasoning',
+        text: '',
+        redactedData: Buffer.from(r.redactedContent).toString('base64'),
+        provenance: 'bedrock',
+      }
+      return reasoning
+    }
     const reasoning: ReasoningBlock = {
       type: 'reasoning',
       text: r.reasoningText?.text ?? '',
+      ...(r.reasoningText?.signature !== undefined ? { signature: r.reasoningText.signature } : {}),
       provenance: 'bedrock',
     }
     return reasoning
@@ -236,17 +254,7 @@ export class BedrockAdapter implements LLMAdapter {
   readonly name = 'bedrock'
 
   readonly capabilities = {
-    // Held at 'never' until BOTH legs of the round-trip carry Bedrock's
-    // `reasoningContent.reasoningText.signature`:
-    //   1. inbound (toBedrockContentBlock 'reasoning' case): does not
-    //      extract the signature into the IR today, so even after the
-    //      outbound TODO lands there'd be no signature to send back.
-    //   2. outbound (toBedrockContentBlock 'reasoning' case TODO): does
-    //      not write the signature onto the wire format.
-    // Upgrading this field to 'own-issued' requires both follow-ups; doing
-    // only one would still silently break Bedrock's multi-turn extended
-    // thinking protocol.
-    echoesReasoning: 'never' as const,
+    echoesReasoning: 'own-issued' as const,
   }
 
   readonly #client: BedrockRuntimeClient
@@ -327,10 +335,10 @@ export class BedrockAdapter implements LLMAdapter {
 
     // Accumulate tool-use input JSON deltas; keyed by content block index.
     const toolBuffers = new Map<number, { toolUseId: string; name: string; json: string }>()
-    // Accumulate reasoning text deltas; keyed by content block index. Each
-    // index becomes one ReasoningBlock in the final `done` payload, matching
-    // what `chat()` produces for the same response shape.
-    const reasoningBuffers = new Map<number, { text: string }>()
+    // Accumulate reasoning text and signature deltas; keyed by content block
+    // index. Each index becomes one ReasoningBlock in the final `done` payload,
+    // matching what `chat()` produces for the same response shape.
+    const reasoningBuffers = new Map<number, { text: string; signature?: string }>()
     // Accumulated content blocks for the done event.
     const accumulatedContent: ContentBlock[] = []
     let stopReason = 'end_turn'
@@ -368,6 +376,11 @@ export class BedrockAdapter implements LLMAdapter {
             const buf = reasoningBuffers.get(index) ?? { text: '' }
             buf.text += text
             reasoningBuffers.set(index, buf)
+          } else if ((delta as { reasoningContent?: { signature?: string } }).reasoningContent?.signature !== undefined) {
+            const sig = (delta as { reasoningContent: { signature: string } }).reasoningContent.signature
+            const buf = reasoningBuffers.get(index) ?? { text: '' }
+            buf.signature = sig
+            reasoningBuffers.set(index, buf)
           }
         }
 
@@ -378,6 +391,7 @@ export class BedrockAdapter implements LLMAdapter {
             const reasoningBlock: ReasoningBlock = {
               type: 'reasoning',
               text: reasoningBuf.text,
+              ...(reasoningBuf.signature !== undefined ? { signature: reasoningBuf.signature } : {}),
               provenance: 'bedrock',
             }
             accumulatedContent.push(reasoningBlock)
@@ -421,7 +435,12 @@ export class BedrockAdapter implements LLMAdapter {
       // block, flush whatever we buffered so the done payload still matches
       // what chat() would have returned for the same response.
       for (const [, buf] of reasoningBuffers) {
-        accumulatedContent.push({ type: 'reasoning', text: buf.text, provenance: 'bedrock' })
+        accumulatedContent.push({
+          type: 'reasoning',
+          text: buf.text,
+          ...(buf.signature !== undefined ? { signature: buf.signature } : {}),
+          provenance: 'bedrock',
+        })
       }
       reasoningBuffers.clear()
 

--- a/src/llm/bedrock.ts
+++ b/src/llm/bedrock.ts
@@ -335,10 +335,11 @@ export class BedrockAdapter implements LLMAdapter {
 
     // Accumulate tool-use input JSON deltas; keyed by content block index.
     const toolBuffers = new Map<number, { toolUseId: string; name: string; json: string }>()
-    // Accumulate reasoning text and signature deltas; keyed by content block
-    // index. Each index becomes one ReasoningBlock in the final `done` payload,
-    // matching what `chat()` produces for the same response shape.
-    const reasoningBuffers = new Map<number, { text: string; signature?: string }>()
+    // Accumulate reasoning text, signature, and redactedContent deltas; keyed
+    // by content block index. Each index becomes one ReasoningBlock in the
+    // final `done` payload, matching what `chat()` produces for the same
+    // response shape.
+    const reasoningBuffers = new Map<number, { text: string; signature?: string; redactedContent?: Uint8Array }>()
     // Accumulated content blocks for the done event.
     const accumulatedContent: ContentBlock[] = []
     let stopReason = 'end_turn'
@@ -381,6 +382,11 @@ export class BedrockAdapter implements LLMAdapter {
             const buf = reasoningBuffers.get(index) ?? { text: '' }
             buf.signature = sig
             reasoningBuffers.set(index, buf)
+          } else if ((delta as { reasoningContent?: { redactedContent?: Uint8Array } }).reasoningContent?.redactedContent !== undefined) {
+            const redactedContent = (delta as { reasoningContent: { redactedContent: Uint8Array } }).reasoningContent.redactedContent
+            const buf = reasoningBuffers.get(index) ?? { text: '' }
+            buf.redactedContent = redactedContent
+            reasoningBuffers.set(index, buf)
           }
         }
 
@@ -392,6 +398,9 @@ export class BedrockAdapter implements LLMAdapter {
               type: 'reasoning',
               text: reasoningBuf.text,
               ...(reasoningBuf.signature !== undefined ? { signature: reasoningBuf.signature } : {}),
+              ...(reasoningBuf.redactedContent !== undefined
+                ? { redactedData: Buffer.from(reasoningBuf.redactedContent).toString('base64') }
+                : {}),
               provenance: 'bedrock',
             }
             accumulatedContent.push(reasoningBlock)
@@ -439,6 +448,9 @@ export class BedrockAdapter implements LLMAdapter {
           type: 'reasoning',
           text: buf.text,
           ...(buf.signature !== undefined ? { signature: buf.signature } : {}),
+          ...(buf.redactedContent !== undefined
+            ? { redactedData: Buffer.from(buf.redactedContent).toString('base64') }
+            : {}),
           provenance: 'bedrock',
         })
       }

--- a/tests/bedrock-adapter.test.ts
+++ b/tests/bedrock-adapter.test.ts
@@ -637,6 +637,28 @@ describe('BedrockAdapter', () => {
       }])
     })
 
+    it('stream(): accumulates redactedContent delta into ReasoningBlock.redactedData (base64) in done payload', async () => {
+      const redactedBytes = Buffer.from('encrypted-opaque')
+      mockSend.mockResolvedValue(makeStreamResponse([
+        { contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { redactedContent: redactedBytes } } } },
+        { contentBlockStop: { contentBlockIndex: 0 } },
+        { contentBlockDelta: { contentBlockIndex: 1, delta: { text: 'answer' } } },
+        { messageStop: { stopReason: 'end_turn' } },
+        { metadata: { usage: { inputTokens: 5, outputTokens: 3 } } },
+      ]))
+
+      const events = await collectEvents(adapter.stream([textMsg('user', 'Hi')], chatOpts()))
+      const response = events.find(e => e.type === 'done')?.data as LLMResponse
+      const reasoningBlocks = response.content.filter(b => b.type === 'reasoning')
+
+      expect(reasoningBlocks).toEqual([{
+        type: 'reasoning',
+        text: '',
+        redactedData: redactedBytes.toString('base64'),
+        provenance: 'bedrock',
+      }])
+    })
+
     it('stream(): reasoning block without signature delta has no signature field', async () => {
       mockSend.mockResolvedValue(makeStreamResponse([
         { contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: 'thought' } } } },

--- a/tests/bedrock-adapter.test.ts
+++ b/tests/bedrock-adapter.test.ts
@@ -463,4 +463,202 @@ describe('BedrockAdapter', () => {
       ])
     })
   })
+
+  // =========================================================================
+  // Phase 3 of #223 — native Bedrock reasoning round-trip (signature echo)
+  // =========================================================================
+
+  describe('reasoning round-trip (#223 Phase 3)', () => {
+    function lastSentMessages(): Array<Record<string, unknown>> {
+      const cmd = mockSend.mock.calls[0][0]
+      return (cmd.input.messages ?? []) as Array<Record<string, unknown>>
+    }
+
+    // -----------------------------------------------------------------------
+    // inbound: chat()
+    // -----------------------------------------------------------------------
+
+    it('chat(): extracts signature from reasoningText into ReasoningBlock', async () => {
+      mockSend.mockResolvedValue(makeConverseResponse({
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              { reasoningContent: { reasoningText: { text: 'step 1', signature: 'sig-abc' } } },
+              { text: 'Answer.' },
+            ],
+          },
+        },
+      }))
+
+      const result = await adapter.chat([textMsg('user', 'Hi')], chatOpts())
+
+      expect(result.content[0]).toEqual({
+        type: 'reasoning',
+        text: 'step 1',
+        signature: 'sig-abc',
+        provenance: 'bedrock',
+      })
+    })
+
+    it('chat(): extracts redactedContent into ReasoningBlock.redactedData (base64)', async () => {
+      const redactedBytes = Buffer.from('encrypted-opaque')
+      mockSend.mockResolvedValue(makeConverseResponse({
+        output: {
+          message: {
+            role: 'assistant',
+            content: [
+              { reasoningContent: { redactedContent: redactedBytes } },
+              { text: 'Answer.' },
+            ],
+          },
+        },
+      }))
+
+      const result = await adapter.chat([textMsg('user', 'Hi')], chatOpts())
+
+      expect(result.content[0]).toEqual({
+        type: 'reasoning',
+        text: '',
+        redactedData: redactedBytes.toString('base64'),
+        provenance: 'bedrock',
+      })
+    })
+
+    // -----------------------------------------------------------------------
+    // outbound: toBedrockContentBlock
+    // -----------------------------------------------------------------------
+
+    it('outbound: bedrock-provenance block with signature echoes natively (no <thinking>)', async () => {
+      mockSend.mockResolvedValue(makeConverseResponse())
+      const messages: LLMMessage[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'plan', signature: 'sig-xyz', provenance: 'bedrock' },
+            { type: 'text', text: 'reply' },
+          ],
+        },
+      ]
+
+      await adapter.chat(messages, chatOpts())
+
+      const sentContent = lastSentMessages()[0]?.content as Array<Record<string, unknown>>
+      expect(sentContent).toHaveLength(2)
+      expect(sentContent[0]).toEqual({
+        reasoningContent: { reasoningText: { text: 'plan', signature: 'sig-xyz' } },
+      })
+      expect(sentContent[1]).toEqual({ text: 'reply' })
+    })
+
+    it('outbound: bedrock-provenance block with signature echoes natively even when preserveReasoningAsText is off', async () => {
+      mockSend.mockResolvedValue(makeConverseResponse())
+      const messages: LLMMessage[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'plan', signature: 'sig-xyz', provenance: 'bedrock' },
+            { type: 'text', text: 'reply' },
+          ],
+        },
+      ]
+
+      await adapter.chat(messages, chatOpts({ preserveReasoningAsText: false }))
+
+      const sentContent = lastSentMessages()[0]?.content as Array<Record<string, unknown>>
+      expect(sentContent[0]).toEqual({
+        reasoningContent: { reasoningText: { text: 'plan', signature: 'sig-xyz' } },
+      })
+    })
+
+    it('outbound: bedrock-provenance block without signature falls back to text (preserveReasoningAsText=true)', async () => {
+      mockSend.mockResolvedValue(makeConverseResponse())
+      const messages: LLMMessage[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: 'plan', provenance: 'bedrock' },
+            { type: 'text', text: 'reply' },
+          ],
+        },
+      ]
+
+      await adapter.chat(messages, chatOpts({ preserveReasoningAsText: true }))
+
+      const sentContent = lastSentMessages()[0]?.content as Array<Record<string, unknown>>
+      expect(sentContent[0]).toEqual({ text: '<thinking>plan</thinking>' })
+    })
+
+    it('outbound: bedrock-provenance redacted block echoes natively via redactedContent', async () => {
+      mockSend.mockResolvedValue(makeConverseResponse())
+      const b64 = Buffer.from('encrypted').toString('base64')
+      const messages: LLMMessage[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'reasoning', text: '', redactedData: b64, provenance: 'bedrock' },
+            { type: 'text', text: 'reply' },
+          ],
+        },
+      ]
+
+      await adapter.chat(messages, chatOpts())
+
+      const sentContent = lastSentMessages()[0]?.content as Array<Record<string, unknown>>
+      expect(sentContent[0]).toMatchObject({
+        reasoningContent: { redactedContent: Buffer.from('encrypted') },
+      })
+    })
+
+    // -----------------------------------------------------------------------
+    // inbound: stream()
+    // -----------------------------------------------------------------------
+
+    it('stream(): accumulates signature delta into ReasoningBlock in done payload', async () => {
+      mockSend.mockResolvedValue(makeStreamResponse([
+        { contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: 'plan ' } } } },
+        { contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: 'step' } } } },
+        { contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { signature: 'sig-stream' } } } },
+        { contentBlockStop: { contentBlockIndex: 0 } },
+        { contentBlockDelta: { contentBlockIndex: 1, delta: { text: 'answer' } } },
+        { messageStop: { stopReason: 'end_turn' } },
+        { metadata: { usage: { inputTokens: 5, outputTokens: 3 } } },
+      ]))
+
+      const events = await collectEvents(adapter.stream([textMsg('user', 'Hi')], chatOpts()))
+      const response = events.find(e => e.type === 'done')?.data as LLMResponse
+      const reasoningBlocks = response.content.filter(b => b.type === 'reasoning')
+
+      expect(reasoningBlocks).toEqual([{
+        type: 'reasoning',
+        text: 'plan step',
+        signature: 'sig-stream',
+        provenance: 'bedrock',
+      }])
+    })
+
+    it('stream(): reasoning block without signature delta has no signature field', async () => {
+      mockSend.mockResolvedValue(makeStreamResponse([
+        { contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: 'thought' } } } },
+        { contentBlockStop: { contentBlockIndex: 0 } },
+        { messageStop: { stopReason: 'end_turn' } },
+        { metadata: { usage: { inputTokens: 2, outputTokens: 1 } } },
+      ]))
+
+      const events = await collectEvents(adapter.stream([textMsg('user', 'Hi')], chatOpts()))
+      const response = events.find(e => e.type === 'done')?.data as LLMResponse
+      const block = response.content.find(b => b.type === 'reasoning')
+
+      expect(block).toEqual({ type: 'reasoning', text: 'thought', provenance: 'bedrock' })
+      expect((block as { signature?: string }).signature).toBeUndefined()
+    })
+
+    // -----------------------------------------------------------------------
+    // capabilities
+    // -----------------------------------------------------------------------
+
+    it('capabilities.echoesReasoning is "own-issued"', () => {
+      expect(adapter.capabilities.echoesReasoning).toBe('own-issued')
+    })
+  })
 })

--- a/tests/llm-adapter-capabilities.test.ts
+++ b/tests/llm-adapter-capabilities.test.ts
@@ -66,7 +66,7 @@ describe('LLMAdapter Phase 1 capability contract', () => {
     ['minimax', () => new MiniMaxAdapter('dummy-key'), 'never' as const],
     ['mimo', () => new MiMoAdapter('dummy-key'), 'tool-use-only' as const],
     ['hunyuan', () => new HunyuanAdapter('dummy-key'), 'tool-use-only' as const],
-    ['bedrock', () => new BedrockAdapter('us-east-1'), 'never' as const],
+    ['bedrock', () => new BedrockAdapter('us-east-1'), 'own-issued' as const],
   ])('%s declares the documented name and capabilities', (expectedName, factory, expectedEcho) => {
     const adapter = factory()
     expect(adapter.name).toBe(expectedName)


### PR DESCRIPTION
## Summary

Completes the Bedrock extended-thinking multi-turn round-trip by wiring both legs of the `reasoningContent.reasoningText.signature` protocol:

- **Inbound `chat()`** — `fromBedrockContentBlock` now extracts `signature` from `reasoningText.signature` and `redactedContent` bytes (converted to base64 `redactedData`) into the `ReasoningBlock` IR.
- **Inbound `stream()`** — the streaming loop now handles the `reasoningContent.signature` delta variant (a separate `SignatureMember` event that follows the text deltas); the signature is attached to the accumulated `ReasoningBlock` at `contentBlockStop`.
- **Outbound `toBedrockContentBlock`** — `'reasoning'` blocks with `provenance === 'bedrock'` are now echoed natively: blocks with a `signature` emit `{ reasoningContent: { reasoningText: { text, signature } } }`; blocks with `redactedData` emit `{ reasoningContent: { redactedContent: <bytes> } }`. Unsigned or foreign-provenance blocks fall back to the existing `<thinking>` text path (or are dropped silently when `preserveReasoningAsText` is off).
- **Capabilities** — `echoesReasoning` is promoted from `'never'` to `'own-issued'`, unblocking the cross-provider reasoning-fallback logic in `reasoning-fallback.ts`.

## Tests

9 new tests added to `tests/bedrock-adapter.test.ts` under `reasoning round-trip (#223 Phase 3)`:

- `chat()`: extracts `signature` from `reasoningText` into `ReasoningBlock`
- `chat()`: extracts `redactedContent` bytes into `ReasoningBlock.redactedData` (base64)
- Outbound: bedrock-provenance block with `signature` echoes natively (no `<thinking>`)
- Outbound: native echo fires even when `preserveReasoningAsText` is off
- Outbound: bedrock-provenance block without signature still falls back to text path
- Outbound: bedrock-provenance `redactedData` block echoes via `redactedContent`
- `stream()`: signature delta accumulates into `ReasoningBlock` in done payload
- `stream()`: reasoning block without signature delta has no `signature` field
- `capabilities.echoesReasoning` is `'own-issued'`

`tests/llm-adapter-capabilities.test.ts` updated to expect `'own-issued'` for the bedrock adapter.

All 52 tests in the two affected files pass; the full suite passes modulo pre-existing Windows-environment failures in `fs-walk.test.ts` and `built-in-tools.test.ts` (bash/symlink, unrelated to this change).

Closes #223
