### PR TITLE
docs(readme): tighten "How is this different from X?" comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,23 +78,15 @@ Want a full application instead of a script? Two clone-and-run apps embed OMA in
 
 ## How is this different from X?
 
-A quick router. Mechanism breakdown follows.
+Most TypeScript teams picking a multi-agent layer are really choosing between OMA, LangGraph JS, and Mastra. The mechanism is what differs.
 
-| If you need | Pick |
-|-------------|------|
-| Fixed production topology with a mature persistence + time-travel ecosystem | LangGraph JS |
-| Full-stack platform, workflows wired by hand | Mastra |
-| Python stack with mature multi-agent ecosystem | CrewAI |
-| AI app toolkit with broad model-provider support | Vercel AI SDK |
-| **TypeScript, goal to result with auto task decomposition** | **open-multi-agent** |
+**vs. LangGraph JS.** LangGraph has you design a declarative graph (nodes, edges, conditional routing) up front, then compiles it into an invokable; OMA's Coordinator decomposes the goal into a task DAG at runtime and auto-parallelizes independents. Both checkpoint and resume, though LangGraph's persistence ecosystem runs deeper. Reach for OMA when the plan should adapt to the goal instead of being wired ahead of time.
 
-**vs. LangGraph JS.** LangGraph compiles a declarative graph (nodes, edges, conditional routing) into an invokable. `open-multi-agent` runs a Coordinator that decomposes the goal into a task DAG at runtime, then auto-parallelizes independents. Same end (orchestrated execution), opposite directions: LangGraph is graph-first, OMA is goal-first. Both checkpoint and resume: OMA snapshots each completed task over any `MemoryStore` and resumes with `restore()` after a crash; LangGraph's persistence ecosystem just runs deeper, with time-travel over durable state history.
+**vs. Mastra.** Both are TypeScript-native; the difference is who drives orchestration. Mastra has you wire the workflow by hand. OMA is goal-driven: hand its Coordinator a goal and it builds the task DAG at runtime. `runTeam(team, goal)` in one call.
 
-**vs. Mastra.** Both are TypeScript-native; the difference is who drives the orchestration. With Mastra you wire the workflow by hand. OMA is goal-driven: give its Coordinator a goal and it builds the task DAG at runtime, adapting the plan to the goal instead of running a graph you wired step by step. `runTeam(team, goal)` in one call.
+**vs. CrewAI.** CrewAI is the established multi-agent option in Python. OMA brings goal-driven decomposition to TypeScript backends with three runtime dependencies and direct Node.js embedding, with no separate Python service to stand up alongside your stack.
 
-**vs. CrewAI.** CrewAI is the mature multi-agent option in Python. OMA targets TypeScript backends with three runtime dependencies and direct Node.js embedding. Roughly comparable orchestration surface; the choice is the language stack.
-
-**vs. Vercel AI SDK.** AI SDK provides the LLM-call layer — provider abstraction, streaming, tool calls, and structured outputs. It does not orchestrate goal-driven multi-agent teams. The two are complementary: AI SDK for app surfaces and single-agent calls, OMA when you need a team.
+**vs. Vercel AI SDK.** AI SDK is the LLM-call layer (provider abstraction, streaming, tool calls, and structured outputs), not a multi-agent orchestrator. Use it alone for single-agent calls; reach for OMA the moment you need a coordinated team. OMA even ships an optional AI SDK bridge.
 
 ## Ecosystem
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -78,23 +78,15 @@ npx tsx packages/core/examples/basics/team-collaboration.ts
 
 ## 与其他框架对比
 
-按需求快速选型。以下逐一分析差异。
+大多数 TypeScript 团队在选多智能体编排层时，真正是在 OMA、LangGraph JS、Mastra 之间做选择。区别在机制。
 
-| 你的需求 | 选 |
-|----------|----|
-| 固定的生产拓扑 + 成熟的持久化与 time-travel 生态 | LangGraph JS |
-| 全栈平台，workflow 手工连 | Mastra |
-| Python 栈 + 成熟多智能体生态 | CrewAI |
-| AI 应用工具集，广泛 provider 支持 | Vercel AI SDK |
-| **TypeScript + 一句话从目标到结果，自动拆任务** | **open-multi-agent** |
+**对比 LangGraph JS。** LangGraph 要你先把声明式图（节点、边、条件路由）设计好，再编译成可调用对象；OMA 的 Coordinator 在运行时把目标拆成任务 DAG，自动并行无依赖项。两者都能 checkpoint、resume，只是 LangGraph 的持久化生态更深。需要让编排随目标自适应、而不是提前把图连好时，选 OMA。
 
