### PR TITLE
fix: kill full process tree on Windows bash timeout

### DIFF
--- a/packages/core/src/tool/built-in/bash.ts
+++ b/packages/core/src/tool/built-in/bash.ts
@@ -149,9 +149,31 @@ function runCommand(
       signal.addEventListener('abort', onAbort, { once: true })
     }
 
+    // `close` (process exited AND stdio drained) is the normal completion
+    // path. After a forced kill we settle on `exit` instead: on Windows,
+    // MSYS bash's fork emulation can leave descendants that taskkill cannot
+    // reach (their recorded parent PID is a dead intermediate process), and
+    // any such straggler would hold the stdio pipes open and delay `close`
+    // until it exits naturally.
+    //
+    // When we killed the process ourselves, report the conventional exit
+    // codes (124 timeout / 130 abort) authoritatively: the code the OS
+    // reports for a forced termination is platform-dependent (`null` after
+    // SIGKILL on POSIX, `1` after taskkill on Windows).
+    const resolveExitCode = (code: number | null): number => {
+      if (timedOut) return 124
+      if (aborted) return 130
+      return code ?? 1
+    }
+
     child.on('close', (code: number | null) => {
-      const exitCode = code ?? (timedOut ? 124 : aborted ? 130 : 1)
-      done(exitCode)
+      done(resolveExitCode(code))
+    })
+
+    child.on('exit', (code: number | null) => {
+      if (timedOut || aborted) {
+        done(resolveExitCode(code))
+      }
     })
 
     child.on('error', (err: Error) => {
@@ -172,25 +194,40 @@ function runCommand(
 }
 
 /**
- * Kill the child and any descendants spawned through `&` / job-control on
- * POSIX. We rely on `detached: true` at spawn time, which puts the bash
+ * Kill the child and any descendants spawned through `&` / job-control.
+ *
+ * POSIX: we rely on `detached: true` at spawn time, which puts the bash
  * shell in its own process group; sending SIGKILL to the negated PID
  * delivers to every member of that group.
  *
- * Windows does not have process groups; fall back to killing the direct
- * child only.
+ * Windows: there are no POSIX process groups, and `child.kill()` terminates
+ * only the direct child — orphaned descendants would both survive and hold
+ * the stdio pipes open, delaying the `close` event until they exit. Use
+ * `taskkill /T /F` (always present in System32) to terminate the whole tree.
  */
 function killProcessTree(child: ChildProcess): void {
-  if (child.pid !== undefined && process.platform !== 'win32') {
-    try {
-      process.kill(-child.pid, 'SIGKILL')
-      return
-    } catch {
-      // The child may already have exited; fall through to a direct kill,
-      // which is a no-op in that case.
-    }
+  if (child.pid === undefined) {
+    child.kill('SIGKILL')
+    return
   }
-  child.kill('SIGKILL')
+  if (process.platform === 'win32') {
+    const killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
+      stdio: 'ignore',
+    })
+    // taskkill fails when the tree already exited; direct kill is then a no-op.
+    killer.on('error', () => child.kill('SIGKILL'))
+    killer.on('exit', (code) => {
+      if (code !== 0) child.kill('SIGKILL')
+    })
+    return
+  }
+  try {
+    process.kill(-child.pid, 'SIGKILL')
+  } catch {
+    // The child may already have exited; fall through to a direct kill,
+    // which is a no-op in that case.
+    child.kill('SIGKILL')
+  }
 }
 
 function buildSafeShellEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {

--- a/packages/core/tests/built-in-tools.test.ts
+++ b/packages/core/tests/built-in-tools.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { access, mkdir, mkdtemp, rm, symlink, writeFile, readFile } from 'fs/promises'
-import { join } from 'path'
+import { basename, join } from 'path'
 import { tmpdir } from 'os'
+import { detectSymlinkSupport } from './helpers/symlink-support.js'
 import { fileReadTool } from '../src/tool/built-in/file-read.js'
 import { fileWriteTool } from '../src/tool/built-in/file-write.js'
 import { fileEditTool } from '../src/tool/built-in/file-edit.js'
@@ -24,6 +25,8 @@ import type { AgentRunResult, ToolUseContext } from '../src/types.js'
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+const symlinksSupported = await detectSymlinkSupport()
 
 let tmpDir: string
 let defaultContext: ToolUseContext
@@ -313,7 +316,11 @@ describe('bash', () => {
     )
 
     expect(result.isError).toBe(false)
-    expect(result.data).toContain(tmpDir)
+    // Compare by basename: Git Bash on Windows prints the MSYS translation of
+    // the path (`/tmp/oma-test-X` for `C:\...\Temp\oma-test-X`), so the full
+    // native path never appears in `pwd` output there. The mkdtemp suffix
+    // makes the basename unique per run.
+    expect(result.data).toContain(basename(tmpDir))
   })
 
   it('returns exit code for failing commands', async () => {
@@ -623,7 +630,7 @@ describe('glob', () => {
     expect(result.data).toContain('deep.ts')
   })
 
-  it('does not follow symlinked directories outside the sandbox root', async () => {
+  it.skipIf(!symlinksSupported)('does not follow symlinked directories outside the sandbox root', async () => {
     const root = join(tmpDir, 'root')
     const outside = join(tmpDir, 'outside')
     await mkdir(root, { recursive: true })
@@ -646,7 +653,7 @@ describe('glob', () => {
     expect(result.data).not.toContain('linked-outside')
   })
 
-  it('does not follow symlinks to files outside the sandbox root', async () => {
+  it.skipIf(!symlinksSupported)('does not follow symlinks to files outside the sandbox root', async () => {
     const root = join(tmpDir, 'root')
     const outside = join(tmpDir, 'outside')
     await mkdir(root, { recursive: true })
@@ -770,7 +777,7 @@ describe('grep', () => {
 
   // Both branches must reject the symlink — ripgrep defaults to --no-follow,
   // and the Node.js fallback skips symlinks via lstat() in fs-walk.
-  it('does not follow symlinked directories outside the sandbox root', async () => {
+  it.skipIf(!symlinksSupported)('does not follow symlinked directories outside the sandbox root', async () => {
     const root = join(tmpDir, 'root')
     const outside = join(tmpDir, 'outside')
     await mkdir(root, { recursive: true })
@@ -794,7 +801,7 @@ describe('grep', () => {
     expect(result.data).not.toContain('linked-outside')
   })
 
-  it('does not follow symlinks to files outside the sandbox root', async () => {
+  it.skipIf(!symlinksSupported)('does not follow symlinks to files outside the sandbox root', async () => {
     const root = join(tmpDir, 'root')
     const outside = join(tmpDir, 'outside')
     await mkdir(root, { recursive: true })

--- a/packages/core/tests/fs-walk.test.ts
+++ b/packages/core/tests/fs-walk.test.ts
@@ -3,6 +3,9 @@ import { mkdir, mkdtemp, rm, symlink, writeFile } from 'fs/promises'
 import { join } from 'path'
 import { tmpdir } from 'os'
 import { collectFiles } from '../src/tool/built-in/fs-walk.js'
+import { detectSymlinkSupport } from './helpers/symlink-support.js'
+
+const symlinksSupported = await detectSymlinkSupport()
 
 let dir: string
 
@@ -27,7 +30,7 @@ describe('collectFiles', () => {
     expect(files).toContain(join(sub, 'deep.ts'))
   })
 
-  it('skips symlinked directories', async () => {
+  it.skipIf(!symlinksSupported)('skips symlinked directories', async () => {
     const root = join(dir, 'root')
     const outside = join(dir, 'outside')
     await mkdir(root, { recursive: true })
@@ -43,7 +46,7 @@ describe('collectFiles', () => {
     expect(files.some((f) => f.includes('secret.ts'))).toBe(false)
   })
 
-  it('skips symlinks to files', async () => {
+  it.skipIf(!symlinksSupported)('skips symlinks to files', async () => {
     const root = join(dir, 'root')
     const outside = join(dir, 'outside')
     await mkdir(root, { recursive: true })

--- a/packages/core/tests/helpers/symlink-support.ts
+++ b/packages/core/tests/helpers/symlink-support.ts
@@ -1,0 +1,21 @@
+import { mkdtemp, rm, symlink, writeFile } from 'fs/promises'
+import { join } from 'path'
+import { tmpdir } from 'os'
+
+/**
+ * Whether this environment can create symlinks. On Windows, symlink creation
+ * requires Developer Mode or an elevated process, so symlink-behaviour tests
+ * must skip instead of erroring with EPERM.
+ */
+export async function detectSymlinkSupport(): Promise<boolean> {
+  const dir = await mkdtemp(join(tmpdir(), 'oma-symlink-probe-'))
+  try {
+    await writeFile(join(dir, 'target.txt'), '')
+    await symlink(join(dir, 'target.txt'), join(dir, 'link.txt'))
+    return true
+  } catch {
+    return false
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}


### PR DESCRIPTION
## What

Fixes the built-in `bash` tool on Windows: a timed-out command now kills its full process tree and returns promptly, instead of leaving background children alive and hanging until they exit naturally. Also makes the test suite pass on Windows (was 8 failures; now 0 failures, 6 environment-gated skips).

## Why

On Windows, `killProcessTree` fell back to `child.kill('SIGKILL')`, which terminates only the direct bash process. Two bugs followed:

1. **Background children survive the timeout.** Git Bash (MSYS) emulates `fork()` through short-lived intermediate processes, so a descendant's recorded Win32 parent PID often points at a process that no longer exists. No parent-chain walk (including `taskkill /T`) can reach such orphans.
2. **The tool call hangs.** Any surviving descendant inherits the stdio pipes, and the implementation waited for the `close` event (process exit AND stdio drained), so the tool blocked until the orphan exited on its own. Reproduced with `(sleep 0.4; echo alive) & sleep 5` and a 100 ms timeout: the call returned after ~5 s.

Fix, in three parts:

- Use `taskkill /pid <pid> /T /F` on win32 — kills everything still reachable through live parent links (in practice this wins the race against short-lived background children).
- After a forced kill, settle on `exit` instead of `close`, so an unreachable MSYS straggler holding the pipes cannot delay the result.
- Report exit codes 124 (timeout) / 130 (abort) authoritatively: the OS-reported code after a forced kill is platform-dependent (`null` after SIGKILL on POSIX, `1` from taskkill on Windows), which broke the documented 124 contract.

Test-only changes for Windows compatibility:

- New `tests/helpers/symlink-support.ts` probe; the six symlink sandbox-escape tests (`built-in-tools`, `fs-walk`) skip via `it.skipIf` when the environment cannot create symlinks (Windows without Developer Mode raises `EPERM`). They still run everywhere else, including Linux CI.
- The bash `pwd` cwd test now asserts on the unique `mkdtemp` basename, since Git Bash prints the MSYS translation (`/tmp/oma-test-X`) of the native Windows path.

Verified on Windows 11, Node 26: `npm run lint && npm test` → 1108 passed, 6 skipped, 0 failed (three consecutive runs of the timing-sensitive kill test, all stable). POSIX behavior is unchanged: the process-group SIGKILL path is untouched, and the `exit`-settling path only activates after a forced kill, where `exit` and `close` coincide.

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Added/updated tests for changed behavior
- [x] No new runtime dependencies (or justified in the PR description)
