### PR TITLE
Add orchestrator cost budget enforcement

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -194,6 +194,23 @@ const orchestrator = new OpenMultiAgent({
 })
 ```
 
+**Cap estimated cost.** Keep the price table in your app and provide an estimator. OMA passes the effective `model`, `provider`, phase, and `taskId` (when available) so you can price per model. The cap is checked at the same turn/task boundaries as `maxTokenBudget`, so a run can overshoot by up to one model turn; it is not a cent-exact stop.
+
+```ts
+const prices = {
+  'gpt-4.1-mini': { input: 0.40, output: 1.60 }, // USD per 1M tokens
+}
+
+const orchestrator = new OpenMultiAgent({
+  maxCostBudget: 0.25,
+  estimateCost: (usage, { model }) => {
+    const price = prices[model] ?? { input: 0, output: 0 }
+    return (usage.input_tokens / 1_000_000) * price.input
+      + (usage.output_tokens / 1_000_000) * price.output
+  },
+})
+```
+
 **Cancel a run.** Pass an `AbortSignal`; aborting stops the run in flight.
 
 ```ts
@@ -402,7 +419,8 @@ Before going live, wire up the controls that protect token spend, recover from f
 | Cap tool output | `maxToolOutputChars` (or per-tool `maxOutputChars`) + `compressToolResults: true` | `AgentConfig` and `defineTool()` |
 | Recover from failure | Per-task `maxRetries`, `retryDelayMs`, `retryBackoff` (exponential multiplier) | Task config used via `runTasks()` |
 | Survive a crash or restart | `checkpoint` (pass a `runId`, or a durable `MemoryStore` like the bundled `FileStore`) + `restore()` to resume, skipping completed tasks | `OrchestratorConfig` / run options |
