### PR TITLE
docs(readme): clarify which providers work out of the box vs need a peer install

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@
 
 Graph-first frameworks make you enumerate every node and edge up front. `open-multi-agent` is goal-first: you describe the outcome and the coordinator builds the task DAG at runtime, so the orchestration adapts to the goal instead of being hand-wired for one.
 
+`@open-multi-agent/core` keeps a lightweight core. The orchestration engine plus the mainstream model providers (Anthropic, OpenAI, and any OpenAI-compatible endpoint) work out of the box; additional providers (Gemini, Bedrock), MCP, and the Vercel AI SDK bridge are opt-in peer dependencies you install only when you use them.
+
 ## Get started
 
 The fastest way to see it run — one command scaffolds a project and starts a multi-agent DAG:
@@ -84,7 +86,7 @@ Most TypeScript teams picking a multi-agent layer are really choosing between OM
 
 **vs. Mastra.** Both are TypeScript-native; the difference is who drives orchestration. Mastra has you wire the workflow by hand. OMA is goal-driven: hand its Coordinator a goal and it builds the task DAG at runtime. `runTeam(team, goal)` in one call.
 
-**vs. CrewAI.** CrewAI is the established multi-agent option in Python. OMA brings goal-driven decomposition to TypeScript backends with three runtime dependencies and direct Node.js embedding, with no separate Python service to stand up alongside your stack.
+**vs. CrewAI.** CrewAI is the established multi-agent option in Python. OMA brings goal-driven decomposition to TypeScript backends with a lean runtime (three core dependencies, plus opt-in peers you install only when you use them) and direct Node.js embedding, with no separate Python service to stand up alongside your stack.
 
 **vs. Vercel AI SDK.** AI SDK is the LLM-call layer (provider abstraction, streaming, tool calls, and structured outputs), not a multi-agent orchestrator. Use it alone for single-agent calls; reach for OMA the moment you need a coordinated team. OMA even ships an optional AI SDK bridge.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -45,6 +45,8 @@
 
 图优先的框架要求你预先列出每个节点和每条边。`open-multi-agent` 是目标优先：你描述想要的结果，协调者在运行时构建任务 DAG，编排随目标自适应，而不必为某一个流程硬接线。
 
+`@open-multi-agent/core` 坚持轻量内核：编排引擎加上主流模型 provider（Anthropic、OpenAI 及任意 OpenAI 兼容端点）开箱即用；额外的 provider（Gemini、Bedrock）、MCP、Vercel AI SDK bridge 都是可选 peer 依赖，用到才装。
+
 ## 快速开始
 
 最快看到它跑起来 —— 一条命令脚手架出一个项目并启动多 agent DAG：
@@ -84,7 +86,7 @@ npx tsx packages/core/examples/basics/team-collaboration.ts
 
 **对比 Mastra。** 两者都是原生 TypeScript，区别在谁来驱动编排。Mastra 要你手工连图；OMA 是目标驱动的：把目标交给 Coordinator，它在运行时自动构建任务 DAG。`runTeam(team, goal)` 一行搞定。
 
-**对比 CrewAI。** CrewAI 是 Python 阵营成熟的多智能体方案。OMA 把目标驱动的任务拆解带到 TypeScript 后端，3 个运行时依赖、直接嵌入 Node.js，不必在你的技术栈旁边再起一个独立的 Python 服务。
+**对比 CrewAI。** CrewAI 是 Python 阵营成熟的多智能体方案。OMA 把目标驱动的任务拆解带到 TypeScript 后端，运行时精简（三个核心依赖，外加用到才装的可选 peer），直接嵌入 Node.js，不必在你的技术栈旁边再起一个独立的 Python 服务。
 
 **对比 Vercel AI SDK。** AI SDK 是 LLM 调用层（provider 抽象、流式、tool call、结构化输出），不是多智能体编排器。单 agent 调用用它就够；一旦需要协同的团队，就用 OMA。OMA 还提供一个可选的 AI SDK bridge。
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -45,6 +45,8 @@
 
 Graph-first frameworks make you enumerate every node and edge up front. `open-multi-agent` is goal-first: you describe the outcome and the coordinator builds the task DAG at runtime, so the orchestration adapts to the goal instead of being hand-wired for one.
 
