### PR TITLE
fix(dashboard): keep the run details panel as a right sidebar on desktop

### DIFF
--- a/packages/core/src/dashboard/render-team-run-dashboard.ts
+++ b/packages/core/src/dashboard/render-team-run-dashboard.ts
@@ -222,7 +222,11 @@ export function renderTeamRunDashboard(result: TeamRunResult): string {
             #detailsPanel { border-left: 0; border-top: 1px solid rgba(64, 72, 93, 0.4); }
         }
         @media (min-width: 1024px) {
-            main { flex-direction: row; }
+            /* A class selector (.flex-col, specificity 0,1,0) outranks a bare main
+               type selector (0,0,1), so this row override must also be class-level
+               or it never wins and the details panel stays stacked below the canvas
+               on desktop instead of becoming the right-hand sidebar. */
+            main.flex-col { flex-direction: row; }
         }
     </style>
 </head>


### PR DESCRIPTION
## What
The post-run dashboard's NODE_DETAILS panel rendered stacked below the canvas (bottom-left, often cut off) on desktop instead of as the intended 400px right-hand sidebar.

## Why
The hand-rolled utility CSS never defines the `lg:` variants used in the markup, so layout relies on media queries. `<main>` carries the `.flex-col` class (specificity 0,1,0), which outranks the desktop `@media(min-width:1024px){ main { flex-direction: row } }` rule (a bare type selector, 0,0,1). The row override never won, so `main` stayed a column and the panel dropped below the canvas. Only desktop (>=1024px) was affected; narrow screens were already a column by design.

## Fix
Make the desktop override class-level so it wins: `main.flex-col { flex-direction: row }` (0,1,1). One line plus an explanatory comment. Panel width was always correct (set via an id selector). No behavior or JS change.

`npm ci` + lint + test (1060) green; dashboard-render + dashboard-layout tests pass.
