### PR TITLE
docs(readme): surface the website, reorder the comparison, refresh credits & features

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@
 <br />
 
 <p align="center">
+  <a href="https://open-multi-agent.com">Website</a> ·
+  <a href="https://open-multi-agent.com/getting-started/introduction/">Docs</a> ·
+  <a href="https://www.npmjs.com/package/@open-multi-agent/core">npm</a> ·
+  <a href="https://github.com/open-multi-agent/open-multi-agent/discussions">Discussions</a>
+</p>
+
+<p align="center">
   <strong>English</strong> · <a href="./README_zh.md">中文</a>
 </p>
 
@@ -67,18 +74,6 @@ The full quickstart, the three ways to run, provider setup, the production check
 
 Other ways to run: clone the repo and run any [example](packages/core/examples/) with `npx tsx packages/core/examples/basics/team-collaboration.ts`, or embed OMA in a real backend with the [Express](packages/core/examples/integrations/express-customer-support/) and [Next.js](packages/core/examples/integrations/with-vercel-ai-sdk/) apps. To skip local setup, the [Next.js starter](https://github.com/open-multi-agent/oma-nextjs-starter) deploys to Vercel in one click; local models via [Ollama](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) need no API key.
 
-## How is this different from X?
-
-Most TypeScript teams picking a multi-agent layer are really choosing between OMA, LangGraph JS, and Mastra. The mechanism is what differs.
-
-**vs. LangGraph JS.** LangGraph has you design a declarative graph (nodes, edges, conditional routing) up front, then compiles it into an invokable; OMA's Coordinator decomposes the goal into a task DAG at runtime and auto-parallelizes independents. Both checkpoint and resume, though LangGraph's persistence ecosystem runs deeper. Reach for OMA when the plan should adapt to the goal instead of being wired ahead of time.
-
-**vs. Mastra.** Both are TypeScript-native; the difference is who drives orchestration. Mastra has you wire the workflow by hand. OMA is goal-driven: hand its Coordinator a goal and it builds the task DAG at runtime. `runTeam(team, goal)` in one call.
-
-**vs. CrewAI.** CrewAI is the established multi-agent option in Python. OMA brings goal-driven decomposition to TypeScript backends with a lean runtime (three core dependencies, plus opt-in peers you install only when you use them) and direct Node.js embedding, with no separate Python service to stand up alongside your stack.
-
-**vs. Vercel AI SDK.** AI SDK is the LLM-call layer (provider abstraction, streaming, tool calls, and structured outputs), not a multi-agent orchestrator. Use it alone for single-agent calls; reach for OMA the moment you need a coordinated team. OMA even ships an optional AI SDK bridge.
-
 ## Ecosystem
 
 `open-multi-agent` launched 2026-04-01 under MIT. Known users and integrations to date:
@@ -97,6 +92,12 @@ Most TypeScript teams picking a multi-agent layer are really choosing between OM
 - **[CodingScaffold](https://github.com/JRS1986/CodingScaffold)** — Agentic-coding scaffold that lists OMA as an optional orchestration backend, with a `runTeam` workflow template.
 
 Using `open-multi-agent` in production or a side project? [Open a discussion](https://github.com/open-multi-agent/open-multi-agent/discussions) and we will list it here. For a deep integration, see the [Featured partner program](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/featured-partner.md).
+
+## How is this different from X?
+
+Most TypeScript teams choosing a multi-agent layer are weighing OMA against LangGraph JS, Mastra, CrewAI, and the Vercel AI SDK. The short version: OMA is goal-driven. Hand its Coordinator a goal and it builds the task DAG at runtime, instead of making you wire the graph up front.
+
+Full head-to-head on each on the package page: [How is this different?](packages/core/README.md#how-is-this-different-from-x)
 
 ## Repository
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -34,6 +34,13 @@
 <br />
 
 <p align="center">
+  <a href="https://open-multi-agent.com/zh/">官网</a> ·
+  <a href="https://open-multi-agent.com/zh/getting-started/introduction/">文档</a> ·
+  <a href="https://www.npmjs.com/package/@open-multi-agent/core">npm</a> ·
+  <a href="https://github.com/open-multi-agent/open-multi-agent/discussions">讨论区</a>
+</p>
+
+<p align="center">
   <a href="./README.md">English</a> · <strong>中文</strong>
 </p>
 
@@ -75,18 +82,6 @@ npm install @open-multi-agent/core
   <img src="https://raw.githubusercontent.com/open-multi-agent/open-multi-agent/main/.github/brand/wechat-qr.jpg" alt="微信扫码添加 JackChen 咨询" width="180">
 </p>
 
-## 与其他框架对比
-
-大多数 TypeScript 团队在选择多智能体编排层时，实际是在 OMA、LangGraph JS、Mastra 之间取舍。差异在于机制。
-
-**对比 LangGraph JS。** LangGraph 需先设计好声明式图（节点、边、条件路由），再编译为可调用对象；OMA 的 Coordinator 则在运行时将目标拆解为任务 DAG，并自动并行其中的无依赖项。两者均支持 checkpoint 与 resume，只是 LangGraph 的持久化生态更为完善。若需让编排随目标自适应、而非预先固定图结构，OMA 更为合适。
-
-**对比 Mastra。** 两者均为原生 TypeScript，差异在于由谁驱动编排。Mastra 需手工连接工作流；OMA 则是目标驱动：将目标交给 Coordinator，即可在运行时自动构建任务 DAG。`runTeam(team, goal)` 一行调用即可。
-
-**对比 CrewAI。** CrewAI 是 Python 生态中成熟的多智能体方案。OMA 将目标驱动的任务拆解引入 TypeScript 后端，运行时精简（三个核心依赖，外加按需安装的可选 peer），直接嵌入 Node.js，无需在既有技术栈之外另行部署独立的 Python 服务。
-
-**对比 Vercel AI SDK。** AI SDK 是 LLM 调用层（provider 抽象、流式、tool call、结构化输出），而非多智能体编排器。单 agent 调用单独用它即可；一旦需要协同的团队，则选用 OMA。OMA 亦提供可选的 AI SDK bridge。
-
 ## 生态
 
 `open-multi-agent` 2026-04-01 发布，MIT 协议。当前公开在用与集成的项目：
@@ -105,6 +100,12 @@ npm install @open-multi-agent/core
 - **[CodingScaffold](https://github.com/JRS1986/CodingScaffold)** — agentic-coding 脚手架，把 OMA 列为可选编排后端，附带 `runTeam` 工作流模板。
 
 在生产或 side project 中使用了 `open-multi-agent`？[请开个 Discussion](https://github.com/open-multi-agent/open-multi-agent/discussions)，我们会将其列在这里。深度集成的产品见 [Featured partner 计划](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/featured-partner.md)。
+
+## 与其他框架对比
+
+大多数 TypeScript 团队选多智能体编排层时，实际是在 OMA、LangGraph JS、Mastra、CrewAI、Vercel AI SDK 之间取舍。一句话：OMA 是目标驱动的，把目标交给 Coordinator，它在运行时构建任务 DAG，而不必你预先把图连好。
+
+逐个正面对比见包页：[与其他框架对比](packages/core/README_zh.md#与其他框架对比)
 
 ## 仓库结构
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -34,6 +34,13 @@
 <br />
 
 <p align="center">
+  <a href="https://open-multi-agent.com">Website</a> ·
+  <a href="https://open-multi-agent.com/getting-started/introduction/">Docs</a> ·
+  <a href="https://www.npmjs.com/package/@open-multi-agent/core">npm</a> ·
+  <a href="https://github.com/open-multi-agent/open-multi-agent/discussions">Discussions</a>
+</p>
+
+<p align="center">
   <strong>English</strong> · <a href="./README_zh.md">中文</a>
 </p>
 
@@ -168,7 +175,8 @@ Route orchestration phases to different models with an opt-in `modelRouting` pol
 | **Pin and replay plans** | Serialize a `planOnly` decomposition with `createPlanArtifact`, then `runFromPlan` replays the exact task graph without re-invoking the coordinator. ([`patterns/plan-replay`](examples/patterns/plan-replay.ts)) |
 | **Lifecycle hooks + cancellation** | `beforeRun` rewrites the prompt, `afterRun` post-processes or rejects the result; pass an `AbortSignal` to cancel a run in flight. |
 | **Configurable coordinator** | Override the coordinator's model, provider, adapter, system prompt, or tools via `runTeam(team, goal, { coordinator })`. |
-| **Observability** | `onProgress` events, `onTrace` spans, post-run HTML dashboard rendering the executed task DAG. API keys and tokens are redacted from traces, bash output, and the dashboard. ([observability guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)) |
+| **External coding agents (ACP)** | Swap an agent's LLM loop for an external coding CLI over the [Agent Client Protocol](https://agentclientprotocol.com): set `backend: { kind: 'acp', … }` and the subprocess runs its own turns, while the pool, scheduler, queue, shared memory, and budget stay backend-agnostic. ([external agents](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/external-agents.md)) |
+| **Observability** | `onProgress` events, `onTrace` spans, post-run HTML dashboard rendering the executed task DAG, plus a run-level metrics rollup on `TeamRunResult.metrics` (tokens, retries, error/failure counts, task-duration stats). API keys and tokens are redacted from traces, bash output, and the dashboard. ([observability guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)) |
 | **Pluggable shared memory** | Default in-process KV; swap in Redis / Postgres / your own backend by implementing `MemoryStore`. ([shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md)) |
 | **Checkpoint & resume** | Opt-in per-run checkpointing over any `MemoryStore`: snapshot on each completed task, then `restore()` skips finished tasks to continue after a crash or restart. The bundled zero-dependency `FileStore` makes checkpoints durable out of the box; best-effort saves never take the run down. ([checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md)) |
 | **Sandboxed filesystem workspace** | Built-in filesystem tools are sandboxed to `<cwd>/.agent-workspace` by default; agents sharing the default configuration share this root. For per-agent isolation, set `AgentConfig.cwd`; for a different shared root, set `OrchestratorConfig.defaultCwd`; pass `null` to disable. ([sandbox config](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md)) |
@@ -474,6 +482,10 @@ Issues, feature requests, and PRs are welcome. Some areas where contributions wo
 - [@dvirarad](https://github.com/dvirarad) (OpenAI-family adapter hardening)
 - [@cat0825](https://github.com/cat0825) (model routing policy, plan replay, structured shared-memory handoff)
 - [@mvanhorn](https://github.com/mvanhorn) (checkpoint & resume)
+- [@lesbass](https://github.com/lesbass) (run-level metrics rollup on `TeamRunResult`)
+- [@tlysanhuo](https://github.com/tlysanhuo) (trace span parent linkage)
+- [@LambIessz](https://github.com/LambIessz) (orchestrator cost budget, MessageBus persistence in checkpoints)
+- [@Bobuyoucrypto](https://github.com/Bobuyoucrypto) (Windows bash timeout process-tree kill)
 
 **Provider integrations**
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -34,6 +34,13 @@
 <br />
 
 <p align="center">
+  <a href="https://open-multi-agent.com/zh/">官网</a> ·
+  <a href="https://open-multi-agent.com/zh/getting-started/introduction/">文档</a> ·
+  <a href="https://www.npmjs.com/package/@open-multi-agent/core">npm</a> ·
+  <a href="https://github.com/open-multi-agent/open-multi-agent/discussions">讨论区</a>
+</p>
+
+<p align="center">
   <a href="./README.md">English</a> · <strong>中文</strong>
 </p>
 
@@ -168,7 +175,8 @@ const result = await orchestrator.runFromPlan(team, plan)
 | **固定并重放计划** | 用 `createPlanArtifact` 将 `planOnly` 的拆解结果序列化，之后 `runFromPlan` 不再调用协调者，直接重放完全相同的任务图。（[`patterns/plan-replay`](examples/patterns/plan-replay.ts)） |
 | **生命周期钩子 + 取消** | `beforeRun` 改写 prompt，`afterRun` 后处理或拒绝结果；传入 `AbortSignal` 即可中途取消运行。 |
 | **可配置协调者** | 通过 `runTeam(team, goal, { coordinator })` 覆盖协调者的 model、provider、adapter、system prompt 或工具。 |
-| **可观测性** | `onProgress` 事件、`onTrace` span，运行结束后渲染任务 DAG 的 HTML dashboard。API key 和 token 会从 trace、bash 输出和 dashboard 中自动脱敏。([可观测性指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)) |
+| **外部编码 agent（ACP）** | 把某个 agent 的 LLM 循环换成通过 [Agent Client Protocol](https://agentclientprotocol.com) 驱动的外部编码 CLI：设置 `backend: { kind: 'acp', … }`，子进程自行运行其回合，而 pool、scheduler、queue、共享记忆与预算全部与 backend 无关。([外部 agent](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/external-agents.md)) |
+| **可观测性** | `onProgress` 事件、`onTrace` span，运行结束后渲染任务 DAG 的 HTML dashboard，外加 `TeamRunResult.metrics` 运行级指标汇总（token、重试、错误/失败计数、任务时长统计）。API key 和 token 会从 trace、bash 输出和 dashboard 中自动脱敏。([可观测性指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)) |
 | **可插拔共享记忆** | 默认进程内 KV；实现 `MemoryStore` 接口即可换 Redis / Postgres / 自有后端。([共享记忆](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md)) |
 | **Checkpoint & resume** | 可选的按运行 checkpoint，运行于任意 `MemoryStore` 之上：每个任务完成时快照，`restore()` 跳过已完成任务，崩溃或重启后可恢复运行。内置的零依赖 `FileStore` 让 checkpoint 无需额外后端即可持久化；存盘 best-effort，不会拖慢运行。([checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md)) |
 | **沙箱化文件系统工作目录** | 内置文件系统工具默认沙箱化在 `<cwd>/.agent-workspace`；继承默认配置的 agent 共享同一根目录。需要 per-agent 隔离时显式设置 `AgentConfig.cwd`；改换共享根目录用 `OrchestratorConfig.defaultCwd`；传 `null` 关闭沙箱。([沙箱配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md)) |
@@ -474,6 +482,10 @@ Issue、feature request、PR 都欢迎。特别欢迎以下方面的贡献：
 - [@dvirarad](https://github.com/dvirarad)（OpenAI 系列 adapter 健壮性）
 - [@cat0825](https://github.com/cat0825)（model routing 策略、plan 重放、结构化共享记忆 handoff）
 - [@mvanhorn](https://github.com/mvanhorn)（checkpoint & resume）
+- [@lesbass](https://github.com/lesbass)（`TeamRunResult` 运行级 metrics 汇总）
+- [@tlysanhuo](https://github.com/tlysanhuo)（trace span 父级链接）
+- [@LambIessz](https://github.com/LambIessz)（orchestrator 成本预算、MessageBus 持久化进 checkpoint）
+- [@Bobuyoucrypto](https://github.com/Bobuyoucrypto)（Windows bash 超时杀进程树）
 
 **Provider 集成**
 


### PR DESCRIPTION
Across the four READMEs (root + package, EN + ZH):

- **Website presence.** New official-links row (Website / Docs / npm / Discussions) under the title in all four files, pointing at open-multi-agent.com and its docs. The language toggle keeps its own row and its job. Chinese links resolve to the `/zh/` locale.
- **Comparison placement (root only).** Move "How is this different from X?" from right after Get started to after Ecosystem, so the ecosystem proof comes first, and trim the root copy to a two-sentence teaser that links the full comparison on the package page (it was a verbatim copy).
- **Contributor credits (package only).** Add four contributors whose PRs merged after the credits were last refreshed (2026-06-19): run-level metrics rollup, trace span parent linkage, orchestrator cost budget with MessageBus checkpoint persistence, and the Windows bash timeout fix.
- **Features refresh (package only).** Add an "External coding agents (ACP)" row; note the run-level metrics rollup on the Observability row.

Docs-only; no source changes. Enterprise-services (YuanASI) copy is intentionally kept in the Chinese README only.
