### PR TITLE
test(create-oma-app): end-to-end scaffold smoke test + CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,3 +127,16 @@ jobs:
             echo "The scaffolder needs its template/ to function once published."
             exit 1
           fi
+
+  scaffold-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: End-to-end scaffold smoke test (pack -> generate -> install -> run gate)
+        run: npm run test:scaffold

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:watch": "npm run test:watch -w @open-multi-agent/core",
     "test:coverage": "npm run test:coverage -w @open-multi-agent/core",
     "test:e2e": "npm run test:e2e -w @open-multi-agent/core",
+    "test:scaffold": "npm run test:scaffold --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present"
   },
   "license": "MIT",

--- a/packages/create-oma-app/package.json
+++ b/packages/create-oma-app/package.json
@@ -20,6 +20,7 @@
     "lint": "tsc --noEmit",
     "typecheck:template": "tsc -p template/tsconfig.json",
     "test": "vitest run",
+    "test:scaffold": "node scripts/test-scaffold.mjs",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/packages/create-oma-app/scripts/test-scaffold.mjs
+++ b/packages/create-oma-app/scripts/test-scaffold.mjs
@@ -1,0 +1,106 @@
+/**
+ * End-to-end scaffold smoke test for create-oma-app.
+ *
+ * Why this exists: the unit tests (tests/scaffold.test.ts) call scaffold()
+ * directly. They never prove the PACKED tarball — the exact bytes that hit npm —
+ * generates a project that actually installs and runs. This does, in an isolated
+ * temp dir that never touches the repo working tree. (That isolation is the
+ * whole point: scaffolds belong OUTSIDE the repo, not in its working copy.)
+ *
+ * The chain it proves, with NO API key and NO real LLM call:
+ *   build → pack scaffolder → unpack → run the packed CLI → assert structure →
+ *   install → `npm run dev` reaches the missing-key gate.
+ *
+ * That last step is the strong signal: the template exits 1 with
+ * "Missing OPENAI_API_KEY" only AFTER importing @open-multi-agent/core and
+ * running under tsx. Reaching that gate proves the dependency resolved, the
+ * package loads, and tsx executes the TS. A broken core import or a syntax
+ * error would fail differently and trip the assertion instead.
+ *
+ * Core is installed from a freshly packed LOCAL tarball, not from npm, so the
+ * test validates THIS commit's code and stays green during the release window
+ * when the template pins a core version that isn't published yet.
+ */
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const pkgDir = join(dirname(fileURLToPath(import.meta.url)), '..')
+const repoRoot = join(pkgDir, '..', '..')
+const PROJECT = 'oma-e2e-demo'
+
+/** Run a command inheriting stdio; throw a clear error on non-zero exit. */
+function run(cmd, args, opts = {}) {
+  const res = spawnSync(cmd, args, { stdio: 'inherit', encoding: 'utf8', ...opts })
+  if (res.error) throw res.error
+  if (res.status !== 0) throw new Error(`${cmd} ${args.join(' ')} failed (exit ${res.status})`)
+  return res
+}
+
+/** npm pack a workspace into `dest`; return the absolute tarball path. */
+function pack(workspace, dest) {
+  const res = spawnSync('npm', ['pack', '-w', workspace, '--json', `--pack-destination=${dest}`], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+  if (res.status !== 0) throw new Error(`npm pack ${workspace} failed:\n${res.stderr}`)
+  return join(dest, JSON.parse(res.stdout)[0].filename)
+}
+
+let work
+try {
+  console.log('• building core + create-oma-app')
+  run('npm', ['run', 'build', '-w', '@open-multi-agent/core', '-w', 'create-oma-app'], { cwd: repoRoot })
+
+  work = mkdtempSync(join(tmpdir(), 'oma-scaffold-e2e-'))
+  console.log(`• workdir: ${work}`)
+
+  console.log('• packing core + scaffolder')
+  const coreTarball = pack('@open-multi-agent/core', work)
+  const scaffoldTarball = pack('create-oma-app', work)
+
+  console.log('• unpacking the scaffolder tarball (the published bytes)')
+  run('tar', ['-xzf', scaffoldTarball, '-C', work])
+  const cli = join(work, 'package', 'dist', 'index.js')
+
+  console.log(`• generating project "${PROJECT}" via the packed CLI`)
+  // Passing the name skips the interactive prompt; the empty temp dir means no
+  // overwrite confirmation — so the CLI runs fully non-interactively.
+  run('node', [cli, PROJECT], { cwd: work })
+
+  console.log('• asserting generated structure')
+  const proj = join(work, PROJECT)
+  for (const f of ['package.json', 'src/index.ts', '.gitignore', '.env.example', 'tsconfig.json', 'README.md']) {
+    if (!existsSync(join(proj, f))) throw new Error(`generated project is missing ${f}`)
+  }
+  const pkg = JSON.parse(readFileSync(join(proj, 'package.json'), 'utf8'))
+  if (pkg.name !== PROJECT) throw new Error(`project name not stamped (got "${pkg.name}")`)
+  if (!pkg.dependencies?.['@open-multi-agent/core']) {
+    throw new Error('generated project does not depend on @open-multi-agent/core')
+  }
+
+  console.log('• installing (core from the local tarball, the rest from npm)')
+  // Installing the local core tarball satisfies the core dependency from THIS
+  // commit and reconciles the rest of the tree (tsx) from npm in one shot.
+  run('npm', ['install', '--no-audit', '--no-fund', coreTarball], { cwd: proj })
+
+  console.log('• running the demo with NO API key — expecting the env gate')
+  const env = { ...process.env }
+  delete env.OPENAI_API_KEY
+  delete env.OMA_MODEL
+  delete env.OPENAI_BASE_URL
+  const dev = spawnSync('npm', ['run', 'dev'], { cwd: proj, env, encoding: 'utf8' })
+  const output = `${dev.stdout ?? ''}${dev.stderr ?? ''}`
+  if (dev.status === 0 || !/Missing OPENAI_API_KEY/.test(output)) {
+    throw new Error(
+      `expected a non-zero exit with "Missing OPENAI_API_KEY"; got exit ${dev.status}.\n` +
+        `--- demo output ---\n${output}`,
+    )
+  }
+
+  console.log('\n✓ create-oma-app scaffolds, installs, and reaches the run gate end-to-end')
+} finally {
+  if (work) rmSync(work, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Why

The unit tests (`tests/scaffold.test.ts`) call `scaffold()` directly. They never prove the packed tarball, the exact bytes published to npm, generates a project that installs and runs. A user running `npm create oma-app` could hit a broken generated project that no test would catch.

## What

- New `npm run test:scaffold` (`packages/create-oma-app/scripts/test-scaffold.mjs`): build, pack the scaffolder, unpack, run the packed CLI, assert structure, install, and run the demo to the missing-key gate. Runs entirely in an isolated temp dir and never touches the working tree.
- Root `test:scaffold` passthrough.
- New CI `scaffold-e2e` job.

## Notes

- No API key needed: the template exits with "Missing OPENAI_API_KEY" only after importing core and running under tsx, so reaching that gate proves the whole chain resolves, loads, and executes.
- Core installs from a freshly packed local tarball, not npm, so the test validates this commit and stays green during the release window when the template pins a core version that is not published yet.

## Verification

- `npm run test:scaffold` passes locally
- `npm run lint` clean
- existing unit tests pass (6/6)