-| Hard-cap spend | `maxTokenBudget` on the orchestrator | `OrchestratorConfig` |
+| Hard-cap token spend | `maxTokenBudget` on the orchestrator | `OrchestratorConfig` |
+| Cap estimated cost | `maxCostBudget` + `estimateCost`; you own the per-model price table, and checks happen at turn/task boundaries rather than cent-exact mid-call stops | `OrchestratorConfig` |
 | Catch stuck agents | `loopDetection` with `onLoopDetected: 'terminate'` (or a custom handler) | `AgentConfig` |
 | Trace and audit | `onTrace` to your tracing backend; persist `renderTeamRunDashboard(result)` | `OrchestratorConfig` |
 | Redact secrets | Automatic — API keys, tokens, and Authorization headers stripped from traces, bash output, and dashboard payloads | built-in (on by default) |

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -19,6 +19,22 @@ export class TokenBudgetExceededError extends Error {
 }
 
 /**
+ * Raised when an orchestrator run exceeds its configured estimated cost budget.
+ */
+export class CostBudgetExceededError extends Error {
+  readonly code = 'COST_BUDGET_EXCEEDED'
+
+  constructor(
+    readonly agent: string,
+    readonly costUsed: number,
+    readonly budget: number,
+  ) {
+    super(`Agent "${agent}" exceeded cost budget: ${costUsed} estimated cost used (budget: ${budget})`)
+    this.name = 'CostBudgetExceededError'
+  }
+}
+
+/**
  * Raised when a single LLM call (one `adapter.chat()` request) exceeds the
  * per-call deadline configured via {@link AgentConfig.callTimeoutMs}.
  *
@@ -87,6 +103,7 @@ function extractStatus(error: unknown): number | undefined {
  */
 export function isRetryableError(error: unknown): boolean {
   if (error instanceof TokenBudgetExceededError) return false
+  if (error instanceof CostBudgetExceededError) return false
   if (error instanceof InvalidMessageError) return false
   if (error instanceof LLMCallTimeoutError) return true
   if (error instanceof Error && error.name === 'AbortError') return false

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -50,6 +50,7 @@ import type {
   ConsensusResult,
   ConsensusVerifyOptions,
   CoordinatorConfig,
+  CostEstimateContext,
   ModelRouteConfig,
   ModelRoutingPolicy,
   PlanArtifact,
@@ -87,7 +88,7 @@ import { InMemoryStore } from '../memory/store.js'
 import { createTask, validateTaskDependencies } from '../task/task.js'
 import { extractJSON, validateOutput } from '../agent/structured-output.js'
 import { Scheduler } from './scheduler.js'
-import { TokenBudgetExceededError, isRetryableError } from '../errors.js'
+import { CostBudgetExceededError, TokenBudgetExceededError, isRetryableError } from '../errors.js'
 import { abortableDelay } from '../utils/abort.js'
 import { extractKeywords, keywordScore } from '../utils/keywords.js'
 
@@ -285,6 +286,137 @@ function resolveTokenBudget(primary?: number, fallback?: number): number | undef
   if (primary === undefined) return fallback
   if (fallback === undefined) return primary
   return Math.min(primary, fallback)
+}
+
+type BudgetExceededError = TokenBudgetExceededError | CostBudgetExceededError
+
+function totalTokens(usage: TokenUsage): number {
+  return usage.input_tokens + usage.output_tokens
+}
+
+function buildCostEstimateContext(params: {
+  readonly agentName: string
+  readonly model: string
+  readonly provider?: AgentConfig['provider']
+  readonly phase: CostEstimateContext['phase']
+  readonly taskId?: string
+}): CostEstimateContext {
+  return {
+    agentName: params.agentName,
+    model: params.model,
+    phase: params.phase,
+    ...(params.provider !== undefined ? { provider: params.provider } : {}),
+    ...(params.taskId !== undefined ? { taskId: params.taskId } : {}),
+  }
+}
+
+function estimateIncrementalCost(
+  usage: TokenUsage,
+  context: CostEstimateContext,
+  estimateCost: NonNullable<OrchestratorConfig['estimateCost']>,
+): number {
+  const cost = estimateCost(usage, context)
+  if (!Number.isFinite(cost) || cost < 0) {
+    throw new Error(
+      `Cost estimator returned invalid cost for agent "${context.agentName}": ${String(cost)}`,
+    )
+  }
+  return cost
+}
+
+function applyBudgetAccounting(params: {
+  readonly currentUsage: TokenUsage
+  readonly currentCost: number
+  readonly usage: TokenUsage
+  readonly maxTokenBudget?: number
+  readonly maxCostBudget?: number
+  readonly estimateCost?: OrchestratorConfig['estimateCost']
+  readonly costContext: CostEstimateContext
+}): {
+  readonly cumulativeUsage: TokenUsage
+  readonly cumulativeCost: number
+  readonly exceeded?: BudgetExceededError
+} {
+  const cumulativeUsage = addUsage(params.currentUsage, params.usage)
+  const cumulativeCost = params.estimateCost
+    ? params.currentCost + estimateIncrementalCost(params.usage, params.costContext, params.estimateCost)
+    : params.currentCost
+
+  if (
+    params.maxTokenBudget !== undefined
+    && totalTokens(cumulativeUsage) > params.maxTokenBudget
+  ) {
+    return {
+      cumulativeUsage,
+      cumulativeCost,
+      exceeded: new TokenBudgetExceededError(
+        params.costContext.agentName,
+        totalTokens(cumulativeUsage),
+        params.maxTokenBudget,
+      ),
+    }
+  }
+
+  if (
+    params.maxCostBudget !== undefined
+    && params.estimateCost !== undefined
+    && cumulativeCost > params.maxCostBudget
+  ) {
+    return {
+      cumulativeUsage,
+      cumulativeCost,
+      exceeded: new CostBudgetExceededError(
+        params.costContext.agentName,
+        cumulativeCost,
+        params.maxCostBudget,
+      ),
+    }
+  }
+
+  return { cumulativeUsage, cumulativeCost }
+}
+
+function emitBudgetExceeded(
+  config: OrchestratorConfig,
+  error: BudgetExceededError,
+  agent: string,
+  task?: string,
+): void {
+  config.onProgress?.({
+    type: 'budget_exceeded',
+    agent,
+    ...(task !== undefined ? { task } : {}),
+    data: error,
+  } satisfies OrchestratorEvent)
+}
+
+function recordRunUsage(
+  ctx: RunContext,
+  usage: TokenUsage,
+  costContext: CostEstimateContext,
+  agent: string = costContext.agentName,
+  task?: string,
+): BudgetExceededError | undefined {
+  const accounting = applyBudgetAccounting({
+    currentUsage: ctx.cumulativeUsage,
+    currentCost: ctx.cumulativeCost,
+    usage,
+    maxTokenBudget: ctx.maxTokenBudget,
+    maxCostBudget: ctx.maxCostBudget,
+    estimateCost: ctx.estimateCost,
+    costContext,
+  })
+  ctx.cumulativeUsage = accounting.cumulativeUsage
+  ctx.cumulativeCost = accounting.cumulativeCost
+
+  if (!ctx.budgetExceededTriggered && accounting.exceeded) {
+    ctx.budgetExceededTriggered = true
+    ctx.budgetExceededReason = accounting.exceeded.message
+    emitBudgetExceeded(ctx.config, accounting.exceeded, agent, task)
+    return accounting.exceeded
+  }
+
+  return undefined
 }
 
 /**
@@ -687,7 +819,10 @@ interface RunContext {
   /** AbortSignal for run-level cancellation. Checked between task dispatch rounds. */
   readonly abortSignal?: AbortSignal
   cumulativeUsage: TokenUsage
+  cumulativeCost: number
   readonly maxTokenBudget?: number
+  readonly maxCostBudget?: number
+  readonly estimateCost?: OrchestratorConfig['estimateCost']
   budgetExceededTriggered: boolean
   budgetExceededReason?: string
   readonly taskMetrics: Map<string, TaskExecutionMetrics>
@@ -1008,14 +1143,16 @@ async function executeQueue(
         task,
         leaf: ctx.taskLeafById.get(task.id),
       })
+      const workerEffectiveConfig = withModelRoute(applyDefaultToolPreset({
+        ...agentConfig,
+        model: agentConfig.model ?? config.defaultModel,
+        provider: agentConfig.provider ?? config.defaultProvider,
+        baseURL: agentConfig.baseURL ?? config.defaultBaseURL,
+        apiKey: agentConfig.apiKey ?? config.defaultApiKey,
+        cwd: agentConfig.cwd === undefined ? config.defaultCwd : agentConfig.cwd,
+      }, config.defaultToolPreset), workerRoute)
       const routedAgent = workerRoute
-        ? buildAgent(withModelRoute(applyDefaultToolPreset({
-            ...agentConfig,
-            provider: agentConfig.provider ?? config.defaultProvider,
-            baseURL: agentConfig.baseURL ?? config.defaultBaseURL,
-            apiKey: agentConfig.apiKey ?? config.defaultApiKey,
-            cwd: agentConfig.cwd === undefined ? config.defaultCwd : agentConfig.cwd,
-          }, config.defaultToolPreset), workerRoute), { includeDelegateTool: true })
+        ? buildAgent(workerEffectiveConfig, { includeDelegateTool: true })
         : undefined
       const streamCallback = config.onAgentStream
         ? (event: StreamEvent) => {
@@ -1098,23 +1235,13 @@ async function executeQueue(
         toolCalls: result.toolCalls,
         retries: retryCount,
       })
