### PR TITLE
docs(examples): list 3 existing examples missing from the README index

### DIFF
--- a/packages/core/examples/README.md
+++ b/packages/core/examples/README.md
@@ -59,6 +59,7 @@ Reusable shapes for common multi-agent problems.
 | [`patterns/agent-handoff`](patterns/agent-handoff.ts) | Synchronous sub-agent delegation via `delegate_to_agent`. |
 | [`patterns/plan-replay`](patterns/plan-replay.ts) | Pin a coordinator plan with `createPlanArtifact`, then replay it with `runFromPlan`, no coordinator re-run. |
 | [`patterns/consensus`](patterns/consensus.ts) | Proposer→judge refutation loop via `runConsensus()`: default judge prompt and per-judge `judgePrompt` function. |
+| [`patterns/cross-provider-reasoning`](patterns/cross-provider-reasoning.ts) | Preserve a reasoning model's thought stream across providers via `preserveReasoningAsText`. |
 
 ## cookbook — use-case recipes
 
@@ -73,6 +74,8 @@ End-to-end examples framed around a concrete problem (meeting summarization, tra
 | [`cookbook/paper-replication-triage`](cookbook/paper-replication-triage.ts) | Multi-source paper replication triage with artifact discovery, seeded conflicts, and a structured go/no-go plan. |
 | [`cookbook/rare-disease-information-triage`](cookbook/rare-disease-information-triage.ts) | Source-isolated rare disease information triage with mock fixtures, seeded misinformation/conflict detection, and safety-boundary arbitration. |
 | [`cookbook/personalized-interview-simulator`](cookbook/personalized-interview-simulator.ts) | Interactive interviewer loop with observer flags, shared memory, and structured debrief. |
+| [`cookbook/narrative-puzzle-hint-arbitration`](cookbook/narrative-puzzle-hint-arbitration.ts) | Multi-source hint arbitration with an external safety veto that sits outside the generation loop. |
+| [`cookbook/translation-backtranslation`](cookbook/translation-backtranslation.ts) | Translate → back-translate with a different provider → flag semantic drift (cross-model). |
 
 ## integrations — external systems
 


### PR DESCRIPTION
## What

Adds 3 missing rows to `packages/core/examples/README.md` so every example on disk is listed in the index:

| Table    | Example                           | Added by | Indexed until now |
|----------|-----------------------------------|----------|-------------------|
| cookbook | narrative-puzzle-hint-arbitration | #235     | never             |
| cookbook | translation-backtranslation       | #145     | never             |
| patterns | cross-provider-reasoning          | #260     | never             |

## Why

The README is the index for the `examples/` tree ("reading order is set by this README") and its own convention says to add a row per example. These three examples ship and run, but were never listed, so they're only discoverable by listing the directory. After this change all 9 cookbook + 10 patterns examples are covered.

Descriptions are drawn from each file's header docstring and match the table's existing one-line style. Docs-only; no code or test impact.
