### PR TITLE
docs(readme): add npm create oma-app to the first screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Graph-first frameworks make you enumerate every node and edge up front. `open-mu
 
 ## Get started
 
+The fastest way to see it run — one command scaffolds a project and starts a multi-agent DAG:
+
+```bash
+npm create oma-app@latest
+```
+
+Answer one prompt; the first run shows the coordinator turn one goal into a multi-agent DAG and opens a dashboard of the run (OpenAI or any OpenAI-compatible provider). To add the library to your own project:
+
 ```bash
 npm install @open-multi-agent/core
 ```
@@ -56,7 +64,7 @@ The full quickstart, the three ways to run, provider setup, the production check
 
 **→ [`packages/core/README.md`](packages/core/README.md)**
 
-Prefer to run something first? Clone and run an example:
+Prefer to run an example from the repo? Clone and run one:
 
 ```bash
 git clone https://github.com/open-multi-agent/open-multi-agent && cd open-multi-agent

--- a/README_zh.md
+++ b/README_zh.md
@@ -48,6 +48,14 @@
 
 ## 快速开始
 
+最快看到它跑起来 —— 一条命令脚手架出一个项目并启动多 agent DAG：
+
+```bash
+npm create oma-app@latest
+```
+
+回答一个提示；第一次运行就能看到 coordinator 把一个 goal 拆成多 agent DAG，并打开本次运行的 dashboard（OpenAI 或任意 OpenAI 兼容 provider）。若只想把库装进自己的项目：
+
 ```bash
 npm install @open-multi-agent/core
 ```
@@ -56,7 +64,7 @@ npm install @open-multi-agent/core
 
 **→ [`packages/core/README_zh.md`](packages/core/README_zh.md)**
 
-想先跑起来看看？克隆仓库跑个示例：
+想跑仓库里的示例？克隆下来跑一个：
 
 ```bash
 git clone https://github.com/open-multi-agent/open-multi-agent && cd open-multi-agent

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -54,6 +54,14 @@ Graph-first frameworks make you enumerate every node and edge up front. `open-mu
 
 Requires Node.js >= 18.
 
+The fastest way to see a multi-agent run — scaffold a project and start it in one command:
+
+```bash
+npm create oma-app@latest
+```
+
+The first run shows the coordinator decompose one goal into a multi-agent DAG, then opens a dashboard of the run. To add the library to an existing project instead:
+
 ```bash
 npm install @open-multi-agent/core
 ```

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -54,6 +54,14 @@
 
 要求 Node.js >= 18。
 
+最快看到多 agent 跑起来 —— 一条命令脚手架出一个项目并启动：
+
+```bash
+npm create oma-app@latest
+```
+
+第一次运行就能看到 coordinator 把一个 goal 拆成多 agent DAG，并打开本次运行的 dashboard。若只想把库装进已有项目：
+
 ```bash
 npm install @open-multi-agent/core
 ```


### PR DESCRIPTION
## What
Features the published `create-oma-app` scaffold on the first screen of both READMEs — facade (`README.md`) and npm page (`packages/core/README.md`), EN + ZH — as the one-command way to see a multi-agent run:

```bash
npm create oma-app@latest
```

placed above `npm install @open-multi-agent/core`. The existing "run an example from the repo" clone path is kept (reworded so the scaffold is the primary "run it first").

## Why
`create-oma-app` is published but nothing in the repo pointed to it, so a newcomer couldn't discover the lowest-friction path: one command to a multi-agent DAG + dashboard, no clone, no boilerplate. This was the planned trial command from the onboarding work, now unblocked since the package shipped.

## Scope
Docs only — 4 README files, EN/ZH kept equivalent. No code, no badge or three-dependency-narrative changes.
