### PR TITLE
docs(examples): prefix example run commands with packages/core/

### DIFF
--- a/docs/context-management.md
+++ b/docs/context-management.md
@@ -100,7 +100,7 @@ Redacted reasoning (Anthropic safety-filtered) emits the placeholder `<thinking>
 **Notes:**
 - Disabled by default to avoid silently inflating prompt tokens.
 - Default-on truncation (`compressReasoningText`) is mandatory for safety on long chain-of-thought; disable only when debugging.
-- Some local OpenAI-compatible models may echo `<thinking>` text back into their assistant response, which can trip the loop detector. See `examples/patterns/cross-provider-reasoning.ts` for the failure mode and mitigations.
+- Some local OpenAI-compatible models may echo `<thinking>` text back into their assistant response, which can trip the loop detector. See [`examples/patterns/cross-provider-reasoning.ts`](../packages/core/examples/patterns/cross-provider-reasoning.ts) for the failure mode and mitigations.
 - Bedrock has `capabilities.echoesReasoning === 'own-issued'`: signed reasoning blocks (`reasoningContent.reasoningText.signature`) and redacted blocks (`reasoningContent.redactedContent`) round-trip natively on both `chat()` and `stream()`, in both inbound extraction and outbound serialization (see #223).
 - `'tool-use-only'` (DeepSeek V4) is the only capability where same-provider echo works **without** the user opting into `preserveReasoningAsText` — it's forced on internally because the DeepSeek API requires it.
 

--- a/docs/tool-configuration.md
+++ b/docs/tool-configuration.md
@@ -168,7 +168,7 @@ Long tool outputs can blow up conversation size and cost. Two controls work toge
 > — it is always a `ZodSchema<string>` because tool output is serialised as
 > text. The `outputSchema` on [`AgentConfig`](../packages/core/examples/patterns/structured-output.ts)
 > is different: it validates the **agent's final answer** as parsed JSON
-> against an arbitrary Zod schema (see _Structured output_ in `examples/`).
+> against an arbitrary Zod schema (see _Structured output_ in `packages/core/examples/`).
 > Different types, different scopes — TypeScript won't warn you if you mix
 > them up, so pick the one that matches the layer you're working at.
 

--- a/packages/core/examples/README.md
+++ b/packages/core/examples/README.md
@@ -2,7 +2,7 @@
 
 Runnable scripts demonstrating `open-multi-agent`. Organized by category — pick one that matches what you're trying to do.
 
-All scripts run with `npx tsx examples/<category>/<name>.ts`. Scripts that call a model require the corresponding API key in your environment. The full applications (see the apps section below) are the exception: they have their own `package.json` and start scripts.
+All scripts run with `npx tsx packages/core/examples/<category>/<name>.ts`. Scripts that call a model require the corresponding API key in your environment. The full applications (see the apps section below) are the exception: they have their own `package.json` and start scripts.
 
 ---
 

--- a/packages/core/examples/basics/multi-model-team.ts
+++ b/packages/core/examples/basics/multi-model-team.ts
@@ -8,7 +8,7 @@
  * - Running a team goal that uses the custom tools
  *
  * Run:
- *   npx tsx examples/basics/multi-model-team.ts
+ *   npx tsx packages/core/examples/basics/multi-model-team.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY and OPENAI_API_KEY env vars must be set.

--- a/packages/core/examples/basics/single-agent.ts
+++ b/packages/core/examples/basics/single-agent.ts
@@ -5,7 +5,7 @@
  * a coding task. Then shows streaming output using the Agent class directly.
  *
  * Run:
- *   npx tsx examples/basics/single-agent.ts
+ *   npx tsx packages/core/examples/basics/single-agent.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/basics/task-pipeline.ts
+++ b/packages/core/examples/basics/task-pipeline.ts
@@ -8,7 +8,7 @@
  * description plus direct dependency results (not unrelated team outputs).
  *
  * Run:
- *   npx tsx examples/basics/task-pipeline.ts
+ *   npx tsx packages/core/examples/basics/task-pipeline.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/basics/team-collaboration.ts
+++ b/packages/core/examples/basics/team-collaboration.ts
@@ -6,7 +6,7 @@
  * them to the right agents, and collects the results.
  *
  * Run:
- *   npx tsx examples/basics/team-collaboration.ts
+ *   npx tsx packages/core/examples/basics/team-collaboration.ts
  *
  * Prerequisites:
  *   OPENAI_API_KEY env var must be set. Works with any OpenAI-compatible

--- a/packages/core/examples/cookbook/competitive-monitoring.ts
+++ b/packages/core/examples/cookbook/competitive-monitoring.ts
@@ -9,7 +9,7 @@
  * - Timing validation: parallel execution must be <70% of serial sum
  *
  * Run:
- *   npx tsx examples/cookbook/competitive-monitoring.ts
+ *   npx tsx packages/core/examples/cookbook/competitive-monitoring.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/cookbook/contract-review-dag.ts
+++ b/packages/core/examples/cookbook/contract-review-dag.ts
@@ -15,8 +15,8 @@
  * - FORCE_FAIL=task2 env var triggers Task 2 failure on first attempt
  *
  * Run:
- *   npx tsx examples/cookbook/contract-review-dag.ts
- *   FORCE_FAIL=task2 npx tsx examples/cookbook/contract-review-dag.ts
+ *   npx tsx packages/core/examples/cookbook/contract-review-dag.ts
+ *   FORCE_FAIL=task2 npx tsx packages/core/examples/cookbook/contract-review-dag.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/cookbook/incident-postmortem-dag.ts
+++ b/packages/core/examples/cookbook/incident-postmortem-dag.ts
@@ -16,7 +16,7 @@
  *   - Token cost on claude-sonnet-4-6 is printed alongside token totals.
  *
  * Run:
- *   npx tsx examples/cookbook/incident-postmortem-dag.ts
+ *   npx tsx packages/core/examples/cookbook/incident-postmortem-dag.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/cookbook/meeting-summarizer.ts
+++ b/packages/core/examples/cookbook/meeting-summarizer.ts
@@ -8,7 +8,7 @@
  * - Aggregator merges into a single Markdown report
  *
  * Run:
- *   npx tsx examples/cookbook/meeting-summarizer.ts
+ *   npx tsx packages/core/examples/cookbook/meeting-summarizer.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/cookbook/narrative-puzzle-hint-arbitration.ts
+++ b/packages/core/examples/cookbook/narrative-puzzle-hint-arbitration.ts
@@ -19,7 +19,7 @@
  * - Zod-validated structured output and simple runtime assertions
  *
  * Run:
- *   npx tsx examples/cookbook/narrative-puzzle-hint-arbitration.ts
+ *   npx tsx packages/core/examples/cookbook/narrative-puzzle-hint-arbitration.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/cookbook/paper-replication-triage.ts
+++ b/packages/core/examples/cookbook/paper-replication-triage.ts
@@ -9,11 +9,11 @@
  * - Mocked source snapshots are flagged; SOURCE_MODE=live uses Asta + GitHub
  *
  * Run:
- *   npx tsx examples/cookbook/paper-replication-triage.ts
- *   npx tsx examples/cookbook/paper-replication-triage.ts "paper title or arXiv id"
+ *   npx tsx packages/core/examples/cookbook/paper-replication-triage.ts
+ *   npx tsx packages/core/examples/cookbook/paper-replication-triage.ts "paper title or arXiv id"
  *
  * Optional:
- *   SOURCE_MODE=live npx tsx examples/cookbook/paper-replication-triage.ts "ARXIV:1706.03762"
+ *   SOURCE_MODE=live npx tsx packages/core/examples/cookbook/paper-replication-triage.ts "ARXIV:1706.03762"
  *
  * Prerequisites:
  *   LLM_PROVIDER=anthropic (default) requires ANTHROPIC_API_KEY.

--- a/packages/core/examples/cookbook/personalized-interview-simulator.ts
+++ b/packages/core/examples/cookbook/personalized-interview-simulator.ts
@@ -9,7 +9,7 @@
  * - Structured debrief via Zod at the end of the interview loop
  *
  * Run:
- *   npx tsx examples/cookbook/personalized-interview-simulator.ts
+ *   npx tsx packages/core/examples/cookbook/personalized-interview-simulator.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/cookbook/rare-disease-information-triage.ts
+++ b/packages/core/examples/cookbook/rare-disease-information-triage.ts
@@ -16,7 +16,7 @@
  * - Zod-validated structured output and simple runtime assertions
  *
  * Run:
- *   npx tsx examples/cookbook/rare-disease-information-triage.ts
+ *   npx tsx packages/core/examples/cookbook/rare-disease-information-triage.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/cookbook/translation-backtranslation.ts
+++ b/packages/core/examples/cookbook/translation-backtranslation.ts
@@ -8,7 +8,7 @@
  * - Structured output with Zod schemas
  *
  * Run:
- *   npx tsx examples/cookbook/translation-backtranslation.ts
+ *   npx tsx packages/core/examples/cookbook/translation-backtranslation.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY must be set

--- a/packages/core/examples/integrations/express-customer-support/README.md
+++ b/packages/core/examples/integrations/express-customer-support/README.md
@@ -13,7 +13,7 @@ Each agent uses a Zod `outputSchema`; the endpoint assembles the three structure
 ## Setup
 
 ```bash