-**对比 LangGraph JS。** LangGraph 把声明式图（节点、边、条件路由）编译成可调用对象。`open-multi-agent` 是 Coordinator 在运行时把目标拆成任务 DAG，再自动并行无依赖项。终点一样（编排执行），方向相反：LangGraph 图优先，OMA 目标优先。两者都做 checkpoint 和 resume：OMA 每完成一个任务就快照到任意 `MemoryStore`，崩溃后用 `restore()` 续跑；LangGraph 的持久化生态更深，支持基于持久状态历史的 time-travel。
+**对比 Mastra。** 两者都是原生 TypeScript，区别在谁来驱动编排。Mastra 要你手工连图；OMA 是目标驱动的：把目标交给 Coordinator，它在运行时自动构建任务 DAG。`runTeam(team, goal)` 一行搞定。
 
-**对比 Mastra。** 两者都是原生 TypeScript，区别在谁来驱动编排。Mastra 要你手工连图；OMA 是目标驱动的：把目标交给 Coordinator，它在运行时自动构建任务 DAG，让编排随目标自适应，而不是跑一张你一步步连好的图。`runTeam(team, goal)` 一行搞定。
+**对比 CrewAI。** CrewAI 是 Python 阵营成熟的多智能体方案。OMA 把目标驱动的任务拆解带到 TypeScript 后端，3 个运行时依赖、直接嵌入 Node.js，不必在你的技术栈旁边再起一个独立的 Python 服务。
 
-**对比 CrewAI。** CrewAI 是 Python 阵营成熟的多智能体方案。OMA 面向 TypeScript 后端，3 个运行时依赖，直接嵌入 Node.js。编排能力大致持平，按语言栈选。
-
-**对比 Vercel AI SDK。** AI SDK 是应用和 LLM 调用层（provider 抽象、流式、tool call、结构化输出）。它不做多智能体编排。两者互补：单 agent 调用使用 AI SDK，需要多 agent 协作时引入 OMA。
+**对比 Vercel AI SDK。** AI SDK 是 LLM 调用层（provider 抽象、流式、tool call、结构化输出），不是多智能体编排器。单 agent 调用用它就够；一旦需要协同的团队，就用 OMA。OMA 还提供一个可选的 AI SDK bridge。
 
 ## 生态
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -280,23 +280,15 @@ Run any script with `npx tsx packages/core/examples/<path>.ts`; the full applica
 
 ## How is this different from X?
 
-A quick router. Mechanism breakdown follows.
+Most TypeScript teams picking a multi-agent layer are really choosing between OMA, LangGraph JS, and Mastra. The mechanism is what differs.
 
-| If you need | Pick |
-|-------------|------|
-| Fixed production topology with a mature persistence + time-travel ecosystem | LangGraph JS |
-| Full-stack platform, workflows wired by hand | Mastra |
-| Python stack with mature multi-agent ecosystem | CrewAI |
-| AI app toolkit with broad model-provider support | Vercel AI SDK |
-| **TypeScript, goal to result with auto task decomposition** | **open-multi-agent** |
+**vs. LangGraph JS.** LangGraph has you design a declarative graph (nodes, edges, conditional routing) up front, then compiles it into an invokable; OMA's Coordinator decomposes the goal into a task DAG at runtime and auto-parallelizes independents. Both checkpoint and resume, though LangGraph's persistence ecosystem runs deeper. Reach for OMA when the plan should adapt to the goal instead of being wired ahead of time.
 
-**vs. LangGraph JS.** LangGraph compiles a declarative graph (nodes, edges, conditional routing) into an invokable. `open-multi-agent` runs a Coordinator that decomposes the goal into a task DAG at runtime, then auto-parallelizes independents. Same end (orchestrated execution), opposite directions: LangGraph is graph-first, OMA is goal-first. Both checkpoint and resume: OMA snapshots each completed task over any `MemoryStore` and resumes with `restore()` after a crash; LangGraph's persistence ecosystem just runs deeper, with time-travel over durable state history.
+**vs. Mastra.** Both are TypeScript-native; the difference is who drives orchestration. Mastra has you wire the workflow by hand. OMA is goal-driven: hand its Coordinator a goal and it builds the task DAG at runtime. `runTeam(team, goal)` in one call.
 
-**vs. Mastra.** Both are TypeScript-native; the difference is who drives the orchestration. With Mastra you wire the workflow by hand. OMA is goal-driven: give its Coordinator a goal and it builds the task DAG at runtime, adapting the plan to the goal instead of running a graph you wired step by step. `runTeam(team, goal)` in one call.
+**vs. CrewAI.** CrewAI is the established multi-agent option in Python. OMA brings goal-driven decomposition to TypeScript backends with three runtime dependencies and direct Node.js embedding, with no separate Python service to stand up alongside your stack.
 
