### PR TITLE
chore: release core v1.8.1 + create-oma-app v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6459,7 +6459,7 @@
     },
     "packages/core": {
       "name": "@open-multi-agent/core",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
@@ -6507,7 +6507,7 @@
       }
     },
     "packages/create-oma-app": {
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "bin": {
         "create-oma-app": "dist/index.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "TypeScript multi-agent framework: one runTeam() call from goal to result. Auto task decomposition and parallel execution for multi-step LLM jobs. Deploys anywhere Node.js runs.",
   "files": [
     "dist",

--- a/packages/create-oma-app/package.json
+++ b/packages/create-oma-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-oma-app",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Scaffold a runnable multi-agent demo on @open-multi-agent/core — one command from zero to a live agent DAG.",
   "type": "module",
   "bin": {

--- a/packages/create-oma-app/template/package.json
+++ b/packages/create-oma-app/template/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.8.0"
+    "@open-multi-agent/core": "1.8.1"
   },
   "devDependencies": {
     "tsx": "^4.21.0"


### PR DESCRIPTION
Patch release.

## Fixes
- `defaultModel` is now inherited by all executing agents (worker / runAgent / delegate / consensus), not just the coordinator (#323)
- Support Vercel AI SDK v6 in the optional `ai` peer range, fixing ERESOLVE on v6 installs (#324)

## Republish
- core `1.8.0` → `1.8.1`
- create-oma-app `0.2.0` → `0.2.1` (template pin bumped to core `1.8.1`, CI-enforced)

Docs commits #320–#331 ride along.

Verified locally: `npm run build && npm run lint && npm test` all green (1072 tests).
