### PR TITLE
feat(orchestrator): error-aware task retry (classify, jitter, honor abort) (#337)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -161,7 +161,7 @@ Used with **`oma task --file`**.
 ```
 
 - **`dependsOn`** — Task titles (not internal ids), same convention as the coordinator output in the library.
-- Optional per-task fields: `memoryScope` (`"dependencies"` \| `"all"`), `maxRetries`, `retryDelayMs`, `retryBackoff`.
+- Optional per-task fields: `memoryScope` (`"dependencies"` \| `"all"`), `maxRetries`, `retryDelayMs`, `retryBackoff`. When retry is enabled (`maxRetries > 0`), backoff is jittered and provably-terminal failures — 4xx client errors other than 408/409/429, plus token-budget and invalid-message errors — skip retries automatically; no extra config.
 - **`tasks`** must be a non-empty array; each item needs string `title` and `description`.
 
 If **`--team path.json`** is passed, the file’s top-level `team` property is ignored and the external file is used instead (useful when the same team definition is shared across several pipeline files).

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -14,7 +14,7 @@ const orchestrator = new OpenMultiAgent({
 })
 ```
 
-Common event types include `task_start`, `task_complete`, `task_retry`, `task_skipped`, `agent_start`, `agent_complete`, `budget_exceeded`, and `error`.
+Common event types include `task_start`, `task_complete`, `task_retry`, `task_skipped`, `agent_start`, `agent_complete`, `budget_exceeded`, and `error`. A `task_retry` event's `data.nextDelayMs` is the actual, post-jitter delay before the next attempt, not the nominal backoff schedule.
 
 ## Trace Spans
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -406,6 +406,10 @@ export class Agent {
         tokenUsage: ZERO_USAGE,
         toolCalls: [],
         structured: undefined,
+        // Preserve the structured error (e.g. a provider APIError with `.status`)
+        // so retry logic can classify it — the non-streaming path is the only
+        // place this error object survives before it is stringified.
+        error,
       }
       this.emitAgentTrace(callerOptions, agentStartMs, errorResult)
       return errorResult

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -59,3 +59,40 @@ export class InvalidMessageError extends Error {
     this.name = 'InvalidMessageError'
   }
 }
