### PR TITLE
fix(ai-sdk): support Vercel AI SDK v6 in the optional peer range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,15 +16,15 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "2.0.89",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.89.tgz",
-      "integrity": "sha512-oIIsLOTgfuFIg6HGQ3d5gXjUvgx2YKav10T4t+sexnQj1anw6WoMDdSAT24igbfgWrC+Cf2tmlLeRhBUxdsZ9g==",
+      "version": "3.0.133",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.133.tgz",
+      "integrity": "sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.25",
-        "@vercel/oidc": "3.1.0"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30",
+        "@vercel/oidc": "3.2.0"
       },
       "engines": {
         "node": ">=18"
@@ -34,14 +34,14 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "2.0.106",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.106.tgz",
-      "integrity": "sha512-EFC0rpo1wfe4HIz5KZCE72edP2J7fOeR7wPXzjCDljaTRB1wectKDIKRLowpU4F0mbcJ+XScAsoYNPK/Z20aVQ==",
+      "version": "3.0.73",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.73.tgz",
+      "integrity": "sha512-+3x9oxHv9Xp33Iv2L8D+e5hqmZi64jofBKig/9611JKyfV59NdkaDDajtwc0CxOEfARgCVq1BW7dP+526gKOKw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.25"
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30"
       },
       "engines": {
         "node": ">=18"
@@ -51,9 +51,9 @@
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
-      "integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -64,15 +64,15 @@
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "3.0.25",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.25.tgz",
-      "integrity": "sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==",
+      "version": "4.0.30",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.30.tgz",
+      "integrity": "sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "2.0.3",
-        "@standard-schema/spec": "^1.0.0",
-        "eventsource-parser": "^3.0.6"
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -2746,9 +2746,9 @@
       "license": "MIT"
     },
     "node_modules/@vercel/oidc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
-      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2977,16 +2977,16 @@
       }
     },
     "node_modules/ai": {
-      "version": "5.0.188",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.188.tgz",
-      "integrity": "sha512-ABV+wRB1hz3UTZJTTqFIDi85tzUyr9o1ZKO5ZYZluFYlhZgKGOaInWaYv+OnBAb+qLpXWsrTWemd9/XShZJN0g==",
+      "version": "6.0.208",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.208.tgz",
+      "integrity": "sha512-STz+AaZqJ4ZjH7UkpXkbHx+bjgIDOsE8fIUoZjkZ2whoZcfVmG9K/TqEKouJZ03SuZuD7lagntlU3zBhAEkRpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "2.0.89",
-        "@ai-sdk/provider": "2.0.3",
-        "@ai-sdk/provider-utils": "3.0.25",
-        "@opentelemetry/api": "1.9.0"
+        "@ai-sdk/gateway": "3.0.133",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.30",
+        "@opentelemetry/api": "^1.9.0"
       },
       "engines": {
         "node": ">=18"
@@ -3982,9 +3982,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6470,14 +6470,14 @@
         "oma": "dist/cli/oma.js"
       },
       "devDependencies": {
-        "@ai-sdk/openai": "^2.0.106",
-        "@ai-sdk/provider": "^2.0.3",
+        "@ai-sdk/openai": "^3.0.0",
+        "@ai-sdk/provider": "^3.0.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
         "@google/genai": "^1.48.0",
         "@modelcontextprotocol/sdk": "^1.18.0",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^2.1.9",
-        "ai": "^5.0.188",
+        "ai": "^6.0.0",
         "tsx": "^4.21.0",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
@@ -6489,7 +6489,7 @@
         "@aws-sdk/client-bedrock-runtime": "^3.700.0",
         "@google/genai": "^1.48.0",
         "@modelcontextprotocol/sdk": "^1.18.0",
-        "ai": "^5.0.0"
+        "ai": "^5.0.0 || ^6.0.0"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/client-bedrock-runtime": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,7 @@
     "@aws-sdk/client-bedrock-runtime": "^3.700.0",
     "@google/genai": "^1.48.0",
     "@modelcontextprotocol/sdk": "^1.18.0",
-    "ai": "^5.0.0"
+    "ai": "^5.0.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-bedrock-runtime": {
@@ -96,14 +96,14 @@
     }
   },
   "devDependencies": {
-    "@ai-sdk/openai": "^2.0.106",
-    "@ai-sdk/provider": "^2.0.3",
+    "@ai-sdk/openai": "^3.0.0",
+    "@ai-sdk/provider": "^3.0.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
     "@google/genai": "^1.48.0",
     "@modelcontextprotocol/sdk": "^1.18.0",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^2.1.9",
-    "ai": "^5.0.188",
+    "ai": "^6.0.0",
     "tsx": "^4.21.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"

--- a/packages/core/src/llm/ai-sdk.ts
+++ b/packages/core/src/llm/ai-sdk.ts
@@ -365,7 +365,10 @@ export class AISdkAdapter implements LLMAdapter {
       responseId = meta.id ?? ''
       responseModel = meta.modelId ?? ''
 
-      const totalUsage = await result.totalUsage.catch(() => undefined)
+      // AI SDK v6 types `result.totalUsage` as a `PromiseLike` (no `.catch`),
+      // where v5 exposed a full `Promise`. `Promise.resolve()` normalizes both
+      // into a real Promise so the rejection guard compiles against either major.
+      const totalUsage = await Promise.resolve(result.totalUsage).catch(() => undefined)
       if (totalUsage !== undefined) {
         usage = usageToOma(totalUsage)
       }


### PR DESCRIPTION
## Problem
`@open-multi-agent/core` declares its optional Vercel AI SDK peer as
`ai: "^5.0.0"`, but the ecosystem has moved to v6 (`@ai-sdk/react@3` pulls
`ai@6`). A fresh registry install pairing `@open-multi-agent/core` with AI
SDK v6 fails with ERESOLVE:

    Conflicting peer dependency: ai@5.x ... peerOptional ai@"^5.0.0"
    from @open-multi-agent/core

The only workarounds today are `legacy-peer-deps=true` or pinning the app
to AI SDK v5. Found while building a Next.js starter on the published
`@open-multi-agent/core@1.8.0` + `ai@^6` + `@ai-sdk/react@^3`.

## Fix
- Widen the optional peer: `ai: "^5.0.0" -> "^5.0.0 || ^6.0.0"` (still optional).
- `AISdkAdapter`: v6 types `streamText().totalUsage` as a `PromiseLike`
  (no `.catch`); wrap in `Promise.resolve()` so the rejection guard compiles
  against either major. This is the only adapter API shape that changed
  across v5 -> v6.
- Bump dev deps to the v6 line (`ai@6`, `@ai-sdk/provider@3`,
  `@ai-sdk/openai@3`) so CI typechecks the adapter against v6.

The `Promise.resolve()` shim is a no-op on v5, so one codebase supports both
majors. The in-repo `examples/integrations/with-vercel-ai-sdk` already
targets `ai@^6` and installs cleanly against the widened local peer.

## Verification
- `npm run lint` (typecheck vs v6): pass
- `npm test`: 1066 + 6 pass, incl. `ai-sdk-adapter.test.ts` importing real `ai@6`
- `npm run build` + entry-point import smoke: pass

Takes effect for consumers on the next core release.