-cd examples/integrations/express-customer-support
+cd packages/core/examples/integrations/express-customer-support
 npm install
 export DEEPSEEK_API_KEY=sk-...    # default — all three agents use DeepSeek
 ```

--- a/packages/core/examples/integrations/mcp-bilig-workpaper.ts
+++ b/packages/core/examples/integrations/mcp-bilig-workpaper.ts
@@ -5,7 +5,7 @@
  * open-multi-agent Agent the workbook tools for formula readback.
  *
  * Run:
- *   npx tsx examples/integrations/mcp-bilig-workpaper.ts
+ *   npx tsx packages/core/examples/integrations/mcp-bilig-workpaper.ts
  *
  * Prerequisites:
  *   - GEMINI_API_KEY or GOOGLE_API_KEY

--- a/packages/core/examples/integrations/mcp-github.ts
+++ b/packages/core/examples/integrations/mcp-github.ts
@@ -5,7 +5,7 @@
  * standard open-multi-agent tools.
  *
  * Run:
- *   npx tsx examples/integrations/mcp-github.ts
+ *   npx tsx packages/core/examples/integrations/mcp-github.ts
  *
  * Prerequisites:
  *   - GEMINI_API_KEY

--- a/packages/core/examples/integrations/trace-observability.ts
+++ b/packages/core/examples/integrations/trace-observability.ts
@@ -11,7 +11,7 @@
  * dashboard.
  *
  * Run:
- *   npx tsx examples/integrations/trace-observability.ts
+ *   npx tsx packages/core/examples/integrations/trace-observability.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/integrations/with-engram/engram-store.ts
+++ b/packages/core/examples/integrations/with-engram/engram-store.ts
@@ -6,7 +6,7 @@
  * agent are visible to all others in the workspace.
  *
  * Run:
- *   npx tsx examples/integrations/with-engram/research-team.ts
+ *   npx tsx packages/core/examples/integrations/with-engram/research-team.ts
  *
  * Prerequisites:
  *   - Engram server running at http://localhost:7474 (or custom baseUrl)

--- a/packages/core/examples/integrations/with-engram/engram-toolkit.ts
+++ b/packages/core/examples/integrations/with-engram/engram-toolkit.ts
@@ -6,7 +6,7 @@
  * auto-resolutions.
  *
  * Run:
- *   npx tsx examples/integrations/with-engram/research-team.ts
+ *   npx tsx packages/core/examples/integrations/with-engram/research-team.ts
  *
  * Prerequisites:
  *   - Engram server running at http://localhost:7474 (or custom baseUrl)

--- a/packages/core/examples/integrations/with-engram/research-team.ts
+++ b/packages/core/examples/integrations/with-engram/research-team.ts
@@ -17,23 +17,23 @@
  * Defaults to anthropic / claude-sonnet-4-6 when unset.
  *
  * Run:
- *   npx tsx examples/integrations/with-engram/research-team.ts
+ *   npx tsx packages/core/examples/integrations/with-engram/research-team.ts
  *
  * Examples:
  *   # Anthropic (default)
- *   ANTHROPIC_API_KEY=sk-... ENGRAM_INVITE_KEY=ek_live_... npx tsx examples/integrations/with-engram/research-team.ts
+ *   ANTHROPIC_API_KEY=sk-... ENGRAM_INVITE_KEY=ek_live_... npx tsx packages/core/examples/integrations/with-engram/research-team.ts
  *
  *   # OpenAI
- *   AGENT_PROVIDER=openai AGENT_MODEL=gpt-4o OPENAI_API_KEY=sk-... ENGRAM_INVITE_KEY=ek_live_... npx tsx examples/integrations/with-engram/research-team.ts
+ *   AGENT_PROVIDER=openai AGENT_MODEL=gpt-4o OPENAI_API_KEY=sk-... ENGRAM_INVITE_KEY=ek_live_... npx tsx packages/core/examples/integrations/with-engram/research-team.ts
  *
  *   # Gemini
- *   AGENT_PROVIDER=gemini AGENT_MODEL=gemini-2.5-flash GEMINI_API_KEY=... ENGRAM_INVITE_KEY=ek_live_... npx tsx examples/integrations/with-engram/research-team.ts
+ *   AGENT_PROVIDER=gemini AGENT_MODEL=gemini-2.5-flash GEMINI_API_KEY=... ENGRAM_INVITE_KEY=ek_live_... npx tsx packages/core/examples/integrations/with-engram/research-team.ts
  *
  *   # Grok
- *   AGENT_PROVIDER=grok AGENT_MODEL=grok-3 XAI_API_KEY=... ENGRAM_INVITE_KEY=ek_live_... npx tsx examples/integrations/with-engram/research-team.ts
+ *   AGENT_PROVIDER=grok AGENT_MODEL=grok-3 XAI_API_KEY=... ENGRAM_INVITE_KEY=ek_live_... npx tsx packages/core/examples/integrations/with-engram/research-team.ts
  *
  *   # DeepSeek
- *   AGENT_PROVIDER=deepseek AGENT_MODEL=deepseek-v4-flash DEEPSEEK_API_KEY=... ENGRAM_INVITE_KEY=ek_live_... npx tsx examples/integrations/with-engram/research-team.ts
+ *   AGENT_PROVIDER=deepseek AGENT_MODEL=deepseek-v4-flash DEEPSEEK_API_KEY=... ENGRAM_INVITE_KEY=ek_live_... npx tsx packages/core/examples/integrations/with-engram/research-team.ts
  *
  * Prerequisites:
  *   - API key env var for your chosen provider

--- a/packages/core/examples/integrations/with-engram/team-research.ts
+++ b/packages/core/examples/integrations/with-engram/team-research.ts
@@ -20,7 +20,7 @@
  * Defaults to anthropic / claude-sonnet-4-6 when unset.
  *
  * Run:
- *   npx tsx examples/integrations/with-engram/team-research.ts
+ *   npx tsx packages/core/examples/integrations/with-engram/team-research.ts
  *
  * Prerequisites:
  *   - API key env var for your chosen provider

--- a/packages/core/examples/integrations/with-tencentdb-memory/README.md
+++ b/packages/core/examples/integrations/with-tencentdb-memory/README.md
@@ -161,11 +161,11 @@ set.
 
 ```bash
 # Hosted provider (default: anthropic / claude-sonnet-4-6)