+
+/**
+ * Read an HTTP-style status code off an unknown error, if present. Provider
+ * SDK errors (`Anthropic.APIError`, `OpenAI.APIError`) expose it as `.status`;
+ * some libraries use `.statusCode`. Returns `undefined` for network/unknown
+ * errors that carry no numeric status.
+ */
+function extractStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const record = error as { status?: unknown; statusCode?: unknown }
+  const status = record.status ?? record.statusCode
+  return typeof status === 'number' && Number.isFinite(status) ? status : undefined
+}
+
+/**
+ * Classify an error as retryable (transient — another attempt might succeed)
+ * or terminal (a retry cannot help).
+ *
+ * Conservative by design: returns `true` (retryable) unless the error is
+ * *provably* terminal, so turning retry on never silently stops retrying an
+ * error class that was retried before — it only skips attempts that are
+ * pointless. Terminal cases are exhausted-budget, malformed input, an aborted
+ * call, and 4xx client errors other than 408/409/429. Everything else —
+ * network blips (no status), request timeouts (408), conflicts (409), rate
+ * limits (429), and all 5xx server errors — is retryable.
+ */
+export function isRetryableError(error: unknown): boolean {
+  if (error instanceof TokenBudgetExceededError) return false
+  if (error instanceof InvalidMessageError) return false
+  if (error instanceof LLMCallTimeoutError) return true
+  if (error instanceof Error && error.name === 'AbortError') return false
+  const status = extractStatus(error)
+  if (status === undefined) return true
+  if (status === 408 || status === 409 || status === 429) return true
+  if (status >= 400 && status < 500) return false
+  return true
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,7 +113,7 @@ export type { RegisterBuiltInToolsOptions } from './tool/built-in/index.js'
 
 export { createAdapter } from './llm/adapter.js'
 export type { SupportedProvider } from './llm/adapter.js'
-export { TokenBudgetExceededError, InvalidMessageError, LLMCallTimeoutError } from './errors.js'
+export { TokenBudgetExceededError, InvalidMessageError, LLMCallTimeoutError, isRetryableError } from './errors.js'
 
 // ---------------------------------------------------------------------------
 // Memory

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -86,7 +86,8 @@ import { InMemoryStore } from '../memory/store.js'
 import { createTask, validateTaskDependencies } from '../task/task.js'
 import { extractJSON, validateOutput } from '../agent/structured-output.js'
 import { Scheduler } from './scheduler.js'
-import { TokenBudgetExceededError } from '../errors.js'
+import { TokenBudgetExceededError, isRetryableError } from '../errors.js'
+import { abortableDelay } from '../utils/abort.js'
 import { extractKeywords, keywordScore } from '../utils/keywords.js'
 
 // ---------------------------------------------------------------------------
@@ -274,11 +275,6 @@ function applyDefaultToolPreset(
   return { ...config, toolPreset: defaultToolPreset }
 }
 
-/** Promise-based delay. */
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 /** Maximum delay cap to prevent runaway exponential backoff (30 seconds). */
 const MAX_RETRY_DELAY_MS = 30_000
 
@@ -298,18 +294,30 @@ export function computeRetryDelay(
  *
  * Exported for testability — called internally by {@link executeQueue}.
  *
+ * Retry is off by default (`maxRetries: 0`). When enabled it is error-aware:
+ * provably-terminal failures (auth/validation errors, aborted calls, 4xx client
+ * errors other than 408/409/429) skip retries instead of wasting attempts;
+ * backoff is jittered to avoid lockstep re-collision against a rate-limited
+ * provider; and `abortSignal` is honored between attempts so a cancelled run
+ * neither sleeps a full backoff nor fires one more attempt.
+ *
  * @param run      - The function that executes the task (typically `pool.run`).
  * @param task     - The task to execute (retry config read from its fields).
- * @param onRetry  - Called before each retry sleep with event data.
- * @param delayFn  - Injectable delay function (defaults to real `sleep`).
+ * @param onRetry  - Called before each retry sleep with the (post-jitter) delay.
+ * @param delayFn  - Injectable delay function (defaults to `abortableDelay`).
+ * @param opts     - Optional `abortSignal` (checked between attempts) and `rng`
+ *                   (injectable `Math.random` for deterministic jitter in tests).
  * @returns The final {@link AgentRunResult} from the last attempt.
  */
 export async function executeWithRetry(
   run: () => Promise<AgentRunResult>,
   task: Task,
   onRetry?: (data: { attempt: number; maxAttempts: number; error: string; nextDelayMs: number }) => void,
-  delayFn: (ms: number) => Promise<void> = sleep,
+  delayFn: (ms: number, signal?: AbortSignal) => Promise<void> = abortableDelay,
+  opts?: { abortSignal?: AbortSignal; rng?: () => number },
 ): Promise<AgentRunResult> {
+  const abortSignal = opts?.abortSignal
+  const rng = opts?.rng ?? Math.random
   const rawRetries = Number.isFinite(task.maxRetries) ? task.maxRetries! : 0
   const maxAttempts = Math.max(0, rawRetries) + 1
   const baseDelay = Math.max(0, Number.isFinite(task.retryDelayMs) ? task.retryDelayMs! : 1000)
@@ -320,7 +328,32 @@ export async function executeWithRetry(
   // reflects the true cost of retries.
   let totalUsage: TokenUsage = { input_tokens: 0, output_tokens: 0 }
 
+  const failure = (output: string): AgentRunResult => ({
+    success: false,
+    output,
+    messages: [],
+    tokenUsage: totalUsage,
+    toolCalls: [],
+  })
+
+  // Compute the jittered backoff, report it, and sleep. Equal jitter over
+  // [nominal/2, nominal] decorrelates tasks retrying in lockstep while keeping a
+  // floor so a rate-limited provider isn't hammered instantly. Applied to the
+  // already-capped nominal, so the sleep never exceeds MAX_RETRY_DELAY_MS.
+  const backoffSleep = async (attempt: number): Promise<void> => {
+    const nominal = computeRetryDelay(baseDelay, backoff, attempt)
+    const jittered = Math.round(nominal / 2 + rng() * (nominal / 2))
+    onRetry?.({ attempt, maxAttempts, error: lastError, nextDelayMs: jittered })
+    await delayFn(jittered, abortSignal)
+  }
+
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    // Honor abort before every attempt — this turns an abort that landed during
+    // a prior backoff sleep into an early return instead of one more attempt.
+    if (abortSignal?.aborted) {
+      return failure(lastError || 'Run aborted')
+    }
+
     try {
       const result = await run()
       totalUsage = {
@@ -333,11 +366,11 @@ export async function executeWithRetry(
       }
       lastError = result.output
 
-      // Failure — retry or give up
-      if (attempt < maxAttempts) {
-        const delay = computeRetryDelay(baseDelay, backoff, attempt)
-        onRetry?.({ attempt, maxAttempts, error: lastError, nextDelayMs: delay })
-        await delayFn(delay)
+      // Non-streaming path carries the structured error on the result; a
+      // provably-terminal one (e.g. a 401) is not worth retrying.
+      const terminal = result.error !== undefined && !isRetryableError(result.error)
+      if (!terminal && attempt < maxAttempts && !abortSignal?.aborted) {
+        await backoffSleep(attempt)
         continue
       }
 
@@ -345,32 +378,21 @@ export async function executeWithRetry(
     } catch (err) {
       lastError = err instanceof Error ? err.message : String(err)
 
-      if (attempt < maxAttempts) {
-        const delay = computeRetryDelay(baseDelay, backoff, attempt)
-        onRetry?.({ attempt, maxAttempts, error: lastError, nextDelayMs: delay })
-        await delayFn(delay)
+      // Streaming path: the structured error is in scope here. Skip retries on
+      // terminal errors (auth/validation/abort) so they don't waste attempts.
+      const terminal = !isRetryableError(err)
+      if (!terminal && attempt < maxAttempts && !abortSignal?.aborted) {
+        await backoffSleep(attempt)
         continue
       }
 
-      // All retries exhausted — return a failure result
-      return {
-        success: false,
-        output: lastError,
-        messages: [],
-        tokenUsage: totalUsage,
-        toolCalls: [],
-      }
+      // Terminal, aborted, or retries exhausted — return a failure result.
+      return failure(lastError)
     }
   }
 
-  // Should not be reached, but TypeScript needs a return
-  return {
-    success: false,
-    output: lastError,
-    messages: [],
-    tokenUsage: totalUsage,
-    toolCalls: [],
-  }
+  // Should not be reached, but TypeScript needs a return.
+  return failure(lastError)
 }
 
 // ---------------------------------------------------------------------------
@@ -972,6 +994,8 @@ async function executeQueue(
             data: retryData,
           } satisfies OrchestratorEvent)
         },
+        undefined,
+        { abortSignal: ctx.abortSignal },
       )
 
       const taskEndMs = Date.now()

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -696,6 +696,14 @@ export interface AgentRunResult {
   readonly loopDetected?: boolean
   /** True when the run stopped because token budget was exceeded. */
   readonly budgetExceeded?: boolean
+  /**
+   * The underlying thrown error when `success` is false due to an exception
+   * (e.g. a provider `APIError` carrying `.status`), preserved so retry logic
+   * can classify it as retryable vs terminal. `undefined` for app-level
+   * failures. In-process only — collapses to `{}` if the result is
+   * JSON-serialized.
+   */
+  readonly error?: unknown
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/utils/abort.ts
+++ b/packages/core/src/utils/abort.ts
@@ -17,3 +17,23 @@ export function mergeAbortSignals(a: AbortSignal, b: AbortSignal): AbortSignal {
   b.addEventListener('abort', abort, { once: true })
   return controller.signal
 }
+
+/**
+ * Promise-based delay that resolves early if `signal` aborts, so a long backoff
+ * sleep does not outlive a cancelled run. Cleans up its timer and listener on
+ * whichever path resolves first to avoid leaks across many retrying tasks.
+ */
+export function abortableDelay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal?.aborted) return resolve()
+    const onAbort = () => {
+      clearTimeout(timer)
+      resolve()
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}

--- a/packages/core/tests/error-classification.test.ts
+++ b/packages/core/tests/error-classification.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isRetryableError,
+  TokenBudgetExceededError,
+  InvalidMessageError,
+  LLMCallTimeoutError,
+} from '../src/errors.js'
+
+describe('isRetryableError', () => {
+  it('treats terminal 4xx client errors as non-retryable', () => {
+    for (const status of [400, 401, 403, 404, 422]) {
+      expect(isRetryableError({ status })).toBe(false)
+    }
+  })
+
+  it('treats 408 / 409 / 429 as retryable', () => {
+    for (const status of [408, 409, 429]) {
+      expect(isRetryableError({ status })).toBe(true)
+    }
+  })
+
+  it('treats 5xx server errors as retryable', () => {
+    for (const status of [500, 502, 503, 504]) {
+      expect(isRetryableError({ status })).toBe(true)
+    }
+  })
+
+  it('treats network / no-status errors as retryable', () => {
+    expect(isRetryableError(new Error('ECONNRESET'))).toBe(true)
+    expect(isRetryableError(new Error('socket hang up'))).toBe(true)
+    expect(isRetryableError('some string')).toBe(true)
+    expect(isRetryableError(undefined)).toBe(true)
+  })
+
+  it('reads status from `.statusCode` as well as `.status`', () => {
+    expect(isRetryableError({ statusCode: 401 })).toBe(false)
+    expect(isRetryableError({ statusCode: 503 })).toBe(true)
+  })
+
+  it('classifies budget and invalid-message framework errors as terminal', () => {
+    expect(isRetryableError(new TokenBudgetExceededError('a', 100, 50))).toBe(false)
+    expect(isRetryableError(new InvalidMessageError('bad'))).toBe(false)
+  })
+
+  it('classifies a per-call timeout as retryable', () => {
+    expect(isRetryableError(new LLMCallTimeoutError(1000, 'agent'))).toBe(true)
+  })
+
+  it('classifies an AbortError as terminal', () => {
+    const err = new Error('aborted')
+    err.name = 'AbortError'
+    expect(isRetryableError(err)).toBe(false)
+  })
+
+  it('ignores a non-numeric status (defaults to retryable)', () => {
+    expect(isRetryableError({ status: 'nope' })).toBe(true)
+    expect(isRetryableError({ status: NaN })).toBe(true)
+  })
+})

--- a/packages/core/tests/runner-error-propagation.test.ts
+++ b/packages/core/tests/runner-error-propagation.test.ts
@@ -57,6 +57,9 @@ describe('AgentRunner.run() error propagation (#98)', () => {
 
     expect(result.success).toBe(false)
     expect(result.output).toContain('API 500')
+    // Locks the non-streaming write-side: agent.run()'s catch must preserve the
+    // raw error on result.error so executeWithRetry can classify it (#337).
+    expect(result.error).toBe(apiError)
   })
 
   it('AgentRunner.run() throws when adapter errors', async () => {

--- a/packages/core/tests/task-retry.test.ts
+++ b/packages/core/tests/task-retry.test.ts
@@ -123,6 +123,7 @@ describe('executeWithRetry', () => {
       task,
       (data) => retryEvents.push(data),
       noDelay,
+      { rng: () => 1 },
     )
 
     expect(result.success).toBe(true)
@@ -212,6 +213,7 @@ describe('executeWithRetry', () => {
       task,
       (data) => retryEvents.push(data),
       noDelay,
+      { rng: () => 1 },
     )
 
     expect(retryEvents).toHaveLength(3)
@@ -251,10 +253,10 @@ describe('executeWithRetry', () => {
     })
 
     const mockDelay = vi.fn().mockResolvedValue(undefined)
-    await executeWithRetry(run, task, undefined, mockDelay)
+    await executeWithRetry(run, task, undefined, mockDelay, { rng: () => 1 })
 
     expect(mockDelay).toHaveBeenCalledTimes(1)
-    expect(mockDelay).toHaveBeenCalledWith(250)  // 250 * 3^0
+    expect(mockDelay).toHaveBeenCalledWith(250, undefined)  // 250 * 3^0, jitter pinned to nominal
   })
 
   it('caps delay at 30 seconds', async () => {
@@ -271,9 +273,9 @@ describe('executeWithRetry', () => {
     })
 
     const mockDelay = vi.fn().mockResolvedValue(undefined)
-    await executeWithRetry(run, task, undefined, mockDelay)
+    await executeWithRetry(run, task, undefined, mockDelay, { rng: () => 1 })
 
-    expect(mockDelay).toHaveBeenCalledWith(30_000)  // capped
+    expect(mockDelay).toHaveBeenCalledWith(30_000, undefined)  // capped
   })
 
   it('accumulates token usage across retry attempts', async () => {
@@ -360,9 +362,241 @@ describe('executeWithRetry', () => {
     ;(task as any).retryBackoff = -2
 
     const mockDelay = vi.fn().mockResolvedValue(undefined)
-    await executeWithRetry(run, task, undefined, mockDelay)
+    await executeWithRetry(run, task, undefined, mockDelay, { rng: () => 1 })
 
     // backoff clamped to 1, so delay = 100 * 1^0 = 100
-    expect(mockDelay).toHaveBeenCalledWith(100)
+    expect(mockDelay).toHaveBeenCalledWith(100, undefined)
+  })
+
+  // -------------------------------------------------------------------------
+  // Error-aware retry: classify terminal vs retryable
+  // -------------------------------------------------------------------------
+
+  it('skips retries on a terminal thrown error (401)', async () => {
+    const run = vi.fn().mockRejectedValue(
+      Object.assign(new Error('unauthorized'), { status: 401 }),
+    )
+    const task = createTask({
+      title: 'Terminal',
+      description: 'test',
+      maxRetries: 3,
+      retryDelayMs: 10,
+    })
+
+    const retryEvents: unknown[] = []
+    const result = await executeWithRetry(
+      run,
+      task,
+      (data) => retryEvents.push(data),
+      noDelay,
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.output).toBe('unauthorized')
+    expect(run).toHaveBeenCalledTimes(1)  // no retries on a 401
+    expect(retryEvents).toHaveLength(0)
+  })
+
+  it('retries a retryable thrown error (429) then succeeds', async () => {
+    const run = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('rate limited'), { status: 429 }))
+      .mockResolvedValueOnce(SUCCESS_RESULT)
+    const task = createTask({
+      title: 'Retryable',
+      description: 'test',
+      maxRetries: 3,
+      retryDelayMs: 10,
+    })
+
+    const result = await executeWithRetry(run, task, undefined, noDelay)
+
+    expect(result.success).toBe(true)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('skips retries on a terminal success:false result error (non-streaming 401)', async () => {
+    const run = vi.fn().mockResolvedValue({
+      ...FAILURE_RESULT,
+      error: Object.assign(new Error('unauthorized'), { status: 401 }),
+    })
+    const task = createTask({
+      title: 'Terminal result',
+      description: 'test',
+      maxRetries: 3,
+      retryDelayMs: 10,
+    })
+
+    const result = await executeWithRetry(run, task, undefined, noDelay)
+
+    expect(result.success).toBe(false)
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a retryable success:false result error (503) then succeeds', async () => {
+    const run = vi.fn()
+      .mockResolvedValueOnce({ ...FAILURE_RESULT, error: { status: 503 } })
+      .mockResolvedValueOnce(SUCCESS_RESULT)
+    const task = createTask({
+      title: 'Retryable result',
+      description: 'test',
+      maxRetries: 3,
+      retryDelayMs: 10,
+    })
+
+    const result = await executeWithRetry(run, task, undefined, noDelay)
+
+    expect(result.success).toBe(true)
+    expect(run).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a success:false result with no structured error (app-level)', async () => {
+    const run = vi.fn()
+      .mockResolvedValueOnce(FAILURE_RESULT)  // no `error` field
+      .mockResolvedValueOnce(SUCCESS_RESULT)
+    const task = createTask({
+      title: 'App failure',
+      description: 'test',
+      maxRetries: 1,
+      retryDelayMs: 10,
+    })
+
+    const result = await executeWithRetry(run, task, undefined, noDelay)
+
+    expect(result.success).toBe(true)
+    expect(run).toHaveBeenCalledTimes(2)  // app-level failures still retry
+  })
+
+  // -------------------------------------------------------------------------
+  // Jitter — equal jitter over [nominal/2, nominal]
+  // -------------------------------------------------------------------------
+
+  it('applies the equal-jitter floor with rng=0', async () => {
+    const run = vi.fn()
+      .mockRejectedValueOnce(new Error('error'))
+      .mockResolvedValueOnce(SUCCESS_RESULT)
+    const task = createTask({
+      title: 'Jitter floor',
+      description: 'test',
+      maxRetries: 1,
+      retryDelayMs: 100,
+      retryBackoff: 2,
+    })
+
+    const mockDelay = vi.fn().mockResolvedValue(undefined)
+    const retryEvents: Array<{ nextDelayMs: number }> = []
+    await executeWithRetry(
+      run,
+      task,
+      (data) => retryEvents.push(data),
+      mockDelay,
+      { rng: () => 0 },
+    )
+
+    // nominal 100 → floor = 100/2 = 50
+    expect(retryEvents[0]!.nextDelayMs).toBe(50)
+    expect(mockDelay).toHaveBeenCalledWith(50, undefined)
+  })
+
+  it('applies the equal-jitter midpoint with rng=0.5', async () => {
+    const run = vi.fn()
+      .mockRejectedValueOnce(new Error('error'))
+      .mockResolvedValueOnce(SUCCESS_RESULT)
+    const task = createTask({
+      title: 'Jitter mid',
+      description: 'test',
+      maxRetries: 1,
+      retryDelayMs: 100,
+      retryBackoff: 2,
+    })
+
+    const retryEvents: Array<{ nextDelayMs: number }> = []
+    await executeWithRetry(
+      run,
+      task,
+      (data) => retryEvents.push(data),
+      noDelay,
+      { rng: () => 0.5 },
+    )
+
+    // nominal 100 → 100/2 + 0.5*(100/2) = 50 + 25 = 75
+    expect(retryEvents[0]!.nextDelayMs).toBe(75)
+  })
+
+  it('reports the same jittered delay to onRetry and delayFn', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('error'))
+    const task = createTask({
+      title: 'Jitter parity',
+      description: 'test',
+      maxRetries: 2,
+      retryDelayMs: 200,
+      retryBackoff: 2,
+    })
+
+    const delays: number[] = []
+    const retryEvents: Array<{ nextDelayMs: number }> = []
+    await executeWithRetry(
+      run,
+      task,
+      (data) => retryEvents.push(data),
+      (ms) => { delays.push(ms); return Promise.resolve() },
+      { rng: () => 0.37 },
+    )
+
+    expect(delays).toEqual(retryEvents.map((e) => e.nextDelayMs))
+    expect(delays).toHaveLength(2)
+  })
+
+  // -------------------------------------------------------------------------
+  // Abort honored between attempts
+  // -------------------------------------------------------------------------
+
+  it('does not run when the abort signal is already aborted', async () => {
+    const run = vi.fn().mockResolvedValue(SUCCESS_RESULT)
+    const task = createTask({
+      title: 'Pre-aborted',
+      description: 'test',
+      maxRetries: 2,
+    })
+    const controller = new AbortController()
+    controller.abort()
+
+    const result = await executeWithRetry(
+      run,
+      task,
+      undefined,
+      noDelay,
+      { abortSignal: controller.signal },
+    )
+
+    expect(run).toHaveBeenCalledTimes(0)
+    expect(result.success).toBe(false)
+    expect(result.output).toBe('Run aborted')
+  })
+
+  it('stops retrying when abort fires during the backoff sleep', async () => {
+    const run = vi.fn().mockRejectedValue(new Error('transient'))
+    const task = createTask({
+      title: 'Abort mid-sleep',
+      description: 'test',
+      maxRetries: 3,
+      retryDelayMs: 10,
+    })
+    const controller = new AbortController()
+    // A delay that aborts the run the moment the first backoff begins.
+    const abortingDelay = () => {
+      controller.abort()
+      return Promise.resolve()
+    }
+
+    const result = await executeWithRetry(
+      run,
+      task,
+      undefined,
+      abortingDelay,
+      { abortSignal: controller.signal },
+    )
+
+    expect(run).toHaveBeenCalledTimes(1)  // no further attempt after abort
+    expect(result.success).toBe(false)
   })
 })

--- a/packages/core/tests/task-retry.test.ts
+++ b/packages/core/tests/task-retry.test.ts
@@ -426,10 +426,17 @@ describe('executeWithRetry', () => {
       retryDelayMs: 10,
     })
 
-    const result = await executeWithRetry(run, task, undefined, noDelay)
+    const retryEvents: unknown[] = []
+    const result = await executeWithRetry(
+      run,
+      task,
+      (data) => retryEvents.push(data),
+      noDelay,
+    )
 
     expect(result.success).toBe(false)
     expect(run).toHaveBeenCalledTimes(1)
+    expect(retryEvents).toHaveLength(0)  // terminal → no retry event
   })
 
   it('retries a retryable success:false result error (503) then succeeds', async () => {


### PR DESCRIPTION
## What

Makes task retry (opt-in via `maxRetries > 0`) error-aware, so enabling retry does the right thing instead of blindly re-running every failure.

### 1. Classify retryable vs terminal
New `isRetryableError()` skips retries on provably-terminal failures (4xx client errors other than 408/409/429, token-budget, invalid-message, aborted calls) instead of burning attempts, wall-clock, and tokens on a request that cannot succeed. Retryable failures (429, 5xx, network blips, per-call timeouts) still retry.

Classification works on both execution paths:
- **Streaming**: the thrown provider error reaches the retry loop with its `.status` intact.
- **Non-streaming** (the default `runTeam` path): `agent.run` previously stringified the error, discarding `.status`. It now preserves the structured error on `AgentRunResult.error`, so classification fires here too.

### 2. Jitter
Equal jitter over `[nominal/2, nominal]` decorrelates tasks that would otherwise retry in lockstep against a rate-limited provider, while keeping a floor so a 429 is not hammered instantly.

### 3. Honor abort between attempts
`executeWithRetry` now checks `abortSignal` before each attempt and uses an abort-aware delay, so a cancelled run neither sleeps a full backoff nor fires one more attempt.

## Deliberate design choices
- **Jitter lives in the executor, not `computeRetryDelay`.** The issue suggested jittering inside `computeRetryDelay`, but that function has direct unit tests asserting exact values and is a public export used as a predictable backoff ceiling. Keeping it pure and applying jitter (injectable `rng`) in the executor preserves that contract.
- **`AgentRunResult` gains an optional `error` field.** Required so classification works on the default non-streaming path; matches the existing optional-metadata pattern (`loopDetected`, `budgetExceeded`).

## Compatibility
Retry is off by default (`maxRetries: 0`); this changes behavior only when retry is enabled. `executeWithRetry`'s signature is extended backward-compatibly (new 5th `opts` param).

## Tests
- New `isRetryableError` unit suite (status classification, framework errors, abort).
- New `executeWithRetry` cases: terminal vs retryable on both paths, jitter floor/midpoint bounds, abort stops mid-backoff.
- Existing exact-delay tests pinned with `rng: () => 1`.
- `npm run lint` + full suite green (1103 passing).

Closes #337
