### PR TITLE
docs: make the quickstart provider-neutral (OpenAI-compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Prefer to run something first? Clone and run an example:
 ```bash
 git clone https://github.com/open-multi-agent/open-multi-agent && cd open-multi-agent
 npm install
-export ANTHROPIC_API_KEY=sk-...
+export OPENAI_API_KEY=sk-...
 npx tsx packages/core/examples/basics/team-collaboration.ts
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -61,7 +61,7 @@ npm install @open-multi-agent/core
 ```bash
 git clone https://github.com/open-multi-agent/open-multi-agent && cd open-multi-agent
 npm install
-export ANTHROPIC_API_KEY=sk-...
+export OPENAI_API_KEY=sk-...
 npx tsx packages/core/examples/basics/team-collaboration.ts
 ```
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -63,23 +63,28 @@ npm install @open-multi-agent/core
 ```typescript
 import { OpenMultiAgent, type AgentConfig } from '@open-multi-agent/core'
 
+// Works with any OpenAI-compatible provider. Set OPENAI_API_KEY for OpenAI, or
+// set OPENAI_BASE_URL + OMA_MODEL for Groq, DeepSeek, Ollama, etc.
+const model = process.env.OMA_MODEL ?? 'gpt-5.4'
+
 // Built-in tools are opt-in (default-deny): each agent gets only the tools it
 // lists in `tools` (or a `toolPreset`). List neither and the agent gets none.
 const agents: AgentConfig[] = [
-  { name: 'architect', model: 'claude-sonnet-4-6', systemPrompt: 'Design clean API contracts.', tools: ['file_write'] },
-  { name: 'developer', model: 'claude-sonnet-4-6', systemPrompt: 'Implement runnable TypeScript.', tools: ['bash', 'file_read', 'file_write', 'file_edit'] },
-  { name: 'reviewer', model: 'claude-sonnet-4-6', systemPrompt: 'Review correctness and security.', tools: ['file_read', 'grep'] },
+  { name: 'architect', model, systemPrompt: 'Design clean API contracts.', tools: ['file_write'] },
+  { name: 'developer', model, systemPrompt: 'Implement runnable TypeScript.', tools: ['bash', 'file_read', 'file_write', 'file_edit'] },
+  { name: 'reviewer', model, systemPrompt: 'Review correctness and security.', tools: ['file_read', 'grep'] },
 ]
 
 const orchestrator = new OpenMultiAgent({
-  defaultModel: 'claude-sonnet-4-6',
+  defaultProvider: 'openai',
+  defaultModel: model,
+  defaultBaseURL: process.env.OPENAI_BASE_URL, // unset = OpenAI
   onProgress: (event) => console.log(event.type, event.task ?? event.agent ?? ''),
 })
 
 const team = orchestrator.createTeam('api-team', { name: 'api-team', agents, sharedMemory: true })
 
 // Built-in filesystem tools default to a `<cwd>/.agent-workspace` sandbox.
-// Point the agent at an absolute path inside that root.
 const result = await orchestrator.runTeam(
   team,
   `Create a REST API for a todo list in ${process.cwd()}/.agent-workspace/todo-api/`,
@@ -93,7 +98,7 @@ console.log(result.success, result.totalTokenUsage.output_tokens)
 ```bash
 git clone https://github.com/open-multi-agent/open-multi-agent && cd open-multi-agent
 npm install
-export ANTHROPIC_API_KEY=sk-...
+export OPENAI_API_KEY=sk-...
 npx tsx examples/basics/team-collaboration.ts
 ```
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -63,23 +63,28 @@ npm install @open-multi-agent/core
 ```typescript
 import { OpenMultiAgent, type AgentConfig } from '@open-multi-agent/core'
 
+// 适配任意 OpenAI 兼容 provider：用 OpenAI 就设 OPENAI_API_KEY；
+// 用 Groq / DeepSeek / Ollama 等就设 OPENAI_BASE_URL + OMA_MODEL。
+const model = process.env.OMA_MODEL ?? 'gpt-5.4'
+
 // 内置工具默认拒绝（default-deny）：每个 agent 只拿到自己在 `tools`（或 `toolPreset`）
 // 里列出的工具；两者都不写就一个都不给。
 const agents: AgentConfig[] = [
-  { name: 'architect', model: 'claude-sonnet-4-6', systemPrompt: 'Design clean API contracts.', tools: ['file_write'] },
-  { name: 'developer', model: 'claude-sonnet-4-6', systemPrompt: 'Implement runnable TypeScript.', tools: ['bash', 'file_read', 'file_write', 'file_edit'] },
-  { name: 'reviewer', model: 'claude-sonnet-4-6', systemPrompt: 'Review correctness and security.', tools: ['file_read', 'grep'] },
+  { name: 'architect', model, systemPrompt: 'Design clean API contracts.', tools: ['file_write'] },
+  { name: 'developer', model, systemPrompt: 'Implement runnable TypeScript.', tools: ['bash', 'file_read', 'file_write', 'file_edit'] },
+  { name: 'reviewer', model, systemPrompt: 'Review correctness and security.', tools: ['file_read', 'grep'] },
 ]
 
 const orchestrator = new OpenMultiAgent({
-  defaultModel: 'claude-sonnet-4-6',
+  defaultProvider: 'openai',
+  defaultModel: model,
+  defaultBaseURL: process.env.OPENAI_BASE_URL, // 不设 = OpenAI
   onProgress: (event) => console.log(event.type, event.task ?? event.agent ?? ''),
 })
 
 const team = orchestrator.createTeam('api-team', { name: 'api-team', agents, sharedMemory: true })
 
-// 内置文件系统工具默认沙箱根目录为 `<cwd>/.agent-workspace`，
-// 给 agent 的 prompt 里需要使用该目录内的绝对路径。
+// 内置文件系统工具默认沙箱根目录为 `<cwd>/.agent-workspace`。
 const result = await orchestrator.runTeam(
   team,
   `Create a REST API for a todo list in ${process.cwd()}/.agent-workspace/todo-api/`,
@@ -93,7 +98,7 @@ console.log(result.success, result.totalTokenUsage.output_tokens)
 ```bash
 git clone https://github.com/open-multi-agent/open-multi-agent && cd open-multi-agent
 npm install
-export ANTHROPIC_API_KEY=sk-...
+export OPENAI_API_KEY=sk-...
 npx tsx examples/basics/team-collaboration.ts
 ```
 

--- a/packages/core/examples/basics/team-collaboration.ts
+++ b/packages/core/examples/basics/team-collaboration.ts
@@ -9,12 +9,17 @@
  *   npx tsx examples/basics/team-collaboration.ts
  *
  * Prerequisites:
- *   ANTHROPIC_API_KEY env var must be set.
+ *   OPENAI_API_KEY env var must be set. Works with any OpenAI-compatible
+ *   provider: set OPENAI_BASE_URL + OMA_MODEL for Groq, DeepSeek, Ollama, etc.
  */
 
 import { join } from 'node:path'
 import { OpenMultiAgent } from '../../src/index.js'
 import type { AgentConfig, OrchestratorEvent } from '../../src/types.js'
+
+// Works with any OpenAI-compatible provider. Set OPENAI_API_KEY for OpenAI, or
+// OPENAI_BASE_URL + OMA_MODEL for Groq, DeepSeek, Ollama, etc.
+const model = process.env.OMA_MODEL ?? 'gpt-5.4'
 
 // Built-in filesystem tools are sandboxed to `<cwd>/.agent-workspace` by
 // default; the generated API lives under that root so the demo runs
@@ -27,8 +32,7 @@ const OUTPUT_DIR = join(process.cwd(), '.agent-workspace', 'express-api')
 
 const architect: AgentConfig = {
   name: 'architect',
-  model: 'claude-sonnet-4-6',
-  provider: 'anthropic',
+  model,
   systemPrompt: `You are a software architect with deep experience in Node.js and REST API design.
 Your job is to design clear, production-quality API contracts and file/directory structures.
 Output concise plans in markdown — no unnecessary prose.`,
@@ -39,8 +43,7 @@ Output concise plans in markdown — no unnecessary prose.`,
 
 const developer: AgentConfig = {
   name: 'developer',
-  model: 'claude-sonnet-4-6',
-  provider: 'anthropic',
+  model,
   systemPrompt: `You are a TypeScript/Node.js developer. You implement what the architect specifies.
 Write clean, runnable code with proper error handling. Use the tools to write files and run tests.`,
   tools: ['bash', 'file_read', 'file_write', 'file_edit'],
@@ -50,8 +53,7 @@ Write clean, runnable code with proper error handling. Use the tools to write fi
 
 const reviewer: AgentConfig = {
   name: 'reviewer',
-  model: 'claude-sonnet-4-6',
-  provider: 'anthropic',
+  model,
   systemPrompt: `You are a senior code reviewer. Review code for correctness, security, and clarity.
 Provide a structured review with: LGTM items, suggestions, and any blocking issues.
 Read files using the tools before reviewing.`,
@@ -107,7 +109,9 @@ function handleProgress(event: OrchestratorEvent): void {
 // ---------------------------------------------------------------------------
 
 const orchestrator = new OpenMultiAgent({
-  defaultModel: 'claude-sonnet-4-6',
+  defaultProvider: 'openai',
+  defaultModel: model,
+  defaultBaseURL: process.env.OPENAI_BASE_URL, // unset = OpenAI
   maxConcurrency: 1, // run agents sequentially so output is readable
   onProgress: handleProgress,
 })


### PR DESCRIPTION
## What

The Quick Start's first-screen example anchored on Anthropic (`claude-sonnet-4-6` + `ANTHROPIC_API_KEY`), a real barrier for developers without Anthropic access. This makes the first impression provider-neutral: an OpenAI-compatible, env-driven setup that runs unchanged on OpenAI, Groq, DeepSeek, Ollama, or any compatible endpoint.

## Changes

- `examples/basics/team-collaboration.ts`: `defaultProvider: 'openai'`, model from `OMA_MODEL` (default `gpt-5.4`), `defaultBaseURL` from `OPENAI_BASE_URL` (unset = OpenAI). Dropped per-agent `provider: 'anthropic'`.
- npm-page README (`packages/core/README.md` + `_zh`): first code block uses the same OpenAI-compatible setup; run command uses `OPENAI_API_KEY`.
- Facade README (`README.md` + `_zh`): run command uses `OPENAI_API_KEY`.

The demo stays substantive (3-agent team + tools building a REST API). No runtime-dependency changes; the 3-dependency contract and the badge are untouched.

## Verification

- `npm run lint` passes.
- Ran the updated example end-to-end against an OpenAI-compatible (DeepSeek) key: the coordinator decomposed the goal, architect/developer/reviewer ran with tools (47 tool calls total), `Success: true`.