### PR TITLE
ci: harden pipeline with build smoke test, concurrency, permissions, and timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,29 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [18, 20, 22]
@@ -19,11 +39,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
-      - run: npm run lint
       - run: npm test
 
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -40,6 +60,7 @@ jobs:
 
   package:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -48,6 +69,12 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - name: Smoke-test that the built entry points import and the CLI runs
+        working-directory: packages/core
+        run: |
+          node -e "Promise.all([import('./dist/index.js'), import('./dist/mcp.js'), import('./dist/ai-sdk.js')]).then(() => console.log('entry points import OK')).catch((e) => { console.error(e); process.exit(1); })"
+          node dist/cli/oma.js help > /dev/null
+          echo "CLI help runs OK"
       - name: Assert the create-oma-app template pins the current core version
         run: |
           core_version=$(jq -r .version packages/core/package.json)


### PR DESCRIPTION
Hardens the CI workflow without changing what it tests on the happy path.

1. **Build smoke test** (`package` job): after `npm run build`, import the three published entry points (`dist/index.js`, `dist/mcp.js`, `dist/ai-sdk.js`) and run `oma help`. CI previously asserted only the tarball file list, so a build that compiled but threw on import (top-level side effect, missing runtime dependency, broken emit) would still pass.
2. **Concurrency**: `cancel-in-progress` for the same ref so rapid pushes no longer pile up redundant runs.
3. **Least-privilege permissions**: `contents: read` at the workflow level.
4. **Job timeouts**: `timeout-minutes: 15` on every job so a hung step cannot hold a runner for the 6-hour default.
5. **Lint in its own job**: `tsc --noEmit` no longer repeats across the Node version matrix (its result does not depend on the Node runtime); the matrix now runs tests only.

Verified locally: build succeeds, all three entry points import, `oma help` exits 0, workflow YAML parses.