### PR TITLE
feat(memory): ship FileStore, a zero-dependency durable MemoryStore (#338)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ The framework's key feature. The coordinator receives goal + roster → emits a 
 | Task | `task/queue.ts`, `task.ts` | Dependency-aware queue, auto-unblock on completion, cascade failure to dependents |
 | Tool | `tool/framework.ts`, `executor.ts`, `mcp.ts`, `text-tool-extractor.ts`, `built-in/` | `defineTool()` + Zod, ToolRegistry, parallel batch exec, MCP bridge, local-model text tool-call fallback, filesystem sandbox |
 | LLM | `llm/adapter.ts` + 12 per-provider files + `openai-common.ts` + `reasoning-fallback.ts` | `LLMAdapter` (`chat` + `stream`); lazy `createAdapter()` factory; `baseURL` for OpenAI-compatible servers; cross-provider reasoning round-tripping |
-| Memory | `memory/shared.ts`, `store.ts` | Namespaced KV store (`agentName/key`), markdown summary injection; pluggable `MemoryStore` backends |
+| Memory | `memory/shared.ts`, `store.ts`, `file-store.ts` | Namespaced KV store (`agentName/key`), markdown summary injection; pluggable `MemoryStore` backends (in-memory + durable file-backed `FileStore`) |
 | Dashboard | `dashboard/*.ts` | Pure HTML renderer for the post-run task DAG (no I/O) |
 | CLI | `cli/oma.ts` | Shell/CI entry; built to `dist/cli/oma.js`, exposed as the `oma` npm bin |
 | Utils | `utils/*.ts` | Semaphore, token accounting, keyword helpers, trace plumbing, secret/PII redaction |

--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -11,7 +11,7 @@ Pass `checkpoint` per call, or set a default for every run via `OrchestratorConf
 ```typescript
 import { OpenMultiAgent, Team, InMemoryStore } from '@open-multi-agent/core'
 
-const store = new InMemoryStore() // or a durable MemoryStore (Redis, SQLite, ...)
+const store = new InMemoryStore() // for durability across restarts, use FileStore (below) or a custom MemoryStore
 
 const team = new Team({
   name: 'research',
@@ -41,6 +41,31 @@ const orchestrator = new OpenMultiAgent({ checkpoint: true }) // default for all
 | `key` | `string` | — | Exact store key. Takes precedence over `runId`. |
 
 > **A `runId`, `key`, or explicit `store` is required when the team has no shared-memory store.** The instance-level fallback store is shared across every run on the orchestrator, so without a distinct key two concurrent runs would overwrite each other at the default checkpoint key. The call throws rather than risk a silent stomp.
+
+## Durable persistence: `FileStore`
+
+`InMemoryStore` is a plain `Map` — it dies with the process, so a checkpoint held there does not survive a restart. For durability out of the box, use the bundled **`FileStore`**: a zero-dependency, filesystem-backed `MemoryStore` (Node built-ins only, so the three-dependency promise holds). Each write lands atomically — temp file → `fsync` → `rename` — so a reader never sees a half-written file, even across a power loss, not just a process crash.
+
+```typescript
+import { OpenMultiAgent, Team, InMemoryStore, FileStore } from '@open-multi-agent/core'
+
+const team = new Team({
+  name: 'research',
+  agents: [researcher, writer],
+  sharedMemoryStore: new InMemoryStore(), // hot-path memory stays in RAM
+})
+
+const orchestrator = new OpenMultiAgent()
+
+// Checkpoints are durable; a fresh process can resume from the same path.
+await orchestrator.runTasks(team, tasks, {
+  checkpoint: { store: new FileStore('./.oma/checkpoint.json') },
+})
+```
+
+**Which store gets the `FileStore`.** Prefer it as the *checkpoint* store, leaving shared memory on a fast `InMemoryStore` (above). A separate checkpoint store self-embeds the shared-memory snapshot (see [What gets saved](#what-gets-saved)), so resume rebuilds everything from the one file — while durability I/O stays at checkpoint cadence (once per completed task) instead of firing on every agent memory write. Using `FileStore` as `sharedMemoryStore` also works and is durable, but then *every* shared-memory write rewrites the whole file; reach for that only when shared memory itself must survive a restart independently of checkpoints.
+
+**Scope.** One process at a time — there is no cross-process file lock, so this is not a shared database. Concurrent writes *within* a process are serialized and safe. That matches the resume story, which is inherently sequential (process A crashes, process B resumes). A corrupt or unreadable state file makes the store throw rather than silently start empty, so durable data is never quietly discarded.
 
 ## Resume
 

--- a/docs/shared-memory.md
+++ b/docs/shared-memory.md
@@ -10,7 +10,7 @@ const team = orchestrator.createTeam('research-team', {
 })
 ```
 
-For durable or cross-process backends (Redis, Postgres, Engram, etc.), implement the `MemoryStore` interface and pass it via `sharedMemoryStore`. Keys are still namespaced as `<agentName>/<key>` before reaching the store:
+For durable persistence without writing any storage code, pass the bundled **`FileStore`** — a zero-dependency, filesystem-backed `MemoryStore` with atomic writes (see [Checkpoint & resume](checkpoint.md#durable-persistence-filestore)). For cross-process or infrastructure backends (Redis, Postgres, Engram, etc.), implement the `MemoryStore` interface yourself and pass it via `sharedMemoryStore`. Keys are still namespaced as `<agentName>/<key>` before reaching the store:
 
 ```typescript
 import type { MemoryStore } from '@open-multi-agent/core'

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -170,7 +170,7 @@ Route orchestration phases to different models with an opt-in `modelRouting` pol
 | **Configurable coordinator** | Override the coordinator's model, provider, adapter, system prompt, or tools via `runTeam(team, goal, { coordinator })`. |
 | **Observability** | `onProgress` events, `onTrace` spans, post-run HTML dashboard rendering the executed task DAG. API keys and tokens are redacted from traces, bash output, and the dashboard. ([observability guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)) |
 | **Pluggable shared memory** | Default in-process KV; swap in Redis / Postgres / your own backend by implementing `MemoryStore`. ([shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md)) |
-| **Checkpoint & resume** | Opt-in per-run checkpointing over any `MemoryStore`: snapshot on each completed task, then `restore()` skips finished tasks to continue after a crash or restart. Best-effort saves never take the run down. ([checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md)) |
+| **Checkpoint & resume** | Opt-in per-run checkpointing over any `MemoryStore`: snapshot on each completed task, then `restore()` skips finished tasks to continue after a crash or restart. The bundled zero-dependency `FileStore` makes checkpoints durable out of the box; best-effort saves never take the run down. ([checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md)) |
 | **Sandboxed filesystem workspace** | Built-in filesystem tools are sandboxed to `<cwd>/.agent-workspace` by default; agents sharing the default configuration share this root. For per-agent isolation, set `AgentConfig.cwd`; for a different shared root, set `OrchestratorConfig.defaultCwd`; pass `null` to disable. ([sandbox config](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md)) |
 
 Production controls ([context strategies](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md), task retry with backoff, loop detection, tool output truncation/compression) are covered in the [Production Checklist](#production-checklist).
@@ -407,7 +407,7 @@ Before going live, wire up the controls that protect token spend, recover from f
 | Bound a single LLM call | `callTimeoutMs` per agent (aborts one stalled `adapter.chat()`, uniform across providers) | `AgentConfig` |
 | Cap tool output | `maxToolOutputChars` (or per-tool `maxOutputChars`) + `compressToolResults: true` | `AgentConfig` and `defineTool()` |
 | Recover from failure | Per-task `maxRetries`, `retryDelayMs`, `retryBackoff` (exponential multiplier) | Task config used via `runTasks()` |
-| Survive a crash or restart | `checkpoint` (pass a `runId` or a durable `MemoryStore`) + `restore()` to resume, skipping completed tasks | `OrchestratorConfig` / run options |
+| Survive a crash or restart | `checkpoint` (pass a `runId`, or a durable `MemoryStore` like the bundled `FileStore`) + `restore()` to resume, skipping completed tasks | `OrchestratorConfig` / run options |
 | Hard-cap spend | `maxTokenBudget` on the orchestrator | `OrchestratorConfig` |
 | Catch stuck agents | `loopDetection` with `onLoopDetected: 'terminate'` (or a custom handler) | `AgentConfig` |
 | Trace and audit | `onTrace` to your tracing backend; persist `renderTeamRunDashboard(result)` | `OrchestratorConfig` |

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -170,7 +170,7 @@ const result = await orchestrator.runFromPlan(team, plan)
 | **可配置协调者** | 通过 `runTeam(team, goal, { coordinator })` 覆盖协调者的 model、provider、adapter、system prompt 或工具。 |
 | **可观测性** | `onProgress` 事件、`onTrace` span，运行结束后渲染任务 DAG 的 HTML dashboard。API key 和 token 会从 trace、bash 输出和 dashboard 中自动脱敏。([可观测性指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)) |
 | **可插拔共享记忆** | 默认进程内 KV；实现 `MemoryStore` 接口即可换 Redis / Postgres / 自有后端。([共享记忆](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md)) |
-| **Checkpoint & resume** | 可选的按运行 checkpoint，运行于任意 `MemoryStore` 之上：每个任务完成时快照，`restore()` 跳过已完成任务，崩溃或重启后可恢复运行。存盘 best-effort，不会拖慢运行。([checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md)) |
+| **Checkpoint & resume** | 可选的按运行 checkpoint，运行于任意 `MemoryStore` 之上：每个任务完成时快照，`restore()` 跳过已完成任务，崩溃或重启后可恢复运行。内置的零依赖 `FileStore` 让 checkpoint 无需额外后端即可持久化；存盘 best-effort，不会拖慢运行。([checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md)) |
 | **沙箱化文件系统工作目录** | 内置文件系统工具默认沙箱化在 `<cwd>/.agent-workspace`；继承默认配置的 agent 共享同一根目录。需要 per-agent 隔离时显式设置 `AgentConfig.cwd`；改换共享根目录用 `OrchestratorConfig.defaultCwd`；传 `null` 关闭沙箱。([沙箱配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md)) |
 
 生产级控制（[上下文策略](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md)、任务重试退避、循环检测、工具输出截断/压缩）见 [生产级检查清单](#生产级检查清单)。
@@ -407,7 +407,7 @@ await oma.runAgent(
 | 控制单次调用 | `callTimeoutMs`（每个 agent，单次 `adapter.chat()` 卡住时中止；跨 provider 统一） | `AgentConfig` |
 | 限制工具输出 | `maxToolOutputChars`（或单工具 `maxOutputChars`）+ `compressToolResults: true` | `AgentConfig` 和 `defineTool()` |
 | 失败重试 | 任务级 `maxRetries`、`retryDelayMs`、`retryBackoff`（指数退避倍率） | 通过 `runTasks()` 用的任务配置 |
-| 崩溃/重启后恢复 | `checkpoint`（给 `runId` 或持久化 `MemoryStore`）+ `restore()` 恢复运行，跳过已完成任务 | `OrchestratorConfig` / 运行选项 |
+| 崩溃/重启后恢复 | `checkpoint`（给 `runId`，或内置 `FileStore` 等持久化 `MemoryStore`）+ `restore()` 恢复运行，跳过已完成任务 | `OrchestratorConfig` / 运行选项 |
 | 总额封顶 | orchestrator 上设 `maxTokenBudget` | `OrchestratorConfig` |
 | 卡死检测 | `loopDetection` + `onLoopDetected: 'terminate'`（或自定义 handler） | `AgentConfig` |
 | 追踪与审计 | `onTrace` 接你的 tracing 后端；落盘 `renderTeamRunDashboard(result)` | `OrchestratorConfig` |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,6 +120,7 @@ export { TokenBudgetExceededError, InvalidMessageError, LLMCallTimeoutError } fr
 // ---------------------------------------------------------------------------
 
 export { InMemoryStore } from './memory/store.js'
+export { FileStore } from './memory/file-store.js'
 export { SharedMemory } from './memory/shared.js'
 export {
   Checkpoint,

--- a/packages/core/src/memory/file-store.ts
+++ b/packages/core/src/memory/file-store.ts
@@ -1,0 +1,332 @@
+/**
+ * @fileoverview Filesystem-backed {@link MemoryStore} — the zero-dependency,
+ * durable reference store so checkpoint/resume survives a process restart out
+ * of the box.
+ *
+ * {@link InMemoryStore} lives in a `Map` and dies with the process, so the
+ * checkpoint it holds does not outlive a crash. `FileStore` closes that gap
+ * using only Node built-ins (no new runtime dependency), keeping the
+ * three-dependency promise intact.
+ *
+ * **Design.** One JSON file holds the whole store. An in-memory `Map` mirrors
+ * it, so reads (`get`/`list`) are served from memory and match
+ * {@link InMemoryStore} semantics exactly (including `createdAt` preservation);
+ * only mutations touch disk. Each mutation rewrites the file **atomically**:
+ * write a sibling temp file, `fsync` it so the bytes are on stable storage,
+ * then `rename` it over the target. A reader therefore always sees either the
+ * whole previous state or the whole next one, never a half-written file — even
+ * across a power loss, not just a process crash.
+ *
+ * **Where to wire it.** Prefer it as the *checkpoint* store
+ * (`checkpoint: { store: new FileStore(path) }`) and leave shared memory on a
+ * fast {@link InMemoryStore}: a separate checkpoint store self-embeds the
+ * shared-memory snapshot, so resume rebuilds everything from the one file while
+ * durability I/O stays at checkpoint cadence (once per completed task) instead
+ * of on every agent memory write. Using it as `sharedMemoryStore` also works
+ * and is durable, but then every shared-memory write flushes the whole file.
+ *
+ * **Scope.** Single Node process at a time — there is no cross-process file
+ * lock. Concurrent writes *within* a process are serialized and safe. The
+ * resume story ("process A crashes, process B resumes") is inherently
+ * sequential, which is exactly this scope.
+ *
+ * @example
+ * ```ts
+ * import { OpenMultiAgent, Team, InMemoryStore, FileStore } from '@open-multi-agent/core'
+ *
+ * const team = new Team({ name: 'research', agents: [...], sharedMemoryStore: new InMemoryStore() })
+ * const orchestrator = new OpenMultiAgent()
+ *
+ * // Durable checkpoints; resume works after a restart from the same path.
+ * await orchestrator.runTasks(team, tasks, {
+ *   checkpoint: { store: new FileStore('./.oma/checkpoint.json') },
+ * })
+ * ```
+ */
+
+import { mkdir, open, readFile, rename, unlink } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { MemoryEntry, MemoryStore } from '../types.js'
+
+// ---------------------------------------------------------------------------
+// On-disk format
+// ---------------------------------------------------------------------------
+
+/** Bump when the on-disk shape changes; {@link FileStore} rejects other versions. */
+const FILE_FORMAT_VERSION = 1
+
+/**
+ * A single {@link MemoryEntry} as stored on disk. JSON has no `Date`, so
+ * `createdAt` is persisted as an ISO string and revived on load.
+ */
+interface StoredEntry {
+  key: string
+  value: string
+  metadata?: Record<string, unknown>
+  createdAt: string
+  expiresAtTurn?: number
+}
+
+/** The whole file: a version tag plus every entry, in insertion order. */
+interface StoreFile {
+  version: number
+  entries: StoredEntry[]
+}
+
+// ---------------------------------------------------------------------------
+// FileStore
+// ---------------------------------------------------------------------------
+
+export class FileStore implements MemoryStore {
+  private readonly filePath: string
+  private readonly data = new Map<string, MemoryEntry>()
+  /** Memoized one-time load of the on-disk state into {@link data}. */
+  private loadPromise: Promise<void> | null = null
+  /** Serializes flushes so concurrent writes rename in enqueue order (no lost writes). */
+  private writeChain: Promise<void> = Promise.resolve()
+  /** Makes each in-flight temp file name unique within this process. */
+  private tempCounter = 0
+
+  /**
+   * @param filePath - Path to the single JSON state file. Parent directories
+   *   are created on first write; a missing file is treated as an empty store.
+   */
+  constructor(filePath: string) {
+    this.filePath = resolve(filePath)
+  }
+
+  // ---------------------------------------------------------------------------
+  // MemoryStore interface
+  // ---------------------------------------------------------------------------
+
+  /** Returns the entry for `key`, or `null` if not present. */
+  async get(key: string): Promise<MemoryEntry | null> {
+    await this.ensureLoaded()
+    return this.data.get(key) ?? null
+  }
+
+  /**
+   * Upserts `key`, then flushes atomically. `createdAt` is **preserved** on
+   * update, matching {@link InMemoryStore}.
+   */
+  async set(
+    key: string,
+    value: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    await this.ensureLoaded()
+    const existing = this.data.get(key)
+    this.data.set(key, {
+      key,
+      value,
+      metadata: metadata !== undefined ? { ...metadata } : undefined,
+      createdAt: existing?.createdAt ?? new Date(),
+    })
+    await this.persist()
+  }
+
+  /**
+   * Like {@link set}, but also records a turn-count expiry. Expiry filtering is
+   * the caller's responsibility (typically {@link SharedMemory}); this store
+   * only persists the field. `createdAt` is preserved on update.
+   */
+  async setWithExpiry(
+    key: string,
+    value: string,
+    expiresAtTurn: number,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    await this.ensureLoaded()
+    const existing = this.data.get(key)
+    this.data.set(key, {
+      key,
+      value,
+      metadata: metadata !== undefined ? { ...metadata } : undefined,
+      createdAt: existing?.createdAt ?? new Date(),
+      expiresAtTurn,
+    })
+    await this.persist()
+  }
+
+  /** Returns a snapshot of all entries in insertion order. */
+  async list(): Promise<MemoryEntry[]> {
+    await this.ensureLoaded()
+    return Array.from(this.data.values())
+  }
+
+  /**
+   * Removes the entry for `key`, flushing only when something changed.
+   * Deleting a non-existent key is a no-op and touches no disk.
+   */
+  async delete(key: string): Promise<void> {
+    await this.ensureLoaded()
+    if (this.data.delete(key)) {
+      await this.persist()
+    }
+  }
+
+  /** Removes **all** entries and persists the now-empty store. */
+  async clear(): Promise<void> {
+    await this.ensureLoaded()
+    this.data.clear()
+    await this.persist()
+  }
+
+  // ---------------------------------------------------------------------------
+  // Loading
+  // ---------------------------------------------------------------------------
+
+  /** Loads the on-disk state exactly once; subsequent calls reuse the promise. */
+  private ensureLoaded(): Promise<void> {
+    if (this.loadPromise === null) {
+      this.loadPromise = this.load()
+    }
+    return this.loadPromise
+  }
+
+  private async load(): Promise<void> {
+    let raw: string
+    try {
+      raw = await readFile(this.filePath, 'utf8')
+    } catch (err) {
+      // A missing file is a fresh store (first run); anything else is real.
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return
+      throw err
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(raw)
+    } catch {
+      throw new Error(
+        `FileStore: state file at "${this.filePath}" is not valid JSON. ` +
+          `Refusing to start with a fresh store so durable data is not silently discarded; ` +
+          `inspect, move, or delete the file to reset.`,
+      )
+    }
+
+    const file = FileStore.assertStoreFile(parsed, this.filePath)
+    for (const row of file.entries) {
+      const entry = FileStore.reviveEntry(row, this.filePath)
+      this.data.set(entry.key, entry)
+    }
+  }
+
+  private static assertStoreFile(value: unknown, path: string): StoreFile {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error(`FileStore: state file at "${path}" is not a store object.`)
+    }
+    const obj = value as Record<string, unknown>
+    if (obj['version'] !== FILE_FORMAT_VERSION) {
+      throw new Error(
+        `FileStore: unsupported state file version ${String(obj['version'])} at "${path}" ` +
+          `(expected ${FILE_FORMAT_VERSION}).`,
+      )
+    }
+    if (!Array.isArray(obj['entries'])) {
+      throw new Error(`FileStore: state file at "${path}" has no "entries" array.`)
+    }
+    return obj as unknown as StoreFile
+  }
+
+  private static reviveEntry(row: unknown, path: string): MemoryEntry {
+    if (row === null || typeof row !== 'object') {
+      throw new Error(`FileStore: malformed entry in "${path}".`)
+    }
+    const r = row as Record<string, unknown>
+    if (
+      typeof r['key'] !== 'string' ||
+      typeof r['value'] !== 'string' ||
+      typeof r['createdAt'] !== 'string'
+    ) {
+      throw new Error(`FileStore: malformed entry in "${path}" (missing key/value/createdAt).`)
+    }
+    const createdAt = new Date(r['createdAt'])
+    if (Number.isNaN(createdAt.getTime())) {
+      throw new Error(`FileStore: entry "${r['key']}" in "${path}" has an invalid createdAt.`)
+    }
+    return {
+      key: r['key'],
+      value: r['value'],
+      ...(r['metadata'] !== undefined ? { metadata: r['metadata'] as Record<string, unknown> } : {}),
+      createdAt,
+      ...(typeof r['expiresAtTurn'] === 'number' ? { expiresAtTurn: r['expiresAtTurn'] } : {}),
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Persistence
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Enqueues a flush. Chaining serializes the atomic renames so that, under
+   * concurrent mutations, the last-enqueued flush (which re-serializes the live
+   * `Map`) lands last — no write is lost. A failed flush rejects its own
+   * caller but does not poison the chain for later writes.
+   */
+  private persist(): Promise<void> {
+    const run = this.writeChain.then(() => this.flush())
+    this.writeChain = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
+  }
+
+  private async flush(): Promise<void> {
+    const file: StoreFile = {
+      version: FILE_FORMAT_VERSION,
+      entries: Array.from(this.data.values()).map(FileStore.toStored),
+    }
+    const json = JSON.stringify(file)
+    const dir = dirname(this.filePath)
+    await mkdir(dir, { recursive: true })
+
+    // Same-directory temp so the rename stays on one filesystem (atomic).
+    const tempPath = `${this.filePath}.tmp-${String(process.pid)}-${String(this.tempCounter++)}`
+    try {
+      const handle = await open(tempPath, 'w')
+      try {
+        await handle.writeFile(json, 'utf8')
+        // fsync the data before the swap: covers power loss / OS crash, not
+        // just a process crash (which the rename alone would survive).
+        await handle.sync()
+      } finally {
+        await handle.close()
+      }
+      await rename(tempPath, this.filePath)
+    } catch (err) {
+      await unlink(tempPath).catch(() => undefined) // best-effort temp cleanup
+      throw err
+    }
+    await FileStore.syncDir(dir)
+  }
+
+  /**
+   * Best-effort `fsync` of the directory so the rename itself is durable across
+   * a power loss. Some platforms/filesystems reject directory fsync; the
+   * temp-file fsync + rename already give crash consistency, so a failure here
+   * is non-fatal and swallowed.
+   */
+  private static async syncDir(dir: string): Promise<void> {
+    let handle: Awaited<ReturnType<typeof open>> | undefined
+    try {
+      handle = await open(dir, 'r')
+      await handle.sync()
+    } catch {
+      // ignore — see doc comment
+    } finally {
+      await handle?.close()
+    }
+  }
+
+  private static toStored(entry: MemoryEntry): StoredEntry {
+    return {
+      key: entry.key,
+      value: entry.value,
+      ...(entry.metadata !== undefined ? { metadata: { ...entry.metadata } } : {}),
+      createdAt: entry.createdAt.toISOString(),
+      ...(entry.expiresAtTurn !== undefined ? { expiresAtTurn: entry.expiresAtTurn } : {}),
+    }
+  }
+}

--- a/packages/core/src/memory/file-store.ts
+++ b/packages/core/src/memory/file-store.ts
@@ -245,11 +245,26 @@ export class FileStore implements MemoryStore {
     if (Number.isNaN(createdAt.getTime())) {
       throw new Error(`FileStore: entry "${r['key']}" in "${path}" has an invalid createdAt.`)
     }
+    // metadata, if present, must be a plain object. A non-object value (null,
+    // array, or primitive) would be silently shredded by `{ ...metadata }` on
+    // the next flush, so reject it loudly to honor the fail-on-corruption
+    // contract. FileStore's own writes never produce non-object metadata, so
+    // this only guards hand-edited or foreign files.
+    let metadata: Record<string, unknown> | undefined
+    if (r['metadata'] !== undefined) {
+      const raw = r['metadata']
+      if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+        throw new Error(`FileStore: entry "${r['key']}" in "${path}" has non-object metadata.`)
+      }
+      metadata = raw as Record<string, unknown>
+    }
     return {
       key: r['key'],
       value: r['value'],
-      ...(r['metadata'] !== undefined ? { metadata: r['metadata'] as Record<string, unknown> } : {}),
+      ...(metadata !== undefined ? { metadata } : {}),
       createdAt,
+      // Unlike metadata, a malformed expiresAtTurn cannot corrupt into garbage:
+      // the numeric guard safely degrades it to "no expiry", so no throw needed.
       ...(typeof r['expiresAtTurn'] === 'number' ? { expiresAtTurn: r['expiresAtTurn'] } : {}),
     }
   }

--- a/packages/core/tests/file-store.test.ts
+++ b/packages/core/tests/file-store.test.ts
@@ -166,6 +166,19 @@ describe('FileStore — load edge cases', () => {
     const store = new FileStore(filePath)
     await expect(store.list()).rejects.toThrow(/malformed entry/)
   })
+
+  it('throws on non-object metadata rather than silently corrupting it', async () => {
+    const createdAt = new Date().toISOString()
+    const bads: unknown[] = [null, 'a string', [1, 2]]
+    for (const bad of bads) {
+      await writeFile(
+        filePath,
+        JSON.stringify({ version: 1, entries: [{ key: 'a', value: 'v', createdAt, metadata: bad }] }),
+        'utf8',
+      )
+      await expect(new FileStore(filePath).list()).rejects.toThrow(/non-object metadata/)
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/core/tests/file-store.test.ts
+++ b/packages/core/tests/file-store.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { FileStore } from '../src/memory/file-store.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { Team } from '../src/team/team.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMChatOptions,
+  LLMMessage,
+  LLMResponse,
+  RunTaskSpec,
+} from '../src/types.js'
+
+let dir: string
+let filePath: string
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'oma-filestore-'))
+  filePath = join(dir, 'state.json')
+})
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true })
+})
+
+describe('FileStore — basic KV semantics', () => {
+  it('round-trips set/get/list/delete/clear in one instance', async () => {
+    const store = new FileStore(filePath)
+
+    expect(await store.get('missing')).toBeNull()
+    expect(await store.list()).toEqual([])
+
+    await store.set('a', 'alpha', { source: 'test' })
+    await store.set('b', 'beta')
+
+    const a = await store.get('a')
+    expect(a?.value).toBe('alpha')
+    expect(a?.metadata).toEqual({ source: 'test' })
+    expect(a?.createdAt).toBeInstanceOf(Date)
+    expect((await store.list()).map((e) => e.key)).toEqual(['a', 'b'])
+
+    await store.delete('a')
+    expect(await store.get('a')).toBeNull()
+    expect((await store.list()).map((e) => e.key)).toEqual(['b'])
+
+    await store.clear()
+    expect(await store.list()).toEqual([])
+  })
+
+  it('copies metadata so later caller mutation does not leak in', async () => {
+    const store = new FileStore(filePath)
+    const metadata = { tag: 'v1' }
+    await store.set('a', 'alpha', metadata)
+    metadata.tag = 'mutated'
+    expect((await store.get('a'))?.metadata).toEqual({ tag: 'v1' })
+  })
+})
+
+describe('FileStore — durability across instances (survives restart)', () => {
+  it('reads back values written by a previous instance on the same path', async () => {
+    const writer = new FileStore(filePath)
+    await writer.set('k', 'durable', { keep: true })
+
+    // A fresh instance (new in-memory mirror) simulates a process restart.
+    const reader = new FileStore(filePath)
+    const entry = await reader.get('k')
+    expect(entry?.value).toBe('durable')
+    expect(entry?.metadata).toEqual({ keep: true })
+  })
+
+  it('preserves createdAt on update and across reload', async () => {
+    const first = new FileStore(filePath)
+    await first.set('k', 'v1')
+    const created = (await first.get('k'))!.createdAt
+
+    await first.set('k', 'v2') // update: createdAt must not move
+    expect((await first.get('k'))!.createdAt.getTime()).toBe(created.getTime())
+
+    const reloaded = new FileStore(filePath)
+    const after = await reloaded.get('k')
+    expect(after?.value).toBe('v2')
+    expect(after?.createdAt.getTime()).toBe(created.getTime())
+  })
+
+  it('persists setWithExpiry expiry across reload', async () => {
+    const first = new FileStore(filePath)
+    await first.setWithExpiry('k', 'ttl', 7, { a: 1 })
+
+    const reloaded = new FileStore(filePath)
+    const entry = await reloaded.get('k')
+    expect(entry?.value).toBe('ttl')
+    expect(entry?.expiresAtTurn).toBe(7)
+    expect(entry?.metadata).toEqual({ a: 1 })
+  })
+
+  it('persists delete and clear across reload', async () => {
+    const first = new FileStore(filePath)
+    await first.set('a', '1')
+    await first.set('b', '2')
+    await first.delete('a')
+    expect((await new FileStore(filePath).list()).map((e) => e.key)).toEqual(['b'])
+
+    await first.clear()
+    expect(await new FileStore(filePath).list()).toEqual([])
+  })
+})
+
+describe('FileStore — concurrency and atomicity', () => {
+  it('does not lose writes under concurrent set()', async () => {
+    const store = new FileStore(filePath)
+    const keys = Array.from({ length: 25 }, (_, i) => `k${String(i)}`)
+
+    await Promise.all(keys.map((k) => store.set(k, `v-${k}`)))
+
+    const reloaded = new FileStore(filePath)
+    const seen = (await reloaded.list()).map((e) => e.key).sort()
+    expect(seen).toEqual([...keys].sort())
+  })
+
+  it('leaves no temp files behind after writes', async () => {
+    const store = new FileStore(filePath)
+    await Promise.all([store.set('a', '1'), store.set('b', '2'), store.set('c', '3')])
+    const entries = await readdir(dir)
+    expect(entries).toEqual(['state.json'])
+  })
+
+  it('writes valid, version-tagged JSON', async () => {
+    const store = new FileStore(filePath)
+    await store.set('a', '1')
+    const raw = JSON.parse(await readFile(filePath, 'utf8'))
+    expect(raw.version).toBe(1)
+    expect(Array.isArray(raw.entries)).toBe(true)
+    expect(raw.entries[0]).toMatchObject({ key: 'a', value: '1' })
+    expect(typeof raw.entries[0].createdAt).toBe('string')
+  })
+})
+
+describe('FileStore — load edge cases', () => {
+  it('treats a missing file as an empty store', async () => {
+    const store = new FileStore(join(dir, 'does-not-exist.json'))
+    expect(await store.list()).toEqual([])
+  })
+
+  it('throws (not silently resets) on a corrupt JSON file', async () => {
+    await writeFile(filePath, 'not json at all', 'utf8')
+    const store = new FileStore(filePath)
+    await expect(store.list()).rejects.toThrow(/not valid JSON/)
+  })
+
+  it('throws on an unsupported file version', async () => {
+    await writeFile(filePath, JSON.stringify({ version: 999, entries: [] }), 'utf8')
+    const store = new FileStore(filePath)
+    await expect(store.list()).rejects.toThrow(/unsupported state file version/)
+  })
+
+  it('throws on a malformed entry', async () => {
+    await writeFile(
+      filePath,
+      JSON.stringify({ version: 1, entries: [{ key: 'a' /* no value/createdAt */ }] }),
+      'utf8',
+    )
+    const store = new FileStore(filePath)
+    await expect(store.list()).rejects.toThrow(/malformed entry/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// End-to-end: FileStore as the checkpoint store survives a process restart
+// ---------------------------------------------------------------------------
+
+function textResponse(text: string, model: string): LLMResponse {
+  return {
+    id: `resp-${text}`,
+    content: [{ type: 'text', text }],
+    model,
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function scriptedAdapter(outputs: string[]) {
+  let callCount = 0
+  const adapter: LLMAdapter = {
+    name: 'file-store-test',
+    async chat(_messages: LLMMessage[], options: LLMChatOptions): Promise<LLMResponse> {
+      const output = outputs[callCount] ?? `output-${String(callCount)}`
+      callCount++
+      return textResponse(output, options.model)
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: textResponse('stream-unused', 'mock-model') }
+    },
+  }
+  return { adapter, calls: () => callCount }
+}
+
+function worker(name: string, adapter: LLMAdapter): AgentConfig {
+  return { name, model: 'mock-model', adapter, systemPrompt: `You are ${name}.` }
+}
+
+describe('FileStore — checkpoint/resume across a simulated restart', () => {
+  it('resumes from a durable checkpoint file with a fresh store instance', async () => {
+    const tasks: RunTaskSpec[] = [
+      { title: 'first', description: 'do first', assignee: 'worker' },
+      { title: 'second', description: 'do second', assignee: 'worker', dependsOn: ['first'] },
+    ]
+    const scripted = scriptedAdapter(['first output', 'second output'])
+    const abort = new AbortController()
+    const orchestrator = new OpenMultiAgent({
+      onProgress(event) {
+        if (event.type === 'task_complete') abort.abort()
+      },
+    })
+
+    // Run 1: shared memory in RAM, checkpoints to a durable file. Abort after
+    // the first task completes — the second is left pending.
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+      sharedMemoryStore: new InMemoryStore(),
+    })
+    await orchestrator.runTasks(team, tasks, {
+      abortSignal: abort.signal,
+      checkpoint: { store: new FileStore(filePath) },
+    })
+    expect(scripted.calls()).toBe(1)
+
+    // Run 2: brand-new orchestrator, team, RAM shared memory, and — crucially —
+    // a fresh FileStore reading the checkpoint back off disk.
+    const resumedOrchestrator = new OpenMultiAgent()
+    const resumedTeam = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+      sharedMemoryStore: new InMemoryStore(),
+    })
+    const restored = await resumedOrchestrator.restore(resumedTeam, {
+      checkpoint: { store: new FileStore(filePath) },
+    })
+
+    // Only the remaining task ran; both end completed.
+    expect(scripted.calls()).toBe(2)
+    expect(restored.tasks?.map((r) => [r.title, r.status])).toEqual([
+      ['first', 'completed'],
+      ['second', 'completed'],
+    ])
+  })
+})


### PR DESCRIPTION
## What

Ships `FileStore`, a zero-dependency, filesystem-backed `MemoryStore`, so checkpoint/resume survives a process restart out of the box. Until now the only bundled store was `InMemoryStore` (a plain `Map`), so a checkpoint died with the process and durability required the caller to implement their own store. Closes #338.

## Design

- **One JSON file, mirrored in memory.** Reads are served from an in-memory `Map` (semantics identical to `InMemoryStore`, including `createdAt` preservation); only mutations touch disk.
- **Atomic durable writes.** Each write goes to a sibling temp file, is `fsync`ed, then `rename`d over the target, so a reader never sees a half-written file, even across a power loss rather than only a process crash. Concurrent in-process writes are serialized so no write is lost.
- **Fails loud on corruption.** A corrupt or unreadable state file throws instead of silently starting empty, so durable data is never quietly discarded. A missing file is a fresh store.
- **Node built-ins only** (`node:fs/promises`, `node:path`), so the three-dependency promise is untouched.

## Recommended wiring

Prefer `FileStore` as the checkpoint store, leaving shared memory on a fast `InMemoryStore`:

```ts
await orchestrator.runTasks(team, tasks, {
  checkpoint: { store: new FileStore('./.oma/checkpoint.json') },
})
```

A separate checkpoint store self-embeds the shared-memory snapshot, so resume rebuilds everything from the one file while durability I/O stays at checkpoint cadence (once per completed task) instead of firing on every agent memory write. Using it as `sharedMemoryStore` also works and is durable, but rewrites the whole file on every memory write.

## Scope

Single process at a time (no cross-process file lock), which matches the inherently sequential resume story (process A crashes, process B resumes). Infrastructure backends (Redis, Postgres, DynamoDB) stay out of core, as discussed in the issue.

## Tests

14 new tests in `tests/file-store.test.ts`: KV round-trips, durability across instances, `createdAt` preservation across reload, `setWithExpiry` persistence, concurrent-write safety, atomic-write temp cleanup, corrupt/missing/versioned-file handling, and an end-to-end checkpoint/resume across a simulated restart (abort mid-run, then a fresh `FileStore` instance resumes and skips completed tasks).

## Verification

- `npm run lint` clean; `npm test` green (1092 existing plus 14 new).
- Build plus runtime import smoke from `dist/index.js`: cross-instance reload round-trips value, metadata, `createdAt`, and `expiresAtTurn`.
