### PR TITLE
fix(orchestrator): worker agents inherit defaultModel; standalone Agent requires explicit model

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -116,6 +116,15 @@ export class Agent {
     toolExecutor: ToolExecutor,
   ) {
     this.name = config.name
+    // `model` is optional on AgentConfig so orchestrated agents can inherit
+    // `OrchestratorConfig.defaultModel`. A standalone Agent has no orchestrator
+    // to inherit from, so it must declare a model explicitly.
+    if (config.model === undefined) {
+      throw new Error(
+        `Agent "${config.name}" has no model. Set 'model' in its config, or run it ` +
+          `through OpenMultiAgent to inherit 'defaultModel'.`,
+      )
+    }
     this.config = config
     this._toolRegistry = toolRegistry
     this._toolExecutor = toolExecutor
@@ -157,7 +166,9 @@ export class Agent {
     }
 
     const runnerOptions: RunnerOptions = {
-      model: this.config.model,
+      // Non-null: the constructor rejects a missing model, so by the time a
+      // runner is built `model` is guaranteed present.
+      model: this.config.model!,
       systemPrompt: effectiveSystemPrompt,
       maxTurns: this.config.maxTurns,
       maxTokens: this.config.maxTokens,
@@ -665,7 +676,7 @@ export class Agent {
       agent: {
         name: this.name,
         role: this.config.systemPrompt?.slice(0, 60) ?? 'assistant',
-        model: this.config.model,
+        model: this.config.model!,
       },
       abortSignal,
       cwd: this.config.cwd === undefined ? defaultWorkspaceDir() : this.config.cwd,

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -693,6 +693,7 @@ function buildTaskAgentTeamInfo(
     })
     const effective: AgentConfig = withModelRoute(applyDefaultToolPreset({
       ...targetConfig,
+      model: targetConfig.model ?? ctx.config.defaultModel,
       provider: targetConfig.provider ?? ctx.config.defaultProvider,
       baseURL: targetConfig.baseURL ?? ctx.config.defaultBaseURL,
       apiKey: targetConfig.apiKey ?? ctx.config.defaultApiKey,
@@ -1179,6 +1180,7 @@ async function buildTaskPrompt(
 
 /** Orchestrator-level defaults applied to ephemeral consensus agents. */
 interface ConsensusAgentDefaults {
+  readonly defaultModel: OrchestratorConfig['defaultModel']
   readonly defaultProvider: OrchestratorConfig['defaultProvider']
   readonly defaultBaseURL: OrchestratorConfig['defaultBaseURL']
   readonly defaultApiKey: OrchestratorConfig['defaultApiKey']
@@ -1212,6 +1214,7 @@ const VERDICT_INSTRUCTION =
 function applyConsensusDefaults(config: AgentConfig, defaults: ConsensusAgentDefaults): AgentConfig {
   return {
     ...config,
+    model: config.model ?? defaults.defaultModel,
     provider: config.provider ?? defaults.defaultProvider,
     baseURL: config.baseURL ?? defaults.defaultBaseURL,
     apiKey: config.apiKey ?? defaults.defaultApiKey,
@@ -1451,6 +1454,7 @@ async function runTaskVerify(
     budget: ctx.maxTokenBudget,
     reviseProposer: assigneeConfig,
     defaults: {
+      defaultModel: config.defaultModel,
       defaultProvider: config.defaultProvider,
       defaultBaseURL: config.defaultBaseURL,
       defaultApiKey: config.defaultApiKey,
@@ -1596,6 +1600,7 @@ export class OpenMultiAgent {
     const effectiveBudget = resolveTokenBudget(config.maxTokenBudget, this.config.maxTokenBudget)
     const effective: AgentConfig = applyDefaultToolPreset({
       ...config,
+      model: config.model ?? this.config.defaultModel,
       provider: config.provider ?? this.config.defaultProvider,
       baseURL: config.baseURL ?? this.config.defaultBaseURL,
       apiKey: config.apiKey ?? this.config.defaultApiKey,
@@ -1703,6 +1708,7 @@ export class OpenMultiAgent {
       const effectiveBudget = resolveTokenBudget(bestAgent.maxTokenBudget, this.config.maxTokenBudget)
       const effective: AgentConfig = withModelRoute(applyDefaultToolPreset({
         ...bestAgent,
+        model: bestAgent.model ?? this.config.defaultModel,
         provider: bestAgent.provider ?? this.config.defaultProvider,
         baseURL: bestAgent.baseURL ?? this.config.defaultBaseURL,
         apiKey: bestAgent.apiKey ?? this.config.defaultApiKey,
@@ -2253,6 +2259,7 @@ export class OpenMultiAgent {
     const onDissent = options.onDissent ?? 'revise'
     const budget = this.config.maxTokenBudget
     const defaults: ConsensusAgentDefaults = {
+      defaultModel: this.config.defaultModel,
       defaultProvider: this.config.defaultProvider,
       defaultBaseURL: this.config.defaultBaseURL,
       defaultApiKey: this.config.defaultApiKey,
@@ -2902,7 +2909,7 @@ export class OpenMultiAgent {
     for (const config of agentConfigs) {
       const effective: AgentConfig = applyDefaultToolPreset({
         ...config,
-        model: config.model,
+        model: config.model ?? this.config.defaultModel,
         provider: config.provider ?? this.config.defaultProvider,
         baseURL: config.baseURL ?? this.config.defaultBaseURL,
         apiKey: config.apiKey ?? this.config.defaultApiKey,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -376,7 +376,16 @@ export interface BeforeRunHookContext {
 /** Static configuration for a single agent. */
 export interface AgentConfig {
   readonly name: string
-  readonly model: string
+  /**
+   * Model identifier (e.g. `'claude-opus-4-6'`).
+   *
+   * Optional in an orchestrated run: under `runTeam` / `runTasks` / `runAgent`
+   * an unset model inherits {@link OrchestratorConfig.defaultModel} (mirroring
+   * how `provider` / `baseURL` / `apiKey` inherit their `default*` siblings).
+   * A standalone `new Agent(...)` has no orchestrator to inherit from, so it
+   * must set this explicitly — the constructor throws when it is absent.
+   */
+  readonly model?: string
   /**
    * Optional custom {@link LLMAdapter}. When set, the agent uses this adapter
    * directly and skips {@link createAdapter} — `provider`, `apiKey`, `baseURL`,
@@ -1021,6 +1030,13 @@ export interface OrchestratorConfig {
   readonly maxDelegationDepth?: number
   /** Maximum cumulative tokens (input + output) allowed per orchestrator run. */
   readonly maxTokenBudget?: number
+  /**
+   * Default model inherited by every agent that does not set its own
+   * {@link AgentConfig.model} — workers, the coordinator, and consensus agents
+   * alike (mirroring how {@link defaultProvider} is inherited). Defaults to
+   * `'claude-opus-4-6'`. Has no effect on a standalone `new Agent(...)`, which
+   * has no orchestrator to inherit from and must set `model` itself.
+   */
   readonly defaultModel?: string
   readonly defaultProvider?: SupportedProvider
   readonly defaultBaseURL?: string

--- a/packages/core/tests/orchestrator.test.ts
+++ b/packages/core/tests/orchestrator.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { Agent } from '../src/agent/agent.js'
+import { ToolRegistry } from '../src/tool/framework.js'
+import { ToolExecutor } from '../src/tool/executor.js'
 import type {
   AgentConfig,
   AgentRunResult,
@@ -424,6 +427,37 @@ describe('OpenMultiAgent', () => {
 
       expect(capturedChatOptions[0]?.model).toBe('default-worker-model')
       expect(capturedChatOptions[1]?.model).toBe('premium-review-model')
+    })
+  })
+
+  describe('defaultModel inheritance', () => {
+    it('worker without its own model inherits OrchestratorConfig.defaultModel', async () => {
+      mockAdapterResponses = ['worker output']
+
+      const oma = new OpenMultiAgent({ defaultModel: 'inherited-default-model' })
+      // Agent declares no model: it should inherit defaultModel, mirroring how
+      // provider/baseURL/apiKey inherit their default* siblings.
+      const team = oma.createTeam('t', teamCfg([
+        { name: 'worker-a', provider: 'openai', systemPrompt: 'You are worker-a.' },
+      ]))
+
+      await oma.runTasks(team, [
+        { title: 'Leaf', description: 'Do leaf work', assignee: 'worker-a' },
+      ])
+
+      expect(capturedChatOptions[0]?.model).toBe('inherited-default-model')
+    })
+
+    it('standalone Agent without a model throws at construction', () => {
+      // No orchestrator to inherit defaultModel from, so model is mandatory.
+      expect(
+        () =>
+          new Agent(
+            { name: 'orphan', provider: 'openai', systemPrompt: 'x' },
+            new ToolRegistry(),
+            new ToolExecutor(new ToolRegistry()),
+          ),
+      ).toThrow(/has no model/)
     })
   })
 


### PR DESCRIPTION
## Problem

`OrchestratorConfig.defaultModel` was only ever read by the internal coordinator.
Every executing agent path (buildPool workers, `runAgent`, the simple-goal
short-circuit, `delegate_to_agent`, consensus agents) inherited `provider` /
`baseURL` / `apiKey` from their `default*` siblings but never `model`. Because
`AgentConfig.model` was required, users were forced to set `model` on every
agent, which masked the gap: setting `defaultModel` once looked like a global
default but did nothing for the agents actually doing the work.

Surfaced while running the provider examples (e.g. `examples/providers/deepseek.ts`),
where every agent repeats its `model` even though `defaultModel` is already set.

## Fix

- Make `AgentConfig.model` optional. Orchestrated agents now inherit
  `OrchestratorConfig.defaultModel` when they declare no model of their own,
  mirroring how `provider` / `baseURL` / `apiKey` already inherit their
  `default*` siblings. Applied uniformly across worker, runAgent, short-circuit,
  delegate, and consensus paths.
- A standalone `new Agent(...)` has no orchestrator to inherit from, so it throws
  at construction when `model` is absent. As a provider-neutral framework, OMA
  does not silently fall back to a hardcoded model (which would mismatch a
  non-Anthropic provider).

## Compatibility

Purely additive. Existing code sets `model` explicitly on every agent, so behavior
is unchanged; the optional type only relaxes a requirement.

## Tests

- Worker without its own `model` inherits `defaultModel`.
- Standalone `Agent` without a `model` throws at construction.
- `tsc --noEmit` clean; full suite passes (1066 + 6).
