### PR TITLE
docs(readme): link the one-click Vercel deploy starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ npx tsx packages/core/examples/basics/team-collaboration.ts
 
 Three agents collaborate on a REST API while `onProgress` streams the coordinator's task DAG — independent tasks run in parallel, dependents unblock as their inputs land, and the coordinator synthesizes the final result. Local models via Ollama need no API key; see the [providers guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md).
 
-Want a full application instead of a script? Two clone-and-run apps embed OMA in a real backend: an [Express REST API](packages/core/examples/integrations/express-customer-support/) and a [Next.js app](packages/core/examples/integrations/with-vercel-ai-sdk/).
+Want a full application instead of a script? Two clone-and-run apps embed OMA in a real backend: an [Express REST API](packages/core/examples/integrations/express-customer-support/) and a [Next.js app](packages/core/examples/integrations/with-vercel-ai-sdk/). Or skip the local setup: the [Next.js deploy starter](https://github.com/open-multi-agent/oma-nextjs-starter) goes live on Vercel in one click.
 
 ## How is this different from X?
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -74,7 +74,7 @@ npx tsx packages/core/examples/basics/team-collaboration.ts
 
 三个 agent 协作产出 REST API，`onProgress` 实时输出协调者的任务 DAG——无依赖的任务并行执行，依赖项在输入就绪后自动解锁，协调者最终合成结果。通过 Ollama 运行本地模型不需要 API key，见 [provider 指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md)。
 
-想要一个完整应用而不是脚本？两个克隆即跑的应用把 OMA 嵌进了真实后端：一个 [Express REST API](packages/core/examples/integrations/express-customer-support/) 和一个 [Next.js 应用](packages/core/examples/integrations/with-vercel-ai-sdk/)。
+想要一个完整应用而不是脚本？两个克隆即跑的应用把 OMA 嵌进了真实后端：一个 [Express REST API](packages/core/examples/integrations/express-customer-support/) 和一个 [Next.js 应用](packages/core/examples/integrations/with-vercel-ai-sdk/)。或者跳过本地搭建：[Next.js 部署模板](https://github.com/open-multi-agent/oma-nextjs-starter) 一键部署到 Vercel。
 
 ## 与其他框架对比
 


### PR DESCRIPTION
Links the new one-click deploy starter from the "full application" line in both README.md and README_zh.md.

oma-nextjs-starter (https://github.com/open-multi-agent/oma-nextjs-starter) is a standalone Next.js + Vercel AI SDK app that runs runTeam() behind a streaming chat UI and deploys to Vercel in one click. It lowers the cost of a first run: a developer gets a working multi-agent app in the cloud without cloning or local setup.

Docs-only change. EN and ZH updated together.