### PR TITLE
chore: release core v1.9.0 + create-oma-app v0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6504,7 +6504,7 @@
       }
     },
     "packages/create-oma-app": {
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "bin": {
         "create-oma-app": "dist/index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6456,7 +6456,7 @@
     },
     "packages/core": {
       "name": "@open-multi-agent/core",
-      "version": "1.8.1",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
@@ -6504,7 +6504,7 @@
       }
     },
     "packages/create-oma-app": {
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "bin": {
         "create-oma-app": "dist/index.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "TypeScript multi-agent framework: one runTeam() call from goal to result. Auto task decomposition and parallel execution for multi-step LLM jobs. Deploys anywhere Node.js runs.",
   "files": [
     "dist",

--- a/packages/create-oma-app/package.json
+++ b/packages/create-oma-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-oma-app",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Scaffold a runnable multi-agent demo on @open-multi-agent/core — one command from zero to a live agent DAG.",
   "type": "module",
   "bin": {

--- a/packages/create-oma-app/package.json
+++ b/packages/create-oma-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-oma-app",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Scaffold a runnable multi-agent demo on @open-multi-agent/core — one command from zero to a live agent DAG.",
   "type": "module",
   "bin": {

--- a/packages/create-oma-app/template/package.json
+++ b/packages/create-oma-app/template/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.8.1"
+    "@open-multi-agent/core": "1.9.0"
   },
   "devDependencies": {
     "tsx": "^4.21.0"


### PR DESCRIPTION
## Features

- **Durable memory: `FileStore`** (#347 by @JackChen-me). A zero-dependency, filesystem-backed `MemoryStore`, so checkpoint/resume survives a process restart out of the box. Writes are atomic (temp file, fsync, rename) and reads come from an in-memory mirror; a corrupt state file fails loud instead of silently. Until now the only bundled store was `InMemoryStore`, so durability meant writing your own.
- **Error-aware task retry** (#346 by @JackChen-me). Retry (opt-in via `maxRetries > 0`) now classifies failures: `isRetryableError()` skips provably-terminal errors (most 4xx, token-budget, aborted calls) instead of burning attempts, while 429, 5xx, network blips, and per-call timeouts still retry. Adds equal jitter and honors abort signals, on both streaming and non-streaming paths.
- **Per-call LLM timeout** (#344 by @JackChen-me). New opt-in `AgentConfig.callTimeoutMs` (and on `CoordinatorConfig`) bounds a single `adapter.chat()` call, so one stalled request no longer hangs the whole run. Uniform across every adapter and surfaced as `LLMCallTimeoutError`, distinct from a deliberate abort or a real API error. Unset preserves current behavior exactly.
- **Run-level metrics on `TeamRunResult`** (#345 by @lesbass). `TeamRunResult` now carries a `metrics` rollup (total tokens, retries, error/failure/completed counts, and task-latency aggregates) computed from per-task data, and the dashboard renders a matching summary bar.
- **Vercel AI SDK 7 support** (#348 by @JackChen-me). The optional `ai` peer range now spans `^5 || ^6 || ^7`, so you can use the AI SDK bridge on the latest release without peer-dependency warnings. No adapter code changes. The AI SDK 7 bridge needs Node >= 22 (core stays >= 18).

## Docs

- Plan preview and replay guide, surfaced from both READMEs (#349 by @JackChen-me).

## Install

```
npm install @open-multi-agent/core@1.9.0
```

New project: `npm create oma-app@latest`

Thanks to @lesbass and @JackChen-me.
