### PR TITLE
chore: release core 1.8.0 + create-oma-app 0.2.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,7 +32,7 @@ Paste any error messages or logs here
 
 - OS: [e.g. macOS 14, Ubuntu 22.04]
 - Node.js version: [e.g. 20.11]
-- Package version: [e.g. 1.7.0]
+- Package version: [e.g. 1.8.0]
 - LLM provider: [e.g. Anthropic, OpenAI]
 
 ## Additional context

--- a/package-lock.json
+++ b/package-lock.json
@@ -6459,7 +6459,7 @@
     },
     "packages/core": {
       "name": "@open-multi-agent/core",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
@@ -6507,7 +6507,7 @@
       }
     },
     "packages/create-oma-app": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "bin": {
         "create-oma-app": "dist/index.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "TypeScript multi-agent framework: one runTeam() call from goal to result. Auto task decomposition and parallel execution for multi-step LLM jobs. Deploys anywhere Node.js runs.",
   "files": [
     "dist",

--- a/packages/create-oma-app/package.json
+++ b/packages/create-oma-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-oma-app",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Scaffold a runnable multi-agent demo on @open-multi-agent/core — one command from zero to a live agent DAG.",
   "type": "module",
   "bin": {

--- a/packages/create-oma-app/template/package.json
+++ b/packages/create-oma-app/template/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.7.0"
+    "@open-multi-agent/core": "1.8.0"
   },
   "devDependencies": {
     "tsx": "^4.21.0"


### PR DESCRIPTION
Release core 1.8.0 and create-oma-app 0.2.0.

- core 1.7.0 -> 1.8.0
- create-oma-app 0.1.0 -> 0.2.0
- template pins @open-multi-agent/core 1.8.0 (CI-enforced match)
- lockfile + bug_report example bumped

Headline: checkpoint/resume (#294, #314). Also consensus verify in runTeam (#301), native Bedrock reasoning round-trip (#302), dashboard sidebar fix (#308). Full notes go in the GitHub release.
