### PR TITLE
docs(readme): list PR-Copilot under the Built with OMA ecosystem group (#241)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ A quick router. Mechanism breakdown follows.
 
 `open-multi-agent` launched 2026-04-01 under MIT. Known users and integrations to date:
 
-**In production**
+**Built with OMA**
 
 - **[temodar-agent](https://github.com/xeloxa/temodar-agent)** (~60 stars). WordPress security analysis platform by [Ali Sünbül](https://github.com/xeloxa). Uses our built-in tools (`bash`, `file_*`, `grep`) directly inside a Docker runtime. Confirmed production use.
+- **[PR-Copilot](https://github.com/kidoom/PR-Copilot)**. AI pull-request review assistant by [kidoom](https://github.com/kidoom). Runs an OMA review team (coordinator + scoped reviewer agents), defines repo-context tools with `defineTool`, and adds a custom `ContextStrategy` for token-aware PR-diff compression. Public code on `@open-multi-agent/core`.
 
 **Integrations**
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -99,9 +99,10 @@ npx tsx packages/core/examples/basics/team-collaboration.ts
 
 `open-multi-agent` 2026-04-01 发布，MIT 协议。当前公开在用与集成的项目：
 
-**生产环境在用**
+**基于 OMA 构建**
 
 - **[temodar-agent](https://github.com/xeloxa/temodar-agent)**（约 60 stars）。WordPress 安全分析平台，作者 [Ali Sünbül](https://github.com/xeloxa)。在 Docker runtime 里直接用我们的内置工具（`bash`、`file_*`、`grep`）。已确认生产环境使用。
+- **[PR-Copilot](https://github.com/kidoom/PR-Copilot)**。AI pull request 审查助手，作者 [kidoom](https://github.com/kidoom)。运行一个 OMA 审查 team（coordinator + 限定范围的 reviewer agent），用 `defineTool` 定义仓库上下文工具，并加入自定义 `ContextStrategy` 做 token-aware 的 PR diff 压缩。公开代码，基于 `@open-multi-agent/core`。
 
 **集成**
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -216,9 +216,10 @@ await orchestrator.runTeam(team, goal, {
 
 `open-multi-agent` launched 2026-04-01 under MIT. Known users and integrations to date:
 
-### In production
+### Built with OMA
 
 - **[temodar-agent](https://github.com/xeloxa/temodar-agent)** (~60 stars). WordPress security analysis platform by [Ali Sünbül](https://github.com/xeloxa). Uses our built-in tools (`bash`, `file_*`, `grep`) directly inside a Docker runtime. Confirmed production use.
+- **[PR-Copilot](https://github.com/kidoom/PR-Copilot)**. AI pull-request review assistant by [kidoom](https://github.com/kidoom). Runs an OMA review team (coordinator + scoped reviewer agents), defines repo-context tools with `defineTool`, and adds a custom `ContextStrategy` for token-aware PR-diff compression. Public code on `@open-multi-agent/core`.
 
 Using `open-multi-agent` in production or a side project? [Open a discussion](https://github.com/open-multi-agent/open-multi-agent/discussions) and we will list it here.
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -214,9 +214,10 @@ await orchestrator.runTeam(team, goal, {
 
 `open-multi-agent` 2026-04-01 发布，MIT 协议。当前公开在用与集成的项目：
 
-### 生产环境在用
+### 基于 OMA 构建
 
 - **[temodar-agent](https://github.com/xeloxa/temodar-agent)**（约 60 stars）。WordPress 安全分析平台，作者 [Ali Sünbül](https://github.com/xeloxa)。在 Docker runtime 里直接用我们的内置工具（`bash`、`file_*`、`grep`）。已确认生产环境使用。
+- **[PR-Copilot](https://github.com/kidoom/PR-Copilot)**。AI pull request 审查助手，作者 [kidoom](https://github.com/kidoom)。运行一个 OMA 审查 team（coordinator + 限定范围的 reviewer agent），用 `defineTool` 定义仓库上下文工具，并加入自定义 `ContextStrategy` 做 token-aware 的 PR diff 压缩。公开代码，基于 `@open-multi-agent/core`。
 
 如果在生产或 side project 中使用了 `open-multi-agent`，[请开个 Discussion](https://github.com/open-multi-agent/open-multi-agent/discussions)，我们会将其列在这里。
 


### PR DESCRIPTION
Lists PR-Copilot in the README ecosystem section, submitted via the project-intake tracker (#241).

- Renames the first ecosystem bucket "In production" → "Built with OMA" (+ zh). temodar-agent and PR-Copilot are both downstream apps built on OMA, so the broader header fits both; temodar keeps its per-entry "Confirmed production use" note, so no signal is lost.
- Adds PR-Copilot (by kidoom): an AI PR-review assistant that runs an OMA review team, defines repo-context tools with `defineTool`, and adds a custom `ContextStrategy` for token-aware PR-diff compression.

Verified before listing: `server/package.json` depends on `@open-multi-agent/core ^1.7.0` (resolved in the lockfile) with real imports of `OpenMultiAgent`, `createAdapter`, `defineTool`, and a custom `ContextStrategy`.

Synced across all four READMEs (root + package, EN + ZH). Docs-only.