+`@open-multi-agent/core` keeps a lightweight core. The orchestration engine plus the mainstream model providers (Anthropic, OpenAI, and any OpenAI-compatible endpoint) work out of the box; additional providers (Gemini, Bedrock), MCP, and the Vercel AI SDK bridge are opt-in peer dependencies you install only when you use them.
+
 ## Contents
 
 [Quick Start](#quick-start) · [Three Ways to Run](#three-ways-to-run) · [Features](#features) · [Orchestration Controls](#orchestration-controls) · [Ecosystem](#ecosystem) · [Examples](#examples) · [How Is This Different?](#how-is-this-different-from-x) · [Architecture](#architecture) · [Supported Providers](#supported-providers) · [Production Checklist](#production-checklist) · [Documentation](#documentation) · [Contributing](#contributing)
@@ -286,7 +288,7 @@ Most TypeScript teams picking a multi-agent layer are really choosing between OM
 
 **vs. Mastra.** Both are TypeScript-native; the difference is who drives orchestration. Mastra has you wire the workflow by hand. OMA is goal-driven: hand its Coordinator a goal and it builds the task DAG at runtime. `runTeam(team, goal)` in one call.
 
-**vs. CrewAI.** CrewAI is the established multi-agent option in Python. OMA brings goal-driven decomposition to TypeScript backends with three runtime dependencies and direct Node.js embedding, with no separate Python service to stand up alongside your stack.
+**vs. CrewAI.** CrewAI is the established multi-agent option in Python. OMA brings goal-driven decomposition to TypeScript backends with a lean runtime (three core dependencies, plus opt-in peers you install only when you use them) and direct Node.js embedding, with no separate Python service to stand up alongside your stack.
 
 **vs. Vercel AI SDK.** AI SDK is the LLM-call layer (provider abstraction, streaming, tool calls, and structured outputs), not a multi-agent orchestrator. Use it alone for single-agent calls; reach for OMA the moment you need a coordinated team. OMA even ships an optional AI SDK bridge.
 
@@ -348,15 +350,29 @@ const agent: AgentConfig = {
 
 | Kind | How to configure | Services |
 |------|------------------|----------|
-| Built-in shortcuts | Set `provider` to `anthropic`, `gemini`, `openai`, `azure-openai`, `copilot`, `grok`, `deepseek`, `doubao`, `hunyuan`, `minimax`, `mimo`, `qiniu`, or `bedrock`; the framework supplies the endpoint. | Anthropic, Gemini, OpenAI, Azure OpenAI, GitHub Copilot, xAI Grok, DeepSeek, Doubao (Volcengine), Hunyuan (Tencent MaaS), MiniMax, MiMo, Qiniu, AWS Bedrock |
-| OpenAI-compatible endpoints | Set `provider: 'openai'` plus `baseURL` and, when needed, `apiKey`. | Ollama, vLLM, LM Studio, llama.cpp server, OpenRouter, Groq, Mistral, Moonshot (Kimi), Qwen, Zhipu |
+| Built-in, no extra install | Set `provider` to `anthropic`, `openai`, `azure-openai`, `copilot`, `grok`, `deepseek`, `doubao`, `hunyuan`, `minimax`, `mimo`, or `qiniu`; the bundled `@anthropic-ai/sdk` / `openai` SDK supplies the endpoint. | Anthropic, OpenAI, Azure OpenAI, GitHub Copilot, xAI Grok, DeepSeek, Doubao (Volcengine), Hunyuan (Tencent MaaS), MiniMax, MiMo, Qiniu |
+| Built-in, needs a peer install | Set `provider: 'gemini'` after `npm i @google/genai`, or `provider: 'bedrock'` after `npm i @aws-sdk/client-bedrock-runtime`. | Google Gemini, AWS Bedrock |
+| OpenAI-compatible endpoints | Set `provider: 'openai'` plus `baseURL` and, when needed, `apiKey`. No extra install. | Ollama, vLLM, LM Studio, llama.cpp server, OpenRouter, Groq, Mistral, Moonshot (Kimi), Qwen, Zhipu |
 | Vercel AI SDK | Import `AISdkAdapter` from `@open-multi-agent/core/ai-sdk`; install optional peer `ai` plus an `@ai-sdk/*` provider. | [Any AI SDK provider](https://ai-sdk.dev/providers) (60+ models and hosts) |
 
 See [docs/providers.md](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) for env vars, model examples, local tool-calling, timeouts, and troubleshooting.
 
+### Dependencies
+
+Installing `@open-multi-agent/core` pulls in three runtime dependencies: `@anthropic-ai/sdk`, `openai`, and `zod`. That is the entire core: Anthropic, OpenAI, and every OpenAI-compatible endpoint run on these three alone.
+
+Everything else is an opt-in peer dependency you install only when you reach for it. Each loads lazily, so a project that never uses one never installs it.
+
+| Capability | Install | Trigger |
+|------------|---------|---------|
+| Gemini provider | `npm i @google/genai` | `provider: 'gemini'` |
+| Bedrock provider | `npm i @aws-sdk/client-bedrock-runtime` | `provider: 'bedrock'` |
+| MCP tools | `npm i @modelcontextprotocol/sdk` | `connectMCPTools()` |
+| Vercel AI SDK bridge | `npm i ai @ai-sdk/<provider>` | `new AISdkAdapter(...)` |
+
 ### Vercel AI SDK (optional)
 
-Install the optional peer [`ai`](https://www.npmjs.com/package/ai) plus any [`@ai-sdk` provider](https://ai-sdk.dev/providers) you need (for example [`@ai-sdk/openai`](https://www.npmjs.com/package/@ai-sdk/openai)). Pass `adapter: new AISdkAdapter(model)` on `AgentConfig` to route that agent through the AI SDK instead of the built-in `provider` factory. `provider`, `apiKey`, `baseURL`, and `region` are ignored when `adapter` is set. Mixed teams work as usual: only agents with `adapter` use the AI SDK.
+With the bridge peers installed (see the table above), pass `adapter: new AISdkAdapter(model)` on `AgentConfig` to route that agent through the AI SDK instead of the built-in `provider` factory. `provider`, `apiKey`, `baseURL`, and `region` are ignored when `adapter` is set. Mixed teams work as usual: only agents with `adapter` use the AI SDK.
 
 ```typescript
 import { openai } from '@ai-sdk/openai'

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -45,6 +45,8 @@
 
 图优先的框架要求你预先列出每个节点和每条边。`open-multi-agent` 是目标优先：你描述想要的结果，协调者在运行时构建任务 DAG，编排随目标自适应，而不必为某一个流程硬接线。
 
+`@open-multi-agent/core` 坚持轻量内核：编排引擎加上主流模型 provider（Anthropic、OpenAI 及任意 OpenAI 兼容端点）开箱即用；额外的 provider（Gemini、Bedrock）、MCP、Vercel AI SDK bridge 都是可选 peer 依赖，用到才装。
+
 ## 目录
 
 [快速开始](#快速开始) · [三种运行模式](#三种运行模式) · [功能一览](#功能一览) · [编排控制](#编排控制) · [生态](#生态) · [示例](#示例) · [与其他框架对比](#与其他框架对比) · [架构](#架构) · [支持的 Provider](#支持的-provider) · [生产级检查清单](#生产级检查清单) · [文档](#文档) · [参与贡献](#参与贡献)
@@ -286,7 +288,7 @@ await orchestrator.runTeam(team, goal, {
 
 **对比 Mastra。** 两者都是原生 TypeScript，区别在谁来驱动编排。Mastra 要你手工连图；OMA 是目标驱动的：把目标交给 Coordinator，它在运行时自动构建任务 DAG。`runTeam(team, goal)` 一行搞定。
 
-**对比 CrewAI。** CrewAI 是 Python 阵营成熟的多智能体方案。OMA 把目标驱动的任务拆解带到 TypeScript 后端，3 个运行时依赖、直接嵌入 Node.js，不必在你的技术栈旁边再起一个独立的 Python 服务。
+**对比 CrewAI。** CrewAI 是 Python 阵营成熟的多智能体方案。OMA 把目标驱动的任务拆解带到 TypeScript 后端，运行时精简（三个核心依赖，外加用到才装的可选 peer），直接嵌入 Node.js，不必在你的技术栈旁边再起一个独立的 Python 服务。
 
 **对比 Vercel AI SDK。** AI SDK 是 LLM 调用层（provider 抽象、流式、tool call、结构化输出），不是多智能体编排器。单 agent 调用用它就够；一旦需要协同的团队，就用 OMA。OMA 还提供一个可选的 AI SDK bridge。
 
@@ -348,15 +350,29 @@ const agent: AgentConfig = {
 
 | 类型 | 配置方式 | 服务 |
 |------|--------|------|
-| 内置快捷方式 | 设 `provider` 为 `anthropic`、`gemini`、`openai`、`azure-openai`、`copilot`、`grok`、`deepseek`、`doubao`、`hunyuan`、`minimax`、`mimo`、`qiniu`、`bedrock`；框架自带 endpoint。 | Anthropic、Gemini、OpenAI、Azure OpenAI、GitHub Copilot、xAI Grok、DeepSeek、Doubao（火山引擎）、Hunyuan（腾讯混元 MaaS）、MiniMax、MiMo、Qiniu、AWS Bedrock |
-| OpenAI 兼容端点 | 设 `provider: 'openai'` + `baseURL`，必要时加 `apiKey`。 | Ollama、vLLM、LM Studio、llama.cpp server、OpenRouter、Groq、Mistral、Moonshot（Kimi）、Qwen、Zhipu（智谱） |
+| 内置，无需额外安装 | 设 `provider` 为 `anthropic`、`openai`、`azure-openai`、`copilot`、`grok`、`deepseek`、`doubao`、`hunyuan`、`minimax`、`mimo`、`qiniu`；由自带的 `@anthropic-ai/sdk` / `openai` SDK 提供 endpoint。 | Anthropic、OpenAI、Azure OpenAI、GitHub Copilot、xAI Grok、DeepSeek、Doubao（火山引擎）、Hunyuan（腾讯混元 MaaS）、MiniMax、MiMo、Qiniu |
+| 内置，需装 peer | `npm i @google/genai` 后设 `provider: 'gemini'`；`npm i @aws-sdk/client-bedrock-runtime` 后设 `provider: 'bedrock'`。 | Google Gemini、AWS Bedrock |
+| OpenAI 兼容端点 | 设 `provider: 'openai'` + `baseURL`，必要时加 `apiKey`。无需额外安装。 | Ollama、vLLM、LM Studio、llama.cpp server、OpenRouter、Groq、Mistral、Moonshot（Kimi）、Qwen、Zhipu（智谱） |
 | Vercel AI SDK | 从 `@open-multi-agent/core/ai-sdk` 导入 `AISdkAdapter`；安装可选 peer `ai` 加一个 `@ai-sdk/*` provider。 | [任意 AI SDK provider](https://ai-sdk.dev/providers)（60+ 模型与平台） |
 
 详见 [docs/providers.md](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md)，含环境变量、模型示例、本地模型工具调用、超时设置、常见问题。
 
+### 依赖
+
+安装 `@open-multi-agent/core` 会带入三个运行时依赖：`@anthropic-ai/sdk`、`openai`、`zod`。内核就这些：Anthropic、OpenAI 及所有 OpenAI 兼容端点只靠这三个就能跑。
+
+其余都是可选 peer 依赖，用到哪个才装哪个。每个都是懒加载，没用到的项目根本不会安装。
+
+| 能力 | 安装 | 触发 |
+|------|------|------|
+| Gemini provider | `npm i @google/genai` | `provider: 'gemini'` |
+| Bedrock provider | `npm i @aws-sdk/client-bedrock-runtime` | `provider: 'bedrock'` |
+| MCP 工具 | `npm i @modelcontextprotocol/sdk` | `connectMCPTools()` |
+| Vercel AI SDK bridge | `npm i ai @ai-sdk/<provider>` | `new AISdkAdapter(...)` |
+
 ### Vercel AI SDK（可选）
 
-安装可选 peer [`ai`](https://www.npmjs.com/package/ai) 以及你需要的任意 [`@ai-sdk` provider](https://ai-sdk.dev/providers)（例如 [`@ai-sdk/openai`](https://www.npmjs.com/package/@ai-sdk/openai)）。在 `AgentConfig` 上传入 `adapter: new AISdkAdapter(model)`，即可让该 agent 走 AI SDK，而不是内置的 `provider` 工厂。设置了 `adapter` 时，`provider`、`apiKey`、`baseURL`、`region` 都会被忽略。混合团队照常工作：只有带 `adapter` 的 agent 才走 AI SDK。
+装好 bridge 的 peer 后（见上方表格），在 `AgentConfig` 上传入 `adapter: new AISdkAdapter(model)`，即可让该 agent 走 AI SDK，而不是内置的 `provider` 工厂。设置了 `adapter` 时，`provider`、`apiKey`、`baseURL`、`region` 都会被忽略。混合团队照常工作：只有带 `adapter` 的 agent 才走 AI SDK。
 
 ```typescript
 import { openai } from '@ai-sdk/openai'


### PR DESCRIPTION
## What

The README over-emphasized the three auto-installed runtime dependencies (which npm handles for you) while never flagging the peer dependencies you must install by hand. Following `provider: 'gemini'` straight from the table, for example, hit an undocumented `Cannot find module '@google/genai'`.

This PR fixes how dependencies and optional capabilities are communicated, and adds a short "what is core" positioning anchor.

## Changes

- **Core positioning anchor** (root + package READMEs, EN/ZH): one line stating the engine plus the out-of-the-box providers (Anthropic, OpenAI, any OpenAI-compatible endpoint) work on install; Gemini, Bedrock, MCP, and the Vercel AI SDK bridge are opt-in peers.
- **Supported Providers table** (package READMEs, EN/ZH): split into "no extra install" vs "needs a peer install", so Gemini (`@google/genai`) and Bedrock (`@aws-sdk/client-bedrock-runtime`) are no longer mixed in with the out-of-the-box providers.
- **New Dependencies section** (package READMEs, EN/ZH): the three runtime deps installed automatically, plus a table of on-demand peers (Gemini, Bedrock, MCP, Vercel AI SDK bridge) with the exact install command and trigger for each.
- **CrewAI comparison** (all four READMEs): reframed the dependency claim from "three runtime dependencies" to "a lean runtime: three core deps plus opt-in peers".
- **Vercel AI SDK subsection** (package READMEs): trimmed the now-duplicated install sentence; it defers to the Dependencies table and leads with usage.

Verified against `packages/core/package.json` (`dependencies` vs `peerDependencies`) and `src/llm/adapter.ts` (per-provider SDK): 11 of the 13 built-in providers run on the bundled `@anthropic-ai/sdk` / `openai`; only `gemini` and `bedrock` need a peer.

Docs only. No code or test changes.
