### PR TITLE
feat(ai-sdk): support Vercel AI SDK 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,66 +16,67 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.133",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.133.tgz",
-      "integrity": "sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.6.tgz",
+      "integrity": "sha512-8GjssUxXeTd8tst2fYXNOFbtNNZFv3sG7aq7wKnQYrU2eB3JFR7np6o4F3Snp/fy/rJZSeH28LvjSWq5wkdL8Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.30",
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "3.0.73",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.73.tgz",
-      "integrity": "sha512-+3x9oxHv9Xp33Iv2L8D+e5hqmZi64jofBKig/9611JKyfV59NdkaDDajtwc0CxOEfARgCVq1BW7dP+526gKOKw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.4.tgz",
+      "integrity": "sha512-p6VDEzEx52PIzRnFoUpiw6ABn07h4Rt+atL+M51W9SqwhselaZFRnz/pzv7LF9D1Gok5qfzOmR+JwvDDvDWS3w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.30"
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.1.tgz",
+      "integrity": "sha512-6p3C/vGqVIjcptBu1DnVd/BZJ2wWmV9TUv9192vT6ZvT9KNED8EwRTqyqFpoQZKgSbMDSvBSq3dqR524Nt/Crw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.30",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.30.tgz",
-      "integrity": "sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.2.tgz",
+      "integrity": "sha512-EcmdjJb7yggsZPCbS3MFBpvAUnKaPW+QvanU5GzF00XCq0bqqAmvJ3MN19ejlmOETbW8sJNiq6qam48wTcbUNw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider": "4.0.1",
         "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
         "eventsource-parser": "^3.0.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -1578,16 +1579,6 @@
       "resolved": "packages/core",
       "link": true
     },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2901,6 +2892,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2977,19 +2975,18 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.208",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.208.tgz",