-ANTHROPIC_API_KEY=sk-... npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+ANTHROPIC_API_KEY=sk-... npx tsx packages/core/examples/integrations/with-tencentdb-memory/team-with-memory.ts
 
 # Fully local (agents + Gateway extraction all on Ollama)
 AGENT_PROVIDER=openai AGENT_MODEL=qwen3.5:9b-mlx AGENT_BASE_URL=http://localhost:11434/v1 \
-  npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+  npx tsx packages/core/examples/integrations/with-tencentdb-memory/team-with-memory.ts
 ```
 
 | Env var | Default | Purpose |

--- a/packages/core/examples/integrations/with-tencentdb-memory/tdam-store.ts
+++ b/packages/core/examples/integrations/with-tencentdb-memory/tdam-store.ts
@@ -26,7 +26,7 @@
  * distilled TDAM memories are what persist.
  *
  * Run:
- *   npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+ *   npx tsx packages/core/examples/integrations/with-tencentdb-memory/team-with-memory.ts
  *
  * Prerequisites:
  *   - TDAM Hermes Gateway running at http://127.0.0.1:8420 (see README.md)

--- a/packages/core/examples/integrations/with-tencentdb-memory/tdam-toolkit.ts
+++ b/packages/core/examples/integrations/with-tencentdb-memory/tdam-toolkit.ts
@@ -12,7 +12,7 @@
  * path.
  *
  * Run:
- *   npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+ *   npx tsx packages/core/examples/integrations/with-tencentdb-memory/team-with-memory.ts
  *
  * Prerequisites:
  *   - TDAM Hermes Gateway running at http://127.0.0.1:8420 (see README.md)

--- a/packages/core/examples/integrations/with-tencentdb-memory/team-with-memory.ts
+++ b/packages/core/examples/integrations/with-tencentdb-memory/team-with-memory.ts
@@ -25,15 +25,15 @@
  * Defaults to anthropic / claude-sonnet-4-6 when unset.
  *
  * Run:
- *   npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+ *   npx tsx packages/core/examples/integrations/with-tencentdb-memory/team-with-memory.ts
  *
  * Examples:
  *   # Anthropic (default)
- *   ANTHROPIC_API_KEY=sk-... npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+ *   ANTHROPIC_API_KEY=sk-... npx tsx packages/core/examples/integrations/with-tencentdb-memory/team-with-memory.ts
  *
  *   # Fully local: agents on Ollama, Gateway extraction also on Ollama
  *   AGENT_PROVIDER=openai AGENT_MODEL=qwen3 AGENT_BASE_URL=http://localhost:11434/v1 \
- *     npx tsx examples/integrations/with-tencentdb-memory/team-with-memory.ts
+ *     npx tsx packages/core/examples/integrations/with-tencentdb-memory/team-with-memory.ts
  *
  * Prerequisites:
  *   - TDAM Hermes Gateway running at http://127.0.0.1:8420 (see README.md)

--- a/packages/core/examples/patterns/agent-handoff.ts
+++ b/packages/core/examples/patterns/agent-handoff.ts
@@ -9,7 +9,7 @@
  * standalone `runAgent()` does not register this tool by default.
  *
  * Run:
- *   npx tsx examples/patterns/agent-handoff.ts
+ *   npx tsx packages/core/examples/patterns/agent-handoff.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY

--- a/packages/core/examples/patterns/consensus.ts
+++ b/packages/core/examples/patterns/consensus.ts
@@ -12,7 +12,7 @@
  *      evaluates from a different angle (security vs. maintainability).
  *
  * Run:
- *   npx tsx examples/patterns/consensus.ts
+ *   npx tsx packages/core/examples/patterns/consensus.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/patterns/cost-tiered-pipeline.ts
+++ b/packages/core/examples/patterns/cost-tiered-pipeline.ts
@@ -8,7 +8,7 @@
  * - Estimating USD cost from provider-specific model pricing
  *
  * Run:
- *   npx tsx examples/patterns/cost-tiered-pipeline.ts
+ *   npx tsx packages/core/examples/patterns/cost-tiered-pipeline.ts
  *
  * Prerequisites:
  *   Set one of:

--- a/packages/core/examples/patterns/cross-provider-reasoning.ts
+++ b/packages/core/examples/patterns/cross-provider-reasoning.ts
@@ -16,7 +16,7 @@
  * has full context of what was previously considered. See #223 for design.
  *
  * Run:
- *   npx tsx examples/patterns/cross-provider-reasoning.ts
+ *   npx tsx packages/core/examples/patterns/cross-provider-reasoning.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY

--- a/packages/core/examples/patterns/fan-out-aggregate.ts
+++ b/packages/core/examples/patterns/fan-out-aggregate.ts
@@ -9,7 +9,7 @@
  * - No tools needed — pure LLM reasoning to keep the focus on the pattern
  *
  * Run:
- *   npx tsx examples/patterns/fan-out-aggregate.ts
+ *   npx tsx packages/core/examples/patterns/fan-out-aggregate.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/patterns/multi-perspective-code-review.ts
+++ b/packages/core/examples/patterns/multi-perspective-code-review.ts
@@ -12,7 +12,7 @@
  *   generator → [security-reviewer, performance-reviewer, style-reviewer] (parallel) → synthesizer
  *
  * Run:
- *   npx tsx examples/patterns/multi-perspective-code-review.ts
+ *   npx tsx packages/core/examples/patterns/multi-perspective-code-review.ts
  *
  * Prerequisites:
  *   If LLM_PROVIDER is unset, this example auto-selects the first available key

--- a/packages/core/examples/patterns/plan-replay.ts
+++ b/packages/core/examples/patterns/plan-replay.ts
@@ -12,7 +12,7 @@
  * plan to disk, then rebuild it from the saved file and replay it.
  *
  * Run:
- *   npx tsx examples/patterns/plan-replay.ts
+ *   npx tsx packages/core/examples/patterns/plan-replay.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/patterns/research-aggregation.ts
+++ b/packages/core/examples/patterns/research-aggregation.ts
@@ -14,7 +14,7 @@
  *   [technical-analyst, market-analyst, community-analyst] (parallel) → synthesizer
  *
  * Run:
- *   npx tsx examples/patterns/research-aggregation.ts "<topic>"
+ *   npx tsx packages/core/examples/patterns/research-aggregation.ts "<topic>"
  *
  * Provider selection (env):
  *   - LLM_PROVIDER=anthropic   (default)  → requires ANTHROPIC_API_KEY

--- a/packages/core/examples/patterns/structured-output.ts
+++ b/packages/core/examples/patterns/structured-output.ts
@@ -8,7 +8,7 @@
  * The validated result is available via `result.structured`.
  *
  * Run:
- *   npx tsx examples/patterns/structured-output.ts
+ *   npx tsx packages/core/examples/patterns/structured-output.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/patterns/task-retry.ts
+++ b/packages/core/examples/patterns/task-retry.ts
@@ -10,7 +10,7 @@
  * to retry on failure, and the second task (analysis) depends on it.
  *
  * Run:
- *   npx tsx examples/patterns/task-retry.ts
+ *   npx tsx packages/core/examples/patterns/task-retry.ts
  *
  * Prerequisites:
  *   ANTHROPIC_API_KEY env var must be set.

--- a/packages/core/examples/providers/azure-openai.ts
+++ b/packages/core/examples/providers/azure-openai.ts
@@ -5,7 +5,7 @@
  * to build a minimal Express.js REST API. Every agent uses Azure-hosted OpenAI models.
  *
  * Run:
- *   npx tsx examples/providers/azure-openai.ts
+ *   npx tsx packages/core/examples/providers/azure-openai.ts
  *
  * Prerequisites:
  *   AZURE_OPENAI_API_KEY      — Your Azure OpenAI API key (required)

--- a/packages/core/examples/providers/bedrock.ts
+++ b/packages/core/examples/providers/bedrock.ts
@@ -7,7 +7,7 @@
  * work the same way regardless of which underlying model family you target.
  *
  * Run:
- *   npx tsx examples/providers/bedrock.ts
+ *   npx tsx packages/core/examples/providers/bedrock.ts
  *
  * Prerequisites:
  *   `@aws-sdk/client-bedrock-runtime` is an optional peer dependency — install it first:

--- a/packages/core/examples/providers/copilot.ts
+++ b/packages/core/examples/providers/copilot.ts
@@ -6,7 +6,7 @@
  * endpoint, mixing GPT-4o (architect/reviewer) and Claude Sonnet (developer) in one team.
  *
  * Run:
- *   npx tsx examples/providers/copilot.ts
+ *   npx tsx packages/core/examples/providers/copilot.ts
  *
  * Authentication (one of):
  *   GITHUB_COPILOT_TOKEN env var (preferred)

--- a/packages/core/examples/providers/deepseek.ts
+++ b/packages/core/examples/providers/deepseek.ts
@@ -5,7 +5,7 @@
  * to build a minimal Express.js REST API. Every agent uses DeepSeek's flagship model.
  *
  * Run:
- *   npx tsx examples/providers/deepseek.ts
+ *   npx tsx packages/core/examples/providers/deepseek.ts
  *
  * Prerequisites:
  *   DEEPSEEK_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/doubao.ts
+++ b/packages/core/examples/providers/doubao.ts
@@ -5,7 +5,7 @@
  * to build a minimal Express.js REST API. Every agent uses the built-in Doubao provider shortcut.
  *
  * Run:
- *   npx tsx examples/providers/doubao.ts
+ *   npx tsx packages/core/examples/providers/doubao.ts
  *
  * Prerequisites:
  *   ARK_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/gemini.ts
+++ b/packages/core/examples/providers/gemini.ts
@@ -6,7 +6,7 @@
  * via the official `@google/genai` SDK.
  *
  * Run:
- *   npx tsx examples/providers/gemini.ts
+ *   npx tsx packages/core/examples/providers/gemini.ts
  *
  * Prerequisites:
  *   GEMINI_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/gemma4-local.ts
+++ b/packages/core/examples/providers/gemma4-local.ts
@@ -13,7 +13,7 @@
  * Gemma 4 e2b (5.1B params) handles both reliably.
  *
  * Run:
- *   no_proxy=localhost npx tsx examples/providers/gemma4-local.ts
+ *   no_proxy=localhost npx tsx packages/core/examples/providers/gemma4-local.ts
  *
  * Prerequisites:
  *   1. Ollama >= 0.20.0 installed and running: https://ollama.com

--- a/packages/core/examples/providers/grok.ts
+++ b/packages/core/examples/providers/grok.ts
@@ -5,7 +5,7 @@
  * to build a minimal Express.js REST API. Every agent uses Grok's coding-optimized model.
  *
  * Run:
- *   npx tsx examples/providers/grok.ts
+ *   npx tsx packages/core/examples/providers/grok.ts
  *
  * Prerequisites:
  *   XAI_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/groq.ts
+++ b/packages/core/examples/providers/groq.ts
@@ -5,7 +5,7 @@
  * to build a minimal Express.js REST API. Every agent uses Groq via the OpenAI-compatible adapter.
  *
  * Run:
- *   npx tsx examples/providers/groq.ts
+ *   npx tsx packages/core/examples/providers/groq.ts
  *
  * Prerequisites:
  *   GROQ_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/hunyuan.ts
+++ b/packages/core/examples/providers/hunyuan.ts
@@ -5,7 +5,7 @@
  * to build a minimal Express.js REST API. Every agent uses the built-in Hunyuan provider shortcut.
  *
  * Run:
- *   npx tsx examples/providers/hunyuan.ts
+ *   npx tsx packages/core/examples/providers/hunyuan.ts
  *
  * Prerequisites:
  *   HUNYUAN_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/local-quantized.ts
+++ b/packages/core/examples/providers/local-quantized.ts
@@ -15,7 +15,7 @@
  *   models. This is a local-quantized concern.
  *
  * Run:
- *   no_proxy=localhost npx tsx examples/providers/local-quantized.ts
+ *   no_proxy=localhost npx tsx packages/core/examples/providers/local-quantized.ts
  *
  * Prerequisites — pick one OpenAI-compatible local server:
  *   • vLLM:        `vllm serve Qwen/Qwen2.5-7B-Instruct-AWQ --port 8000`

--- a/packages/core/examples/providers/mimo.ts
+++ b/packages/core/examples/providers/mimo.ts
@@ -5,7 +5,7 @@
  * to build a minimal Express.js REST API. Every agent uses MiMo's OpenAI-compatible API.
  *
  * Run:
- *   npx tsx examples/providers/mimo.ts
+ *   npx tsx packages/core/examples/providers/mimo.ts
  *
  * Prerequisites:
  *   MIMO_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/minimax.ts
+++ b/packages/core/examples/providers/minimax.ts
@@ -5,7 +5,7 @@
  * to build a minimal Express.js REST API. Every agent uses MiniMax's flagship model.
  *
  * Run:
- *   npx tsx examples/providers/minimax.ts
+ *   npx tsx packages/core/examples/providers/minimax.ts
  *
  * Prerequisites:
  *   MINIMAX_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/mistral.ts
+++ b/packages/core/examples/providers/mistral.ts
@@ -5,7 +5,7 @@
  * to build a minimal Express.js REST API. Every agent uses Mistral via the OpenAI-compatible adapter.
  *
  * Run:
- *   npx tsx examples/providers/mistral.ts
+ *   npx tsx packages/core/examples/providers/mistral.ts
  *
  * Prerequisites:
  *   MISTRAL_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/moonshot.ts
+++ b/packages/core/examples/providers/moonshot.ts
@@ -6,7 +6,7 @@
  * OpenAI-compatible endpoint.
  *
  * Run:
- *   npx tsx examples/providers/moonshot.ts
+ *   npx tsx packages/core/examples/providers/moonshot.ts
  *
  * Prerequisites:
  *   MOONSHOT_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/ollama.ts
+++ b/packages/core/examples/providers/ollama.ts
@@ -14,7 +14,7 @@
  * Just change the baseURL and model name below.
  *
  * Run:
- *   npx tsx examples/providers/ollama.ts
+ *   npx tsx packages/core/examples/providers/ollama.ts
  *
  * Prerequisites:
  *   1. Ollama installed and running: https://ollama.com

--- a/packages/core/examples/providers/openrouter.ts
+++ b/packages/core/examples/providers/openrouter.ts
@@ -6,7 +6,7 @@
  * framework's OpenAI-compatible adapter.
  *
  * Run:
- *   npx tsx examples/providers/openrouter.ts
+ *   npx tsx packages/core/examples/providers/openrouter.ts
  *
  * Prerequisites:
  *   OPENROUTER_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/qiniu.ts
+++ b/packages/core/examples/providers/qiniu.ts
@@ -6,7 +6,7 @@
  * OpenAI-compatible AI inference endpoint (https://api.qnaigc.com/v1).
  *
  * Run:
- *   npx tsx examples/providers/qiniu.ts
+ *   npx tsx packages/core/examples/providers/qiniu.ts
  *
  * Prerequisites:
  *   QINIU_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/qwen.ts
+++ b/packages/core/examples/providers/qwen.ts
@@ -6,7 +6,7 @@
  * DashScope's OpenAI-compatible endpoint.
  *
  * Run:
- *   npx tsx examples/providers/qwen.ts
+ *   npx tsx packages/core/examples/providers/qwen.ts
  *
  * Prerequisites:
  *   DASHSCOPE_API_KEY environment variable must be set.

--- a/packages/core/examples/providers/zhipu.ts
+++ b/packages/core/examples/providers/zhipu.ts
@@ -5,7 +5,7 @@
  * to build a minimal Express.js REST API. Every agent uses Zhipu GLM via the OpenAI-compatible adapter.
  *
  * Run:
- *   npx tsx examples/providers/zhipu.ts
+ *   npx tsx packages/core/examples/providers/zhipu.ts
  *
  * Prerequisites:
  *   ZHIPU_API_KEY environment variable must be set.


### PR DESCRIPTION
## What
Prefix every example run command with `packages/core/` so they match how the READMEs say to run them.

## Why
Examples live under `packages/core/examples/`, and both READMEs document running from the repo root:

    npx tsx packages/core/examples/basics/team-collaboration.ts

But the in-file `Run:` headers (and a few READMEs) still used the pre-restructure path:

    npx tsx examples/basics/team-collaboration.ts

The repo root has no top-level `examples/`, so copy-pasting an in-file command and running it from root failed with file-not-found. The two integration READMEs were even inconsistent with each other (with-vercel-ai-sdk already had the prefix, express-customer-support did not), which is the tell this is leftover staleness from moving examples under `packages/core/`.

## Scope
- 67 commands across 56 files: 53 example scripts (`Run:` headers) + `examples/README.md` + 2 integration READMEs (`npx tsx`, and one `cd`).
- Markdown links using the bare `examples/` path (e.g. in `packages/core/README.md`) are correct relative links and are left unchanged.
- Docs/comment-only change. `npm run lint` and `npm test` pass.