-**vs. CrewAI.** CrewAI is the mature multi-agent option in Python. OMA targets TypeScript backends with three runtime dependencies and direct Node.js embedding. Roughly comparable orchestration surface; the choice is the language stack.
-
-**vs. Vercel AI SDK.** AI SDK provides the LLM-call layer — provider abstraction, streaming, tool calls, and structured outputs. It does not orchestrate goal-driven multi-agent teams. The two are complementary: AI SDK for app surfaces and single-agent calls, OMA when you need a team.
+**vs. Vercel AI SDK.** AI SDK is the LLM-call layer (provider abstraction, streaming, tool calls, and structured outputs), not a multi-agent orchestrator. Use it alone for single-agent calls; reach for OMA the moment you need a coordinated team. OMA even ships an optional AI SDK bridge.
 
 ## Architecture
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -280,23 +280,15 @@ await orchestrator.runTeam(team, goal, {
 
 ## 与其他框架对比
 
-按需求快速选型。以下逐一分析差异。
+大多数 TypeScript 团队在选多智能体编排层时，真正是在 OMA、LangGraph JS、Mastra 之间做选择。区别在机制。
 
-| 你的需求 | 选 |
-|----------|----|
-| 固定的生产拓扑 + 成熟的持久化与 time-travel 生态 | LangGraph JS |
-| 全栈平台，workflow 手工连 | Mastra |
-| Python 栈 + 成熟多智能体生态 | CrewAI |
-| AI 应用工具集，广泛 provider 支持 | Vercel AI SDK |
-| **TypeScript + 一句话从目标到结果，自动拆任务** | **open-multi-agent** |
+**对比 LangGraph JS。** LangGraph 要你先把声明式图（节点、边、条件路由）设计好，再编译成可调用对象；OMA 的 Coordinator 在运行时把目标拆成任务 DAG，自动并行无依赖项。两者都能 checkpoint、resume，只是 LangGraph 的持久化生态更深。需要让编排随目标自适应、而不是提前把图连好时，选 OMA。
 
-**对比 LangGraph JS。** LangGraph 把声明式图（节点、边、条件路由）编译成可调用对象。`open-multi-agent` 是 Coordinator 在运行时把目标拆成任务 DAG，再自动并行无依赖项。终点一样（编排执行），方向相反：LangGraph 图优先，OMA 目标优先。两者都做 checkpoint 和 resume：OMA 每完成一个任务就快照到任意 `MemoryStore`，崩溃后用 `restore()` 续跑；LangGraph 的持久化生态更深，支持基于持久状态历史的 time-travel。
+**对比 Mastra。** 两者都是原生 TypeScript，区别在谁来驱动编排。Mastra 要你手工连图；OMA 是目标驱动的：把目标交给 Coordinator，它在运行时自动构建任务 DAG。`runTeam(team, goal)` 一行搞定。
 
-**对比 Mastra。** 两者都是原生 TypeScript，区别在谁来驱动编排。Mastra 要你手工连图；OMA 是目标驱动的：把目标交给 Coordinator，它在运行时自动构建任务 DAG，让编排随目标自适应，而不是跑一张你一步步连好的图。`runTeam(team, goal)` 一行搞定。
+**对比 CrewAI。** CrewAI 是 Python 阵营成熟的多智能体方案。OMA 把目标驱动的任务拆解带到 TypeScript 后端，3 个运行时依赖、直接嵌入 Node.js，不必在你的技术栈旁边再起一个独立的 Python 服务。
 
-**对比 CrewAI。** CrewAI 是 Python 阵营成熟的多智能体方案。OMA 面向 TypeScript 后端，3 个运行时依赖，直接嵌入 Node.js。编排能力大致持平，按语言栈选。
-
-**对比 Vercel AI SDK。** AI SDK 是应用和 LLM 调用层（provider 抽象、流式、tool call、结构化输出）。它不做多智能体编排。两者互补：单 agent 调用使用 AI SDK，需要多 agent 协作时引入 OMA。
+**对比 Vercel AI SDK。** AI SDK 是 LLM 调用层（provider 抽象、流式、tool call、结构化输出），不是多智能体编排器。单 agent 调用用它就够；一旦需要协同的团队，就用 OMA。OMA 还提供一个可选的 AI SDK bridge。
 
 ## 架构
 


### PR DESCRIPTION
## What

Tighten the **How is this different from X?** section across all four READMEs.

- Drop the "If you need / Pick" selector table. Four of its five rows pointed
  readers to another framework, and the prose below already carries the
  comparison.
- Keep the four mechanism-level contrasts (LangGraph JS, Mastra, CrewAI,
  Vercel AI SDK), and re-tilt each one to close on when OMA fits instead of
  on the competitor.
- Slim the LangGraph entry (previously the longest) to match the others.
  Dropped the `MemoryStore` / `restore()` / time-travel detail, which lives in
  the docs; the honest "LangGraph's persistence runs deeper" note stays, just
  no longer as the closing line.
- Add a one-line framing sentence: the real choice for a TS team is OMA vs
  LangGraph JS vs Mastra.

## Why

The section read more like a router out of OMA than a comparison. This keeps
the honest mechanism contrast (goal-first vs graph-first) while making each
entry land on what OMA is for.

## Scope

Docs only. Synced across `README.md`, `README_zh.md`,
`packages/core/README.md`, `packages/core/README_zh.md`. Section anchors
unchanged, `npm run lint` passes, no code touched.