-      "integrity": "sha512-STz+AaZqJ4ZjH7UkpXkbHx+bjgIDOsE8fIUoZjkZ2whoZcfVmG9K/TqEKouJZ03SuZuD7lagntlU3zBhAEkRpQ==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.8.tgz",
+      "integrity": "sha512-vTEKl6fDBZ2IxBXTRaZOajf9W2Ev57Ju8iKtUvqlmDk8Z9BrEP4c22SWJsg1RcWHSFmJMSBa/s5dlUBHUq3YwA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.133",
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.30",
-        "@opentelemetry/api": "^1.9.0"
+        "@ai-sdk/gateway": "4.0.6",
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -6470,14 +6467,14 @@
         "oma": "dist/cli/oma.js"
       },
       "devDependencies": {
-        "@ai-sdk/openai": "^3.0.0",
-        "@ai-sdk/provider": "^3.0.0",
+        "@ai-sdk/openai": "^4.0.0",
+        "@ai-sdk/provider": "^4.0.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
         "@google/genai": "^1.48.0",
         "@modelcontextprotocol/sdk": "^1.18.0",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^2.1.9",
-        "ai": "^6.0.0",
+        "ai": "^7.0.0",
         "tsx": "^4.21.0",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
@@ -6489,7 +6486,7 @@
         "@aws-sdk/client-bedrock-runtime": "^3.700.0",
         "@google/genai": "^1.48.0",
         "@modelcontextprotocol/sdk": "^1.18.0",
-        "ai": "^5.0.0 || ^6.0.0"
+        "ai": "^5.0.0 || ^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/client-bedrock-runtime": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -53,7 +53,7 @@ Graph-first frameworks make you enumerate every node and edge up front. OMA runs
 
 ## Quick Start
 
-Requires Node.js >= 18.
+Requires Node.js >= 18 (the optional Vercel AI SDK 7 bridge needs Node.js >= 22).
 
 The fastest way to see a multi-agent run — scaffold a project and start it in one command:
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -53,7 +53,7 @@
 
 ## 快速开始
 
-要求 Node.js >= 18。
+要求 Node.js >= 18（可选的 Vercel AI SDK 7 桥接需要 Node.js >= 22）。
 
 一条命令即可初始化项目并启动多 agent 运行：
 

--- a/packages/core/examples/integrations/with-vercel-ai-sdk/README.md
+++ b/packages/core/examples/integrations/with-vercel-ai-sdk/README.md
@@ -47,7 +47,7 @@ Open [http://localhost:3000](http://localhost:3000), type a topic, and watch the
 
 ## Prerequisites
 
-- Node.js >= 18
+- Node.js >= 22 (Vercel AI SDK 7 requires Node 22+)
 - `DEEPSEEK_API_KEY` environment variable (used by both OMA and AI SDK)
 
 ## Key files

--- a/packages/core/examples/integrations/with-vercel-ai-sdk/app/api/chat/route.ts
+++ b/packages/core/examples/integrations/with-vercel-ai-sdk/app/api/chat/route.ts
@@ -1,4 +1,4 @@
-import { streamText, convertToModelMessages, type UIMessage } from 'ai'
+import { streamText, convertToModelMessages, createUIMessageStreamResponse, toUIMessageStream, type UIMessage } from 'ai'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { OpenMultiAgent } from '@open-multi-agent/core'
 import type { AgentConfig } from '@open-multi-agent/core'
@@ -87,5 +87,5 @@ ${teamOutput}`,
     messages: await convertToModelMessages(messages),
   })
 
-  return result.toUIMessageStreamResponse()
+  return createUIMessageStreamResponse({ stream: toUIMessageStream({ stream: result.fullStream }) })
 }

--- a/packages/core/examples/integrations/with-vercel-ai-sdk/package-lock.json
+++ b/packages/core/examples/integrations/with-vercel-ai-sdk/package-lock.json
@@ -6,10 +6,10 @@
     "": {
       "name": "with-vercel-ai-sdk",
       "dependencies": {
-        "@ai-sdk/openai-compatible": "^2.0.41",
-        "@ai-sdk/react": "^3.0.0",
+        "@ai-sdk/openai-compatible": "^3.0.0",
+        "@ai-sdk/react": "^4.0.0",
         "@open-multi-agent/core": "file:../../..",
-        "ai": "^6.0.0",
+        "ai": "^7.0.0",
         "next": "^16.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -23,7 +23,7 @@
     },
     "../../..": {
       "name": "@open-multi-agent/core",
-      "version": "1.7.0",
+      "version": "1.8.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
@@ -34,14 +34,14 @@
         "oma": "dist/cli/oma.js"
       },
       "devDependencies": {
-        "@ai-sdk/openai": "^2.0.106",
-        "@ai-sdk/provider": "^2.0.3",
+        "@ai-sdk/openai": "^4.0.0",
+        "@ai-sdk/provider": "^4.0.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
         "@google/genai": "^1.48.0",
         "@modelcontextprotocol/sdk": "^1.18.0",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^2.1.9",
-        "ai": "^5.0.188",
+        "ai": "^7.0.0",
         "tsx": "^4.21.0",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
@@ -53,7 +53,7 @@
         "@aws-sdk/client-bedrock-runtime": "^3.700.0",
         "@google/genai": "^1.48.0",
         "@modelcontextprotocol/sdk": "^1.18.0",
-        "ai": "^5.0.0"
+        "ai": "^5.0.0 || ^6.0.0 || ^7.0.0"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/client-bedrock-runtime": {
@@ -71,80 +71,100 @@
       }
     },
     "node_modules/@ai-sdk/gateway": {
-      "version": "3.0.133",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.133.tgz",
-      "integrity": "sha512-Ebs+7iS9zUgJu5B0RlxM2JmDWzq79Cpd6YdiqcCzB5qFdpfQJPUDiXutqlQP89F2XGjOdDeidulBTXUdXWzOxw==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.6.tgz",
+      "integrity": "sha512-8GjssUxXeTd8tst2fYXNOFbtNNZFv3sG7aq7wKnQYrU2eB3JFR7np6o4F3Snp/fy/rJZSeH28LvjSWq5wkdL8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.30",
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2",
         "@vercel/oidc": "3.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.4.tgz",
+      "integrity": "sha512-o5edIxgQrssKl/DABaXOzTUG/DUOyn25ilnnczQeLpnlSEUNXqYc3TSOZ7u6aBB+vkersQ7MXkfNMzqulR6CKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2",
+        "pkce-challenge": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/openai-compatible": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-2.0.51.tgz",
-      "integrity": "sha512-A6qfyaVs4lxmRxRux6U3ViOa8mMbsSd0OaHghpei2MpiBT6791J4zFH5MN7kaW1tLfQ246rSC2DVTMOavsycjQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai-compatible/-/openai-compatible-3.0.2.tgz",
+      "integrity": "sha512-C6qUMe+qSMn7HVr1a0v5H9BXYKhsT5uO4Q2VYVHYdT7johzx+d1gYgFMhkRIoheBpCl5NPhljR4I4sHMWWfz6w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.30"
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
-      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.1.tgz",
+      "integrity": "sha512-6p3C/vGqVIjcptBu1DnVd/BZJ2wWmV9TUv9192vT6ZvT9KNED8EwRTqyqFpoQZKgSbMDSvBSq3dqR524Nt/Crw==",
       "license": "Apache-2.0",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.30",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.30.tgz",
-      "integrity": "sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.2.tgz",
+      "integrity": "sha512-EcmdjJb7yggsZPCbS3MFBpvAUnKaPW+QvanU5GzF00XCq0bqqAmvJ3MN19ejlmOETbW8sJNiq6qam48wTcbUNw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider": "4.0.1",
         "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
         "eventsource-parser": "^3.0.8"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@ai-sdk/react": {
-      "version": "3.0.210",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.210.tgz",
-      "integrity": "sha512-VprBlyc8yvwlpIdcIICL307vRncXrLlmcRTY/7JR5ND9+LvUcxJU16yW6prClFahqEWVza8Vr8P4Bgk5ZBtp4A==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.9.tgz",
+      "integrity": "sha512-KJ/b9OOHgWHIwugupb+ARBlfh1dqBJhO1hEPzLmlp5R0yD9kARSO0JZxS7a9MFoFML/DytHbcFUUbIuUMAvmsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/provider-utils": "4.0.30",
-        "ai": "6.0.208",
-        "swr": "^2.2.5",
+        "@ai-sdk/mcp": "2.0.4",
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2",
+        "ai": "7.0.8",
+        "swr": "^2.4.1",
         "throttleit": "2.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
@@ -769,6 +789,8 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -827,19 +849,24 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/ai": {
-      "version": "6.0.208",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.208.tgz",
-      "integrity": "sha512-STz+AaZqJ4ZjH7UkpXkbHx+bjgIDOsE8fIUoZjkZ2whoZcfVmG9K/TqEKouJZ03SuZuD7lagntlU3zBhAEkRpQ==",
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.8.tgz",
+      "integrity": "sha512-vTEKl6fDBZ2IxBXTRaZOajf9W2Ev57Ju8iKtUvqlmDk8Z9BrEP4c22SWJsg1RcWHSFmJMSBa/s5dlUBHUq3YwA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/gateway": "3.0.133",
-        "@ai-sdk/provider": "3.0.10",
-        "@ai-sdk/provider-utils": "4.0.30",
-        "@opentelemetry/api": "^1.9.0"
+        "@ai-sdk/gateway": "4.0.6",
+        "@ai-sdk/provider": "4.0.1",
+        "@ai-sdk/provider-utils": "5.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "peerDependencies": {
         "zod": "^3.25.76 || ^4.1.8"
@@ -1000,6 +1027,15 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.4.31",

--- a/packages/core/examples/integrations/with-vercel-ai-sdk/package.json
+++ b/packages/core/examples/integrations/with-vercel-ai-sdk/package.json
@@ -8,10 +8,10 @@
     "start": "next start"
   },
   "dependencies": {
-    "@ai-sdk/openai-compatible": "^2.0.41",
-    "@ai-sdk/react": "^3.0.0",
+    "@ai-sdk/openai-compatible": "^3.0.0",
+    "@ai-sdk/react": "^4.0.0",
     "@open-multi-agent/core": "file:../../..",
-    "ai": "^6.0.0",
+    "ai": "^7.0.0",
     "next": "^16.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,7 @@
     "@aws-sdk/client-bedrock-runtime": "^3.700.0",
     "@google/genai": "^1.48.0",
     "@modelcontextprotocol/sdk": "^1.18.0",
-    "ai": "^5.0.0 || ^6.0.0"
+    "ai": "^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-bedrock-runtime": {
@@ -96,14 +96,14 @@
     }
   },
   "devDependencies": {
-    "@ai-sdk/openai": "^3.0.0",
-    "@ai-sdk/provider": "^3.0.0",
+    "@ai-sdk/openai": "^4.0.0",
+    "@ai-sdk/provider": "^4.0.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
     "@google/genai": "^1.48.0",
     "@modelcontextprotocol/sdk": "^1.18.0",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^2.1.9",
-    "ai": "^6.0.0",
+    "ai": "^7.0.0",
     "tsx": "^4.21.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"


### PR DESCRIPTION
## What
Declare and verify compatibility with Vercel AI SDK 7 (ai@7), so developers on the latest AI SDK can use the AISdkAdapter bridge without peer-dependency warnings.

## Changes
- Peer range: `ai` now `^5 || ^6 || ^7` (core)
- Dev deps: `ai`→^7, `@ai-sdk/provider`→^4, `@ai-sdk/openai`→^4, so CI exercises v7
- Example with-vercel-ai-sdk: `ai`→^7, `@ai-sdk/react`→^4, `@ai-sdk/openai-compatible`→^3; migrate the deprecated `result.toUIMessageStreamResponse()` to the v7 standalone `createUIMessageStreamResponse` + `toUIMessageStream` helpers
- Docs: the optional AI SDK 7 bridge needs Node >= 22 (core stays >= 18) — core README (EN + ZH) + example README

## No adapter code changes
The AISdkAdapter surface is unchanged in v7: fullStream, text-delta/reasoning-delta `.text`, finish.totalUsage, the system option, generateText's top-level result fields, and @ai-sdk/provider's JSONSchema7/JSONValue/SharedV2ProviderOptions all still exist. Verified by type-checking the real adapter source against ai@7.

## Node note
ai@7 requires Node >= 22, but it is an optional peer, so OMA core stays Node >= 18. The CI matrix (18/20/22) is unchanged: ai@7 emits an EBADENGINE warning on 18/20 but installs and all tests pass (verified locally on Node 18, 20, 22).

## Verification
- lint + test green on Node 18/20/22 (1112 core + 6 scaffold tests)
- example `next build` + TypeScript check pass under ai@7 + @ai-sdk/react@4
- lockfiles regenerated incrementally (Linux optional deps preserved)
- example end-to-end verified on Node 22 with a real DeepSeek run: HTTP 200, streamed OMA team output via the v7 UI-message-stream helpers, finishReason=stop, zero error chunks
- rebased/synced onto the latest default branch; merged test suite green