-      ctx.cumulativeUsage = addUsage(ctx.cumulativeUsage, result.tokenUsage)
-      const totalTokens = ctx.cumulativeUsage.input_tokens + ctx.cumulativeUsage.output_tokens
-      if (
-        !ctx.budgetExceededTriggered
-        && ctx.maxTokenBudget !== undefined
-        && totalTokens > ctx.maxTokenBudget
-      ) {
-        ctx.budgetExceededTriggered = true
-        const err = new TokenBudgetExceededError('orchestrator', totalTokens, ctx.maxTokenBudget)
-        ctx.budgetExceededReason = err.message
-        config.onProgress?.({
-          type: 'budget_exceeded',
-          agent: assignee,
-          task: task.id,
-          data: err,
-        } satisfies OrchestratorEvent)
-      }
+      recordRunUsage(ctx, result.tokenUsage, buildCostEstimateContext({
+        agentName: assignee,
+        model: workerEffectiveConfig.model ?? config.defaultModel ?? DEFAULT_MODEL,
+        provider: workerEffectiveConfig.provider,
+        phase: 'worker',
+        taskId: task.id,
+      }), assignee, task.id)
 
       if (result.success) {
         const sharedMem = team.getSharedMemoryInstance()
@@ -1416,6 +1543,8 @@ interface ConsensusCoreParams {
   readonly defaults: ConsensusAgentDefaults
   readonly onTrace?: OrchestratorConfig['onTrace']
   readonly runId?: string
+  readonly onUsage?: (usage: TokenUsage, effectiveConfig: AgentConfig) => void
+  readonly shouldStop?: () => boolean
   /** Existing pool to reuse; a fresh one is created when omitted. */
   readonly pool?: AgentPool
 }
@@ -1443,11 +1572,15 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
   const overBudget = (): boolean =>
     budget !== undefined && budgetBaseTokens + usage.input_tokens + usage.output_tokens > budget
 
-  const runEphemeral = (config: AgentConfig, text: string): Promise<AgentRunResult> =>
-    pool.runEphemeral(buildAgent(applyConsensusDefaults(config, defaults)), text)
+  const runEphemeral = async (config: AgentConfig, text: string): Promise<AgentRunResult> => {
+    const effective = applyConsensusDefaults(config, defaults)
+    const result = await pool.runEphemeral(buildAgent(effective), text)
+    params.onUsage?.(result.tokenUsage, effective)
+    return result
+  }
 
   // Proposer usage was already accumulated by the caller; bail before judging if it blew the budget.
-  if (overBudget()) {
+  if (overBudget() || params.shouldStop?.()) {
     return { answer, verdict: 'rejected', dissent, rounds, tokenUsage: usage }
   }
 
@@ -1462,7 +1595,7 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
       const judgeText = buildJudgePrompt({ judge: judge.name, answer, prompt, mode, judgeIndex: j, judgePrompt })
       const r = await runEphemeral(judge, judgeText)
       usage = addUsage(usage, r.tokenUsage)
-      if (overBudget()) { budgetHit = true; break }
+      if (overBudget() || params.shouldStop?.()) { budgetHit = true; break }
 
       const verdict = parseJudgeVerdict(r.output, verdictSchema)
 
@@ -1503,7 +1636,7 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
       const r = await runEphemeral(reviseProposer, buildRevisePrompt(prompt, answer, roundDissent))
       usage = addUsage(usage, r.tokenUsage)
       if (r.success && r.output) answer = r.output
-      if (overBudget()) { budgetHit = true; break }
+      if (overBudget() || params.shouldStop?.()) { budgetHit = true; break }
       continue
     }
     break
@@ -1561,9 +1694,17 @@ async function runTaskVerify(
     },
     onTrace: config.onTrace,
     ...(ctx.runId ? { runId: ctx.runId } : {}),
+    onUsage: (usage, effectiveConfig) => {
+      recordRunUsage(ctx, usage, buildCostEstimateContext({
+        agentName: effectiveConfig.name,
+        model: effectiveConfig.model ?? config.defaultModel ?? DEFAULT_MODEL,
+        provider: effectiveConfig.provider,
+        phase: 'consensus',
+        taskId: task.id,
+      }), assignee, task.id)
+    },
+    shouldStop: () => ctx.budgetExceededTriggered,
   })
-
-  ctx.cumulativeUsage = addUsage(ctx.cumulativeUsage, consensus.tokenUsage)
 
   // Surface the verdict as a task-level outcome so downstream agents and the
   // final synthesis can see whether the result survived scrutiny.
@@ -1572,19 +1713,6 @@ async function runTaskVerify(
       ? 'accepted'
       : `rejected${consensus.dissent.length ? `: ${consensus.dissent.join('; ')}` : ''}`
     await sharedMem.write(assignee, `task:${task.id}:verdict`, summary)
-  }
-
-  const total = ctx.cumulativeUsage.input_tokens + ctx.cumulativeUsage.output_tokens
-  if (!ctx.budgetExceededTriggered && ctx.maxTokenBudget !== undefined && total > ctx.maxTokenBudget) {
-    ctx.budgetExceededTriggered = true
-    const err = new TokenBudgetExceededError('orchestrator', total, ctx.maxTokenBudget)
-    ctx.budgetExceededReason = err.message
-    config.onProgress?.({
-      type: 'budget_exceeded',
-      agent: assignee,
-      task: task.id,
-      data: err,
-    } satisfies OrchestratorEvent)
   }
 
   // Only an *accepted* revision supersedes the task result; a rejected revision is
