### PR TITLE
feat(runner): OMA-owned per-call LLM timeout, uniform across adapters

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -404,6 +404,7 @@ Before going live, wire up the controls that protect token spend, recover from f
 |---------|------|----------------|
 | Bound the conversation | `maxTurns` per agent + `contextStrategy` (`sliding-window` / `summarize` / `compact` / `custom`) | `AgentConfig` |
 | Bound wall-clock time | `timeoutMs` per agent (aborts a run that hangs, common with local models) | `AgentConfig` |
+| Bound a single LLM call | `callTimeoutMs` per agent (aborts one stalled `adapter.chat()`, uniform across providers) | `AgentConfig` |
 | Cap tool output | `maxToolOutputChars` (or per-tool `maxOutputChars`) + `compressToolResults: true` | `AgentConfig` and `defineTool()` |
 | Recover from failure | Per-task `maxRetries`, `retryDelayMs`, `retryBackoff` (exponential multiplier) | Task config used via `runTasks()` |
 | Survive a crash or restart | `checkpoint` (pass a `runId` or a durable `MemoryStore`) + `restore()` to resume, skipping completed tasks | `OrchestratorConfig` / run options |

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -404,6 +404,7 @@ await oma.runAgent(
 |--------|--------|--------|
 | 控制对话长度 | `maxTurns`（每个 agent）+ `contextStrategy`（`sliding-window` / `summarize` / `compact` / `custom`） | `AgentConfig` |
 | 控制运行时长 | `timeoutMs`（每个 agent，运行挂起时中止；本地模型常见） | `AgentConfig` |
+| 控制单次调用 | `callTimeoutMs`（每个 agent，单次 `adapter.chat()` 卡住时中止；跨 provider 统一） | `AgentConfig` |
 | 限制工具输出 | `maxToolOutputChars`（或单工具 `maxOutputChars`）+ `compressToolResults: true` | `AgentConfig` 和 `defineTool()` |
 | 失败重试 | 任务级 `maxRetries`、`retryDelayMs`、`retryBackoff`（指数退避倍率） | 通过 `runTasks()` 用的任务配置 |
 | 崩溃/重启后恢复 | `checkpoint`（给 `runId` 或持久化 `MemoryStore`）+ `restore()` 恢复运行，跳过已完成任务 | `OrchestratorConfig` / 运行选项 |

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -47,6 +47,7 @@ import type {
   ToolUseContext,
 } from '../types.js'
 import { emitTrace, generateRunId } from '../utils/trace.js'
+import { mergeAbortSignals } from '../utils/abort.js'
 import type { ToolDefinition as FrameworkToolDefinition, ToolRegistry } from '../tool/framework.js'
 import type { ToolExecutor } from '../tool/executor.js'
 import { defaultWorkspaceDir } from '../tool/built-in/path-safety.js'
@@ -63,19 +64,6 @@ import {
 // ---------------------------------------------------------------------------
 
 const ZERO_USAGE: TokenUsage = { input_tokens: 0, output_tokens: 0 }
-
-/**
- * Combine two {@link AbortSignal}s so that aborting either one cancels the
- * returned signal.  Works on Node 18+ (no `AbortSignal.any` required).
- */
-function mergeAbortSignals(a: AbortSignal, b: AbortSignal): AbortSignal {
-  const controller = new AbortController()
-  if (a.aborted || b.aborted) { controller.abort(); return controller.signal }
-  const abort = () => controller.abort()
-  a.addEventListener('abort', abort, { once: true })
-  b.addEventListener('abort', abort, { once: true })
-  return controller.signal
-}
 
 function addUsage(a: TokenUsage, b: TokenUsage): TokenUsage {
   return {
@@ -187,6 +175,7 @@ export class Agent {
       cwd: this.config.cwd,
       agentName: this.name,
       agentRole: this.config.systemPrompt?.slice(0, 50) ?? 'assistant',
+      callTimeoutMs: this.config.callTimeoutMs,
       loopDetection: this.config.loopDetection,
       maxTokenBudget: this.config.maxTokenBudget,
       contextStrategy: this.config.contextStrategy,

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -26,6 +26,7 @@ import type {
   TeamInfo,
   LLMAdapter,
   LLMChatOptions,
+  LLMResponse,
   TraceEvent,
   LoopDetectionConfig,
   LoopDetectionInfo,
@@ -33,9 +34,10 @@ import type {
   ContextStrategy,
   ThinkingConfig,
 } from '../types.js'
-import { TokenBudgetExceededError } from '../errors.js'
+import { LLMCallTimeoutError, TokenBudgetExceededError } from '../errors.js'
 import { LoopDetector } from './loop-detector.js'
 import { emitTrace } from '../utils/trace.js'
+import { mergeAbortSignals } from '../utils/abort.js'
 import { estimateTokens } from '../utils/tokens.js'
 import { redactSensitiveObject, redactSensitiveText } from '../utils/redaction.js'
 import type { ToolRegistry } from '../tool/framework.js'
@@ -117,6 +119,8 @@ export interface RunnerOptions {
   readonly thinking?: ThinkingConfig
   /** AbortSignal that cancels any in-flight adapter call and stops the loop. */
   readonly abortSignal?: AbortSignal
+  /** See {@link AgentConfig.callTimeoutMs}. Per single `adapter.chat()` call. */
+  readonly callTimeoutMs?: number
   /**
    * Tool access control configuration.
    * - `toolPreset`: Predefined tool sets for common use cases
@@ -439,6 +443,46 @@ export class AgentRunner {
     return result
   }
 
+  /**
+   * Send one `adapter.chat()` request bounded by an OMA-owned per-call timeout.
+   *
+   * When {@link RunnerOptions.callTimeoutMs} is set, a fresh
+   * `AbortSignal.timeout()` is minted for THIS call and merged with any signal
+   * already on `options`, so the per-call bound and the whole-run bound
+   * ({@link RunnerOptions.abortSignal}) compose — whichever fires first wins.
+   * A fresh signal per call is essential: baking one `AbortSignal.timeout()`
+   * into the shared chat options would degrade it into a whole-run deadline.
+   *
+   * If our per-call deadline fires (and the caller's own signal did not), the
+   * provider's abort rejection is translated into an {@link LLMCallTimeoutError}
+   * so a stalled provider is observable and distinguishable from a deliberate
+   * cancellation. Applied uniformly to every model call the runner owns (the
+   * main agentic loop and summarize-based context compaction), so behavior no
+   * longer depends on each vendor SDK's default request timeout.
+   */
+  private async chatWithCallTimeout(
+    messages: LLMMessage[],
+    options: LLMChatOptions,
+  ): Promise<LLMResponse> {
+    const timeoutMs = this.options.callTimeoutMs
+    if (timeoutMs === undefined || timeoutMs <= 0) {
+      return this.adapter.chat(messages, options)
+    }
+    const timeoutSignal = AbortSignal.timeout(timeoutMs)
+    const base = options.abortSignal
+    const abortSignal = base ? mergeAbortSignals(base, timeoutSignal) : timeoutSignal
+    try {
+      return await this.adapter.chat(messages, { ...options, abortSignal })
+    } catch (err) {
+      // Only claim a per-call timeout when our deadline fired and the caller's
+      // own signal did not — otherwise surface the original abort/error as-is.
+      if (timeoutSignal.aborted && base?.aborted !== true) {
+        throw new LLMCallTimeoutError(timeoutMs, this.options.agentName)
+      }
+      throw err
+    }
+  }
+
   private async summarizeMessages(
     messages: LLMMessage[],
     maxTokens: number,
@@ -510,7 +554,7 @@ export class AgentRunner {
     }
 
     const summaryStartMs = Date.now()
-    const summaryResponse = await this.adapter.chat(summaryInput, summaryOptions)
+    const summaryResponse = await this.chatWithCallTimeout(summaryInput, summaryOptions)
     if (options.onTrace) {
       const summaryEndMs = Date.now()
       emitTrace(options.onTrace, {
@@ -812,7 +856,7 @@ export class AgentRunner {
         // Step 1: Call the LLM and collect the full response for this turn.
         // ------------------------------------------------------------------
         const llmStartMs = Date.now()
-        const response = await this.adapter.chat(conversationMessages, baseChatOptions)
+        const response = await this.chatWithCallTimeout(conversationMessages, baseChatOptions)
         if (options.onTrace) {
           const llmEndMs = Date.now()
           emitTrace(options.onTrace, {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -19,6 +19,33 @@ export class TokenBudgetExceededError extends Error {
 }
 
 /**
+ * Raised when a single LLM call (one `adapter.chat()` request) exceeds the
+ * per-call deadline configured via {@link AgentConfig.callTimeoutMs}.
+ *
+ * Distinct from a whole-run timeout ({@link AgentConfig.timeoutMs}) and from a
+ * caller-supplied `abortSignal` cancellation: the runner only raises this when
+ * its own per-call deadline fired and the caller's signal did not, so a stalled
+ * provider is observable and tellable apart from a deliberate abort.
+ */
+export class LLMCallTimeoutError extends Error {
+  readonly code = 'LLM_CALL_TIMEOUT'
+
+  constructor(
+    /** The per-call deadline, in milliseconds, that was exceeded. */
+    readonly timeoutMs: number,
+    /** Name of the agent whose call timed out, when known. */
+    readonly agent?: string,
+  ) {
+    super(
+      agent !== undefined
+        ? `Agent "${agent}" LLM call exceeded per-call timeout of ${timeoutMs}ms`
+        : `LLM call exceeded per-call timeout of ${timeoutMs}ms`,
+    )
+    this.name = 'LLMCallTimeoutError'
+  }
+}
+
+/**
  * Raised when a message list passed to an adapter violates the
  * {@link LLMMessage}[] contract (e.g. a `content` that isn't a `ContentBlock[]`).
  * Surfaced at the adapter entry so the violation fails loudly instead of

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,7 +113,7 @@ export type { RegisterBuiltInToolsOptions } from './tool/built-in/index.js'
 
 export { createAdapter } from './llm/adapter.js'
 export type { SupportedProvider } from './llm/adapter.js'
-export { TokenBudgetExceededError, InvalidMessageError } from './errors.js'
+export { TokenBudgetExceededError, InvalidMessageError, LLMCallTimeoutError } from './errors.js'
 
 // ---------------------------------------------------------------------------
 // Memory

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -2517,6 +2517,7 @@ export class OpenMultiAgent {
         : coordinatorOverrides.cwd,
       loopDetection: coordinatorOverrides?.loopDetection,
       timeoutMs: coordinatorOverrides?.timeoutMs,
+      callTimeoutMs: coordinatorOverrides?.callTimeoutMs,
     }
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -508,6 +508,22 @@ export interface AgentConfig {
    */
   readonly timeoutMs?: number
   /**
+   * Maximum wall-clock time (in milliseconds) for a **single** LLM call
+   * (one `adapter.chat()` request), re-armed fresh for every model call the
+   * agent makes. Unset (the default) leaves each call bound only by the vendor
+   * SDK's own request timeout, which is inconsistent across providers and
+   * absent for some (a stalled provider can then hang the whole run).
+   *
+   * When set, OMA merges an `AbortSignal.timeout()` into each call so the bound
+   * is uniform across every adapter and composes with {@link timeoutMs} (the
+   * whole-run bound) — whichever fires first wins. A per-call timeout surfaces
+   * as an {@link LLMCallTimeoutError}, distinct from a caller `abortSignal`
+   * cancellation. Because OMA calls the model non-streaming internally, this is
+   * a wall-clock deadline over the entire response, so keep it generous for
+   * slow local models or large reasoning outputs.
+   */
+  readonly callTimeoutMs?: number
+  /**
    * Loop detection configuration. When set, the agent tracks repeated tool
    * calls and text outputs to detect stuck loops before `maxTurns` is reached.
    */
@@ -1283,6 +1299,8 @@ export interface CoordinatorConfig {
   readonly cwd?: string | null
   readonly loopDetection?: LoopDetectionConfig
   readonly timeoutMs?: number
+  /** See {@link AgentConfig.callTimeoutMs}. Bounds each coordinator LLM call. */
+  readonly callTimeoutMs?: number
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/utils/abort.ts
+++ b/packages/core/src/utils/abort.ts
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview AbortSignal composition helpers shared across the agent layer.
+ */
+
+/**
+ * Combine two {@link AbortSignal}s so that aborting either one aborts the
+ * returned signal. Works on Node 18+ (no `AbortSignal.any` required).
+ */
+export function mergeAbortSignals(a: AbortSignal, b: AbortSignal): AbortSignal {
+  const controller = new AbortController()
+  if (a.aborted || b.aborted) {
+    controller.abort()
+    return controller.signal
+  }
+  const abort = () => controller.abort()
+  a.addEventListener('abort', abort, { once: true })
+  b.addEventListener('abort', abort, { once: true })
+  return controller.signal
+}

--- a/packages/core/tests/call-timeout.test.ts
+++ b/packages/core/tests/call-timeout.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Per-LLM-call timeout (#336).
+ *
+ * `callTimeoutMs` bounds a *single* `adapter.chat()` request with an OMA-owned
+ * `AbortSignal.timeout()`, re-armed fresh per call and merged with any existing
+ * signal — so the bound is uniform across adapters and composes with the
+ * whole-run `abortSignal` / `timeoutMs`. When our deadline fires (and the
+ * caller's own signal did not) the stalled call surfaces as an
+ * `LLMCallTimeoutError`, distinct from a deliberate cancellation.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { AgentRunner } from '../src/agent/runner.js'
+import { Agent } from '../src/agent/agent.js'
+import { ToolRegistry, defineTool } from '../src/tool/framework.js'
+import { ToolExecutor } from '../src/tool/executor.js'
+import { LLMCallTimeoutError } from '../src/errors.js'
+import { z } from 'zod'
+import type { LLMAdapter, LLMChatOptions, LLMResponse } from '../src/types.js'
+
+const USER_HI = [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'hi' }] }]
+
+function textResponse(text: string): LLMResponse {
+  return {
+    id: '1',
+    content: [{ type: 'text', text }],
+    model: 'mock',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 0, output_tokens: 0 },
+  }
+}
+
+/**
+ * An adapter whose `chat()` never resolves on its own but rejects as soon as
+ * the passed `abortSignal` fires — models a stalled provider that still honors
+ * cancellation. Rejects immediately if no signal is present so a misconfigured
+ * test fails fast instead of hanging.
+ */
+function hangingAdapter(onCall?: (opts: LLMChatOptions) => void): LLMAdapter {
+  return {
+    name: 'hanging',
+    chat: (_messages, options) => {
+      onCall?.(options)
+      return new Promise<LLMResponse>((_resolve, reject) => {
+        const signal = options.abortSignal
+        if (signal === undefined) {
+          reject(new Error('test bug: hangingAdapter reached with no abortSignal'))
+          return
+        }
+        if (signal.aborted) {
+          reject(new Error('aborted by signal'))
+          return
+        }
+        signal.addEventListener('abort', () => reject(new Error('aborted by signal')), { once: true })
+      })
+    },
+    async *stream() { /* unused */ },
+  }
+}
+
+function makeRunner(adapter: LLMAdapter, options: Partial<ConstructorParameters<typeof AgentRunner>[3]> = {}) {
+  const registry = new ToolRegistry()
+  const executor = new ToolExecutor(registry)
+  return {
+    registry,
+    runner: new AgentRunner(adapter, registry, executor, { model: 'mock', ...options }),
+  }
+}
+
+describe('callTimeoutMs — per-call LLM timeout (#336)', () => {
+  it('does not inject a timeout signal when callTimeoutMs is unset', async () => {
+    let seen: AbortSignal | undefined
+    const chat = vi.fn(async (_m, opts: LLMChatOptions) => {
+      seen = opts.abortSignal
+      return textResponse('done')
+    })
+    const { runner } = makeRunner({ name: 'mock', chat, async *stream() {} })
+
+    const result = await runner.run(USER_HI)
+
+    expect(chat).toHaveBeenCalledOnce()
+    expect(result.output).toBe('done')
+    // With callTimeoutMs unset and no caller signal, nothing is injected.
+    expect(seen).toBeUndefined()
+  })
+
+  it('passes the caller signal through unchanged (identity) when callTimeoutMs is unset', async () => {
+    const controller = new AbortController()
+    let seen: AbortSignal | undefined
+    const { runner } = makeRunner({
+      name: 'mock',
+      chat: async (_m, opts) => { seen = opts.abortSignal; return textResponse('ok') },
+      async *stream() {},
+    })
+
+    await runner.run(USER_HI, { abortSignal: controller.signal })
+
+    // Exact identity — the signal is neither merged nor wrapped.
+    expect(seen).toBe(controller.signal)
+  })
+
+  it('aborts a stalled call and throws LLMCallTimeoutError after callTimeoutMs', async () => {
+    const { runner } = makeRunner(hangingAdapter(), { agentName: 'slowpoke', callTimeoutMs: 20 })
+
+    const err = await runner.run(USER_HI).catch((e) => e)
+
+    expect(err).toBeInstanceOf(LLMCallTimeoutError)
+    expect(err.code).toBe('LLM_CALL_TIMEOUT')
+    expect(err.timeoutMs).toBe(20)
+    expect(err.agent).toBe('slowpoke')
+  })
+
+  it('mints a fresh timeout signal for every call (per-call, not whole-run)', async () => {
+    const signals: (AbortSignal | undefined)[] = []
+    const chat = vi.fn()
+      .mockImplementationOnce(async (_m: unknown, opts: LLMChatOptions) => {
+        signals.push(opts.abortSignal)
+        return {
+          id: '1',
+          content: [{ type: 'tool_use', id: 'c1', name: 'noop', input: {} }],
+          model: 'mock',
+          stop_reason: 'tool_use',
+          usage: { input_tokens: 0, output_tokens: 0 },
+        }
+      })
+      .mockImplementationOnce(async (_m: unknown, opts: LLMChatOptions) => {
+        signals.push(opts.abortSignal)
+        return textResponse('done')
+      })
+    const { runner, registry } = makeRunner(
+      { name: 'mock', chat, async *stream() {} },
+      // Large budget so the fast mock calls never actually time out.
+      { agentName: 'a', allowedTools: ['noop'], callTimeoutMs: 10_000 },
+    )
+    registry.register(defineTool({
+      name: 'noop',
+      description: 'noop',
+      inputSchema: z.object({}),
+      execute: async () => ({ data: 'ok', isError: false }),
+    }))
+
+    const result = await runner.run(USER_HI)
+
+    expect(result.output).toBe('done')
+    expect(signals).toHaveLength(2)
+    expect(signals[0]).toBeDefined()
+    expect(signals[1]).toBeDefined()
+    // A fresh AbortSignal.timeout() is created for each call, so a fast first
+    // turn never eats into a later turn's budget.
+    expect(signals[0]).not.toBe(signals[1])
+  })
+
+  it('rethrows a caller abort as-is (not mislabeled as a timeout) when the caller signal fires first', async () => {
+    const controller = new AbortController()
+    // Large per-call budget so the timeout cannot be what fires.
+    const { runner } = makeRunner(hangingAdapter(), { agentName: 'a', callTimeoutMs: 10_000 })
+
+    const promise = runner.run(USER_HI, { abortSignal: controller.signal })
+    // Abort once the call is in flight (the pre-call abort check has passed).
+    setTimeout(() => controller.abort(), 5)
+    const err = await promise.catch((e) => e)
+
+    expect(err).not.toBeInstanceOf(LLMCallTimeoutError)
+    expect((err as Error).message).toContain('aborted by signal')
+  })
+
+  it('threads AgentConfig.callTimeoutMs through to the runner', async () => {
+    const registry = new ToolRegistry()
+    const agent = new Agent(
+      { name: 'a', model: 'mock', adapter: hangingAdapter(), callTimeoutMs: 20 },
+      registry,
+      new ToolExecutor(registry),
+    )
+
+    const result = await agent.run('hi')
+
+    // Agent catches run failures and surfaces them as a non-success result.
+    expect(result.success).toBe(false)
+    expect(result.output).toContain('per-call timeout')
+  })
+})

--- a/packages/core/tests/errors.test.ts
+++ b/packages/core/tests/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { TokenBudgetExceededError, InvalidMessageError } from '../src/errors.js'
+import { TokenBudgetExceededError, InvalidMessageError, LLMCallTimeoutError } from '../src/errors.js'
 
 describe('TokenBudgetExceededError', () => {
   it('sets .name to TokenBudgetExceededError', () => {
@@ -58,6 +58,41 @@ describe('InvalidMessageError', () => {
 
   it('is an instance of Error (extends built-in Error)', () => {
     const err = new InvalidMessageError('test')
+    expect(err).toBeInstanceOf(Error)
+  })
+})
+
+describe('LLMCallTimeoutError', () => {
+  it('sets .name to LLMCallTimeoutError', () => {
+    const err = new LLMCallTimeoutError(30_000, 'agent-1')
+    expect(err.name).toBe('LLMCallTimeoutError')
+  })
+
+  it('sets .code to LLM_CALL_TIMEOUT', () => {
+    const err = new LLMCallTimeoutError(30_000, 'agent-1')
+    expect(err.code).toBe('LLM_CALL_TIMEOUT')
+  })
+
+  it('stores timeoutMs and agent as readonly properties', () => {
+    const err = new LLMCallTimeoutError(15_000, 'worker-a')
+    expect(err.timeoutMs).toBe(15_000)
+    expect(err.agent).toBe('worker-a')
+  })
+
+  it('formats the message with agent name and timeout', () => {
+    const err = new LLMCallTimeoutError(20_000, 'analyst')
+    expect(err.message).toBe('Agent "analyst" LLM call exceeded per-call timeout of 20000ms')
+  })
+
+  it('omits the agent name from the message when unknown', () => {
+    const err = new LLMCallTimeoutError(20_000)
+    expect(err.agent).toBeUndefined()
+    expect(err.message).toBe('LLM call exceeded per-call timeout of 20000ms')
+  })
+
+  it('is an instance of LLMCallTimeoutError and Error', () => {
+    const err = new LLMCallTimeoutError(1000, 'b')
+    expect(err).toBeInstanceOf(LLMCallTimeoutError)
     expect(err).toBeInstanceOf(Error)
   })
 })


### PR DESCRIPTION
## What

Adds an opt-in, OMA-owned per-call LLM timeout so a single stalled model
request no longer hangs the whole run, with behavior uniform across every
adapter instead of left to each vendor SDK's default.

Closes #336.

## The gap

`AgentConfig.timeoutMs` bounds an entire agent run, but nothing bounded a
single `adapter.chat()`. That was left to each SDK and was inconsistent:
OpenAI / Anthropic inherit their vendor default, the AI SDK adapter
disables retries (`maxRetries: 0`), and a custom adapter with no internal
timeout can hang the turn indefinitely.

## Mechanism

New `AgentConfig.callTimeoutMs` (also on `CoordinatorConfig`). When set, the
runner mints a fresh `AbortSignal.timeout()` for each `adapter.chat()` and
merges it with any existing whole-run / caller signal, so per-call and
whole-run bounds compose and the per-call deadline is re-armed every call.
A per-call timeout surfaces as a new `LLMCallTimeoutError`, raised only when
the runner's own deadline fired and the caller's signal did not, so it stays
distinguishable from a deliberate abort or a real API error.

- **Opt-in**: unset (the default) preserves current behavior exactly.
- **Uniform**: applied to both runner-owned call sites (the agentic loop and
  summarize-based context compaction).
- Threaded through `RunnerOptions`; coordinator and team members inherit it.
- `mergeAbortSignals` moved to `utils/abort.ts` and shared (was a private
  copy in `agent.ts`).

## Caveat

The timeout relies on the adapter forwarding `abortSignal` to its transport
(all built-in adapters do). A custom adapter that ignores `abortSignal` can
still hang, same as the existing whole-run `timeoutMs`.

## Tests

- `tests/call-timeout.test.ts`: unset injects no signal / passes the caller
  signal through unchanged; a stalled call throws `LLMCallTimeoutError` after
  the deadline; a fresh signal is minted per call (per-call, not whole-run);
  a caller abort is not mislabeled as a timeout; the `AgentConfig` value
  threads through to the runner.
- `tests/errors.test.ts`: `LLMCallTimeoutError` shape and both message
  branches.

`npm run lint` clean; full suite green (core: 1078 tests).
