### PR TITLE
feat(examples): make the full-app examples runnable on one DeepSeek key

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ npx tsx packages/core/examples/basics/team-collaboration.ts
 
 Three agents collaborate on a REST API while `onProgress` streams the coordinator's task DAG — independent tasks run in parallel, dependents unblock as their inputs land, and the coordinator synthesizes the final result. Local models via Ollama need no API key; see the [providers guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md).
 
+Want a full application instead of a script? Two clone-and-run apps embed OMA in a real backend: an [Express REST API](packages/core/examples/integrations/express-customer-support/) and a [Next.js app](packages/core/examples/integrations/with-vercel-ai-sdk/).
+
 ## How is this different from X?
 
 A quick router. Mechanism breakdown follows.

--- a/README_zh.md
+++ b/README_zh.md
@@ -75,6 +75,8 @@ npx tsx packages/core/examples/basics/team-collaboration.ts
 
 三个 agent 协作产出 REST API，`onProgress` 实时输出协调者的任务 DAG——无依赖的任务并行执行，依赖项在输入就绪后自动解锁，协调者最终合成结果。通过 Ollama 运行本地模型不需要 API key，见 [provider 指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md)。
 
+想要一个完整应用而不是脚本？两个克隆即跑的应用把 OMA 嵌进了真实后端：一个 [Express REST API](packages/core/examples/integrations/express-customer-support/) 和一个 [Next.js 应用](packages/core/examples/integrations/with-vercel-ai-sdk/)。
+
 ## 与其他框架对比
 
 按需求快速选型。以下逐一分析差异。

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -267,10 +267,16 @@ End-to-end scenarios you can run today. Each one is a complete, opinionated work
 - [`patterns/plan-replay`](examples/patterns/plan-replay.ts): decompose a goal once with `planOnly`, serialize it with `createPlanArtifact`, then replay the same DAG via `runFromPlan` without re-running the coordinator.
 - [`integrations/trace-observability`](examples/integrations/trace-observability.ts): `onTrace` spans for LLM calls, tools, and tasks.
 - [`integrations/mcp-github`](examples/integrations/mcp-github.ts): expose an MCP server's tools to an agent via `connectMCPTools()`.
-- [`integrations/with-vercel-ai-sdk`](examples/integrations/with-vercel-ai-sdk/): Next.js app combining OMA `runTeam()` with AI SDK `useChat` streaming.
 - **Provider examples**: scripts under [`examples/providers/`](examples/providers/) covering hosted providers, OpenAI-compatible endpoints, and local models.
 