@@ -1611,8 +1739,8 @@ async function runTaskVerify(
  */
 export class OpenMultiAgent {
   private readonly config: Required<
-    Omit<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'defaultToolPreset' | 'checkpoint'>
-  > & Pick<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'defaultToolPreset' | 'checkpoint'>
+    Omit<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
+  > & Pick<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
 
   private readonly teams: Map<string, Team> = new Map()
   private readonly fallbackCheckpointStore = new InMemoryStore()
@@ -1640,6 +1768,8 @@ export class OpenMultiAgent {
       // disable the filesystem sandbox; a string sets a custom sandbox root.
       defaultCwd: config.defaultCwd === undefined ? defaultWorkspaceDir() : config.defaultCwd,
       maxTokenBudget: config.maxTokenBudget,
+      maxCostBudget: config.maxCostBudget,
+      estimateCost: config.estimateCost,
       defaultToolPreset: config.defaultToolPreset,
       checkpoint: config.checkpoint,
       onApproval: config.onApproval,
@@ -1728,6 +1858,7 @@ export class OpenMultiAgent {
         : undefined
 
     const result = await agent.run(prompt, runOptions)
+    let finalResult = result
 
     if (result.budgetExceeded) {
       this.config.onProgress?.({
@@ -1741,17 +1872,45 @@ export class OpenMultiAgent {
       })
     }
 
+    if (!result.budgetExceeded && this.config.estimateCost) {
+      const accounting = applyBudgetAccounting({
+        currentUsage: ZERO_USAGE,
+        currentCost: 0,
+        usage: result.tokenUsage,
+        maxCostBudget: this.config.maxCostBudget,
+        estimateCost: this.config.estimateCost,
+        costContext: buildCostEstimateContext({
+          agentName: config.name,
+          model: effective.model ?? this.config.defaultModel,
+          provider: effective.provider,
+          phase: 'agent',
+        }),
+      })
+      if (accounting.exceeded instanceof CostBudgetExceededError) {
+        this.config.onProgress?.({
+          type: 'budget_exceeded',
+          agent: config.name,
+          data: accounting.exceeded,
+        })
+        finalResult = {
+          ...result,
+          success: false,
+          budgetExceeded: true,
+        }
+      }
+    }
+
     this.config.onProgress?.({
       type: 'agent_complete',
       agent: config.name,
-      data: result,
+      data: finalResult,
     })
 
-    if (result.success) {
+    if (finalResult.success) {
       this.completedTaskCount++
     }
 
-    return result
+    return finalResult
   }
 
   // -------------------------------------------------------------------------
@@ -1833,6 +1992,7 @@ export class OpenMultiAgent {
       const scStartMs = Date.now()
       const result = await agent.run(goal, runOptions)
       const scEndMs = Date.now()
+      let finalResult = result
 
       if (result.budgetExceeded) {
         this.config.onProgress?.({
@@ -1846,28 +2006,56 @@ export class OpenMultiAgent {
         })
       }
 
+      if (!result.budgetExceeded && this.config.estimateCost) {
+        const accounting = applyBudgetAccounting({
+          currentUsage: ZERO_USAGE,
+          currentCost: 0,
+          usage: result.tokenUsage,
+          maxCostBudget: this.config.maxCostBudget,
+          estimateCost: this.config.estimateCost,
+          costContext: buildCostEstimateContext({
+            agentName: bestAgent.name,
+            model: effective.model ?? this.config.defaultModel,
+            provider: effective.provider,
+            phase: 'short-circuit',
+          }),
+        })
+        if (accounting.exceeded instanceof CostBudgetExceededError) {
+          this.config.onProgress?.({
+            type: 'budget_exceeded',
+            agent: bestAgent.name,
+            data: accounting.exceeded,
+          })
+          finalResult = {
+            ...result,
+            success: false,
+            budgetExceeded: true,
+          }
+        }
+      }
+
       this.config.onProgress?.({
         type: 'agent_complete',
         agent: bestAgent.name,
-        data: { phase: 'short-circuit', result },
+        data: { phase: 'short-circuit', result: finalResult },
       })
 
       const agentResults = new Map<string, AgentRunResult>()
-      agentResults.set(bestAgent.name, result)
+      agentResults.set(bestAgent.name, finalResult)
 
 
       const tasks: readonly TaskExecutionRecord[] = [{
         id: 'short-circuit',
         title: `Short-circuit: ${bestAgent.name}`,
         assignee: bestAgent.name,
-        status: result.success ? 'completed' : 'failed',
+        status: finalResult.success ? 'completed' : 'failed',
         dependsOn: [],
         metrics: {
           startMs: scStartMs,
           endMs: scEndMs,
           durationMs: Math.max(0, scEndMs - scStartMs),
-          tokenUsage: result.tokenUsage,
-          toolCalls: result.toolCalls,
+          tokenUsage: finalResult.tokenUsage,
+          toolCalls: finalResult.toolCalls,
           retries: 0,
         },
       }]
@@ -1911,21 +2099,26 @@ export class OpenMultiAgent {
     const agentResults = new Map<string, AgentRunResult>()
     agentResults.set('coordinator:decompose', decompositionResult)
     const maxTokenBudget = this.config.maxTokenBudget
-    let cumulativeUsage = addUsage(ZERO_USAGE, decompositionResult.tokenUsage)
+    const maxCostBudget = this.config.maxCostBudget
+    const decompositionBudget = applyBudgetAccounting({
+      currentUsage: ZERO_USAGE,
+      currentCost: 0,
+      usage: decompositionResult.tokenUsage,
+      maxTokenBudget,
+      maxCostBudget,
+      estimateCost: this.config.estimateCost,
+      costContext: buildCostEstimateContext({
+        agentName: 'coordinator',
+        model: coordinatorConfig.model ?? this.config.defaultModel,
+        provider: coordinatorConfig.provider,
+        phase: 'coordinator',
+      }),
+    })
+    let cumulativeUsage = decompositionBudget.cumulativeUsage
+    let cumulativeCost = decompositionBudget.cumulativeCost
 
-    if (
-      maxTokenBudget !== undefined
-      && cumulativeUsage.input_tokens + cumulativeUsage.output_tokens > maxTokenBudget
-    ) {
-      this.config.onProgress?.({
-        type: 'budget_exceeded',
-        agent: 'coordinator',
-        data: new TokenBudgetExceededError(
-          'coordinator',
-          cumulativeUsage.input_tokens + cumulativeUsage.output_tokens,
-          maxTokenBudget,
-        ),
-      })
+    if (decompositionBudget.exceeded) {
+      emitBudgetExceeded(this.config, decompositionBudget.exceeded, 'coordinator')
       return this.buildTeamRunResult(agentResults, goal, [])
     }
 
@@ -1980,7 +2173,10 @@ export class OpenMultiAgent {
       runId,
       abortSignal: options?.abortSignal,
       cumulativeUsage,
+      cumulativeCost,
       maxTokenBudget,
+      maxCostBudget,
+      estimateCost: this.config.estimateCost,
       budgetExceededTriggered: false,
       budgetExceededReason: undefined,
       taskMetrics,
@@ -2054,6 +2250,7 @@ export class OpenMultiAgent {
 
     await executeQueue(queue, ctx)
     cumulativeUsage = ctx.cumulativeUsage
+    cumulativeCost = ctx.cumulativeCost
     const taskRecords: readonly TaskExecutionRecord[] = queue.list().map((task) => ({
       id: task.id,
       title: task.title,
@@ -2077,7 +2274,10 @@ export class OpenMultiAgent {
       runId,
       abortSignal: options?.abortSignal,
       cumulativeUsage,
+      cumulativeCost,
       maxTokenBudget,
+      maxCostBudget,
+      estimateCost: this.config.estimateCost,
     })
     if (synthesis === null) {
       // Aborted or already over budget — return raw task outputs, no synthesis.
@@ -2085,6 +2285,7 @@ export class OpenMultiAgent {
     }
     agentResults.set('coordinator', synthesis.result)
     cumulativeUsage = synthesis.cumulativeUsage
+    cumulativeCost = synthesis.cumulativeCost
 
     // Note: coordinator decompose and synthesis are internal meta-steps.
     // Only actual user tasks (non-coordinator keys) are counted in
@@ -2647,41 +2848,54 @@ export class OpenMultiAgent {
       readonly runId?: string
       readonly abortSignal?: AbortSignal
       readonly cumulativeUsage: TokenUsage
+      readonly cumulativeCost: number
       readonly maxTokenBudget?: number
+      readonly maxCostBudget?: number
+      readonly estimateCost?: OrchestratorConfig['estimateCost']
     },
-  ): Promise<{ readonly result: AgentRunResult; readonly cumulativeUsage: TokenUsage } | null> {
+  ): Promise<{ readonly result: AgentRunResult; readonly cumulativeUsage: TokenUsage; readonly cumulativeCost: number } | null> {
     if (opts.abortSignal?.aborted) return null
     if (
       opts.maxTokenBudget !== undefined
-      && opts.cumulativeUsage.input_tokens + opts.cumulativeUsage.output_tokens > opts.maxTokenBudget
+      && totalTokens(opts.cumulativeUsage) > opts.maxTokenBudget
+    ) {
+      return null
+    }
+    if (
+      opts.maxCostBudget !== undefined
+      && opts.estimateCost !== undefined
+      && opts.cumulativeCost > opts.maxCostBudget
     ) {
       return null
     }
 
     const synthesisPrompt = await this.buildSynthesisPrompt(goal, queue.list(), team)
-    const synthesisAgent = buildAgent(withModelRoute(
+    const synthesisConfig = withModelRoute(
       coordinatorBaseConfig,
       routeMatches(opts.modelRouting, { phase: 'synthesis', agent: 'coordinator' }),
-    ))
+    )
+    const synthesisAgent = buildAgent(synthesisConfig)
     const synthTraceOptions: Partial<RunOptions> | undefined = this.config.onTrace
       ? { onTrace: this.config.onTrace, runId: opts.runId ?? '', traceAgent: 'coordinator' }
       : undefined
     const result = await synthesisAgent.run(synthesisPrompt, synthTraceOptions)
-    const cumulativeUsage = addUsage(opts.cumulativeUsage, result.tokenUsage)
+    const accounting = applyBudgetAccounting({
+      currentUsage: opts.cumulativeUsage,
+      currentCost: opts.cumulativeCost,
+      usage: result.tokenUsage,
+      maxTokenBudget: opts.maxTokenBudget,
+      maxCostBudget: opts.maxCostBudget,
+      estimateCost: opts.estimateCost,
+      costContext: buildCostEstimateContext({
+        agentName: 'coordinator',
+        model: synthesisConfig.model ?? this.config.defaultModel,
+        provider: synthesisConfig.provider,
+        phase: 'synthesis',
+      }),
+    })
 
-    if (
-      opts.maxTokenBudget !== undefined
-      && cumulativeUsage.input_tokens + cumulativeUsage.output_tokens > opts.maxTokenBudget
-    ) {
-      this.config.onProgress?.({
-        type: 'budget_exceeded',
-        agent: 'coordinator',
-        data: new TokenBudgetExceededError(
-          'coordinator',
-          cumulativeUsage.input_tokens + cumulativeUsage.output_tokens,
-          opts.maxTokenBudget,
-        ),
-      })
+    if (accounting.exceeded) {
+      emitBudgetExceeded(this.config, accounting.exceeded, 'coordinator')
     }
 
     this.config.onProgress?.({
@@ -2690,7 +2904,11 @@ export class OpenMultiAgent {
       data: result,
     })
 
-    return { result, cumulativeUsage }
+    return {
+      result,
+      cumulativeUsage: accounting.cumulativeUsage,
+      cumulativeCost: accounting.cumulativeCost,
+    }
   }
 
   /** Build the synthesis prompt shown to the coordinator after all tasks complete. */
@@ -2789,7 +3007,10 @@ export class OpenMultiAgent {
       runId: this.config.onTrace ? generateRunId() : undefined,
       abortSignal: options?.abortSignal,
       cumulativeUsage: ZERO_USAGE,
+      cumulativeCost: 0,
       maxTokenBudget: this.config.maxTokenBudget,
+      maxCostBudget: this.config.maxCostBudget,
+      estimateCost: this.config.estimateCost,
       budgetExceededTriggered: false,
       budgetExceededReason: undefined,
       taskMetrics: new Map<string, TaskExecutionMetrics>(),
@@ -2813,11 +3034,15 @@ export class OpenMultiAgent {
           runId: ctx.runId,
           abortSignal: options?.abortSignal,
           cumulativeUsage: ctx.cumulativeUsage,
+          cumulativeCost: ctx.cumulativeCost,
           maxTokenBudget: ctx.maxTokenBudget,
+          maxCostBudget: ctx.maxCostBudget,
+          estimateCost: ctx.estimateCost,
         })
         if (synthesis !== null && synthesis.result.success) {
           agentResults.set('coordinator', synthesis.result)
           ctx.cumulativeUsage = synthesis.cumulativeUsage
+          ctx.cumulativeCost = synthesis.cumulativeCost
         } else if (synthesis !== null) {
           // Synthesis ran but the coordinator agent failed (e.g. the LLM call
           // errored). Keep the recovered task outputs and surface the failure

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -294,6 +294,10 @@ function totalTokens(usage: TokenUsage): number {
   return usage.input_tokens + usage.output_tokens
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
 function buildCostEstimateContext(params: {
   readonly agentName: string
   readonly model: string
@@ -1235,13 +1239,31 @@ async function executeQueue(
         toolCalls: result.toolCalls,
         retries: retryCount,
       })
-      recordRunUsage(ctx, result.tokenUsage, buildCostEstimateContext({
-        agentName: assignee,
-        model: workerEffectiveConfig.model ?? config.defaultModel ?? DEFAULT_MODEL,
-        provider: workerEffectiveConfig.provider,
-        phase: 'worker',
-        taskId: task.id,
-      }), assignee, task.id)
+      try {
+        recordRunUsage(ctx, result.tokenUsage, buildCostEstimateContext({
+          agentName: assignee,
+          model: workerEffectiveConfig.model ?? config.defaultModel ?? DEFAULT_MODEL,
+          provider: workerEffectiveConfig.provider,
+          phase: 'worker',
+          taskId: task.id,
+        }), assignee, task.id)
+      } catch (error) {
+        const message = errorMessage(error)
+        ctx.agentResults.set(`${assignee}:${task.id}`, {
+          ...result,
+          success: false,
+          output: message,
+          error,
+        })
+        queue.fail(task.id, message)
+        config.onProgress?.({
+          type: 'error',
+          task: task.id,
+          agent: assignee,
+          data: message,
+        } satisfies OrchestratorEvent)
+        return
+      }
 
       if (result.success) {
         const sharedMem = team.getSharedMemoryInstance()
@@ -1756,6 +1778,10 @@ export class OpenMultiAgent {
    *   - `defaultProvider`: `'anthropic'`
    */
   constructor(config: OrchestratorConfig = {}) {
+    if (config.maxCostBudget !== undefined && config.estimateCost === undefined) {
+      throw new Error('maxCostBudget requires estimateCost so cost caps cannot be silently ignored.')
+    }
+
     this.config = {
       maxConcurrency: config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
       maxDelegationDepth: config.maxDelegationDepth ?? DEFAULT_MAX_DELEGATION_DEPTH,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -157,6 +157,20 @@ export interface TokenUsage {
   readonly output_tokens: number
 }
 
+/** Context passed to user-supplied cost estimators. */
+export interface CostEstimateContext {
+  /** Agent whose LLM usage is being costed. */
+  readonly agentName: string
+  /** Model identifier used for the LLM call. */
+  readonly model: string
+  /** Provider used for the LLM call, when known. */
+  readonly provider?: SupportedProvider
+  /** Execution phase that produced this usage. */
+  readonly phase: 'agent' | 'short-circuit' | 'coordinator' | 'worker' | 'synthesis' | 'consensus' | 'delegated'
+  /** Task ID associated with the usage, when usage came from a task. */
+  readonly taskId?: string
+}
+
 /** Normalised response returned by every {@link LLMAdapter} implementation. */
 export interface LLMResponse {
   readonly id: string
@@ -1070,6 +1084,26 @@ export interface OrchestratorConfig {
   readonly maxDelegationDepth?: number
   /** Maximum cumulative tokens (input + output) allowed per orchestrator run. */
   readonly maxTokenBudget?: number
+  /**
+   * Maximum estimated run cost allowed for an orchestrator-managed run.
+   *
+   * Requires {@link estimateCost}. The framework intentionally does not ship a
+   * model price table; callers own provider-specific pricing. Checked at the
+   * same turn/task boundaries as {@link maxTokenBudget}, so a run may overshoot
+   * by up to one model turn and should not be treated as a cent-exact stop.
+   */
+  readonly maxCostBudget?: number
+  /**
+   * Converts incremental token usage into a caller-defined cost unit.
+   *
+   * Called with usage from one LLM result, not cumulative usage. Return the
+   * amount to add to the run's cumulative estimated cost. The context includes
+   * the effective model after defaults and model routing.
+   */
+  readonly estimateCost?: (
+    usage: TokenUsage,
+    context: CostEstimateContext,
+  ) => number
   /**
    * Default model inherited by every agent that does not set its own
    * {@link AgentConfig.model} — workers, the coordinator, and consensus agents

--- a/packages/core/tests/token-budget.test.ts
+++ b/packages/core/tests/token-budget.test.ts
@@ -3,7 +3,15 @@ import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
 import { Agent } from '../src/agent/agent.js'
 import { ToolRegistry } from '../src/tool/framework.js'
 import { ToolExecutor } from '../src/tool/executor.js'
-import type { AgentConfig, LLMChatOptions, LLMMessage, LLMResponse, OrchestratorEvent } from '../src/types.js'
+import type {
+  AgentConfig,
+  CostEstimateContext,
+  LLMChatOptions,
+  LLMMessage,
+  LLMResponse,
+  OrchestratorEvent,
+  TokenUsage,
+} from '../src/types.js'
 
 let mockAdapterResponses: string[] = []
 let mockAdapterUsage: Array<{ input_tokens: number; output_tokens: number }> = []
@@ -42,6 +50,18 @@ function agentConfig(name: string, maxTokenBudget?: number): AgentConfig {
   }
 }
 
+function usageCost(usage: TokenUsage, _context: CostEstimateContext): number {
+  return (usage.input_tokens + usage.output_tokens) / 100
+}
+
+function hasCostBudgetEvent(events: OrchestratorEvent[]): boolean {
+  return events.some((event) => {
+    if (event.type !== 'budget_exceeded') return false
+    const data = event.data as { code?: string } | undefined
+    return data?.code === 'COST_BUDGET_EXCEEDED'
+  })
+}
+
 describe('token budget enforcement', () => {
   beforeEach(() => {
     mockAdapterResponses = []
@@ -66,6 +86,53 @@ describe('token budget enforcement', () => {
     expect(result.messages[0]?.role).toBe('assistant')
     expect(result.messages[0]?.content[0]).toMatchObject({ type: 'text', text: 'over budget' })
     expect(events.some(e => e.type === 'budget_exceeded')).toBe(true)
+  })
+
+  it('enforces orchestrator cost budget in runAgent', async () => {
+    mockAdapterResponses = ['over cost budget']
+    mockAdapterUsage = [{ input_tokens: 20, output_tokens: 15 }]
+
+    const events: OrchestratorEvent[] = []
+    const oma = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      maxCostBudget: 0.30,
+      estimateCost: usageCost,
+      onProgress: e => events.push(e),
+    })
+
+    const result = await oma.runAgent(agentConfig('solo'), 'test')
+
+    expect(result.success).toBe(false)
+    expect(result.budgetExceeded).toBe(true)
+    expect(hasCostBudgetEvent(events)).toBe(true)
+  })
+
+  it('passes model information to the cost estimator', async () => {
+    mockAdapterResponses = ['priced by model']
+    mockAdapterUsage = [{ input_tokens: 5, output_tokens: 5 }]
+
+    const contexts: CostEstimateContext[] = []
+    const oma = new OpenMultiAgent({
+      defaultModel: 'default-model',
+      maxCostBudget: 100,
+      estimateCost: (usage, context) => {
+        contexts.push(context)
+        return usageCost(usage, context)
+      },
+    })
+
+    await oma.runAgent({
+      ...agentConfig('premium'),
+      model: 'premium-model',
+    }, 'test')
+
+    expect(contexts).toHaveLength(1)
+    expect(contexts[0]).toMatchObject({
+      agentName: 'premium',
+      model: 'premium-model',
+      provider: 'openai',
+      phase: 'agent',
+    })
   })
 
   it('emits budget_exceeded stream event without error transition', async () => {
@@ -184,6 +251,38 @@ describe('token budget enforcement', () => {
     expect(events.some(e => e.type === 'task_skipped')).toBe(true)
   })
 
+  it('enforces cost budget in runTasks and skips remaining tasks', async () => {
+    mockAdapterResponses = ['done-a', 'done-b', 'done-c']
+    mockAdapterUsage = [
+      { input_tokens: 20, output_tokens: 15 },
+      { input_tokens: 20, output_tokens: 15 },
+      { input_tokens: 20, output_tokens: 15 },
+    ]
+
+    const events: OrchestratorEvent[] = []
+    const oma = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      maxCostBudget: 0.60,
+      estimateCost: usageCost,
+      onProgress: e => events.push(e),
+    })
+    const team = oma.createTeam('cost-team', {
+      name: 'cost-team',
+      agents: [agentConfig('worker')],
+      sharedMemory: false,
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'A', description: 'A', assignee: 'worker' },
+      { title: 'B', description: 'B', assignee: 'worker', dependsOn: ['A'] },
+      { title: 'C', description: 'C', assignee: 'worker', dependsOn: ['B'] },
+    ])
+
+    expect(result.totalTokenUsage.input_tokens + result.totalTokenUsage.output_tokens).toBe(70)
+    expect(hasCostBudgetEvent(events)).toBe(true)
+    expect(events.some(e => e.type === 'task_skipped')).toBe(true)
+  })
+
   it('counts retry token usage before enforcing team budget', async () => {
     mockAdapterResponses = ['attempt-1', 'attempt-2', 'should-skip']
     mockAdapterUsage = [
@@ -244,5 +343,37 @@ describe('token budget enforcement', () => {
     const result = await oma.runTeam(team, 'First plan the work, then execute it')
     expect(result.totalTokenUsage.input_tokens + result.totalTokenUsage.output_tokens).toBe(70)
     expect(events.some(e => e.type === 'budget_exceeded')).toBe(true)
+  })
+
+  it('enforces cost budget in runTeam before synthesis', async () => {
+    mockAdapterResponses = [
+      '```json\n[{"title":"Task A","description":"Do A","assignee":"worker"}]\n```',
+      'worker result',
+      'synthesis should not run when cost budget is exceeded',
+    ]
+    mockAdapterUsage = [
+      { input_tokens: 20, output_tokens: 15 },
+      { input_tokens: 20, output_tokens: 15 },
+      { input_tokens: 20, output_tokens: 15 },
+    ]
+
+    const events: OrchestratorEvent[] = []
+    const oma = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      maxCostBudget: 0.60,
+      estimateCost: usageCost,
+      onProgress: e => events.push(e),
+    })
+    const team = oma.createTeam('cost-team-runteam', {
+      name: 'cost-team-runteam',
+      agents: [agentConfig('worker')],
+      sharedMemory: false,
+    })
+
+    const result = await oma.runTeam(team, 'First plan the work, then execute it')
+
+    expect(result.totalTokenUsage.input_tokens + result.totalTokenUsage.output_tokens).toBe(70)
+    expect(hasCostBudgetEvent(events)).toBe(true)
+    expect(result.agentResults.get('coordinator')?.output).toContain('Task A')
   })
 })

--- a/packages/core/tests/token-budget.test.ts
+++ b/packages/core/tests/token-budget.test.ts
@@ -107,6 +107,13 @@ describe('token budget enforcement', () => {
     expect(hasCostBudgetEvent(events)).toBe(true)
   })
 
+  it('rejects maxCostBudget without a cost estimator', () => {
+    expect(() => new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      maxCostBudget: 1,
+    })).toThrow(/maxCostBudget requires estimateCost/)
+  })
+
   it('passes model information to the cost estimator', async () => {
     mockAdapterResponses = ['priced by model']
     mockAdapterUsage = [{ input_tokens: 5, output_tokens: 5 }]
@@ -281,6 +288,43 @@ describe('token budget enforcement', () => {
     expect(result.totalTokenUsage.input_tokens + result.totalTokenUsage.output_tokens).toBe(70)
     expect(hasCostBudgetEvent(events)).toBe(true)
     expect(events.some(e => e.type === 'task_skipped')).toBe(true)
+  })
+
+  it('marks a task failed when the cost estimator returns an invalid cost', async () => {
+    mockAdapterResponses = ['done-a', 'should-not-run']
+    mockAdapterUsage = [
+      { input_tokens: 20, output_tokens: 15 },
+      { input_tokens: 20, output_tokens: 15 },
+    ]
+
+    const events: OrchestratorEvent[] = []
+    const oma = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      maxCostBudget: 100,
+      estimateCost: () => Number.NaN,
+      onProgress: e => events.push(e),
+    })
+    const team = oma.createTeam('bad-estimator-team', {
+      name: 'bad-estimator-team',
+      agents: [agentConfig('worker')],
+      sharedMemory: false,
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'A', description: 'A', assignee: 'worker' },
+      { title: 'B', description: 'B', assignee: 'worker', dependsOn: ['A'] },
+    ])
+
+    expect(result.success).toBe(false)
+    expect(result.tasks?.find(task => task.title === 'A')).toMatchObject({
+      status: 'failed',
+    })
+    expect(result.tasks?.find(task => task.title === 'B')?.status).toBe('failed')
+    expect(result.agentResults.get('worker')?.output).toContain('Cost estimator returned invalid cost')
+    expect(events.some((event) => {
+      if (event.type !== 'error') return false
+      return String(event.data).includes('Cost estimator returned invalid cost')
+    })).toBe(true)
   })
 
   it('counts retry token usage before enforcing team budget', async () => {


### PR DESCRIPTION
## Summary
- Add `maxCostBudget` and `estimateCost` to orchestrator config for user-defined cost caps.
- Pass effective model/provider/phase/taskId into the estimator so callers can price per model.
- Enforce estimated cost budgets across `runAgent`, `runTasks`, `runTeam`, consensus, and synthesis paths, mirroring token-budget boundaries.

## Test Plan
- [x] npm test --workspace @open-multi-agent/core -- token-budget.test.ts
- [x] npm run lint --workspace @open-multi-agent/core
- [x] npm run build --workspace @open-multi-agent/core