### PR TITLE
chore: release core v1.10.0 + create-oma-app v0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6466,7 +6466,7 @@
     },
     "packages/core": {
       "name": "@open-multi-agent/core",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
@@ -6519,7 +6519,7 @@
       }
     },
     "packages/create-oma-app": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "bin": {
         "create-oma-app": "dist/index.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "TypeScript multi-agent framework: one runTeam() call from goal to result. Auto task decomposition and parallel execution for multi-step LLM jobs. Deploys anywhere Node.js runs.",
   "files": [
     "dist",

--- a/packages/create-oma-app/package.json
+++ b/packages/create-oma-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-oma-app",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Scaffold a runnable multi-agent demo on @open-multi-agent/core — one command from zero to a live agent DAG.",
   "type": "module",
   "bin": {

--- a/packages/create-oma-app/template/package.json
+++ b/packages/create-oma-app/template/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.9.0"
+    "@open-multi-agent/core": "1.10.0"
   },
   "devDependencies": {
     "tsx": "^4.21.0"


### PR DESCRIPTION
Release core 1.10.0 (minor) and create-oma-app 0.3.1 (patch).

## core 1.10.0

6 features + 1 fix since 1.9.0:

- External coding agents over ACP (#360)
- Orchestrator cost budget (#358)
- Per-agent scoped tool credentials (#362)
- Secret redaction on the persistence path via RedactingStore (#359)
- MessageBus persisted in checkpoints (#363)
- Trace span parent linkage (#354)
- Windows: kill full process tree on bash timeout (#357)

## create-oma-app 0.3.1

No code changes. Bumps the template's `@open-multi-agent/core` pin to 1.10.0 (CI-enforced) and republishes so `npm create oma-app` scaffolds on the new core.

Bump only: 3 `package.json` versions + lockfile. Full notes go in the GitHub release.
