### PR TITLE
feat(create-oma): scaffold a runnable multi-agent demo in one command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,24 @@ jobs:
             echo "Either the build did not run or an entry was dropped from package.json \"files\"."
             exit 1
           fi
+
+      - name: Assert the create-oma tarball ships dist + template
+        working-directory: packages/create-oma
+        run: |
+          paths=$(npm pack --dry-run --json | jq -r '.[0].files[].path')
+          unexpected=$(echo "$paths" | grep -vE '^(dist/|template/|README\.md$|LICENSE$|package\.json$)' || true)
+          if [ -n "$unexpected" ]; then
+            echo "Unexpected files staged for the create-oma tarball:"
+            echo "$unexpected"
+            echo "Only dist/, template/, README.md, LICENSE, package.json may ship."
+            exit 1
+          fi
+          missing=""
+          for f in dist/index.js dist/scaffold.js template/package.json template/src/index.ts template/_env.example template/_gitignore; do
+            echo "$paths" | grep -qxF "$f" || missing="$missing $f"
+          done
+          if [ -n "$missing" ]; then
+            echo "Required files missing from the create-oma tarball:$missing"
+            echo "The scaffolder needs its template/ to function once published."
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,17 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - name: Assert the create-oma template pins the current core version
+        run: |
+          core_version=$(jq -r .version packages/core/package.json)
+          pinned=$(jq -r '.dependencies["@open-multi-agent/core"]' packages/create-oma/template/package.json)
+          if [ "$pinned" != "$core_version" ]; then
+            echo "create-oma template pins @open-multi-agent/core@$pinned but this repo's core is $core_version."
+            echo "Bump the pin in packages/create-oma/template/package.json to match before release."
+            exit 1
+          fi
+      - name: Typecheck the create-oma template against core
+        run: npm run typecheck:template -w create-oma
       - name: Assert the npm tarball ships exactly the expected files
         working-directory: packages/core
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -3336,6 +3336,10 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/create-oma": {
+      "resolved": "packages/create-oma",
+      "link": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6500,6 +6504,21 @@
         "ai": {
           "optional": true
         }
+      }
+    },
+    "packages/create-oma": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "create-oma": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build -w @open-multi-agent/core",
+    "build": "npm run build --workspaces --if-present",
     "dev": "npm run dev -w @open-multi-agent/core",
-    "test": "npm run test -w @open-multi-agent/core",
+    "test": "npm run test --workspaces --if-present",
     "test:watch": "npm run test:watch -w @open-multi-agent/core",
     "test:coverage": "npm run test:coverage -w @open-multi-agent/core",
     "test:e2e": "npm run test:e2e -w @open-multi-agent/core",
