### PR TITLE
feat(core): add trace span parent linkage

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -18,7 +18,7 @@ Common event types include `task_start`, `task_complete`, `task_retry`, `task_sk
 
 ## Trace Spans
 
-Use `onTrace` when you need structured spans for LLM calls, tool executions, and tasks. Each span carries parent IDs, durations, token counts, and best-effort-redacted tool I/O.
+Use `onTrace` when you need structured spans for LLM calls, tool executions, and tasks. Each span carries a `runId`, its own `spanId`, an optional `parentId`, durations, token counts, and best-effort-redacted tool I/O.
 
 ```typescript
 const orchestrator = new OpenMultiAgent({
@@ -29,6 +29,8 @@ const orchestrator = new OpenMultiAgent({
 ```
 
 Forward trace spans to OpenTelemetry, Datadog, Honeycomb, Langfuse, or your own run database only after deciding what data is safe for that sink. See [`integrations/trace-observability`](../packages/core/examples/integrations/trace-observability.ts) for a runnable example.
+
+Span parentage is best-effort and uses the causal structure known to the runtime. In team runs, worker agent spans point to their task span, and LLM/tool/stream spans point to the agent span. Root spans such as top-level agent runs omit `parentId`.
 
 ## Post-Run Dashboard
 
@@ -52,5 +54,5 @@ For production runs, persist enough data to reconstruct a failure without replay
 
 - `TeamRunResult.tasks` for the executed DAG and task states.
 - `TeamRunResult.totalTokenUsage` for cost attribution.
-- `onTrace` spans for LLM calls and tool executions.
+- `onTrace` spans for LLM calls and tool executions, keyed by `runId` + `spanId`.
 - The rendered dashboard HTML when you need a shareable post-mortem artifact.

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -46,7 +46,7 @@ import type {
   TokenUsage,
   ToolUseContext,
 } from '../types.js'
-import { emitTrace, generateRunId } from '../utils/trace.js'
+import { emitTrace, generateRunId, generateSpanId } from '../utils/trace.js'
 import { mergeAbortSignals } from '../utils/abort.js'
 import type { ToolDefinition as FrameworkToolDefinition, ToolRegistry } from '../tool/framework.js'
 import type { ToolExecutor } from '../tool/executor.js'
@@ -322,6 +322,7 @@ export class Agent {
     this.transitionTo('running')
 
     const agentStartMs = Date.now()
+    let effectiveTraceOptions: Partial<RunOptions> | undefined = callerOptions
 
     try {
       // --- beforeRun hook ---
@@ -336,8 +337,13 @@ export class Agent {
         this.state.messages.push(msg)
         callerOptions?.onMessage?.(msg)
       }
-      // Auto-generate runId when onTrace is provided but runId is missing
-      const needsRunId = callerOptions?.onTrace && !callerOptions.runId
+      // Auto-generate trace identifiers when onTrace is provided but they are missing.
+      const effectiveRunId = callerOptions?.onTrace
+        ? callerOptions.runId || generateRunId()
+        : callerOptions?.runId
+      const effectiveSpanId = callerOptions?.onTrace
+        ? callerOptions.traceSpanId || generateSpanId()
+        : callerOptions?.traceSpanId
       // Create a fresh timeout signal per run (not per runner) so that
       // each run() / prompt() call gets its own timeout window.
       const timeoutSignal = this.config.timeoutMs !== undefined && this.config.timeoutMs > 0
@@ -352,9 +358,11 @@ export class Agent {
       const runOptions: RunOptions = {
         ...callerOptions,
         onMessage: internalOnMessage,
-        ...(needsRunId ? { runId: generateRunId() } : undefined),
+        ...(effectiveRunId ? { runId: effectiveRunId } : undefined),
+        ...(effectiveSpanId ? { traceSpanId: effectiveSpanId } : undefined),
         ...(effectiveAbort ? { abortSignal: effectiveAbort } : undefined),
       }
+      effectiveTraceOptions = runOptions
 
       const result = await runner.run(messages, runOptions)
       this.state.tokenUsage = addUsage(this.state.tokenUsage, result.tokenUsage)
@@ -365,7 +373,7 @@ export class Agent {
           budgetResult = await this.config.afterRun(budgetResult)
         }
         this.transitionTo('completed')
-        this.emitAgentTrace(callerOptions, agentStartMs, budgetResult)
+        this.emitAgentTrace(runOptions, agentStartMs, budgetResult)
         return budgetResult
       }
 
@@ -381,7 +389,7 @@ export class Agent {
         if (this.config.afterRun) {
           validated = await this.config.afterRun(validated)
         }
-        this.emitAgentTrace(callerOptions, agentStartMs, validated)
+        this.emitAgentTrace(runOptions, agentStartMs, validated)
         return validated
       }
 
@@ -393,7 +401,7 @@ export class Agent {
       }
 
       this.transitionTo('completed')
-      this.emitAgentTrace(callerOptions, agentStartMs, agentResult)
+      this.emitAgentTrace(runOptions, agentStartMs, agentResult)
       return agentResult
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err))
@@ -411,7 +419,7 @@ export class Agent {
         // place this error object survives before it is stringified.
         error,
       }
-      this.emitAgentTrace(callerOptions, agentStartMs, errorResult)
+      this.emitAgentTrace(effectiveTraceOptions, agentStartMs, errorResult)
       return errorResult
     }
   }
@@ -427,6 +435,8 @@ export class Agent {
     emitTrace(options.onTrace, {
       type: 'agent',
       runId: options.runId ?? '',
+      spanId: options.traceSpanId ?? generateSpanId(),
+      ...(options.traceParentId ? { parentId: options.traceParentId } : {}),
       taskId: options.taskId,
       agent: options.traceAgent ?? this.name,
       turns: result.messages.filter(m => m.role === 'assistant').length,
@@ -529,6 +539,9 @@ export class Agent {
    */
   private async *executeStream(messages: LLMMessage[], callerOptions?: Partial<RunOptions>): AsyncGenerator<StreamEvent> {
     this.transitionTo('running')
+    const agentStartMs = Date.now()
+    let agentTraceEmitted = false
+    let effectiveTraceOptions: Partial<RunOptions> | undefined = callerOptions
 
     try {
       // --- beforeRun hook ---
@@ -547,13 +560,23 @@ export class Agent {
       const effectiveAbort = timeoutSignal && callerAbort
         ? mergeAbortSignals(timeoutSignal, callerAbort)
         : timeoutSignal ?? callerAbort
-
-      for await (const event of runner.stream(messages, {
+      const effectiveRunId = callerOptions?.onTrace
+        ? callerOptions.runId || generateRunId()
+        : callerOptions?.runId
+      const effectiveSpanId = callerOptions?.onTrace
+        ? callerOptions.traceSpanId || generateSpanId()
+        : callerOptions?.traceSpanId
+      const runOptions: RunOptions = {
         ...callerOptions,
-        ...(effectiveAbort ? { abortSignal: effectiveAbort } : {}),
-      })) {
+        ...(effectiveRunId ? { runId: effectiveRunId } : undefined),
+        ...(effectiveSpanId ? { traceSpanId: effectiveSpanId } : undefined),
+        ...(effectiveAbort ? { abortSignal: effectiveAbort } : undefined),
+      }
+      effectiveTraceOptions = runOptions
+
+      for await (const event of runner.stream(messages, runOptions)) {
         if (event.type === 'done') {
-          const result = event.data as import('./runner.js').RunResult
+          const result = event.data as RunResult
           this.state.tokenUsage = addUsage(this.state.tokenUsage, result.tokenUsage)
 
           let agentResult = this.toAgentRunResult(result, !result.budgetExceeded)
@@ -561,6 +584,8 @@ export class Agent {
             agentResult = await this.config.afterRun(agentResult)
           }
           this.transitionTo('completed')
+          this.emitAgentTrace(runOptions, agentStartMs, agentResult)
+          agentTraceEmitted = true
           yield { type: 'done', data: agentResult } satisfies StreamEvent
           continue
         } else if (event.type === 'error') {
@@ -568,6 +593,16 @@ export class Agent {
             ? event.data
             : new Error(String(event.data))
           this.transitionToError(error)
+          this.emitAgentTrace(runOptions, agentStartMs, {
+            success: false,
+            output: error.message,
+            messages: [],
+            tokenUsage: ZERO_USAGE,
+            toolCalls: [],
+            structured: undefined,
+            error,
+          })
+          agentTraceEmitted = true
         }
 
         yield event
@@ -575,6 +610,17 @@ export class Agent {
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err))
       this.transitionToError(error)
+      if (!agentTraceEmitted) {
+        this.emitAgentTrace(effectiveTraceOptions, agentStartMs, {
+          success: false,
+          output: error.message,
+          messages: [],
+          tokenUsage: ZERO_USAGE,
+          toolCalls: [],
+          structured: undefined,
+          error,
+        })
+      }
       yield { type: 'error', data: error } satisfies StreamEvent
     }
   }

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -36,7 +36,7 @@ import type {
 } from '../types.js'
 import { LLMCallTimeoutError, TokenBudgetExceededError } from '../errors.js'
 import { LoopDetector } from './loop-detector.js'
-import { emitTrace } from '../utils/trace.js'
+import { emitTrace, generateSpanId } from '../utils/trace.js'
 import { mergeAbortSignals } from '../utils/abort.js'
 import { estimateTokens } from '../utils/tokens.js'
 import { redactSensitiveObject, redactSensitiveText } from '../utils/redaction.js'
@@ -182,6 +182,10 @@ export interface RunOptions {
   readonly taskId?: string
   /** Agent name for trace correlation (overrides RunnerOptions.agentName). */
   readonly traceAgent?: string
+  /** Span ID for the current agent run; child LLM/tool spans point at it. */
+  readonly traceSpanId?: string
+  /** Parent span ID for the current agent run. */
+  readonly traceParentId?: string
   /**
    * Per-call abort signal. When set, takes precedence over the static
    * {@link RunnerOptions.abortSignal}. Useful for per-run timeouts.
@@ -560,6 +564,8 @@ export class AgentRunner {
       emitTrace(options.onTrace, {
         type: 'llm_call',
         runId: options.runId ?? '',
+        spanId: generateSpanId(),
+        ...(options.traceSpanId ? { parentId: options.traceSpanId } : {}),
         taskId: options.taskId,
         agent: options.traceAgent ?? this.options.agentName ?? 'unknown',
         model: summaryOptions.model,
@@ -862,6 +868,8 @@ export class AgentRunner {
           emitTrace(options.onTrace, {
             type: 'llm_call',
             runId: options.runId ?? '',
+            spanId: generateSpanId(),
+            ...(options.traceSpanId ? { parentId: options.traceSpanId } : {}),
             taskId: options.taskId,
             agent: options.traceAgent ?? this.options.agentName ?? 'unknown',
             model: this.options.model,
@@ -1052,6 +1060,8 @@ export class AgentRunner {
             emitTrace(options.onTrace, {
               type: 'tool_call',
               runId: options.runId ?? '',
+              spanId: generateSpanId(),
+              ...(options.traceSpanId ? { parentId: options.traceSpanId } : {}),
               taskId: options.taskId,
               agent: options.traceAgent ?? this.options.agentName ?? 'unknown',
               tool: block.name,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -231,4 +231,4 @@ export type {
   SharedMemoryWriteOptions,
 } from './types.js'
 
-export { generateRunId } from './utils/trace.js'
+export { generateRunId, generateSpanId } from './utils/trace.js'

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -75,7 +75,7 @@ import type { ZodSchema } from 'zod'
 import type { RunOptions } from '../agent/runner.js'
 import { Agent } from '../agent/agent.js'
 import { AgentPool } from '../agent/pool.js'
-import { emitTrace, generateRunId } from '../utils/trace.js'
+import { emitTrace, generateRunId, generateSpanId } from '../utils/trace.js'
 import { ToolRegistry } from '../tool/framework.js'
 import { ToolExecutor } from '../tool/executor.js'
 import { registerBuiltInTools } from '../tool/built-in/index.js'
@@ -781,17 +781,24 @@ function buildTaskAgentTeamInfo(
     }, ctx.config.defaultToolPreset), route)
     const tempAgent = buildAgent(effective, { includeDelegateTool: true })
 
+    const delegatedParentId = traceBase.traceSpanId ?? traceBase.traceParentId
+    const delegatedSpanId = traceBase.onTrace ? generateSpanId() : undefined
+    const childTraceBase: Partial<RunOptions> = {
+      ...traceBase,
+      traceAgent: targetAgent,
+      taskId,
+      ...(delegatedParentId ? { traceParentId: delegatedParentId } : {}),
+      ...(delegatedSpanId ? { traceSpanId: delegatedSpanId } : {}),
+    }
     const nestedTeam = buildTaskAgentTeamInfo(
       ctx,
       taskId,
-      traceBase,
+      childTraceBase,
       delegationDepth + 1,
       [...delegationChain, targetAgent],
     )
     const childOpts: Partial<RunOptions> = {
-      ...traceBase,
-      traceAgent: targetAgent,
-      taskId,
+      ...childTraceBase,
       team: nestedTeam,
     }
     return pool.runEphemeral(
@@ -976,6 +983,8 @@ async function executeQueue(
       const prompt = await buildTaskPrompt(task, team, queue, ctx.revealCoordinatorContext)
 
       // Trace + abort + team tool context (delegate_to_agent)
+      const taskSpanId = config.onTrace ? generateSpanId() : undefined
+      const agentSpanId = config.onTrace ? generateSpanId() : undefined
       const traceBase: Partial<RunOptions> = {
         ...(config.onTrace
           ? {
@@ -983,6 +992,8 @@ async function executeQueue(
               runId: ctx.runId ?? '',
               taskId: task.id,
               traceAgent: assignee,
+              ...(taskSpanId ? { traceParentId: taskSpanId } : {}),
+              ...(agentSpanId ? { traceSpanId: agentSpanId } : {}),
             }
           : {}),
         ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
@@ -1013,6 +1024,8 @@ async function executeQueue(
               emitTrace(config.onTrace, {
                 type: 'agent_stream',
                 runId: ctx.runId ?? '',
+                spanId: generateSpanId(),
+                ...(agentSpanId ? { parentId: agentSpanId } : {}),
                 taskId: task.id,
                 agent: assignee,
                 streamType: event.type,
@@ -1063,6 +1076,7 @@ async function executeQueue(
         emitTrace(config.onTrace, {
           type: 'task',
           runId: ctx.runId ?? '',
+          spanId: taskSpanId ?? generateSpanId(),
           taskId: task.id,
           taskTitle: task.title,
           agent: assignee,
@@ -1458,6 +1472,7 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
         emitTrace(onTrace, {
           type: 'consensus',
           runId: runId ?? '',
+          spanId: generateSpanId(),
           agent: judge.name,
           round,
           accepted: verdict.accept,
@@ -1875,6 +1890,7 @@ export class OpenMultiAgent {
     const decompositionPrompt = this.buildDecompositionPrompt(goal, agentConfigs)
     const coordinatorAgent = buildAgent(coordinatorConfig)
     const runId = this.config.onTrace ? generateRunId() : undefined
+    const coordinatorDecomposeSpanId = this.config.onTrace ? generateSpanId() : undefined
 
     this.config.onProgress?.({
       type: 'agent_start',
@@ -1883,7 +1899,13 @@ export class OpenMultiAgent {
     })
 
     const decompTraceOptions: Partial<RunOptions> | undefined = this.config.onTrace
-      ? { onTrace: this.config.onTrace, runId: runId ?? '', traceAgent: 'coordinator', abortSignal: options?.abortSignal }
+      ? {
+          onTrace: this.config.onTrace,
+          runId: runId ?? '',
+          traceAgent: 'coordinator',
+          ...(coordinatorDecomposeSpanId ? { traceSpanId: coordinatorDecomposeSpanId } : {}),
+          ...(options?.abortSignal ? { abortSignal: options.abortSignal } : {}),
+        }
       : options?.abortSignal ? { abortSignal: options.abortSignal } : undefined
     const decompositionResult = await coordinatorAgent.run(decompositionPrompt, decompTraceOptions)
     const agentResults = new Map<string, AgentRunResult>()
@@ -1990,6 +2012,8 @@ export class OpenMultiAgent {
       emitTrace(this.config.onTrace, {
         type: 'plan_ready',
         runId: runId ?? '',
+        spanId: generateSpanId(),
+        ...(coordinatorDecomposeSpanId ? { parentId: coordinatorDecomposeSpanId } : {}),
         agent: 'coordinator',
         taskCount: planTasks.length,
         approved,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1345,6 +1345,10 @@ export type TraceEventType =
 export interface TraceEventBase {
   /** Unique identifier for the entire run (runTeam / runTasks / runAgent call). */
   readonly runId: string
+  /** Unique identifier for this span within the run. */
+  readonly spanId: string
+  /** Span ID of the causal parent, when the framework can determine one. */
+  readonly parentId?: string
   readonly type: TraceEventType
   /** Unix epoch ms when the span started. */
   readonly startMs: number

--- a/packages/core/src/utils/trace.ts
+++ b/packages/core/src/utils/trace.ts
@@ -32,3 +32,8 @@ function noop() {}
 export function generateRunId(): string {
   return randomUUID()
 }
+
+/** Generate a unique span ID for a single trace event. */
+export function generateSpanId(): string {
+  return randomUUID()
+}

--- a/packages/core/tests/orchestrator.test.ts
+++ b/packages/core/tests/orchestrator.test.ts
@@ -1151,8 +1151,13 @@ describe('OpenMultiAgent', () => {
       expect(planReady.taskCount).toBe(1)
       expect(planReady.approved).toBe(false)
       expect(planReady.runId).toMatch(/.+/)
+      expect(planReady.spanId).toMatch(/^[0-9a-f-]{36}$/)
       expect(planReady.durationMs).toBeGreaterThanOrEqual(0)
       expect(planReady.startMs).toBeLessThanOrEqual(planReady.endMs)
+
+      const coordinatorTrace = traces.find((t) => t.type === 'agent' && t.agent === 'coordinator')
+      expect(coordinatorTrace).toBeDefined()
+      expect(planReady.parentId).toBe(coordinatorTrace!.spanId)
     })
   })
 
@@ -1428,10 +1433,17 @@ describe('OpenMultiAgent', () => {
       expect(streamTraces.length).toBeGreaterThan(0)
       expect(streamTraces.some((t) => t.streamType === 'text')).toBe(true)
       expect(streamTraces.some((t) => t.streamType === 'done')).toBe(true)
+      const workerAgentTrace = traces.find((t) => t.type === 'agent' && t.agent === 'worker' && t.taskId)
+      expect(workerAgentTrace).toBeDefined()
+      const taskTrace = traces.find((t) => t.type === 'task' && t.taskId === workerAgentTrace!.taskId)
+      expect(taskTrace).toBeDefined()
+      expect(workerAgentTrace!.parentId).toBe(taskTrace!.spanId)
       for (const trace of streamTraces) {
         expect(trace.agent).toBe('worker')
         expect(trace.taskId).toMatch(/.+/)
         expect(trace.runId).toMatch(/.+/)
+        expect(trace.spanId).toMatch(/^[0-9a-f-]{36}$/)
+        expect(trace.parentId).toBe(workerAgentTrace!.spanId)
         expect(trace.durationMs).toBe(0)
       }
     })

--- a/packages/core/tests/trace.test.ts
+++ b/packages/core/tests/trace.test.ts
@@ -5,7 +5,7 @@ import { AgentRunner, type RunOptions } from '../src/agent/runner.js'
 import { ToolRegistry, defineTool } from '../src/tool/framework.js'
 import { ToolExecutor } from '../src/tool/executor.js'
 import { executeWithRetry } from '../src/orchestrator/orchestrator.js'
-import { emitTrace, generateRunId } from '../src/utils/trace.js'
+import { emitTrace, generateRunId, generateSpanId } from '../src/utils/trace.js'
 import { createTask } from '../src/task/task.js'
 import type {
   AgentConfig,
@@ -93,6 +93,7 @@ describe('emitTrace', () => {
     emitTrace(undefined, {
       type: 'agent',
       runId: 'r1',
+      spanId: 's1',
       agent: 'a',
       turns: 1,
       tokens: { input_tokens: 0, output_tokens: 0 },
@@ -108,6 +109,7 @@ describe('emitTrace', () => {
     const event: TraceEvent = {
       type: 'agent',
       runId: 'r1',
+      spanId: 's1',
       agent: 'a',
       turns: 1,
       tokens: { input_tokens: 0, output_tokens: 0 },
@@ -126,6 +128,7 @@ describe('emitTrace', () => {
       emitTrace(fn, {
         type: 'agent',
         runId: 'r1',
+        spanId: 's1',
         agent: 'a',
         turns: 1,
         tokens: { input_tokens: 0, output_tokens: 0 },
@@ -143,6 +146,7 @@ describe('emitTrace', () => {
     emitTrace(fn as unknown as (event: TraceEvent) => void, {
       type: 'agent',
       runId: 'r1',
+      spanId: 's1',
       agent: 'a',
       turns: 1,
       tokens: { input_tokens: 0, output_tokens: 0 },
@@ -169,6 +173,17 @@ describe('generateRunId', () => {
   })
 })
 
+describe('generateSpanId', () => {
+  it('returns unique UUID strings', () => {
+    const ids = new Set(Array.from({ length: 100 }, generateSpanId))
+
+    expect(ids.size).toBe(100)
+    for (const id of ids) {
+      expect(id).toMatch(/^[0-9a-f-]{36}$/)
+    }
+  })
+})
+
 // ---------------------------------------------------------------------------
 // AgentRunner trace events
 // ---------------------------------------------------------------------------
@@ -189,6 +204,7 @@ describe('AgentRunner trace events', () => {
       onTrace: (e) => { traces.push(e) },
       runId: 'run-1',
       traceAgent: 'test-agent',
+      traceSpanId: 'agent-span-1',
     }
 
     await runner.run(
@@ -202,6 +218,8 @@ describe('AgentRunner trace events', () => {
     const llm = llmTraces[0]!
     expect(llm.type).toBe('llm_call')
     expect(llm.runId).toBe('run-1')
+    expect(llm.spanId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(llm.parentId).toBe('agent-span-1')
     expect(llm.agent).toBe('test-agent')
     expect(llm.model).toBe('test-model')
     expect(llm.turn).toBe(1)
@@ -235,7 +253,12 @@ describe('AgentRunner trace events', () => {
 
     await runner.run(
       [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
-      { onTrace: (e) => { traces.push(e) }, runId: 'run-2', traceAgent: 'tooler' },
+      {
+        onTrace: (e) => { traces.push(e) },
+        runId: 'run-2',
+        traceAgent: 'tooler',
+        traceSpanId: 'agent-span-2',
+      },
     )
 
     const toolTraces = traces.filter(t => t.type === 'tool_call')
@@ -244,6 +267,8 @@ describe('AgentRunner trace events', () => {
     const tool = toolTraces[0]!
     expect(tool.type).toBe('tool_call')
     expect(tool.runId).toBe('run-2')
+    expect(tool.spanId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(tool.parentId).toBe('agent-span-2')
     expect(tool.agent).toBe('tooler')
     expect(tool.tool).toBe('echo')
     expect(tool.isError).toBe(false)
@@ -463,6 +488,15 @@ describe('Agent trace events', () => {
 
     for (const trace of traces) {
       expect(trace.runId).toBe(runId)
+    }
+
+    const agentTrace = traces.find(t => t.type === 'agent')
+    expect(agentTrace).toBeDefined()
+    expect(agentTrace!.spanId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(agentTrace!.parentId).toBeUndefined()
+
+    for (const child of traces.filter(t => t.type === 'llm_call' || t.type === 'tool_call')) {
+      expect(child.parentId).toBe(agentTrace!.spanId)
     }
   })
 


### PR DESCRIPTION
## Summary

Closes #340.

- add `spanId` and optional `parentId` to every `TraceEventBase`
- generate stable agent span IDs so LLM/tool spans can point to their owning agent span
- link team-run worker agents under task spans, stream events under worker agent spans, and `plan_ready` under coordinator decomposition
- document the trace parentage model and add focused tests for span linkage

## Testing

- `npm run lint -w @open-multi-agent/core`
- `npm run build -w @open-multi-agent/core`
- `npm run test -w @open-multi-agent/core -- tests/trace.test.ts tests/orchestrator.test.ts`
- `npm run test -w @open-multi-agent/core` *(fails on this Windows environment in existing symlink/WSL-sensitive tests: `fs-walk.test.ts`, `built-in-tools.test.ts`, `default-deny-tools.test.ts`; trace/orchestrator tests pass)*