-Run any script with `npx tsx examples/<path>.ts`.
+### Full applications
+
+Clone-and-run apps with their own `package.json`, not `npx tsx` scripts. Each embeds OMA in a real backend.
+
+- [`integrations/express-customer-support`](examples/integrations/express-customer-support/): Express REST API. `runTasks()` behind `POST /tickets` with per-agent Zod schemas, swappable provider env vars, and HTTP error mapping. Runs on one DeepSeek key (`npm install && npm start`).
+- [`integrations/with-vercel-ai-sdk`](examples/integrations/with-vercel-ai-sdk/): Next.js app. OMA `runTeam()` plus AI SDK `useChat` streaming (`npm install && npm run dev`).
+
+Run any script with `npx tsx examples/<path>.ts`; the full applications above use their own `npm` scripts.
 
 ## How is this different from X?
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -265,10 +265,16 @@ await orchestrator.runTeam(team, goal, {
 - [`patterns/plan-replay`](examples/patterns/plan-replay.ts)：用 `planOnly` 把目标拆解一次，用 `createPlanArtifact` 序列化，再用 `runFromPlan` 重放同一张 DAG，不重跑协调者。
 - [`integrations/trace-observability`](examples/integrations/trace-observability.ts)：`onTrace` 回调，给 LLM 调用、工具、任务发结构化 span。
 - [`integrations/mcp-github`](examples/integrations/mcp-github.ts)：用 `connectMCPTools()` 把 MCP 服务器的工具暴露给 agent。
-- [`integrations/with-vercel-ai-sdk`](examples/integrations/with-vercel-ai-sdk/)：Next.js 应用，OMA `runTeam()` 配合 AI SDK `useChat` 流式输出。
 - **Provider 示例**：[`examples/providers/`](examples/providers/) 下的脚本，覆盖托管 provider、OpenAI 兼容端点和本地模型。
 
-运行任意脚本：`npx tsx examples/<path>.ts`。
+### 完整应用
+
+带有独立 `package.json` 的克隆即跑应用，不是 `npx tsx` 脚本。每个都把 OMA 嵌进了真实后端。
+
+- [`integrations/express-customer-support`](examples/integrations/express-customer-support/)：Express REST API。`runTasks()` 驱动 `POST /tickets`，每个 agent 用 Zod schema，provider 通过环境变量可切换，并做了 HTTP 错误码映射。一个 DeepSeek key 即可跑通（`npm install && npm start`）。
+- [`integrations/with-vercel-ai-sdk`](examples/integrations/with-vercel-ai-sdk/)：Next.js 应用。OMA `runTeam()` 配合 AI SDK `useChat` 流式输出（`npm install && npm run dev`）。
+
+运行任意脚本：`npx tsx examples/<path>.ts`；上面的完整应用用各自的 `npm` 脚本运行。
 
 ## 与其他框架对比
 

--- a/packages/core/examples/README.md
+++ b/packages/core/examples/README.md
@@ -2,7 +2,7 @@
 
 Runnable scripts demonstrating `open-multi-agent`. Organized by category — pick one that matches what you're trying to do.
 
-All scripts run with `npx tsx examples/<category>/<name>.ts`. Scripts that call a model require the corresponding API key in your environment.
+All scripts run with `npx tsx examples/<category>/<name>.ts`. Scripts that call a model require the corresponding API key in your environment. The full applications (see the apps section below) are the exception: they have their own `package.json` and start scripts.
 
 ---
 
@@ -83,8 +83,14 @@ Hooking the framework up to outside-the-box tooling.
 | [`integrations/trace-observability`](integrations/trace-observability.ts) | `onTrace` spans for LLM calls, tools, and tasks. |
 | [`integrations/mcp-github`](integrations/mcp-github.ts) | An MCP server's tools exposed to an agent via `connectMCPTools()`. |
 | [`integrations/mcp-bilig-workpaper`](integrations/mcp-bilig-workpaper.ts) | Bilig WorkPaper MCP tools for formula readback, recalculation, and persisted workbook JSON. |
-| [`integrations/with-vercel-ai-sdk/`](integrations/with-vercel-ai-sdk/) | Next.js app — OMA `runTeam()` + AI SDK `useChat` streaming. |
-| [`integrations/express-customer-support/`](integrations/express-customer-support/) | Express REST API — `runTasks()` behind POST /tickets with per-agent Zod output schemas, mix-and-match provider env vars, and HTTP error mapping (400/502/504). |
+## apps — full applications
+
+Complete, clone-and-run applications with their own `package.json` and dependencies. These embed OMA in a real backend, so they use `npm install` plus their own start script rather than `npx tsx`.
+
+| Example | Stack | Run |
+|---------|-------|-----|
+| [`integrations/express-customer-support/`](integrations/express-customer-support/) | Express REST API: `runTasks()` behind `POST /tickets`, per-agent Zod schemas, swappable provider env vars, HTTP error mapping (400/502/504) | `npm install && npm start` |
+| [`integrations/with-vercel-ai-sdk/`](integrations/with-vercel-ai-sdk/) | Next.js: OMA `runTeam()` plus AI SDK `useChat` streaming | `npm install && npm run dev` |
 
 ## production — real-world use cases
 
@@ -106,6 +112,6 @@ Conventions:
 
 - **No numeric prefixes.** Folders signal category; reading order is set by this README.
 - **File header docstring** with one-line title, `Run:` block, and prerequisites.
-- **Imports** should resolve as `from '../../src/index.js'` (one level deeper than the old flat layout).
+- **Imports** should resolve as `from '../../src/index.js'` for scripts (one level deeper than the old flat layout); full applications with their own `package.json` import the published `@open-multi-agent/core` package name instead.
 - **Match the provider template** when adding a provider: three-agent team (architect / developer / reviewer) building a small REST API. Keeps comparisons honest.
 - **Add a row** to the table in this file for the corresponding category.

--- a/packages/core/examples/integrations/express-customer-support/README.md
+++ b/packages/core/examples/integrations/express-customer-support/README.md
@@ -2,20 +2,20 @@
 
 An Express REST API that wraps OMA's `runTasks()` explicit-DAG pipeline behind a single `POST /tickets` endpoint. A three-agent pipeline runs on every request:
 
-1. **classifier** (`claude-haiku-4-5-20251001`) — categorises the ticket and assigns urgency
-2. **drafter** (`claude-sonnet-4-6`) — writes a polished customer-facing reply (depends on classifier)
-3. **qa-reviewer** (`claude-opus-4-7`) — reviews the draft for tone and accuracy (depends on classifier + drafter)
+1. **classifier** (`deepseek-v4-flash`) — categorises the ticket and assigns urgency
+2. **drafter** (`deepseek-v4-pro`) — writes a polished customer-facing reply (depends on classifier)
+3. **qa-reviewer** (`deepseek-v4-pro`) — reviews the draft for tone and accuracy (depends on classifier + drafter)
 
 `runTasks()` is the right primitive here because the pipeline shape is fixed: a coordinator-decomposed `runTeam()` would re-derive the same DAG and pay for an extra synthesis call on every request. With `runTasks()` the dependency graph is declared once at the route handler and OMA executes it in topological order, writing each agent's output into the next agent's prompt via the `## Context from prerequisite tasks` block that `runTasks()` injects from each completed task's result.
 
-Each agent uses a Zod `outputSchema`; the endpoint assembles the three structured results into one JSON response. Each agent's model **and** provider are independently swappable via env vars so a free-tier setup can mix providers (see [Swapping providers](#swapping-providers) below).
+Each agent uses a Zod `outputSchema`; the endpoint assembles the three structured results into one JSON response. Each agent's model **and** provider are independently swappable via env vars, so you can move any tier to another provider (see [Swapping providers](#swapping-providers) below).
 
 ## Setup
 
 ```bash
 cd examples/integrations/express-customer-support
 npm install
-export ANTHROPIC_API_KEY=sk-ant-...    # default — all three agents use Anthropic
+export DEEPSEEK_API_KEY=sk-...    # default — all three agents use DeepSeek
 ```
 
 ## Start the server
@@ -46,7 +46,7 @@ Expected response shape:
 
 ## Smoke test
 
-Runs a real request against a local server (requires `ANTHROPIC_API_KEY`):
+Runs a real request against a local server (requires `DEEPSEEK_API_KEY`):
 
 ```bash
 npm run smoke
@@ -67,35 +67,35 @@ Exits 0 and prints the structured response on success, exits 1 on failure.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ANTHROPIC_API_KEY` | *(required for default provider)* | Anthropic API key |
+| `DEEPSEEK_API_KEY` | *(required for default provider)* | DeepSeek API key |
+| `ANTHROPIC_API_KEY` | — | Required if `anthropic` is selected for any agent |
 | `OPENAI_API_KEY` | — | Required if `openai` is selected for any agent |
 | `GEMINI_API_KEY` | — | Required if `gemini` is selected for any agent |
 | `XAI_API_KEY` | — | Required if `grok` is selected for any agent |
-| `DEEPSEEK_API_KEY` | — | Required if `deepseek` is selected for any agent |
 | `GITHUB_TOKEN` | — | Required if `copilot` is selected for any agent |
 | `MINIMAX_API_KEY` | — | Required if `minimax` is selected for any agent |
 | `AZURE_OPENAI_API_KEY` | — | Required if `azure-openai` is selected for any agent |
-| `CLASSIFIER_PROVIDER` | `anthropic` | Provider for the classifier agent |
-| `CLASSIFIER_MODEL`    | `claude-haiku-4-5-20251001` | Model for the classifier agent |
-| `DRAFTER_PROVIDER`    | `anthropic` | Provider for the drafter agent |
-| `DRAFTER_MODEL`       | `claude-sonnet-4-6` | Model for the drafter agent |
-| `QA_PROVIDER`         | `anthropic` | Provider for the QA reviewer agent |
-| `QA_MODEL`            | `claude-opus-4-7` | Model for the QA reviewer agent |
+| `CLASSIFIER_PROVIDER` | `deepseek` | Provider for the classifier agent |
+| `CLASSIFIER_MODEL`    | `deepseek-v4-flash` | Model for the classifier agent |
+| `DRAFTER_PROVIDER`    | `deepseek` | Provider for the drafter agent |
+| `DRAFTER_MODEL`       | `deepseek-v4-pro` | Model for the drafter agent |
+| `QA_PROVIDER`         | `deepseek` | Provider for the QA reviewer agent |
+| `QA_MODEL`            | `deepseek-v4-pro` | Model for the QA reviewer agent |
 | `PORT` | `3000` | Port the server listens on |
 
 Supported `*_PROVIDER` values with startup key validation: `anthropic`, `openai`, `gemini`, `grok`, `deepseek`, `copilot`, `minimax`, `azure-openai`. Providers not in this list are supported by the framework but are not mapped in this file's startup check — a missing key will surface as a 502 mid-request rather than a startup error.
 
 ## Swapping providers
 
-The defaults run the full pipeline on Anthropic across the cheap/mid/strong tier. Each agent can be moved to a different provider independently — useful when only some providers offer a free tier.
+The defaults run the whole pipeline on DeepSeek — `deepseek-v4-flash` for the cheap classifier, `deepseek-v4-pro` for the drafter and QA reviewer — so one `DEEPSEEK_API_KEY` runs everything. Each agent's provider and model are independently overridable via env vars, so you can move any tier to another provider.
 
-Run the cheap classifier on Gemini's free tier and keep the rest on Anthropic:
+Keep the cheap classifier on DeepSeek but run the drafter and QA reviewer on Anthropic:
 
 ```bash
+export DEEPSEEK_API_KEY=...
 export ANTHROPIC_API_KEY=sk-ant-...
-export GEMINI_API_KEY=...
-export CLASSIFIER_PROVIDER=gemini
-export CLASSIFIER_MODEL=gemini-2.5-flash
+export DRAFTER_PROVIDER=anthropic DRAFTER_MODEL=claude-sonnet-4-6
+export QA_PROVIDER=anthropic      QA_MODEL=claude-opus-4-8
 npm start
 ```
 

--- a/packages/core/examples/integrations/express-customer-support/index.ts
+++ b/packages/core/examples/integrations/express-customer-support/index.ts
@@ -17,8 +17,8 @@
 import { fileURLToPath } from 'node:url'
 import express from 'express'
 import { z } from 'zod'
-import { OpenMultiAgent } from '../../../src/index.js'
-import type { AgentConfig, SupportedProvider } from '../../../src/index.js'
+import { OpenMultiAgent } from '@open-multi-agent/core'
+import type { AgentConfig, SupportedProvider } from '@open-multi-agent/core'
 
 // ---------------------------------------------------------------------------
 // Schemas
@@ -74,9 +74,9 @@ function pickAgent(envPrefix: string, defaultProvider: SupportedProvider, defaul
   return { provider, model }
 }
 
-const classifierCfg = pickAgent('CLASSIFIER', 'anthropic', 'claude-haiku-4-5-20251001')
-const drafterCfg    = pickAgent('DRAFTER',    'anthropic', 'claude-sonnet-4-6')
-const qaCfg         = pickAgent('QA',         'anthropic', 'claude-opus-4-7')
+const classifierCfg = pickAgent('CLASSIFIER', 'deepseek', 'deepseek-v4-flash')
+const drafterCfg    = pickAgent('DRAFTER',    'deepseek', 'deepseek-v4-pro')
+const qaCfg         = pickAgent('QA',         'deepseek', 'deepseek-v4-pro')
 
 // ---------------------------------------------------------------------------
 // Agents
@@ -109,9 +109,7 @@ const qaReviewer: AgentConfig = {
   systemPrompt: 'You are a QA reviewer for customer support. Your task prompt will contain a "Context from prerequisite tasks" section with the classifier\'s category/urgency and the drafter\'s reply. Review the draft reply for tone, empathy, and accuracy against the original ticket. Provide concise QA notes. Respond ONLY with valid JSON.',
   outputSchema: QAOutput,
   maxTurns: 3,
-  // Note: omitting `temperature` — `claude-opus-4-7` (the default QA model)
-  // rejects this parameter. If you override QA_MODEL to a model that supports
-  // it, you can add `temperature: 0.2` back here.
+  temperature: 0.2,
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/examples/integrations/express-customer-support/package-lock.json
+++ b/packages/core/examples/integrations/express-customer-support/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "express-customer-support",
       "dependencies": {
+        "@open-multi-agent/core": "file:../../..",
         "zod": "^3.23.0"
       },
       "devDependencies": {
@@ -14,6 +15,55 @@
         "express": "^4.21.0",
         "tsx": "^4.0.0",
         "typescript": "^5.6.0"
+      }
+    },
+    "../../..": {
+      "name": "@open-multi-agent/core",
+      "version": "1.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.52.0",
+        "openai": "^4.73.0",
+        "zod": "^3.23.0"
+      },
+      "bin": {
+        "oma": "dist/cli/oma.js"
+      },
+      "devDependencies": {
+        "@ai-sdk/openai": "^2.0.106",
+        "@ai-sdk/provider": "^2.0.3",
+        "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
+        "@google/genai": "^1.48.0",
+        "@modelcontextprotocol/sdk": "^1.18.0",
+        "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^2.1.9",
+        "ai": "^5.0.188",
+        "tsx": "^4.21.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-bedrock-runtime": "^3.700.0",
+        "@google/genai": "^1.48.0",
+        "@modelcontextprotocol/sdk": "^1.18.0",
+        "ai": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-bedrock-runtime": {
+          "optional": true
+        },
+        "@google/genai": {
+          "optional": true
+        },
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        },
+        "ai": {
+          "optional": true
+        }
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -457,6 +507,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@open-multi-agent/core": {
+      "resolved": "../../..",
+      "link": true
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",

--- a/packages/core/examples/integrations/express-customer-support/package.json
+++ b/packages/core/examples/integrations/express-customer-support/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "prestart": "cd ../../.. && npm run build",
     "start":    "tsx index.ts",
+    "presmoke": "cd ../../.. && npm run build",
     "smoke":   "tsx smoke.ts"
   },
   "dependencies": {
+    "@open-multi-agent/core": "file:../../..",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/core/examples/integrations/with-vercel-ai-sdk/README.md
+++ b/packages/core/examples/integrations/with-vercel-ai-sdk/README.md
@@ -34,8 +34,8 @@ npm install
 cd packages/core/examples/integrations/with-vercel-ai-sdk
 npm install
 
-# 3. Set your API key
-export ANTHROPIC_API_KEY=sk-ant-...
+# 3. Set your DeepSeek API key (the demo runs the team on DeepSeek)
+export DEEPSEEK_API_KEY=sk-...
 
 # 4. Run
 npm run dev
@@ -48,7 +48,7 @@ Open [http://localhost:3000](http://localhost:3000), type a topic, and watch the
 ## Prerequisites
 
 - Node.js >= 18
-- `ANTHROPIC_API_KEY` environment variable (used by both OMA and AI SDK)
+- `DEEPSEEK_API_KEY` environment variable (used by both OMA and AI SDK)
 
 ## Key files
 


### PR DESCRIPTION
## What

Two full-application examples (Express REST API and Next.js) embed OMA in a real backend. This PR makes them runnable on a single DeepSeek key and surfaces them as their own category so they are easy to find.

## Why

A developer's first runnable example should not require an Anthropic key, since most people don't have one. Both apps now default to DeepSeek, so one `DEEPSEEK_API_KEY` runs the whole pipeline. The Express app was also coupled to the monorepo through a relative `../../../src` import; it now imports the published `@open-multi-agent/core` package name, the way a real user would.

## Changes

Runnability:
- `express-customer-support`: default all three agents to DeepSeek (`deepseek-v4-flash` classifier, `deepseek-v4-pro` drafter and QA), import the published package name and declare it in `package.json`, restore the QA `temperature`, add a `presmoke` build so the smoke test works standalone.
- `with-vercel-ai-sdk`: fix the README, which told you to set `ANTHROPIC_API_KEY` while the code reads `DEEPSEEK_API_KEY` (following it verbatim failed).

Discoverability:
- New "Full applications" / "apps" section in the package README and the examples index, listing both apps as clone-and-run applications instead of mixing them into the integrations script list. `express-customer-support` was previously not indexed in the package README at all.
- Root README gains a one-line pointer to the full-app examples.
- Chinese READMEs (`README_zh.md`, `packages/core/README_zh.md`) synced.

## Verification

- `express-customer-support`: end-to-end smoke test passes against the real DeepSeek API (classifier to drafter to QA, Zod-validated response).
- `lint` + full `test` suite green (1060 tests).
- No files moved; all README links checked; no existing links broken.