-    "lint": "npm run lint -w @open-multi-agent/core"
+    "lint": "npm run lint --workspaces --if-present"
   },
   "license": "MIT",
   "repository": {

--- a/packages/create-oma/LICENSE
+++ b/packages/create-oma/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 open-multi-agent contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/create-oma/README.md
+++ b/packages/create-oma/README.md
@@ -1,0 +1,42 @@
+# create-oma
+
+Scaffold a runnable multi-agent demo on [`@open-multi-agent/core`](https://www.npmjs.com/package/@open-multi-agent/core) — one command from zero to a live agent DAG.
+
+```bash
+npm create oma@latest
+```
+
+Answer one prompt (the project name) and you get a small project that, on its first run, shows a **coordinator breaking a single goal into a multi-agent DAG** — agents running in parallel and in dependency order — then opens a dashboard of the run in your browser.
+
+## What you get
+
+```
+my-demo/
+├── src/index.ts     # the demo: one goal → multi-agent DAG → dashboard
+├── .env.example     # OpenAI, or any OpenAI-compatible provider
+├── package.json     # one runtime dependency: @open-multi-agent/core
+├── tsconfig.json
+└── README.md
+```
+
+- **One runtime dependency** — `@open-multi-agent/core`; `tsx` is the only dev dependency.
+- **Provider-neutral** — OpenAI out of the box, or any OpenAI-compatible endpoint (DeepSeek, Groq, Ollama, …) via `OPENAI_BASE_URL` + `OMA_MODEL`.
+- **No tools, no filesystem writes** — the default demo is pure reasoning, so the first run is fast and robust across providers.
+
+## Run it
+
+```bash
+npm create oma@latest my-demo
+cd my-demo
+npm install
+cp .env.example .env   # add your key
+npm run dev
+```
+
+## Next steps
+
+Open `src/index.ts` and change the goal, add an agent, or give an agent tools. See the [examples](https://github.com/open-multi-agent/open-multi-agent/tree/main/packages/core/examples) for tool use, MCP, structured output, and providers.
+
+## License
+
+MIT

--- a/packages/create-oma/package.json
+++ b/packages/create-oma/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "create-oma",
+  "version": "0.1.0",
+  "description": "Scaffold a runnable multi-agent demo on @open-multi-agent/core — one command from zero to a live agent DAG.",
+  "type": "module",
+  "bin": {
+    "create-oma": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "template",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "open-multi-agent",
+    "multi-agent",
+    "scaffold",
+    "create",
+    "starter",
+    "ai",
+    "agent"
+  ],
+  "author": {
+    "name": "open-multi-agent",
+    "url": "https://github.com/open-multi-agent"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-multi-agent/open-multi-agent.git",
+    "directory": "packages/create-oma"
+  },
+  "homepage": "https://github.com/open-multi-agent/open-multi-agent/tree/main/packages/create-oma#readme",
+  "bugs": {
+    "url": "https://github.com/open-multi-agent/open-multi-agent/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/create-oma/package.json
+++ b/packages/create-oma/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build": "tsc",
     "lint": "tsc --noEmit",
+    "typecheck:template": "tsc -p template/tsconfig.json",
     "test": "vitest run",
     "prepublishOnly": "npm run build"
   },

--- a/packages/create-oma/src/index.ts
+++ b/packages/create-oma/src/index.ts
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * create-oma — scaffold a runnable multi-agent demo on @open-multi-agent/core.
+ *
+ * Usage:
+ *   npm create oma@latest [project-name]
+ *
+ * One command from zero to a live coordinator-driven agent DAG. The copy logic
+ * lives in scaffold.ts; this file is the interactive CLI. Zero runtime
+ * dependencies — Node.js built-ins only, so `npm create oma` stays a fast,
+ * clean one-shot whose own deps never reach the generated project or core.
+ */
+import { basename, resolve } from 'node:path'
+import { createInterface } from 'node:readline'
+import { isNonEmptyDir, scaffold } from './scaffold.js'
+
+// Minimal ANSI styling — no dependency.
+const ESC = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  cyan: '\x1b[36m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+}
+const bold = (s: string): string => `${ESC.bold}${s}${ESC.reset}`
+const dim = (s: string): string => `${ESC.dim}${s}${ESC.reset}`
+const cyan = (s: string): string => `${ESC.cyan}${s}${ESC.reset}`
+const green = (s: string): string => `${ESC.green}${s}${ESC.reset}`
+
+function prompt(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  return new Promise((res) => {
+    rl.question(question, (answer) => {
+      rl.close()
+      res(answer.trim())
+    })
+  })
+}
+
+async function main(): Promise<void> {
+  console.log()
+  console.log(`  ${bold('create-oma')}${dim(' — scaffold a multi-agent demo')}`)
+  console.log()
+
+  // 1. Resolve the project directory name (argv, else one prompt).
+  let projectName = process.argv[2]
+  if (!projectName) projectName = await prompt(`  Project name: ${dim('(oma-demo)')} `)
+  projectName = (projectName || 'oma-demo').trim()
+  const dirName = basename(projectName)
+  const targetDir = resolve(process.cwd(), projectName)
+
+  // 2. Refuse to overwrite a non-empty directory without confirmation.
+  if (isNonEmptyDir(targetDir)) {
+    console.log()
+    console.log(`  ${ESC.yellow}!${ESC.reset} ${bold(dirName)} already exists and is not empty.`)
+    const answer = (await prompt(`  Write into it anyway? ${dim('(y/N)')} `)).toLowerCase()
+    if (answer !== 'y' && answer !== 'yes') {
+      console.log(`  ${ESC.red}✗${ESC.reset} Aborted.`)
+      process.exitCode = 1
+      return
+    }
+  }
+
+  // 3. Scaffold. Use the basename for the package name so a path-y project
+  //    name (e.g. ./apps/my-demo) still yields a clean npm name.
+  scaffold({ targetDir, projectName: dirName })
+
+  // 4. Next steps.
+  console.log()
+  console.log(`  ${green('✓')} Created ${bold(dirName)}`)
+  console.log()
+  console.log('  Next steps:')
+  console.log()
+  console.log(`    ${cyan(`cd ${projectName}`)}`)
+  console.log(`    ${cyan('npm install')}`)
+  console.log(`    ${cyan('cp .env.example .env')}   ${dim('# then add your API key')}`)
+  console.log(`    ${cyan('npm run dev')}`)
+  console.log()
+  console.log(dim('  One goal becomes a multi-agent DAG, then a dashboard of the run'))
+  console.log(dim('  opens in your browser. OpenAI or any OpenAI-compatible endpoint'))
+  console.log(dim('  (DeepSeek, Groq, Ollama, …) — see .env.example.'))
+  console.log()
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/packages/create-oma/src/scaffold.ts
+++ b/packages/create-oma/src/scaffold.ts
@@ -1,0 +1,55 @@
+/**
+ * create-oma scaffold core — copy the bundled template into a target directory,
+ * restore the shipped dotfiles, and stamp the project name. No console output,
+ * no prompts: the CLI in index.ts handles interaction so this stays testable.
+ */
+import { cpSync, existsSync, readdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+/** template/ ships alongside dist/ (and src/) one level under the package root. */
+export const TEMPLATE_DIR = fileURLToPath(new URL('../template', import.meta.url))
+
+/** Turn an arbitrary project name into a valid npm package name. */
+export function toPackageName(input: string): string {
+  return (
+    input
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9-~]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'oma-demo'
+  )
+}
+
+/** True when `dir` exists and contains at least one entry. */
+export function isNonEmptyDir(dir: string): boolean {
+  return existsSync(dir) && readdirSync(dir).length > 0
+}
+
+export interface ScaffoldOptions {
+  readonly targetDir: string
+  readonly projectName: string
+  /** Override the template source (tests). Defaults to the bundled template. */
+  readonly templateDir?: string
+}
+
+/** Copy the template into `targetDir`, restore dotfiles, stamp the name. */
+export function scaffold({ targetDir, projectName, templateDir = TEMPLATE_DIR }: ScaffoldOptions): void {
+  cpSync(templateDir, targetDir, { recursive: true })
+  restoreDotfile(targetDir, '_gitignore', '.gitignore')
+  restoreDotfile(targetDir, '_env.example', '.env.example')
+
+  const pkgPath = join(targetDir, 'package.json')
+  const stamped = readFileSync(pkgPath, 'utf8').replace(/__PROJECT_NAME__/g, toPackageName(projectName))
+  writeFileSync(pkgPath, stamped)
+}
+
+/**
+ * Restore a shipped dotfile. npm strips/renames real dotfiles (notably
+ * `.gitignore`) on publish, so the template ships them as `_gitignore` /
+ * `_env.example` and we rename them on scaffold.
+ */
+function restoreDotfile(dir: string, from: string, to: string): void {
+  const fromPath = join(dir, from)
+  if (existsSync(fromPath)) renameSync(fromPath, join(dir, to))
+}

--- a/packages/create-oma/template/README.md
+++ b/packages/create-oma/template/README.md
@@ -1,0 +1,27 @@
+# Multi-agent demo
+
+Built on [`@open-multi-agent/core`](https://www.npmjs.com/package/@open-multi-agent/core), scaffolded with `npm create oma`.
+
+## Run
+
+```bash
+npm install
+cp .env.example .env   # add your API key
+npm run dev
+```
+
+You'll see a **coordinator** break one goal into a task DAG, several agents run in parallel and in dependency order, and a **dashboard** of the run open in your browser (`dashboard.html`).
+
+Works with OpenAI out of the box, or any OpenAI-compatible provider — set `OPENAI_BASE_URL` + `OMA_MODEL` in `.env` (DeepSeek, Groq, Ollama, …). See `.env.example`.
+
+## What's next
+
+Everything lives in [`src/index.ts`](src/index.ts):
+
+- **Change the goal** — swap the goal string for your own multi-step task.
+- **Add an agent** — add an `AgentConfig` to the team roster; the coordinator routes work to it.
+- **Give agents tools** — add e.g. `tools: ['file_read', 'file_write', 'bash']` to an agent so it can read/write files, run commands, or call MCP servers.
+
+More patterns (tool use, MCP, structured output, providers) are in the [examples](https://github.com/open-multi-agent/open-multi-agent/tree/main/packages/core/examples).
+
+> Tip: for full editor type-checking, `npm i -D @types/node`. Not needed to run.

--- a/packages/create-oma/template/_env.example
+++ b/packages/create-oma/template/_env.example
@@ -1,0 +1,22 @@
+# Set ONE provider. The demo uses an OpenAI-compatible client.
+
+# --- OpenAI (default) -------------------------------------------------------
+OPENAI_API_KEY=sk-...
+
+# --- Or any OpenAI-compatible endpoint --------------------------------------
+# Set OPENAI_BASE_URL at the provider and OMA_MODEL to one of its models.
+#
+# DeepSeek:
+#   OPENAI_API_KEY=sk-...
+#   OPENAI_BASE_URL=https://api.deepseek.com
+#   OMA_MODEL=deepseek-chat
+#
+# Groq:
+#   OPENAI_API_KEY=gsk_...
+#   OPENAI_BASE_URL=https://api.groq.com/openai/v1
+#   OMA_MODEL=llama-3.3-70b-versatile
+#
+# Ollama (local, no cloud key — any non-empty value works):
+#   OPENAI_API_KEY=ollama
+#   OPENAI_BASE_URL=http://localhost:11434/v1
+#   OMA_MODEL=llama3.2

--- a/packages/create-oma/template/_gitignore
+++ b/packages/create-oma/template/_gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+dashboard.html
+.agent-workspace/

--- a/packages/create-oma/template/package.json
+++ b/packages/create-oma/template/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "__PROJECT_NAME__",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@open-multi-agent/core": "1.7.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
+  }
+}

--- a/packages/create-oma/template/src/index.ts
+++ b/packages/create-oma/template/src/index.ts
@@ -14,6 +14,8 @@
  */
 import { spawn } from 'node:child_process'
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { OpenMultiAgent, renderTeamRunDashboard } from '@open-multi-agent/core'
 import type { AgentConfig, OrchestratorEvent } from '@open-multi-agent/core'
 
@@ -105,14 +107,21 @@ function onProgress(event: OrchestratorEvent): void {
 
 /** Best-effort open in the default browser; prints the path if it can't. */
 function openInBrowser(file: string): void {
-  const url = `file://${process.cwd()}/${file}`
-  const cmd = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open'
+  // pathToFileURL handles drive letters, slashes, and spaces on every OS —
+  // a hand-built `file://` string breaks on Windows paths.
+  const url = pathToFileURL(resolve(file)).href
+  const fallback = (): void => console.log(`  Open it manually: ${url}`)
   try {
-    const child = spawn(cmd, [url], { stdio: 'ignore', detached: true, shell: process.platform === 'win32' })
-    child.on('error', () => console.log(`  Open it manually: ${url}`))
+    // On Windows the opener is cmd's `start`, whose first quoted arg is the
+    // window title — pass an empty title ("") so the URL isn't swallowed.
+    const child =
+      process.platform === 'win32'
+        ? spawn('cmd', ['/c', 'start', '', url], { stdio: 'ignore', detached: true })
+        : spawn(process.platform === 'darwin' ? 'open' : 'xdg-open', [url], { stdio: 'ignore', detached: true })
+    child.on('error', fallback)
     child.unref()
   } catch {
-    console.log(`  Open it manually: ${url}`)
+    fallback()
   }
 }
 

--- a/packages/create-oma/template/src/index.ts
+++ b/packages/create-oma/template/src/index.ts
@@ -1,0 +1,169 @@
+/**
+ * Multi-agent demo — one goal, automatically decomposed into a task DAG.
+ *
+ * The OpenMultiAgent coordinator reads the goal below, breaks it into tasks,
+ * assigns them to the right agents, and runs them in parallel and in dependency
+ * order. When the run finishes, a dashboard of the DAG opens in your browser.
+ *
+ * These agents use NO tools — pure reasoning — so the first run is fast and
+ * works on any OpenAI-compatible model. To watch agents use tools (read/write
+ * files, run commands, call MCP servers), give an agent a `tools` array; see
+ * the examples linked in the README.
+ *
+ * Run:  npm run dev
+ */
+import { spawn } from 'node:child_process'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { OpenMultiAgent, renderTeamRunDashboard } from '@open-multi-agent/core'
+import type { AgentConfig, OrchestratorEvent } from '@open-multi-agent/core'
+
+// --- Minimal .env loader ----------------------------------------------------
+// Reads .env into process.env so `npm run dev` works right after
+// `cp .env.example .env`. Inlined to keep the project at ONE runtime
+// dependency (no dotenv). Existing env vars win.
+function loadEnv(path = '.env'): void {
+  if (!existsSync(path)) return
+  for (const raw of readFileSync(path, 'utf8').split('\n')) {
+    const line = raw.trim()
+    if (!line || line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq === -1) continue
+    const key = line.slice(0, eq).trim()
+    const val = line.slice(eq + 1).trim().replace(/^["']|["']$/g, '')
+    if (key && !(key in process.env)) process.env[key] = val
+  }
+}
+loadEnv()
+
+// --- Provider (OpenAI-compatible, env-driven) -------------------------------
+// OPENAI_API_KEY is read automatically by the OpenAI client. For another
+// provider, set OPENAI_BASE_URL + OMA_MODEL in .env (DeepSeek, Groq, Ollama…).
+const model = process.env.OMA_MODEL ?? 'gpt-5.4'
+
+if (!process.env.OPENAI_API_KEY) {
+  console.error(
+    '\n  Missing OPENAI_API_KEY.\n\n' +
+      '  1. cp .env.example .env\n' +
+      '  2. add a key — OpenAI, or any OpenAI-compatible provider\n' +
+      '     (DeepSeek, Groq, Ollama, …; see .env.example)\n',
+  )
+  process.exit(1)
+}
+
+// --- The team: four specialists, no tools, pure reasoning -------------------
+const strategist: AgentConfig = {
+  name: 'strategist',
+  model,
+  systemPrompt: `You define sharp, outcome-focused goals.
+Given a brief, name the few outcomes that matter most. Concrete bullet points, no filler.`,
+  maxTurns: 1,
+  temperature: 0.3,
+}
+
+const planner: AgentConfig = {
+  name: 'planner',
+  model,
+  systemPrompt: `You turn outcomes into a concrete, time-boxed plan.
+Produce clear weekly milestones — each a short, checkable line. No filler.`,
+  maxTurns: 1,
+  temperature: 0.2,
+}
+
+const riskAnalyst: AgentConfig = {
+  name: 'risk-analyst',
+  model,
+  systemPrompt: `You stress-test plans.
+Name the few highest-impact risks and give one concrete, specific mitigation for each.`,
+  maxTurns: 1,
+  temperature: 0.4,
+}
+
+const synthesizer: AgentConfig = {
+  name: 'synthesizer',
+  model,
+  systemPrompt: `You assemble the team's work into one clean deliverable.
+Merge the outcomes, weekly plan, and risk mitigations into a single concise document
+a manager could hand over directly. Use short markdown headings.`,
+  maxTurns: 1,
+  temperature: 0.2,
+}
+
+// --- Live progress: watch the DAG run ---------------------------------------
+function onProgress(event: OrchestratorEvent): void {
+  switch (event.type) {
+    case 'task_start':
+      if (event.agent) console.log(`  ▶ ${event.agent} working…`)
+      break
+    case 'task_complete':
+      if (event.agent) console.log(`  ✓ ${event.agent} done`)
+      break
+    case 'error':
+      console.error(`  ✗ ${event.agent ?? 'run'} failed`)
+      break
+  }
+}
+
+/** Best-effort open in the default browser; prints the path if it can't. */
+function openInBrowser(file: string): void {
+  const url = `file://${process.cwd()}/${file}`
+  const cmd = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open'
+  try {
+    const child = spawn(cmd, [url], { stdio: 'ignore', detached: true, shell: process.platform === 'win32' })
+    child.on('error', () => console.log(`  Open it manually: ${url}`))
+    child.unref()
+  } catch {
+    console.log(`  Open it manually: ${url}`)
+  }
+}
+
+const orchestrator = new OpenMultiAgent({
+  defaultProvider: 'openai',
+  defaultModel: model,
+  defaultBaseURL: process.env.OPENAI_BASE_URL, // unset = OpenAI
+  onProgress,
+})
+
+const team = orchestrator.createTeam('demo-team', {
+  name: 'demo-team',
+  agents: [strategist, planner, riskAnalyst, synthesizer],
+  sharedMemory: true,
+})
+
+// --- The goal: multi-step, so the coordinator MUST decompose it -------------
+// Kept well over 200 characters so it never hits the single-agent
+// short-circuit — that is what guarantees you see a multi-agent DAG, not one
+// agent. (create-oma's tests assert this length.)
+const goal = `Design a 30-day onboarding plan for a software engineer joining a fast-moving startup.
+Step 1: identify the 4 outcomes the new hire should reach by day 30.
+Step 2: turn those outcomes into concrete weekly milestones for weeks 1 through 4.
+Step 3: list the 3 risks most likely to derail onboarding, each with a specific mitigation.
+Step 4: synthesize everything into one concise plan a manager could hand over on day one.`
+
+console.log(`\n  Goal: ${goal.split('\n')[0]}\n`)
+console.log('  The coordinator is decomposing the goal into a task DAG:\n')
+
+const result = await orchestrator.runTeam(team, goal)
+
+// --- Summary: the DAG the coordinator built from one goal -------------------
+const line = '─'.repeat(52)
+console.log(`\n  ${line}`)
+console.log(`  Run complete — success: ${result.success}`)
+console.log(`  Tokens: ${result.totalTokenUsage.input_tokens} in / ${result.totalTokenUsage.output_tokens} out`)
+console.log('\n  Task DAG (auto-decomposed — you wrote none of this wiring):')
+for (const task of result.tasks ?? []) {
+  console.log(`    • ${task.title}  [${task.assignee ?? '—'}] ${task.status}`)
+}
+
+// --- Final plan: the synthesizer merged the team's work into one document ---
+const plan = result.agentResults.get('synthesizer')
+if (plan?.success && plan.output.trim()) {
+  console.log(`\n  Final plan (by synthesizer):\n  ${line}`)
+  console.log(plan.output)
+}
+
+// --- Dashboard: render the DAG and open it ----------------------------------
+const dashboardPath = 'dashboard.html'
+writeFileSync(dashboardPath, renderTeamRunDashboard(result))
+console.log(`\n  ${line}`)
+console.log(`  DAG dashboard → ${dashboardPath} (opening in your browser…)`)
+openInBrowser(dashboardPath)

--- a/packages/create-oma/template/tsconfig.json
+++ b/packages/create-oma/template/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/packages/create-oma/tests/scaffold.test.ts
+++ b/packages/create-oma/tests/scaffold.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { isNonEmptyDir, scaffold, TEMPLATE_DIR, toPackageName } from '../src/scaffold.js'
+
+let tmp: string
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'create-oma-'))
+})
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true })
+})
+
+describe('scaffold', () => {
+  it('generates a project that depends only on @open-multi-agent/core', () => {
+    const target = join(tmp, 'my-demo')
+    scaffold({ targetDir: target, projectName: 'My Demo' })
+
+    const pkg = JSON.parse(readFileSync(join(target, 'package.json'), 'utf8'))
+    // The 3-dependency promise extends here: the generated project is just core.
+    expect(Object.keys(pkg.dependencies)).toEqual(['@open-multi-agent/core'])
+    expect(Object.keys(pkg.devDependencies)).toEqual(['tsx'])
+    expect(pkg.name).toBe('my-demo') // stamped + sanitized
+  })
+
+  it('restores dotfiles and ships the demo + env example', () => {
+    const target = join(tmp, 'd')
+    scaffold({ targetDir: target, projectName: 'd' })
+
+    expect(existsSync(join(target, '.gitignore'))).toBe(true)
+    expect(existsSync(join(target, '.env.example'))).toBe(true)
+    expect(existsSync(join(target, '_gitignore'))).toBe(false)
+    expect(existsSync(join(target, '_env.example'))).toBe(false)
+    expect(existsSync(join(target, 'src/index.ts'))).toBe(true)
+    expect(existsSync(join(target, 'README.md'))).toBe(true)
+  })
+
+  // Landmine #1: a short, simple goal hits runTeam's single-agent short-circuit,
+  // which would kill the multi-agent DAG. isSimpleGoal returns false once the
+  // goal exceeds 200 chars (packages/core/src/orchestrator/orchestrator.ts), so
+  // we pin the demo goal well above that.
+  it('demo goal is long enough to bypass the single-agent short-circuit', () => {
+    const demo = readFileSync(join(TEMPLATE_DIR, 'src', 'index.ts'), 'utf8')
+    const match = demo.match(/const goal = `([\s\S]*?)`/)
+    expect(match).not.toBeNull()
+    expect(match![1].length).toBeGreaterThan(200)
+  })
+
+  // Landmine #2: a default tool preset would give the "no tools" demo agents
+  // filesystem/bash access and write to disk. Assert the demo declares neither.
+  it('demo agents declare no tools and set no default preset', () => {
+    const demo = readFileSync(join(TEMPLATE_DIR, 'src', 'index.ts'), 'utf8')
+    expect(demo).not.toMatch(/\btools\s*:/)
+    expect(demo).not.toMatch(/toolPreset/)
+  })
+
+  it('isNonEmptyDir distinguishes empty, non-empty, and missing dirs', () => {
+    expect(isNonEmptyDir(tmp)).toBe(false) // freshly created, empty
+    writeFileSync(join(tmp, 'x'), '1')
+    expect(isNonEmptyDir(tmp)).toBe(true)
+    expect(isNonEmptyDir(join(tmp, 'does-not-exist'))).toBe(false)
+  })
+
+  it('toPackageName sanitizes to a valid npm name', () => {
+    expect(toPackageName('My Demo')).toBe('my-demo')
+    expect(toPackageName('   ')).toBe('oma-demo')
+    expect(toPackageName('@scope/Foo')).toBe('scope-foo')
+    expect(toPackageName('Cool_App!')).toBe('cool-app')
+  })
+})

