### PR TITLE
docs(readme): add Claude Code dynamic workflows comparison and sharpen planning wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 
 > **Your engineers describe the goal, not the graph.**
 
-Graph-first frameworks make you enumerate every node and edge up front. OMA runs a **dynamic workflow**: the task DAG is built at runtime, so it adapts to the goal instead of being hand-wired for one. The coordinator emits that plan as data for a deterministic scheduler to execute, so the plan is inspectable and replayable.
+Graph-first frameworks make you enumerate every node and edge up front. OMA runs a **dynamic workflow**: the task DAG is built at runtime, so it adapts to the goal instead of being hand-wired for one. The coordinator emits that plan as data for a deterministic scheduler to execute, so the plan is inspectable and replayable. It is the same bet Anthropic made with Claude Code's [dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code) in May 2026, offered here as an open library that runs on any provider, inside your own backend.
 
 `@open-multi-agent/core` keeps a lightweight core. The orchestration engine plus the mainstream model providers (Anthropic, OpenAI, and any OpenAI-compatible endpoint) work out of the box; additional providers (Gemini, Bedrock), MCP, and the Vercel AI SDK bridge are opt-in peer dependencies you install only when you use them.
 
@@ -95,7 +95,9 @@ Using `open-multi-agent` in production or a side project? [Open a discussion](ht
 
 ## How is this different from X?
 
-Most TypeScript teams choosing a multi-agent layer are weighing OMA against LangGraph JS, Mastra, CrewAI, and the Vercel AI SDK. The short version: OMA is goal-driven. Hand its Coordinator a goal and it builds the task DAG at runtime, instead of making you wire the graph up front.
+Most TypeScript teams choosing a multi-agent layer are weighing OMA against LangGraph JS, Mastra, CrewAI, and the Vercel AI SDK. The short version: OMA is goal-driven, dynamic planning instead of rigid hand-wired graphs. Hand its Coordinator a goal and it builds the task DAG at runtime.
+
+That comparison includes Claude Code's own [dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code), and OMA is composable with it rather than only competing: over [ACP](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/external-agents.md), an OMA team can run Claude Code itself as one of its agents.
 
 Full head-to-head on each on the package page: [How is this different?](packages/core/README.md#how-is-this-different-from-x)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -50,7 +50,7 @@
 
 > **工程师只描述目标，不画任务图。**
 
-图优先的框架要求预先列出每个节点与每条边；OMA 是**动态工作流**（dynamic workflow）：任务 DAG 在运行时生成，随目标自适应，而非针对单一流程预先固化。协调者将该计划以数据形式交给确定性调度器执行，因此该计划可审查、可回放。
+图优先的框架要求预先列出每个节点与每条边；OMA 是**动态工作流**（dynamic workflow）：任务 DAG 在运行时生成，随目标自适应，而非针对单一流程预先固化。协调者将该计划以数据形式交给确定性调度器执行，因此该计划可审查、可回放。这与 Anthropic 在 2026 年 5 月为 Claude Code 推出的 [dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code) 是同一方向的押注；OMA 以开源库的形式把它带入任意 provider、你自己的后端。
 
 `@open-multi-agent/core` 坚持轻量内核：编排引擎加上主流模型 provider（Anthropic、OpenAI 及任意 OpenAI 兼容端点）开箱即用；额外的 provider（Gemini、Bedrock）、MCP、Vercel AI SDK bridge 均为可选 peer 依赖，按需安装。
 
@@ -103,7 +103,9 @@ npm install @open-multi-agent/core
 
 ## 与其他框架对比
 
-大多数 TypeScript 团队选多智能体编排层时，实际是在 OMA、LangGraph JS、Mastra、CrewAI、Vercel AI SDK 之间取舍。一句话：OMA 是目标驱动的，把目标交给 Coordinator，它在运行时构建任务 DAG，而不必你预先把图连好。
+大多数 TypeScript 团队选多智能体编排层时，实际是在 OMA、LangGraph JS、Mastra、CrewAI、Vercel AI SDK 之间取舍。一句话：OMA 是目标驱动的，动态规划而非僵化的手工连线图。把目标交给 Coordinator，它在运行时构建任务 DAG。
+
+这一对比也涵盖 Claude Code 自身的 [dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code)；相较于单纯竞争，OMA 与它更是可组合的：通过 [ACP](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/external-agents.md)，OMA 团队可以把 Claude Code 本身作为其中一个 agent 来编排。
 
 逐个正面对比见包页：[与其他框架对比](packages/core/README_zh.md#与其他框架对比)
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -50,7 +50,7 @@
 
 > **Your engineers describe the goal, not the graph.**
 
-Graph-first frameworks make you enumerate every node and edge up front. OMA runs a **dynamic workflow**: the task DAG is built at runtime, so it adapts to the goal instead of being hand-wired for one. The coordinator emits that plan as data for a deterministic scheduler to execute, so the plan is inspectable and replayable.
+Graph-first frameworks make you enumerate every node and edge up front. OMA runs a **dynamic workflow**: the task DAG is built at runtime, so it adapts to the goal instead of being hand-wired for one. The coordinator emits that plan as data for a deterministic scheduler to execute, so the plan is inspectable and replayable. It is the same bet Anthropic made with Claude Code's [dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code) in May 2026, offered here as an open library that runs on any provider, inside your own backend.
 
 `@open-multi-agent/core` keeps a lightweight core. The orchestration engine plus the mainstream model providers (Anthropic, OpenAI, and any OpenAI-compatible endpoint) work out of the box; additional providers (Gemini, Bedrock), MCP, and the Vercel AI SDK bridge are opt-in peer dependencies you install only when you use them.
 
@@ -304,7 +304,7 @@ Run any script with `npx tsx packages/core/examples/<path>.ts`; the full applica
 
 ## How is this different from X?
 
-Most TypeScript teams picking a multi-agent layer are really choosing between OMA, LangGraph JS, and Mastra. The mechanism is what differs.
+Most TypeScript teams picking a multi-agent layer are really choosing between OMA, LangGraph JS, and Mastra. The mechanism is what differs: dynamic planning instead of rigid hand-wired graphs.
 
 **vs. LangGraph JS.** LangGraph has you design a declarative graph (nodes, edges, conditional routing) up front, then compiles it into an invokable; OMA's Coordinator decomposes the goal into a task DAG at runtime and auto-parallelizes independents. Both checkpoint and resume, though LangGraph's persistence ecosystem runs deeper. Reach for OMA when the plan should adapt to the goal instead of being wired ahead of time.
 
@@ -313,6 +313,8 @@ Most TypeScript teams picking a multi-agent layer are really choosing between OM
 **vs. CrewAI.** CrewAI is the established multi-agent option in Python. OMA brings goal-driven decomposition to TypeScript backends with a lean runtime (three core dependencies, plus opt-in peers you install only when you use them) and direct Node.js embedding, with no separate Python service to stand up alongside your stack.
 
 **vs. Vercel AI SDK.** AI SDK is the LLM-call layer (provider abstraction, streaming, tool calls, and structured outputs), not a multi-agent orchestrator. Use it alone for single-agent calls; reach for OMA the moment you need a coordinated team. OMA even ships an optional AI SDK bridge.
+
+**vs. Claude Code's dynamic workflows.** Anthropic shipped [dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code) in Claude Code in May 2026: Claude writes its own orchestration scripts and fans out parallel subagents inside a session. The difference is form factor: dynamic workflows run inside Claude Code on Claude subagents, while OMA embeds the same goal-to-DAG mechanism in your own Node.js backend as an MIT library, on any provider. The plan stays data you can inspect and replay (`planOnly`, `createPlanArtifact`, `runFromPlan`), and over [ACP](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/external-agents.md) an OMA team can even run Claude Code itself as one of its agents.
 
 ## Architecture
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -50,7 +50,7 @@
 
 > **工程师只描述目标，不画任务图。**
 
-图优先的框架要求预先列出每个节点与每条边；OMA 是**动态工作流**（dynamic workflow）：任务 DAG 在运行时生成，随目标自适应，而非针对单一流程预先固化。协调者将该计划以数据形式交给确定性调度器执行，因此该计划可审查、可回放。
+图优先的框架要求预先列出每个节点与每条边；OMA 是**动态工作流**（dynamic workflow）：任务 DAG 在运行时生成，随目标自适应，而非针对单一流程预先固化。协调者将该计划以数据形式交给确定性调度器执行，因此该计划可审查、可回放。这与 Anthropic 在 2026 年 5 月为 Claude Code 推出的 [dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code) 是同一方向的押注；OMA 以开源库的形式把它带入任意 provider、你自己的后端。
 
 `@open-multi-agent/core` 坚持轻量内核：编排引擎加上主流模型 provider（Anthropic、OpenAI 及任意 OpenAI 兼容端点）开箱即用；额外的 provider（Gemini、Bedrock）、MCP、Vercel AI SDK bridge 均为可选 peer 依赖，按需安装。
 
@@ -304,7 +304,7 @@ await orchestrator.runTeam(team, goal, {
 
 ## 与其他框架对比
 
-大多数 TypeScript 团队在选择多智能体编排层时，实际是在 OMA、LangGraph JS、Mastra 之间取舍。差异在于机制。
+大多数 TypeScript 团队在选择多智能体编排层时，实际是在 OMA、LangGraph JS、Mastra 之间取舍。差异在于机制：动态规划，而非僵化的手工连线图。
 
 **对比 LangGraph JS。** LangGraph 需先设计好声明式图（节点、边、条件路由），再编译为可调用对象；OMA 的 Coordinator 则在运行时将目标拆解为任务 DAG，并自动并行其中的无依赖项。两者均支持 checkpoint 与 resume，只是 LangGraph 的持久化生态更为完善。若需让编排随目标自适应、而非预先固定图结构，OMA 更为合适。
 
@@ -313,6 +313,8 @@ await orchestrator.runTeam(team, goal, {
 **对比 CrewAI。** CrewAI 是 Python 生态中成熟的多智能体方案。OMA 将目标驱动的任务拆解引入 TypeScript 后端，运行时精简（三个核心依赖，外加按需安装的可选 peer），直接嵌入 Node.js，无需在既有技术栈之外另行部署独立的 Python 服务。
 
 **对比 Vercel AI SDK。** AI SDK 是 LLM 调用层（provider 抽象、流式、tool call、结构化输出），而非多智能体编排器。单 agent 调用单独用它即可；一旦需要协同的团队，则选用 OMA。OMA 亦提供可选的 AI SDK bridge。
+
+**对比 Claude Code 的 dynamic workflows。** Anthropic 于 2026 年 5 月在 Claude Code 中推出 [dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code)：由 Claude 自行编写编排脚本，在会话内并行派生子 agent。差异在于形态：dynamic workflows 运行于 Claude Code 内部、面向 Claude 子 agent，而 OMA 以 MIT 协议的库形式，把同一套目标到 DAG 的机制嵌入你自己的 Node.js 后端，可用任意 provider。计划始终是可审查、可回放的数据（`planOnly`、`createPlanArtifact`、`runFromPlan`）；通过 [ACP](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/external-agents.md)，OMA 团队甚至可以把 Claude Code 本身作为其中一个 agent 来编排。
 
 ## 架构
 


### PR DESCRIPTION
Adds a `vs. Claude Code's dynamic workflows` comparison across the four README copies and sharpens the comparison intro to name the mechanism.

**Why.** Anthropic shipped dynamic workflows in May 2026, putting "the model plans the work at runtime" in front of a large audience. Developers picking an orchestration layer now ask how OMA relates to it, so the READMEs answer directly: same bet, different form factor. Dynamic workflows run inside Claude Code on Claude subagents; OMA embeds the same goal-to-DAG mechanism in your own Node.js backend, on any provider, as an MIT library. The two compose rather than only compete: over ACP an OMA team can run Claude Code itself as one of its agents.

**Changes (root + package, EN + ZH).**
- Hero: one sentence placing OMA alongside the dynamic workflows bet.
- Comparison intro: "dynamic planning instead of rigid hand-wired graphs".
- Comparison body: package READMEs get a full entry (form factor, planOnly / createPlanArtifact / runFromPlan, ACP composability); root READMEs get a one-line ACP note.

Docs only. \`npm run lint && npm test\` green locally (1168 + 6 tests).