### PR TITLE
docs(examples): fix stale Run path in cookbook/meeting-summarizer after reorg

### DIFF
--- a/packages/core/examples/cookbook/meeting-summarizer.ts
+++ b/packages/core/examples/cookbook/meeting-summarizer.ts
@@ -8,7 +8,7 @@
  * - Aggregator merges into a single Markdown report
  *
  * Run:
- *   npx tsx examples/patterns/meeting-summarizer.ts
+ *   npx tsx examples/cookbook/meeting-summarizer.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.


### PR DESCRIPTION
## What

After the examples were reorganized into category subdirectories (basics/,
cookbook/, patterns/, providers/, integrations/, production/), the `Run:`
docstring in examples/cookbook/meeting-summarizer.ts still pointed at the old
examples/patterns/ path. A developer copy-pasting that command would hit a
"file not found" because the example actually lives in cookbook/.

## Change

One comment-only edit so the copy-pasteable command resolves:

  npx tsx examples/patterns/meeting-summarizer.ts
  npx tsx examples/cookbook/meeting-summarizer.ts

## Verification

- Swept every `Run:` / `npx tsx examples/` docstring under
  packages/core/examples/ (60 occurrences); this was the only stale path.
  All other example docstrings already point at their correct category +
  filename.
- `npm run lint` passes (comment-only change).

Found while drafting dev.to articles that source from these examples.