--- a/packages/create-oma/tsconfig.json
+++ b/packages/create-oma/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": false,
+    "sourceMap": false,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "template", "tests"]
+}

--- a/packages/create-oma/vitest.config.ts
+++ b/packages/create-oma/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## What
`npm create oma` scaffolds a small, runnable project that, on its first run, shows a coordinator decompose one goal into a multi-agent task DAG and opens a dashboard of the run. No code to write, no blank page.

This is onboarding step 2: cut the cost of going from "heard of OMA" to "watched a team actually run." Step 0 (#303, monorepo) and step 1 (#304, provider-neutral quickstart) shipped; this adds the one-command scaffold.

## The generated project
- One runtime dependency: `@open-multi-agent/core` (pinned 1.7.0). `tsx` is the only dev dependency.
- Provider-neutral: OpenAI out of the box, or any OpenAI-compatible endpoint (DeepSeek, Groq, Ollama) via `OPENAI_BASE_URL` + `OMA_MODEL`.
- The demo is four agents, no tools, pure reasoning, so the first run is fast and robust across providers. The goal is multi-step and pinned over 200 chars so it never hits the single-agent short-circuit (a regression test asserts it).

## create-oma package
- Zero runtime dependencies (Node built-ins only); ships `dist/` + `template/`.
- Copy logic is split from the CLI and unit-tested: scaffold output, dotfile restore, package-name stamping, non-empty-dir guard, and the two landmines (goal length; no tools / no default preset).

## CI
- Root `build`/`lint`/`test` now run across all workspaces, so create-oma is linted and tested on Node 18/20/22.
- The package job asserts the create-oma tarball ships `dist/` + `template/` and nothing else, so a missing template can't ship a broken scaffolder.

## Verification
`npm run build && npm run lint && npm test` pass (core 1060 + create-oma 6). End-to-end: scaffolded a fresh project, `npm install` (43 packages, 0 vulnerabilities), ran it against an OpenAI-compatible key. The coordinator built a 4-task DAG, all agents ran, `success: true`, and the dashboard rendered.

## Not in this PR
- A richer "with tools" template, deferred until there's user demand.
- Publishing to npm. A merged PR doesn't make it installable; that's a separate `npm publish`.
