### PR TITLE
feat(core): persist MessageBus in checkpoints

### DIFF
--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -989,6 +989,7 @@ async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Promise<voi
       ...(sharedMem && !active.reusesSharedMemoryStore
         ? { sharedMemory: await sharedMem.snapshot() }
         : {}),
+      messageBus: ctx.team.snapshotMessageBus(),
       ...(sharedMem ? { turnCount: sharedMem.getTurnCount() } : {}),
       completedTaskResults,
     }
@@ -2497,6 +2498,9 @@ export class OpenMultiAgent {
       // Reused-store checkpoint: entries are already in the store; only the
       // turn counter needs restoring so TTL expiry resumes correctly.
       sharedMem.setTurnCount(snapshot.turnCount)
+    }
+    if (snapshot.messageBus) {
+      team.restoreMessageBus(snapshot.messageBus)
     }
 
     const queue = TaskQueue.fromSnapshot(snapshot.queue, { resetInProgress: true })

--- a/packages/core/src/team/messaging.ts
+++ b/packages/core/src/team/messaging.ts
@@ -7,6 +7,7 @@
  */
 
 import { randomUUID } from 'node:crypto'
+import type { MessageBusSnapshot } from '../types.js'
 
 // ---------------------------------------------------------------------------
 // Message type
@@ -83,6 +84,57 @@ export class MessageBus {
     string,
     Map<symbol, (message: Message) => void>
   >()
+
+  // ---------------------------------------------------------------------------
+  // Snapshot / restore
+  // ---------------------------------------------------------------------------
+
+  /** Returns a serializable snapshot of retained messages and read state. */
+  snapshot(): MessageBusSnapshot {
+    return {
+      version: 1,
+      messages: this.messages.map((message) => ({
+        ...message,
+        timestamp: message.timestamp.toISOString(),
+      })),
+      readState: Array.from(this.readState.entries()).map(([agentName, ids]) => ({
+        agentName,
+        messageIds: Array.from(ids),
+      })),
+    }
+  }
+
+  /**
+   * Replaces retained messages and read state from a snapshot.
+   *
+   * Active subscribers are intentionally left untouched: callbacks are live
+   * process state, not persisted checkpoint data.
+   */
+  restore(snapshot: MessageBusSnapshot): void {
+    if (snapshot.version !== 1) {
+      throw new Error(`MessageBus.restore: unsupported snapshot version ${String(snapshot.version)}.`)
+    }
+
+    this.messages.splice(
+      0,
+      this.messages.length,
+      ...snapshot.messages.map((message) => ({
+        ...message,
+        timestamp: new Date(message.timestamp),
+      })),
+    )
+    this.readState.clear()
+    for (const entry of snapshot.readState) {
+      this.readState.set(entry.agentName, new Set(entry.messageIds))
+    }
+  }
+
+  /** Builds a fresh MessageBus from a snapshot. */
+  static fromSnapshot(snapshot: MessageBusSnapshot): MessageBus {
+    const bus = new MessageBus()
+    bus.restore(snapshot)
+    return bus
+  }
 
   // ---------------------------------------------------------------------------
   // Write operations

--- a/packages/core/src/team/team.ts
+++ b/packages/core/src/team/team.ts
@@ -10,6 +10,7 @@
 import type {
   AgentConfig,
   MemoryStore,
+  MessageBusSnapshot,
   OrchestratorEvent,
   Task,
   TaskStatus,
@@ -194,6 +195,28 @@ export class Team {
    */
   getMessages(agentName: string): Message[] {
     return this.bus.getAll(agentName)
+  }
+
+  /**
+   * Returns messages addressed to `agentName` that have not been marked read.
+   */
+  getUnreadMessages(agentName: string): Message[] {
+    return this.bus.getUnread(agentName)
+  }
+
+  /** Marks messages as read for `agentName`. */
+  markMessagesRead(agentName: string, messageIds: string[]): void {
+    this.bus.markRead(agentName, messageIds)
+  }
+
+  /** Returns a serializable snapshot of the team's message bus. @internal */
+  snapshotMessageBus(): MessageBusSnapshot {
+    return this.bus.snapshot()
+  }
+
+  /** Restores the team's message bus from a checkpoint snapshot. @internal */
+  restoreMessageBus(snapshot: MessageBusSnapshot): void {
+    this.bus.restore(snapshot)
   }
 
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1235,6 +1235,28 @@ export interface SharedMemorySnapshot {
   readonly entries: readonly MemoryEntrySnapshot[]
 }
 
+/** Serializable form of an inter-agent message. */
+export interface MessageSnapshot {
+  readonly id: string
+  readonly from: string
+  readonly to: string
+  readonly content: string
+  readonly timestamp: string
+}
+
+/** Serializable read-state for one agent on the MessageBus. */
+export interface MessageReadStateSnapshot {
+  readonly agentName: string
+  readonly messageIds: readonly string[]
+}
+
+/** Serializable form of MessageBus state. Runtime subscribers are not persisted. */
+export interface MessageBusSnapshot {
+  readonly version: 1
+  readonly messages: readonly MessageSnapshot[]
+  readonly readState: readonly MessageReadStateSnapshot[]
+}
+
 /** Serializable form of a {@link Task}. */
 export interface TaskSnapshot {
   readonly id: string
@@ -1282,6 +1304,7 @@ export interface CheckpointSnapshot {
   readonly goal?: string
   readonly queue: TaskQueueSnapshot
   readonly sharedMemory?: SharedMemorySnapshot
+  readonly messageBus?: MessageBusSnapshot
   /**
    * Shared-memory turn counter at checkpoint time. Persisted separately from
    * {@link sharedMemory} so TTL/expiry stays correct on resume even when the

--- a/packages/core/tests/checkpoint.test.ts
+++ b/packages/core/tests/checkpoint.test.ts
@@ -472,6 +472,44 @@ describe('OpenMultiAgent checkpoint/restore', () => {
     const persisted = await new Checkpoint(checkpointStore, {}).loadLatest()
     expect(persisted?.sharedMemory?.entries.some((entry) => entry.key === 'seed/note')).toBe(true)
   })
+
+  it('persists MessageBus messages and read state through checkpoint restore', async () => {
+    const checkpointStore = new InMemoryStore()
+    const scripted = scriptedAdapter(['only output'])
+    const orchestrator = new OpenMultiAgent()
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+    })
+    team.sendMessage('alice', 'worker', 'direct handoff')
+    team.broadcast('alice', 'broadcast note')
+    const [readMessage] = team.getUnreadMessages('worker')
+    team.markMessagesRead('worker', [readMessage!.id])
+
+    await orchestrator.runTasks(team, [
+      { title: 'only', description: 'do it', assignee: 'worker' },
+    ], { checkpoint: { store: checkpointStore } })
+
+    const persisted = await new Checkpoint(checkpointStore, {}).loadLatest()
+    expect(persisted?.messageBus?.messages.map((message) => message.content)).toEqual([
+      'direct handoff',
+      'broadcast note',
+    ])
+
+    const resumedTeam = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+    })
+    await orchestrator.restore(resumedTeam, { checkpoint: { store: checkpointStore } })
+
+    expect(resumedTeam.getMessages('worker').map((message) => message.content)).toEqual([
+      'direct handoff',
+      'broadcast note',
+    ])
+    expect(resumedTeam.getUnreadMessages('worker').map((message) => message.content)).toEqual([
+      'broadcast note',
+    ])
+  })
 })
 
 /** A store whose writes always reject, to exercise best-effort checkpointing. */

--- a/packages/core/tests/team-messaging.test.ts
+++ b/packages/core/tests/team-messaging.test.ts
@@ -140,6 +140,67 @@ describe('MessageBus', () => {
       expect(convo[1]!.content).toBe('hi back')
     })
   })
+
+  describe('snapshot / restore', () => {
+    it('round-trips messages and per-agent read state', () => {
+      const bus = new MessageBus()
+      const direct = bus.send('alice', 'bob', 'hello')
+      const broadcast = bus.broadcast('alice', 'stand by')
+      bus.markRead('bob', [direct.id])
+
+      const restored = MessageBus.fromSnapshot(bus.snapshot())
+
+      expect(restored.getAll('bob').map((message) => message.content)).toEqual([
+        'hello',
+        'stand by',
+      ])
+      expect(restored.getUnread('bob').map((message) => message.id)).toEqual([
+        broadcast.id,
+      ])
+      expect(restored.getAll('bob')[0]!.timestamp).toBeInstanceOf(Date)
+      expect(restored.getAll('bob')[0]!.timestamp.getTime()).toBe(direct.timestamp.getTime())
+    })
+
+    it('does not restore live subscribers', () => {
+      const bus = new MessageBus()
+      const received: string[] = []
+      bus.subscribe('bob', (message) => received.push(message.content))
+
+      bus.send('alice', 'bob', 'before snapshot')
+      const restored = MessageBus.fromSnapshot(bus.snapshot())
+      restored.send('alice', 'bob', 'after restore')
+
+      expect(received).toEqual(['before snapshot'])
+    })
+
+    it('keeps current process-local subscribers when restoring into an existing bus', () => {
+      const source = new MessageBus()
+      source.send('alice', 'bob', 'checkpointed')
+      const target = new MessageBus()
+      const received: string[] = []
+      target.subscribe('bob', (message) => received.push(message.content))
+
+      target.restore(source.snapshot())
+      target.send('alice', 'bob', 'after restore')
+
+      expect(target.getAll('bob').map((message) => message.content)).toEqual([
+        'checkpointed',
+        'after restore',
+      ])
+      expect(received).toEqual(['after restore'])
+    })
+
+    it('rejects unsupported snapshot versions', () => {
+      const bus = new MessageBus()
+      const snapshot = {
+        ...bus.snapshot(),
+        version: 2,
+      }
+
+      expect(() => MessageBus.fromSnapshot(snapshot as ReturnType<MessageBus['snapshot']>))
+        .toThrow(/unsupported snapshot version 2/)
+    })
+  })
 })
 
 // ===========================================================================
@@ -173,6 +234,18 @@ describe('Team', () => {
       expect(team.getMessages('bob')).toHaveLength(1)
       expect(team.getMessages('bob')[0]!.content).toBe('hey')
       expect(events).toHaveLength(1)
+    })
+
+    it('tracks unread message state', () => {
+      const team = new Team(teamConfig())
+
+      team.sendMessage('alice', 'bob', 'read me')
+      const unread = team.getUnreadMessages('bob')
+      team.markMessagesRead('bob', unread.map((message) => message.id))
+
+      expect(unread).toHaveLength(1)
+      expect(team.getUnreadMessages('bob')).toHaveLength(0)
+      expect(team.getMessages('bob')).toHaveLength(1)
     })
 
     it('broadcasts and emits broadcast event', () => {


### PR DESCRIPTION
## What

Persist MessageBus state across checkpoint/restore by adding snapshot/restore support for messages and per-agent read state.

This keeps live subscribers process-local, so callback subscriptions are not serialized into checkpoints.

## Why

Closes #343.

Checkpoint/restore already persists task queue and shared memory, but MessageBus state was lost on resume. Teams that coordinate through direct or broadcast messages could lose messages and unread state after restoring from a checkpoint.

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Added/updated tests for changed behavior
- [x] No new runtime dependencies