### PR TITLE
feat(core): add run identity and outcome semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ npm test               # run the test suite
 
 - [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) — env vars, model examples, local tool-calling, timeouts, troubleshooting.
 - [Tool configuration](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) — tool presets, custom tools, the filesystem sandbox, and MCP.
-- [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — `onProgress` events, `onTrace` spans, and the post-run dashboard.
+- [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — stable run identity and outcome semantics on every top-level result, plus `onProgress`, `onTrace`, and the post-run dashboard.
 - [Shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — the default store and custom `MemoryStore` backends.
-- [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — opt-in per-run snapshot/resume over any `MemoryStore`; survive crashes and restarts.
+- [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — opt-in snapshots over any `MemoryStore`; restore preserves `runId`, increments `attempt`, and starts a fresh trace.
 - [Context management](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — sliding window, summarization, compaction, and custom compressors.
 - [CLI](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/cli.md) — the JSON-first `oma` binary for shell and CI.
 - [Consensus](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/consensus.md) — the `runConsensus` proposer→judge primitive, the per-task `verify` hook, and the budget invariant.

--- a/README_zh.md
+++ b/README_zh.md
@@ -136,9 +136,9 @@ npm test               # 运行测试套件
 
 - [Provider](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) — 环境变量、模型示例、本地模型工具调用、超时、常见问题。
 - [工具配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) — 工具预设、自定义工具、文件系统沙箱、MCP。
-- [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — `onProgress` 事件、`onTrace` span、运行后 dashboard。
+- [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — 每个顶层结果都包含稳定的运行标识（identity）与结果（outcome）语义，并提供 `onProgress`、`onTrace` 和运行后 dashboard。
 - [共享记忆](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — 默认存储与自定义 `MemoryStore` 后端。
-- [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — 可选的按运行快照/恢复，跑在任意 `MemoryStore` 上；崩溃、重启后可续跑。
+- [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — 在任意 `MemoryStore` 上保存可选快照；`restore()` 保留 `runId`、递增 `attempt`，并启动新的 trace。
 - [上下文管理](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — 滑动窗口、摘要、压缩、自定义压缩器。
 - [CLI](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/cli.md) — 面向 shell 和 CI 的 JSON-first `oma` 命令行。
 - [Consensus](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/consensus.md) — `runConsensus` proposer→judge 原语、按任务的 `verify` 钩子，以及预算不变量。

--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -106,11 +106,21 @@ await orchestrator.restore(team,        { checkpoint: { store } })  // resume-on
 
 On each successfully completed task, the orchestrator writes a `CheckpointSnapshot`:
 
+- **Execution identity (schema v2)** — `runId`, current `attempt`,
+  `lastTraceId`, and `lastRootSpanId`. Restore preserves the logical `runId`,
+  increments `attempt`, creates fresh trace/root IDs, and returns a
+  `continued_from` link to the prior attempt.
 - **Task queue state** — every task and its status partition (pending / in-progress / completed / failed / blocked / skipped).
 - **Shared memory** — the turn counter is always recorded. The full entry snapshot is embedded **only when the checkpoint store differs from the team's shared-memory store**. When they are the same store (the default for `checkpoint: true`), the entries are already durable there, so re-embedding them every task would be wasted ~O(N²) write volume across a long run; resume reads them straight from the store instead. Either way, resume rehydrates shared memory correctly.
 - **Completed task results** — `taskId`, `assignee`, and `result` for each finished task, so resumed agents see prior outputs.
 
 Snapshots are stored as JSON under a reserved namespace: `__oma_checkpoint__/<runId>/latest` (or `__oma_checkpoint__/latest` when no `runId` is set). Keys under `__oma_checkpoint__/` are reserved — shared-memory snapshot/restore deliberately skips them so one store can hold both agent memory and checkpoints.
+
+New writes use checkpoint schema v2. Schema v1 remains readable: its optional
+top-level `runId` is preserved, and restore treats the saved execution as
+attempt 1. A v1 checkpoint without `runId` receives a new logical run ID. If a
+caller-supplied restore `runId` conflicts with the snapshot, restore throws a
+validation error instead of joining unrelated runs.
 
 ### Saves are best-effort
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,6 +2,37 @@
 
 `open-multi-agent` exposes three telemetry layers: live progress events, structured trace spans, and a static post-run dashboard.
 
+## Run identity and outcome
+
+Every top-level execution (`runAgent`, `runTeam`, `runTasks`, `runFromPlan`,
+`runConsensus`, and `restore`) returns an identity even when `onTrace` is not
+configured:
+
+```typescript
+const result = await orchestrator.runTasks(team, tasks, { runId: 'order-42' })
+
+result.identity // { runId, attempt, traceId, rootSpanId, links? } at runtime
+result.status   // { code, message? } at runtime
+result.errorInfo // redacted, JSON-safe details on failures
+```
+
+`runId` identifies a logical run and can be supplied by the caller (1-128
+characters). `attempt` starts at 1. Each execution attempt gets a new 32-hex
+`traceId` and 16-hex `rootSpanId`. Restore preserves `runId`, increments
+`attempt`, generates new trace/root IDs, and links to the previous attempt when
+restoring a v2 checkpoint.
+
+Status codes are `ok`, `error`, `cancelled`, `timeout`, `budget_exhausted`,
+`rejected`, and `skipped`. Existing `success` fields remain available and are
+derived from `status.code === 'ok'`; cancellations and whole-run timeouts are
+therefore no longer reported as successful runs. A rejected consensus verdict
+is still an `ok` execution outcome—the verdict is a domain result, not a runtime
+failure.
+
+For source compatibility in the first 1.x release, the new result fields are
+optional in TypeScript declarations, but every runtime result from these APIs
+includes `identity` and `status`.
+
 ## Progress Events
 
 Use `onProgress` when you need lightweight lifecycle events for logs, terminal output, or a live UI.
@@ -54,7 +85,8 @@ For production runs, persist enough data to reconstruct a failure without replay
 
 - `TeamRunResult.tasks` for the executed DAG and task states.
 - `TeamRunResult.totalTokenUsage` for cost attribution.
-- `onTrace` spans for LLM calls and tool executions, keyed by `runId` + `spanId`.
+- `result.identity` and `result.status` as the stable run lookup and outcome.
+- `onTrace` spans for LLM calls and tool executions, keyed by legacy `runId` + `spanId`.
 - The rendered dashboard HTML when you need a shareable post-mortem artifact.
 
 > **Redaction scope.** The redaction noted above applies to *telemetry* — trace spans and the dashboard payload. It does **not** cover persisted run state: shared-memory writes and checkpoint saves store agent output verbatim. To scrub secrets there, wrap the durable store with [`RedactingStore`](shared-memory.md#redacting-persisted-secrets).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -106,7 +106,8 @@ const result = await orchestrator.runTeam(
   `Create a REST API for a todo list in ${process.cwd()}/.agent-workspace/todo-api/`,
 )
 
-console.log(result.success, result.totalTokenUsage.output_tokens)
+console.log(result.success, result.status?.code, result.identity?.runId)
+console.log(result.totalTokenUsage.output_tokens)
 ```
 
 ### Run an example locally
@@ -176,9 +177,9 @@ Route orchestration phases to different models with an opt-in `modelRouting` pol
 | **Lifecycle hooks + cancellation** | `beforeRun` rewrites the prompt, `afterRun` post-processes or rejects the result; pass an `AbortSignal` to cancel a run in flight. |
 | **Configurable coordinator** | Override the coordinator's model, provider, adapter, system prompt, or tools via `runTeam(team, goal, { coordinator })`. |
 | **External coding agents (ACP)** | Swap an agent's LLM loop for an external coding CLI over the [Agent Client Protocol](https://agentclientprotocol.com): set `backend: { kind: 'acp', … }` and the subprocess runs its own turns, while the pool, scheduler, queue, shared memory, and budget stay backend-agnostic. ([external agents](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/external-agents.md)) |
-| **Observability** | `onProgress` events, `onTrace` spans, post-run HTML dashboard rendering the executed task DAG, plus a run-level metrics rollup on `TeamRunResult.metrics` (tokens, retries, error/failure counts, task-duration stats). API keys and tokens are redacted from traces, bash output, and the dashboard. ([observability guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)) |
+| **Observability** | Every top-level result carries stable `identity` (`runId`, `attempt`, `traceId`, `rootSpanId`) and normalized `status`, even without `onTrace`; `onProgress` events, trace spans, a post-run HTML dashboard, and `TeamRunResult.metrics` remain available. API keys and tokens are redacted from traces, errors, bash output, and the dashboard. ([observability guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)) |
 | **Pluggable shared memory** | Default in-process KV; swap in Redis / Postgres / your own backend by implementing `MemoryStore`. ([shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md)) |
-| **Checkpoint & resume** | Opt-in per-run checkpointing over any `MemoryStore`: snapshot on each completed task, then `restore()` skips finished tasks to continue after a crash or restart. The bundled zero-dependency `FileStore` makes checkpoints durable out of the box; best-effort saves never take the run down. ([checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md)) |
+| **Checkpoint & resume** | Opt-in per-run checkpointing over any `MemoryStore`: snapshot on each completed task, then `restore()` skips finished tasks to continue after a crash or restart. Checkpoint v2 preserves `runId`, increments `attempt`, and starts a fresh trace; v1 snapshots remain readable. The bundled zero-dependency `FileStore` makes checkpoints durable out of the box; best-effort saves never take the run down. ([checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md)) |
 | **Sandboxed filesystem workspace** | Built-in filesystem tools are sandboxed to `<cwd>/.agent-workspace` by default; agents sharing the default configuration share this root. For per-agent isolation, set `AgentConfig.cwd`; for a different shared root, set `OrchestratorConfig.defaultCwd`; pass `null` to disable. ([sandbox config](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md)) |
 
 Production controls ([context strategies](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md), task retry with backoff, loop detection, tool output truncation/compression) are covered in the [Production Checklist](#production-checklist).
@@ -441,9 +442,9 @@ Before going live, wire up the controls that protect token spend, recover from f
 
 - [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) — env vars, model examples, local tool-calling, timeouts, troubleshooting.
 - [Tool configuration](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) — tool presets, custom tools, the filesystem sandbox, and MCP.
-- [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — `onProgress` events, `onTrace` spans, and the post-run dashboard.
+- [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — stable run identity and outcome semantics on every top-level result, plus `onProgress`, `onTrace`, and the post-run dashboard.
 - [Shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — the default store and custom `MemoryStore` backends.
-- [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — opt-in per-run snapshot/resume over any `MemoryStore`; survive crashes and restarts.
+- [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — checkpoint v2 identity rules, v1 compatibility, and restore over any `MemoryStore`.
 - [Context management](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — sliding window, summarization, compaction, and custom compressors.
 - [CLI](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/cli.md) — the JSON-first `oma` binary for shell and CI.
 - [Consensus](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/consensus.md) — the `runConsensus` proposer→judge primitive, the per-task `verify` hook, and the budget invariant.

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -106,7 +106,8 @@ const result = await orchestrator.runTeam(
   `Create a REST API for a todo list in ${process.cwd()}/.agent-workspace/todo-api/`,
 )
 
-console.log(result.success, result.totalTokenUsage.output_tokens)
+console.log(result.success, result.status?.code, result.identity?.runId)
+console.log(result.totalTokenUsage.output_tokens)
 ```
 
 ### 本地运行示例
@@ -176,9 +177,9 @@ const result = await orchestrator.runFromPlan(team, plan)
 | **生命周期钩子 + 取消** | `beforeRun` 改写 prompt，`afterRun` 后处理或拒绝结果；传入 `AbortSignal` 即可中途取消运行。 |
 | **可配置协调者** | 通过 `runTeam(team, goal, { coordinator })` 覆盖协调者的 model、provider、adapter、system prompt 或工具。 |
 | **外部编码 agent（ACP）** | 把某个 agent 的 LLM 循环换成通过 [Agent Client Protocol](https://agentclientprotocol.com) 驱动的外部编码 CLI：设置 `backend: { kind: 'acp', … }`，子进程自行运行其回合，而 pool、scheduler、queue、共享记忆与预算全部与 backend 无关。([外部 agent](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/external-agents.md)) |
-| **可观测性** | `onProgress` 事件、`onTrace` span，运行结束后渲染任务 DAG 的 HTML dashboard，外加 `TeamRunResult.metrics` 运行级指标汇总（token、重试、错误/失败计数、任务时长统计）。API key 和 token 会从 trace、bash 输出和 dashboard 中自动脱敏。([可观测性指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)) |
+| **可观测性** | 每个顶层结果都包含稳定的 `identity`（`runId`、`attempt`、`traceId`、`rootSpanId`）和标准化 `status`，即使未配置 `onTrace` 也不例外；同时继续提供 `onProgress` 事件、trace span、运行后 HTML dashboard 和 `TeamRunResult.metrics`。API key 和 token 会从 trace、错误、bash 输出和 dashboard 中自动脱敏。([可观测性指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)) |
 | **可插拔共享记忆** | 默认进程内 KV；实现 `MemoryStore` 接口即可换 Redis / Postgres / 自有后端。([共享记忆](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md)) |
-| **Checkpoint & resume** | 可选的按运行 checkpoint，运行于任意 `MemoryStore` 之上：每个任务完成时快照，`restore()` 跳过已完成任务，崩溃或重启后可恢复运行。内置的零依赖 `FileStore` 让 checkpoint 无需额外后端即可持久化；存盘 best-effort，不会拖慢运行。([checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md)) |
+| **Checkpoint & resume** | 可选的按运行 checkpoint，运行于任意 `MemoryStore` 之上：每个任务完成时快照，`restore()` 跳过已完成任务，崩溃或重启后可恢复运行。Checkpoint v2 保留 `runId`、递增 `attempt`，并启动新的 trace；v1 快照仍可读取。内置的零依赖 `FileStore` 让 checkpoint 无需额外后端即可持久化；存盘 best-effort，不会拖慢运行。([checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md)) |
 | **沙箱化文件系统工作目录** | 内置文件系统工具默认沙箱化在 `<cwd>/.agent-workspace`；继承默认配置的 agent 共享同一根目录。需要 per-agent 隔离时显式设置 `AgentConfig.cwd`；改换共享根目录用 `OrchestratorConfig.defaultCwd`；传 `null` 关闭沙箱。([沙箱配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md)) |
 
 生产级控制（[上下文策略](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md)、任务重试退避、循环检测、工具输出截断/压缩）见 [生产级检查清单](#生产级检查清单)。
@@ -441,9 +442,9 @@ await oma.runAgent(
 
 - [Provider](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) — 环境变量、模型示例、本地模型工具调用、超时、常见问题。
 - [工具配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) — 工具预设、自定义工具、文件系统沙箱、MCP。
-- [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — `onProgress` 事件、`onTrace` span、运行后 dashboard。
+- [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — 每个顶层结果都包含稳定的运行标识（identity）与结果（outcome）语义，并提供 `onProgress`、`onTrace` 和运行后 dashboard。
 - [共享记忆](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — 默认存储与自定义 `MemoryStore` 后端。
-- [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — 可选的按运行快照/恢复，跑在任意 `MemoryStore` 上；崩溃、重启后可续跑。
+- [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — checkpoint v2 identity 规则、v1 兼容，以及基于任意 `MemoryStore` 的恢复流程。
 - [上下文管理](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — 滑动窗口、摘要、压缩、自定义压缩器。
 - [CLI](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/cli.md) — 面向 shell 和 CI 的 JSON-first `oma` 命令行。
 - [Consensus](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/consensus.md) — `runConsensus` proposer→judge 原语、按任务的 `verify` 钩子，以及预算不变量。

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -46,9 +46,15 @@ import type {
   StreamEvent,
   TokenUsage,
   ToolUseContext,
+  RunIdentity,
+  RunStatus,
+  TraceErrorKind,
 } from '../types.js'
-import { emitTrace, generateRunId, generateSpanId } from '../utils/trace.js'
+import { emitTrace, generateSpanId } from '../utils/trace.js'
 import { mergeAbortSignals } from '../utils/abort.js'
+import { createRunIdentity } from '../observability/identity.js'
+import { classifyRunFailure, statusOnly } from '../observability/status.js'
+import { TokenBudgetExceededError } from '../errors.js'
 import type { ToolDefinition as FrameworkToolDefinition, ToolRegistry } from '../tool/framework.js'
 import type { ToolExecutor } from '../tool/executor.js'
 import { defaultWorkspaceDir } from '../tool/built-in/path-safety.js'
@@ -367,13 +373,21 @@ export class Agent {
 
     const agentStartMs = Date.now()
     let effectiveTraceOptions: Partial<RunOptions> | undefined = callerOptions
+    const identity = callerOptions?.identity ?? createRunIdentity(
+      callerOptions?.runId !== undefined ? { runId: callerOptions.runId } : {},
+    )
+    let timeoutSignal: AbortSignal | undefined
+    let callerAbort: AbortSignal | undefined
+    let failureKind: TraceErrorKind | undefined
 
     try {
       // --- beforeRun hook ---
       if (this.config.beforeRun) {
+        failureKind = 'callback'
         const hookCtx = this.buildBeforeRunHookContext(messages)
         const modified = await this.config.beforeRun(hookCtx)
         this.applyHookContext(messages, modified, hookCtx.prompt)
+        failureKind = undefined
       }
 
       const backend = await this.getBackend()
@@ -382,25 +396,24 @@ export class Agent {
         callerOptions?.onMessage?.(msg)
       }
       // Auto-generate trace identifiers when onTrace is provided but they are missing.
-      const effectiveRunId = callerOptions?.onTrace
-        ? callerOptions.runId || generateRunId()
-        : callerOptions?.runId
+      const effectiveRunId = identity.runId
       const effectiveSpanId = callerOptions?.onTrace
         ? callerOptions.traceSpanId || generateSpanId()
         : callerOptions?.traceSpanId
       // Create a fresh timeout signal per run (not per runner) so that
       // each run() / prompt() call gets its own timeout window.
-      const timeoutSignal = this.config.timeoutMs !== undefined && this.config.timeoutMs > 0
+      timeoutSignal = this.config.timeoutMs !== undefined && this.config.timeoutMs > 0
         ? AbortSignal.timeout(this.config.timeoutMs)
         : undefined
       // Merge caller-provided abortSignal with the timeout signal so that
       // either cancellation source is respected.
-      const callerAbort = callerOptions?.abortSignal
+      callerAbort = callerOptions?.abortSignal
       const effectiveAbort = timeoutSignal && callerAbort
         ? mergeAbortSignals(timeoutSignal, callerAbort)
         : timeoutSignal ?? callerAbort
       const runOptions: RunOptions = {
         ...callerOptions,
+        identity,
         onMessage: internalOnMessage,
         ...(effectiveRunId ? { runId: effectiveRunId } : undefined),
         ...(effectiveSpanId ? { traceSpanId: effectiveSpanId } : undefined),
@@ -412,10 +425,26 @@ export class Agent {
       this.state.tokenUsage = addUsage(this.state.tokenUsage, result.tokenUsage)
 
       if (result.budgetExceeded) {
-        let budgetResult = this.toAgentRunResult(result, false)
+        const budgetError = new TokenBudgetExceededError(
+          this.name,
+          result.tokenUsage.input_tokens + result.tokenUsage.output_tokens,
+          this.config.maxTokenBudget ?? 0,
+        )
+        const classified = classifyRunFailure(budgetError)
+        let budgetResult = this.toAgentRunResult(
+          result,
+          false,
+          undefined,
+          identity,
+          classified.status,
+          classified.errorInfo,
+        )
         if (this.config.afterRun) {
+          failureKind = 'callback'
           budgetResult = await this.config.afterRun(budgetResult)
+          failureKind = undefined
         }
+        budgetResult = this.ensureAgentOutcome(budgetResult, identity)
         this.transitionTo('completed')
         this.emitAgentTrace(runOptions, agentStartMs, budgetResult)
         return budgetResult
@@ -428,21 +457,52 @@ export class Agent {
           result,
           backend,
           runOptions,
+          identity,
         )
         // --- afterRun hook ---
         if (this.config.afterRun) {
+          failureKind = 'callback'
           validated = await this.config.afterRun(validated)
+          failureKind = undefined
         }
+        validated = this.ensureAgentOutcome(validated, identity)
         this.emitAgentTrace(runOptions, agentStartMs, validated)
         return validated
       }
 
-      let agentResult = this.toAgentRunResult(result, true)
+      let agentResult: AgentRunResult
+      if (timeoutSignal?.aborted) {
+        const timeoutError = new Error(
+          `Agent "${this.name}" exceeded whole-run timeout of ${this.config.timeoutMs}ms`,
+        )
+        timeoutError.name = 'TimeoutError'
+        const classified = classifyRunFailure(timeoutError, {
+          kind: 'timeout',
+          statusCode: 'timeout',
+        })
+        agentResult = this.toAgentRunResult(
+          result, false, undefined, identity, classified.status, classified.errorInfo,
+        )
+      } else if (callerAbort?.aborted && result.aborted) {
+        const abortError = new Error('Run cancelled by caller.')
+        abortError.name = 'AbortError'
+        const classified = classifyRunFailure(abortError)
+        agentResult = this.toAgentRunResult(
+          result, false, undefined, identity, classified.status, classified.errorInfo,
+        )
+      } else {
+        agentResult = this.toAgentRunResult(
+          result, true, undefined, identity, statusOnly('ok'),
+        )
+      }
 
       // --- afterRun hook ---
       if (this.config.afterRun) {
+        failureKind = 'callback'
         agentResult = await this.config.afterRun(agentResult)
+        failureKind = undefined
       }
+      agentResult = this.ensureAgentOutcome(agentResult, identity)
 
       this.transitionTo('completed')
       this.emitAgentTrace(runOptions, agentStartMs, agentResult)
@@ -451,8 +511,20 @@ export class Agent {
       const error = err instanceof Error ? err : new Error(String(err))
       this.transitionToError(error)
 
+      const classified = timeoutSignal?.aborted
+        ? classifyRunFailure(error, { kind: 'timeout', statusCode: 'timeout' })
+        : callerAbort?.aborted
+          ? classifyRunFailure(error, { kind: 'cancellation', statusCode: 'cancelled' })
+          : classifyRunFailure(error, {
+              ...(failureKind !== undefined ? { kind: failureKind } : {}),
+              provider: this.config.provider,
+            })
+
       const errorResult: AgentRunResult = {
         success: false,
+        identity,
+        status: classified.status,
+        errorInfo: classified.errorInfo,
         output: error.message,
         messages: [],
         tokenUsage: ZERO_USAGE,
@@ -501,6 +573,7 @@ export class Agent {
     result: RunResult,
     backend: AgentBackend,
     runOptions: RunOptions,
+    identity: RunIdentity,
   ): Promise<AgentRunResult> {
     const schema = this.config.outputSchema!
 
@@ -510,7 +583,7 @@ export class Agent {
       const parsed = extractJSON(result.output)
       const validated = validateOutput(schema, parsed)
       this.transitionTo('completed')
-      return this.toAgentRunResult(result, true, validated)
+      return this.toAgentRunResult(result, true, validated, identity, statusOnly('ok'))
     } catch (e) {
       firstAttemptError = e
     }
@@ -555,6 +628,8 @@ export class Agent {
       this.transitionTo('completed')
       return {
         success: true,
+        identity,
+        status: statusOnly('ok'),
         output: retryResult.output,
         messages: mergedMessages,
         tokenUsage: mergedTokenUsage,
@@ -565,8 +640,13 @@ export class Agent {
     } catch {
       // Retry also failed
       this.transitionTo('completed')
+      const validationError = new Error('Structured output validation failed after retry.')
+      const classified = classifyRunFailure(validationError, { kind: 'validation' })
       return {
         success: false,
+        identity,
+        status: classified.status,
+        errorInfo: classified.errorInfo,
         output: retryResult.output,
         messages: mergedMessages,
         tokenUsage: mergedTokenUsage,
@@ -584,6 +664,9 @@ export class Agent {
   private async *executeStream(messages: LLMMessage[], callerOptions?: Partial<RunOptions>): AsyncGenerator<StreamEvent> {
     this.transitionTo('running')
     const agentStartMs = Date.now()
+    const identity = callerOptions?.identity ?? createRunIdentity(
+      callerOptions?.runId !== undefined ? { runId: callerOptions.runId } : {},
+    )
     let agentTraceEmitted = false
     let effectiveTraceOptions: Partial<RunOptions> | undefined = callerOptions
 
@@ -604,14 +687,13 @@ export class Agent {
       const effectiveAbort = timeoutSignal && callerAbort
         ? mergeAbortSignals(timeoutSignal, callerAbort)
         : timeoutSignal ?? callerAbort
-      const effectiveRunId = callerOptions?.onTrace
-        ? callerOptions.runId || generateRunId()
-        : callerOptions?.runId
+      const effectiveRunId = identity.runId
       const effectiveSpanId = callerOptions?.onTrace
         ? callerOptions.traceSpanId || generateSpanId()
         : callerOptions?.traceSpanId
       const runOptions: RunOptions = {
         ...callerOptions,
+        identity,
         ...(effectiveRunId ? { runId: effectiveRunId } : undefined),
         ...(effectiveSpanId ? { traceSpanId: effectiveSpanId } : undefined),
         ...(effectiveAbort ? { abortSignal: effectiveAbort } : undefined),
@@ -623,10 +705,14 @@ export class Agent {
           const result = event.data as RunResult
           this.state.tokenUsage = addUsage(this.state.tokenUsage, result.tokenUsage)
 
-          let agentResult = this.toAgentRunResult(result, !result.budgetExceeded)
+          const status = result.budgetExceeded ? statusOnly('budget_exhausted') : statusOnly('ok')
+          let agentResult = this.toAgentRunResult(
+            result, !result.budgetExceeded, undefined, identity, status,
+          )
           if (this.config.afterRun) {
             agentResult = await this.config.afterRun(agentResult)
           }
+          agentResult = this.ensureAgentOutcome(agentResult, identity)
           this.transitionTo('completed')
           this.emitAgentTrace(runOptions, agentStartMs, agentResult)
           agentTraceEmitted = true
@@ -639,6 +725,9 @@ export class Agent {
           this.transitionToError(error)
           this.emitAgentTrace(runOptions, agentStartMs, {
             success: false,
+            identity,
+            status: classifyRunFailure(error).status,
+            errorInfo: classifyRunFailure(error).errorInfo,
             output: error.message,
             messages: [],
             tokenUsage: ZERO_USAGE,
@@ -657,6 +746,9 @@ export class Agent {
       if (!agentTraceEmitted) {
         this.emitAgentTrace(effectiveTraceOptions, agentStartMs, {
           success: false,
+          identity,
+          status: classifyRunFailure(error).status,
+          errorInfo: classifyRunFailure(error).errorInfo,
           output: error.message,
           messages: [],
           tokenUsage: ZERO_USAGE,
@@ -733,9 +825,15 @@ export class Agent {
     result: RunResult,
     success: boolean,
     structured?: unknown,
+    identity: RunIdentity = result.identity ?? createRunIdentity(),
+    status: RunStatus = statusOnly(success ? 'ok' : 'error'),
+    errorInfo?: AgentRunResult['errorInfo'],
   ): AgentRunResult {
     return {
       success,
+      identity,
+      status,
+      ...(errorInfo !== undefined ? { errorInfo } : {}),
       output: result.output,
       messages: result.messages,
       tokenUsage: result.tokenUsage,
@@ -743,6 +841,35 @@ export class Agent {
       structured,
       ...(result.loopDetected ? { loopDetected: true } : {}),
       ...(result.budgetExceeded ? { budgetExceeded: true } : {}),
+    }
+  }
+
+  /** Restore runtime-required outcome fields after compatibility hooks run. */
+  private ensureAgentOutcome(result: AgentRunResult, identity: RunIdentity): AgentRunResult {
+    let status = result.status
+    let errorInfo = result.errorInfo
+    if (result.budgetExceeded) {
+      const budgetError = new TokenBudgetExceededError(
+        this.name,
+        result.tokenUsage.input_tokens + result.tokenUsage.output_tokens,
+        this.config.maxTokenBudget ?? 0,
+      )
+      const classified = classifyRunFailure(budgetError)
+      status = classified.status
+      errorInfo = errorInfo ?? classified.errorInfo
+    } else if (result.success && status?.code !== 'ok') {
+      status = statusOnly('ok')
+      errorInfo = undefined
+    } else if (!result.success && (status === undefined || status.code === 'ok')) {
+      status = statusOnly('error', result.output)
+    }
+    status ??= statusOnly(result.success ? 'ok' : 'error', result.success ? undefined : result.output)
+    return {
+      ...result,
+      success: status.code === 'ok',
+      identity,
+      status,
+      ...(errorInfo !== undefined ? { errorInfo } : {}),
     }
   }
 

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -33,6 +33,7 @@ import type {
   LLMToolDef,
   ContextStrategy,
   ThinkingConfig,
+  RunIdentity,
 } from '../types.js'
 import { LLMCallTimeoutError, TokenBudgetExceededError } from '../errors.js'
 import { LoopDetector } from './loop-detector.js'
@@ -165,6 +166,8 @@ export interface RunnerOptions {
  * All callbacks are optional; unused ones are simply skipped.
  */
 export interface RunOptions {
+  /** Top-level run identity. Optional for custom backend compatibility. */
+  readonly identity?: RunIdentity
   /** Fired just before each tool is dispatched. */
   readonly onToolCall?: (name: string, input: Record<string, unknown>) => void
   /** Fired after each tool result is received. */
@@ -202,6 +205,8 @@ export interface RunOptions {
 
 /** The aggregated result returned when a full run completes. */
 export interface RunResult {
+  /** Optional identity echoed by custom backends. Agent supplies it when absent. */
+  readonly identity?: RunIdentity
   /** All messages accumulated during this run (assistant + tool results). */
   readonly messages: LLMMessage[]
   /** The final text output from the last assistant turn. */
@@ -216,6 +221,8 @@ export interface RunResult {
   readonly loopDetected?: boolean
   /** True when the run was terminated due to token budget limits. */
   readonly budgetExceeded?: boolean
+  /** True when the runner stopped before its next LLM call because the signal was aborted. */
+  readonly aborted?: boolean
 }
 
 /**
@@ -790,6 +797,7 @@ export class AgentRunner implements AgentBackend {
     let finalOutput = ''
     let turns = 0
     let budgetExceeded = false
+    let aborted = false
 
     // Build the stable LLM options once; model / tokens / temp don't change.
     // resolveTools() returns LLMToolDef[] with default-deny + filtering applied.
@@ -850,6 +858,7 @@ export class AgentRunner implements AgentBackend {
       while (true) {
         // Respect abort before each LLM call.
         if (effectiveAbortSignal?.aborted) {
+          aborted = true
           break
         }
 
@@ -1211,6 +1220,7 @@ export class AgentRunner implements AgentBackend {
       turns,
       ...(loopDetected ? { loopDetected: true } : {}),
       ...(budgetExceeded ? { budgetExceeded: true } : {}),
+      ...(aborted ? { aborted: true } : {}),
     }
 
     yield { type: 'done', data: runResult } satisfies StreamEvent

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -116,7 +116,9 @@ export type { RegisterBuiltInToolsOptions } from './tool/built-in/index.js'
 
 export { createAdapter } from './llm/adapter.js'
 export type { SupportedProvider } from './llm/adapter.js'
-export { TokenBudgetExceededError, InvalidMessageError, LLMCallTimeoutError, isRetryableError } from './errors.js'
+export { TokenBudgetExceededError, CostBudgetExceededError, InvalidMessageError, LLMCallTimeoutError, isRetryableError } from './errors.js'
+export { createRunIdentity, createRestoreIdentity, validateRunId } from './observability/identity.js'
+export { classifyRunFailure } from './observability/status.js'
 
 // ---------------------------------------------------------------------------
 // Memory
@@ -170,6 +172,16 @@ export type {
   AgentConfig,
   AgentState,
   AgentRunResult,
+  RunAgentOptions,
+  RunIdentity,
+  RunIdentityLink,
+  TraceLink,
+  RunIdentityOptions,
+  RunStatus,
+  RunStatusCode,
+  RunOutcomeFields,
+  StructuredTraceError,
+  TraceErrorKind,
   AgentBackendConfig,
   AcpPermissionPolicy,
   AcpPermissionRequest,
@@ -213,6 +225,9 @@ export type {
   CoordinatorConfig,
   CheckpointOptions,
   CheckpointSnapshot,
+  CheckpointSnapshotV1,
+  CheckpointSnapshotV2,
+  CheckpointRunIdentity,
   CompletedTaskCheckpoint,
   TaskQueueSnapshot,
   TaskSnapshot,

--- a/packages/core/src/memory/checkpoint.ts
+++ b/packages/core/src/memory/checkpoint.ts
@@ -46,16 +46,19 @@ export class Checkpoint {
 
   /** Persist `snapshot` as the latest checkpoint. */
   async save(snapshot: CheckpointSnapshot): Promise<void> {
-    const stored: CheckpointSnapshot = {
-      ...snapshot,
-      ...(snapshot.runId !== undefined || this.runId === undefined
-        ? {}
-        : { runId: this.runId }),
-    }
+    const stored: CheckpointSnapshot = snapshot.version === 1
+      ? {
+          ...snapshot,
+          ...(snapshot.runId !== undefined || this.runId === undefined
+            ? {}
+            : { runId: this.runId }),
+        }
+      : snapshot
+    const storedRunId = stored.version === 2 ? stored.identity.runId : stored.runId
     await this.store.set(this.key, JSON.stringify(stored), {
       namespace: 'checkpoint',
       version: stored.version,
-      ...(stored.runId !== undefined ? { runId: stored.runId } : {}),
+      ...(storedRunId !== undefined ? { runId: storedRunId } : {}),
       createdAt: stored.createdAt,
     })
   }
@@ -91,10 +94,20 @@ export class Checkpoint {
   private static isSnapshot(value: unknown): value is CheckpointSnapshot {
     if (value === null || typeof value !== 'object') return false
     const snapshot = value as Record<string, unknown>
-    if (snapshot['version'] !== 1) return false
+    if (snapshot['version'] !== 1 && snapshot['version'] !== 2) return false
     if (snapshot['mode'] !== 'runTeam' && snapshot['mode'] !== 'runTasks') return false
     if (typeof snapshot['createdAt'] !== 'string') return false
     if (!Array.isArray(snapshot['completedTaskResults'])) return false
+
+    if (snapshot['version'] === 2) {
+      const identity = snapshot['identity']
+      if (identity === null || typeof identity !== 'object') return false
+      const record = identity as Record<string, unknown>
+      if (typeof record['runId'] !== 'string') return false
+      if (!Number.isInteger(record['attempt']) || (record['attempt'] as number) < 1) return false
+      if (typeof record['lastTraceId'] !== 'string') return false
+      if (typeof record['lastRootSpanId'] !== 'string') return false
+    }
 
     const queue = snapshot['queue']
     if (queue === null || typeof queue !== 'object') return false

--- a/packages/core/src/observability/identity.ts
+++ b/packages/core/src/observability/identity.ts
@@ -1,0 +1,75 @@
+import { randomBytes, randomUUID } from 'node:crypto'
+import type {
+  CheckpointSnapshot,
+  RunIdentity,
+  RunIdentityOptions,
+} from '../types.js'
+
+function randomHex(bytes: number): string {
+  let value = randomBytes(bytes).toString('hex')
+  // W3C identifiers may not be all zero. randomBytes producing all zero is
+  // vanishingly unlikely, but enforcing the invariant is cheap and explicit.
+  while (/^0+$/.test(value)) value = randomBytes(bytes).toString('hex')
+  return value
+}
+
+export function validateRunId(runId: string): string {
+  if (runId.length < 1 || runId.length > 128) {
+    throw new Error('runId must contain between 1 and 128 characters.')
+  }
+  return runId
+}
+
+/** Create the identity for a new logical run. */
+export function createRunIdentity(options: RunIdentityOptions = {}): RunIdentity {
+  return {
+    runId: options.runId === undefined ? randomUUID() : validateRunId(options.runId),
+    attempt: 1,
+    traceId: randomHex(16),
+    rootSpanId: randomHex(8),
+  }
+}
+
+/** Create the next execution attempt from a v1 or v2 checkpoint. */
+export function createRestoreIdentity(
+  snapshot: CheckpointSnapshot,
+  options: RunIdentityOptions = {},
+): RunIdentity {
+  const checkpointRunId = snapshot.version === 2
+    ? snapshot.identity.runId
+    : snapshot.runId
+
+  if (
+    options.runId !== undefined
+    && checkpointRunId !== undefined
+    && options.runId !== checkpointRunId
+  ) {
+    throw new Error(
+      `restore runId conflict: requested "${options.runId}" but checkpoint belongs to "${checkpointRunId}".`,
+    )
+  }
+
+  const runId = checkpointRunId === undefined
+    ? options.runId
+    : checkpointRunId
+  const baseAttempt = snapshot.version === 2 ? snapshot.identity.attempt : 1
+  const identity: RunIdentity = {
+    runId: runId === undefined ? randomUUID() : validateRunId(runId),
+    attempt: baseAttempt + 1,
+    traceId: randomHex(16),
+    rootSpanId: randomHex(8),
+  }
+
+  if (snapshot.version === 2) {
+    return {
+      ...identity,
+      links: [{
+        traceId: snapshot.identity.lastTraceId,
+        spanId: snapshot.identity.lastRootSpanId,
+        relation: 'continued_from',
+      }],
+    }
+  }
+
+  return identity
+}

--- a/packages/core/src/observability/status.ts
+++ b/packages/core/src/observability/status.ts
@@ -1,0 +1,84 @@
+import { CostBudgetExceededError, LLMCallTimeoutError, TokenBudgetExceededError, isRetryableError } from '../errors.js'
+import type {
+  RunStatus,
+  StructuredTraceError,
+  TraceErrorKind,
+} from '../types.js'
+import { redactSensitiveText } from '../utils/redaction.js'
+
+const MAX_STATUS_MESSAGE = 256
+const MAX_ERROR_MESSAGE = 1024
+
+function safeMessage(value: unknown, limit: number): string | undefined {
+  const raw = value instanceof Error ? value.message : typeof value === 'string' ? value : undefined
+  if (!raw) return undefined
+  return redactSensitiveText(raw).slice(0, limit)
+}
+
+function errorCode(error: unknown): string | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const code = (error as { code?: unknown }).code
+  return typeof code === 'string' || typeof code === 'number' ? String(code) : undefined
+}
+
+function httpStatus(error: unknown): number | undefined {
+  if (typeof error !== 'object' || error === null) return undefined
+  const record = error as { status?: unknown; statusCode?: unknown }
+  const value = record.status ?? record.statusCode
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined
+}
+
+export interface FailureClassificationOptions {
+  readonly kind?: TraceErrorKind
+  readonly provider?: string
+  readonly attempt?: number
+  readonly statusCode?: RunStatus['code']
+}
+
+/** Convert a thrown/runtime failure into stable, JSON-safe outcome fields. */
+export function classifyRunFailure(
+  error: unknown,
+  options: FailureClassificationOptions = {},
+): { status: RunStatus; errorInfo: StructuredTraceError } {
+  let statusCode: RunStatus['code'] = options.statusCode ?? 'error'
+  let kind: TraceErrorKind = options.kind ?? 'unknown'
+
+  if (error instanceof TokenBudgetExceededError || error instanceof CostBudgetExceededError) {
+    statusCode = 'budget_exhausted'
+    kind = 'budget'
+  } else if (error instanceof LLMCallTimeoutError) {
+    statusCode = 'timeout'
+    kind = 'timeout'
+  } else if (error instanceof Error && error.name === 'AbortError') {
+    statusCode = 'cancelled'
+    kind = 'cancellation'
+  } else if (
+    options.kind === undefined
+    && (httpStatus(error) !== undefined || options.provider !== undefined)
+  ) {
+    kind = 'provider'
+  }
+
+  const message = safeMessage(error, MAX_ERROR_MESSAGE)
+  const statusMessage = safeMessage(error, MAX_STATUS_MESSAGE)
+  const status: RunStatus = {
+    code: statusCode,
+    ...(statusMessage !== undefined ? { message: statusMessage } : {}),
+  }
+  const info: StructuredTraceError = {
+    kind,
+    ...(errorCode(error) !== undefined ? { code: errorCode(error) } : {}),
+    ...(error instanceof Error ? { name: error.name } : {}),
+    ...(message !== undefined ? { message } : {}),
+    retryable: isRetryableError(error),
+    ...(httpStatus(error) !== undefined ? { httpStatus: httpStatus(error) } : {}),
+    ...(options.provider !== undefined ? { provider: options.provider } : {}),
+    ...(options.attempt !== undefined ? { attempt: options.attempt } : {}),
+  }
+  return { status, errorInfo: info }
+}
+
+export function statusOnly(code: RunStatus['code'], message?: string): RunStatus {
+  const safe = safeMessage(message, MAX_STATUS_MESSAGE)
+  return { code, ...(safe !== undefined ? { message: safe } : {}) }
+}

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -58,6 +58,10 @@ import type {
   OrchestratorConfig,
   OrchestratorEvent,
   RestoreOptions,
+  RunAgentOptions,
+  RunIdentity,
+  RunStatus,
+  StructuredTraceError,
   RunMetrics,
   RunTaskSpec,
   RunTasksOptions,
@@ -90,6 +94,8 @@ import { extractJSON, validateOutput } from '../agent/structured-output.js'
 import { Scheduler } from './scheduler.js'
 import { CostBudgetExceededError, TokenBudgetExceededError, isRetryableError } from '../errors.js'
 import { abortableDelay } from '../utils/abort.js'
+import { createRestoreIdentity, createRunIdentity } from '../observability/identity.js'
+import { classifyRunFailure, statusOnly } from '../observability/status.js'
 import { extractKeywords, keywordScore } from '../utils/keywords.js'
 
 // ---------------------------------------------------------------------------
@@ -100,6 +106,23 @@ const ZERO_USAGE: TokenUsage = { input_tokens: 0, output_tokens: 0 }
 const DEFAULT_MAX_CONCURRENCY = 5
 const DEFAULT_MAX_DELEGATION_DEPTH = 3
 const DEFAULT_MODEL = 'claude-opus-4-6'
+
+function identityOptionsForRun(options?: RunTasksOptions): { runId?: string } {
+  const checkpointRunId = options?.checkpoint && typeof options.checkpoint === 'object'
+    ? options.checkpoint.runId
+    : undefined
+  if (
+    options?.runId !== undefined
+    && checkpointRunId !== undefined
+    && options.runId !== checkpointRunId
+  ) {
+    throw new Error(
+      `runId conflict: run options requested "${options.runId}" but checkpoint options requested "${checkpointRunId}".`,
+    )
+  }
+  const runId = options?.runId ?? checkpointRunId
+  return runId === undefined ? {} : { runId }
+}
 
 // ---------------------------------------------------------------------------
 // Short-circuit helpers (exported for testability)
@@ -416,6 +439,9 @@ function recordRunUsage(
   if (!ctx.budgetExceededTriggered && accounting.exceeded) {
     ctx.budgetExceededTriggered = true
     ctx.budgetExceededReason = accounting.exceeded.message
+    const classified = classifyRunFailure(accounting.exceeded)
+    ctx.outcomeStatus = classified.status
+    ctx.outcomeErrorInfo = classified.errorInfo
     emitBudgetExceeded(ctx.config, accounting.exceeded, agent, task)
     return accounting.exceeded
   }
@@ -818,8 +844,10 @@ interface RunContext {
   readonly agentResults: Map<string, AgentRunResult>
   readonly config: OrchestratorConfig
   readonly checkpoint?: ActiveCheckpoint
-  /** Trace run ID, present when `onTrace` is configured. */
-  readonly runId?: string
+  /** Stable top-level execution identity, independent of trace callbacks. */
+  readonly identity: RunIdentity
+  /** Legacy trace correlation alias. */
+  readonly runId: string
   /** AbortSignal for run-level cancellation. Checked between task dispatch rounds. */
   readonly abortSignal?: AbortSignal
   cumulativeUsage: TokenUsage
@@ -829,6 +857,8 @@ interface RunContext {
   readonly estimateCost?: OrchestratorConfig['estimateCost']
   budgetExceededTriggered: boolean
   budgetExceededReason?: string
+  outcomeStatus?: RunStatus
+  outcomeErrorInfo?: StructuredTraceError
   readonly taskMetrics: Map<string, TaskExecutionMetrics>
   /**
    * Present only when `runTeam` is called with `{ revealCoordinator: true }`.
@@ -976,10 +1006,15 @@ async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Promise<voi
     }))
 
     const snapshot: CheckpointSnapshot = {
-      version: 1,
+      version: 2,
       mode: active.mode,
       createdAt: new Date().toISOString(),
-      ...(active.runId !== undefined ? { runId: active.runId } : {}),
+      identity: {
+        runId: ctx.identity.runId,
+        attempt: ctx.identity.attempt,
+        lastTraceId: ctx.identity.traceId,
+        lastRootSpanId: ctx.identity.rootSpanId,
+      },
       ...(active.goal !== undefined ? { goal: active.goal } : {}),
       queue: queue.snapshot(),
       // When the checkpoint store IS the shared-memory store, the entries are
@@ -1043,6 +1078,11 @@ async function executeQueue(
     // Check for cancellation before each dispatch round.
     if (ctx.abortSignal?.aborted) {
       queue.skipRemaining('Skipped: run aborted.')
+      const abortError = new Error('Run cancelled by caller.')
+      abortError.name = 'AbortError'
+      const classified = classifyRunFailure(abortError)
+      ctx.outcomeStatus = classified.status
+      ctx.outcomeErrorInfo = classified.errorInfo
       break
     }
 
@@ -1126,10 +1166,11 @@ async function executeQueue(
       const taskSpanId = config.onTrace ? generateSpanId() : undefined
       const agentSpanId = config.onTrace ? generateSpanId() : undefined
       const traceBase: Partial<RunOptions> = {
+        identity: ctx.identity,
+        runId: ctx.runId,
         ...(config.onTrace
           ? {
               onTrace: config.onTrace,
-              runId: ctx.runId ?? '',
               taskId: task.id,
               traceAgent: assignee,
               ...(taskSpanId ? { traceParentId: taskSpanId } : {}),
@@ -1338,10 +1379,14 @@ async function executeQueue(
         } catch (err) {
           const reason = `Skipped: approval callback error — ${err instanceof Error ? err.message : String(err)}`
           queue.skipRemaining(reason)
+          const classified = classifyRunFailure(err, { kind: 'callback' })
+          ctx.outcomeStatus = classified.status
+          ctx.outcomeErrorInfo = classified.errorInfo
           break
         }
         if (!approved) {
           queue.skipRemaining('Skipped: approval rejected.')
+          ctx.outcomeStatus = statusOnly('rejected', 'Approval rejected.')
           break
         }
       }
@@ -1566,6 +1611,8 @@ interface ConsensusCoreParams {
   readonly defaults: ConsensusAgentDefaults
   readonly onTrace?: OrchestratorConfig['onTrace']
   readonly runId?: string
+  readonly identity?: RunIdentity
+  readonly abortSignal?: AbortSignal
   readonly onUsage?: (usage: TokenUsage, effectiveConfig: AgentConfig) => void
   readonly shouldStop?: () => boolean
   /** Existing pool to reuse; a fresh one is created when omitted. */
@@ -1591,13 +1638,17 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
   const dissent: string[] = []
   let rounds = 0
   let accepted = false
+  let executionFailure: AgentRunResult | undefined
 
   const overBudget = (): boolean =>
     budget !== undefined && budgetBaseTokens + usage.input_tokens + usage.output_tokens > budget
 
   const runEphemeral = async (config: AgentConfig, text: string): Promise<AgentRunResult> => {
     const effective = applyConsensusDefaults(config, defaults)
-    const result = await pool.runEphemeral(buildAgent(effective), text)
+    const result = await pool.runEphemeral(buildAgent(effective), text, {
+      ...(params.identity ? { identity: params.identity, runId: params.identity.runId } : {}),
+      ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
+    })
     params.onUsage?.(result.tokenUsage, effective)
     return result
   }
@@ -1618,6 +1669,7 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
       const judgeText = buildJudgePrompt({ judge: judge.name, answer, prompt, mode, judgeIndex: j, judgePrompt })
       const r = await runEphemeral(judge, judgeText)
       usage = addUsage(usage, r.tokenUsage)
+      if (!r.success && executionFailure === undefined) executionFailure = r
       if (overBudget() || params.shouldStop?.()) { budgetHit = true; break }
 
       const verdict = parseJudgeVerdict(r.output, verdictSchema)
@@ -1658,6 +1710,7 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
     if (onDissent === 'revise' && round < maxRounds && reviseProposer) {
       const r = await runEphemeral(reviseProposer, buildRevisePrompt(prompt, answer, roundDissent))
       usage = addUsage(usage, r.tokenUsage)
+      if (!r.success && executionFailure === undefined) executionFailure = r
       if (r.success && r.output) answer = r.output
       if (overBudget() || params.shouldStop?.()) { budgetHit = true; break }
       continue
@@ -1667,7 +1720,15 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
 
   const verdict: 'accepted' | 'rejected' =
     accepted || (!budgetHit && onDissent === 'keep') ? 'accepted' : 'rejected'
-  return { answer, verdict, dissent, rounds, tokenUsage: usage }
+  return {
+    answer,
+    verdict,
+    dissent,
+    rounds,
+    tokenUsage: usage,
+    ...(executionFailure?.status ? { status: executionFailure.status } : {}),
+    ...(executionFailure?.errorInfo ? { errorInfo: executionFailure.errorInfo } : {}),
+  }
 }
 
 /**
@@ -1716,7 +1777,9 @@ async function runTaskVerify(
       maxConcurrency: config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
     },
     onTrace: config.onTrace,
-    ...(ctx.runId ? { runId: ctx.runId } : {}),
+    runId: ctx.runId,
+    identity: ctx.identity,
+    abortSignal: ctx.abortSignal,
     onUsage: (usage, effectiveConfig) => {
       recordRunUsage(ctx, usage, buildCostEstimateContext({
         agentName: effectiveConfig.name,
@@ -1728,6 +1791,11 @@ async function runTaskVerify(
     },
     shouldStop: () => ctx.budgetExceededTriggered,
   })
+
+  if (consensus.status && consensus.status.code !== 'ok') {
+    ctx.outcomeStatus = consensus.status
+    ctx.outcomeErrorInfo = consensus.errorInfo
+  }
 
   // Surface the verdict as a task-level outcome so downstream agents and the
   // final synthesis can see whether the result survived scrutiny.
@@ -1850,8 +1918,9 @@ export class OpenMultiAgent {
   async runAgent(
     config: AgentConfig,
     prompt: string,
-    options?: { abortSignal?: AbortSignal },
+    options?: RunAgentOptions,
   ): Promise<AgentRunResult> {
+    const identity = createRunIdentity(options)
     const effectiveBudget = resolveTokenBudget(config.maxTokenBudget, this.config.maxTokenBudget)
     const effective: AgentConfig = applyDefaultToolPreset({
       ...config,
@@ -1874,15 +1943,14 @@ export class OpenMultiAgent {
     const traceFields = this.config.onTrace
       ? {
           onTrace: this.config.onTrace,
-          runId: generateRunId(),
           traceAgent: config.name,
         }
       : null
     const abortFields = options?.abortSignal ? { abortSignal: options.abortSignal } : null
     const runOptions: Partial<RunOptions> | undefined =
       traceFields || abortFields
-        ? { ...(traceFields ?? {}), ...(abortFields ?? {}) }
-        : undefined
+        ? { identity, runId: identity.runId, ...(traceFields ?? {}), ...(abortFields ?? {}) }
+        : { identity, runId: identity.runId }
 
     const result = await agent.run(prompt, runOptions)
     let finalResult = result
@@ -1923,6 +1991,7 @@ export class OpenMultiAgent {
           ...result,
           success: false,
           budgetExceeded: true,
+          ...classifyRunFailure(accounting.exceeded),
         }
       }
     }
@@ -1970,6 +2039,7 @@ export class OpenMultiAgent {
     goal: string,
     options?: RunTeamOptions,
   ): Promise<TeamRunResult> {
+    const identity = createRunIdentity(identityOptionsForRun(options))
     const agentConfigs = team.getAgents()
     const coordinatorOverrides = options?.coordinator
 
@@ -2008,13 +2078,13 @@ export class OpenMultiAgent {
       })
 
       const traceFields = this.config.onTrace
-        ? { onTrace: this.config.onTrace, runId: generateRunId(), traceAgent: bestAgent.name }
+        ? { onTrace: this.config.onTrace, traceAgent: bestAgent.name }
         : null
       const abortFields = options?.abortSignal ? { abortSignal: options.abortSignal } : null
       const runOptions: Partial<RunOptions> | undefined =
         traceFields || abortFields
-          ? { ...(traceFields ?? {}), ...(abortFields ?? {}) }
-          : undefined
+          ? { identity, runId: identity.runId, ...(traceFields ?? {}), ...(abortFields ?? {}) }
+          : { identity, runId: identity.runId }
 
       const scStartMs = Date.now()
       const result = await agent.run(goal, runOptions)
@@ -2057,6 +2127,7 @@ export class OpenMultiAgent {
             ...result,
             success: false,
             budgetExceeded: true,
+            ...classifyRunFailure(accounting.exceeded),
           }
         }
       }
@@ -2086,7 +2157,7 @@ export class OpenMultiAgent {
           retries: 0,
         },
       }]
-      return this.buildTeamRunResult(agentResults, goal, tasks)
+      return this.buildTeamRunResult(agentResults, identity, goal, tasks)
     }
 
     // ------------------------------------------------------------------
@@ -2104,7 +2175,7 @@ export class OpenMultiAgent {
 
     const decompositionPrompt = this.buildDecompositionPrompt(goal, agentConfigs)
     const coordinatorAgent = buildAgent(coordinatorConfig)
-    const runId = this.config.onTrace ? generateRunId() : undefined
+    const runId = identity.runId
     const coordinatorDecomposeSpanId = this.config.onTrace ? generateSpanId() : undefined
 
     this.config.onProgress?.({
@@ -2115,13 +2186,18 @@ export class OpenMultiAgent {
 
     const decompTraceOptions: Partial<RunOptions> | undefined = this.config.onTrace
       ? {
+          identity,
           onTrace: this.config.onTrace,
-          runId: runId ?? '',
+          runId,
           traceAgent: 'coordinator',
           ...(coordinatorDecomposeSpanId ? { traceSpanId: coordinatorDecomposeSpanId } : {}),
           ...(options?.abortSignal ? { abortSignal: options.abortSignal } : {}),
         }
-      : options?.abortSignal ? { abortSignal: options.abortSignal } : undefined
+      : {
+          identity,
+          runId,
+          ...(options?.abortSignal ? { abortSignal: options.abortSignal } : {}),
+        }
     const decompositionResult = await coordinatorAgent.run(decompositionPrompt, decompTraceOptions)
     const agentResults = new Map<string, AgentRunResult>()
     agentResults.set('coordinator:decompose', decompositionResult)
@@ -2146,7 +2222,10 @@ export class OpenMultiAgent {
 
     if (decompositionBudget.exceeded) {
       emitBudgetExceeded(this.config, decompositionBudget.exceeded, 'coordinator')
-      return this.buildTeamRunResult(agentResults, goal, [])
+      const classified = classifyRunFailure(decompositionBudget.exceeded)
+      return this.buildTeamRunResult(
+        agentResults, identity, goal, [], classified.status, classified.errorInfo,
+      )
     }
 
     // ------------------------------------------------------------------
@@ -2198,6 +2277,7 @@ export class OpenMultiAgent {
       config: this.config,
       ...(activeCheckpoint ? { checkpoint: activeCheckpoint } : {}),
       runId,
+      identity,
       abortSignal: options?.abortSignal,
       cumulativeUsage,
       cumulativeCost,
@@ -2223,11 +2303,13 @@ export class OpenMultiAgent {
     const planTasks = queue.list()
     const planReadyStartMs = Date.now()
     let approved = true
+    let planApprovalError: unknown
     if (this.config.onPlanReady) {
       try {
         approved = await this.config.onPlanReady(planTasks)
-      } catch {
+      } catch (error) {
         approved = false
+        planApprovalError = error
       }
     }
     if (this.config.onTrace) {
@@ -2246,7 +2328,19 @@ export class OpenMultiAgent {
       })
     }
     if (!approved) {
-      return { ...this.buildTeamRunResult(agentResults, goal, []), success: false }
+      if (planApprovalError !== undefined) {
+        const classified = classifyRunFailure(planApprovalError, { kind: 'callback' })
+        return this.buildTeamRunResult(
+          agentResults, identity, goal, [], classified.status, classified.errorInfo,
+        )
+      }
+      return this.buildTeamRunResult(
+        agentResults,
+        identity,
+        goal,
+        [],
+        statusOnly('rejected', 'Plan approval rejected.'),
+      )
     }
 
     if (options?.planOnly) {
@@ -2270,12 +2364,15 @@ export class OpenMultiAgent {
         data: decompositionResult,
       })
       return {
-        ...this.buildTeamRunResult(agentResults, goal, planOnlyTasks),
+        ...this.buildTeamRunResult(agentResults, identity, goal, planOnlyTasks),
         planOnly: true,
       }
     }
 
     await executeQueue(queue, ctx)
+    if (queue.list().every((task) => task.status === 'completed')) {
+      await saveRunCheckpoint(queue, ctx)
+    }
     cumulativeUsage = ctx.cumulativeUsage
     cumulativeCost = ctx.cumulativeCost
     const taskRecords: readonly TaskExecutionRecord[] = queue.list().map((task) => ({
@@ -2297,6 +2394,7 @@ export class OpenMultiAgent {
     // Step 5: Coordinator synthesises final result
     // ------------------------------------------------------------------
     const synthesis = await this.runCoordinatorSynthesis(team, queue, goal, coordinatorBaseConfig, {
+      identity,
       modelRouting: options?.modelRouting,
       runId,
       abortSignal: options?.abortSignal,
@@ -2308,7 +2406,16 @@ export class OpenMultiAgent {
     })
     if (synthesis === null) {
       // Aborted or already over budget — return raw task outputs, no synthesis.
-      return this.buildTeamRunResult(agentResults, goal, taskRecords)
+      if (options?.abortSignal?.aborted && ctx.outcomeStatus === undefined) {
+        const abortError = new Error('Run cancelled by caller.')
+        abortError.name = 'AbortError'
+        const classified = classifyRunFailure(abortError)
+        ctx.outcomeStatus = classified.status
+        ctx.outcomeErrorInfo = classified.errorInfo
+      }
+      return this.buildTeamRunResult(
+        agentResults, identity, goal, taskRecords, ctx.outcomeStatus, ctx.outcomeErrorInfo,
+      )
     }
     agentResults.set('coordinator', synthesis.result)
     cumulativeUsage = synthesis.cumulativeUsage
@@ -2318,7 +2425,9 @@ export class OpenMultiAgent {
     // Only actual user tasks (non-coordinator keys) are counted in
     // buildTeamRunResult, so we do not increment completedTaskCount here.
 
-    return this.buildTeamRunResult(agentResults, goal, taskRecords)
+    return this.buildTeamRunResult(
+      agentResults, identity, goal, taskRecords, ctx.outcomeStatus, ctx.outcomeErrorInfo,
+    )
   }
 
   // -------------------------------------------------------------------------
@@ -2503,6 +2612,12 @@ export class OpenMultiAgent {
       team.restoreMessageBus(snapshot.messageBus)
     }
 
+    const requestedRunId = identityOptionsForRun(options).runId
+    const identity = createRestoreIdentity(
+      snapshot,
+      requestedRunId === undefined ? {} : { runId: requestedRunId },
+    )
+
     const queue = TaskQueue.fromSnapshot(snapshot.queue, { resetInProgress: true })
     const agentResults = this.agentResultsFromCheckpoint(snapshot, queue)
     const checkpointForResume: ActiveCheckpoint | undefined = activeCheckpoint
@@ -2510,7 +2625,7 @@ export class OpenMultiAgent {
           ...activeCheckpoint,
           mode: snapshot.mode,
           ...(snapshot.goal !== undefined ? { goal: snapshot.goal } : {}),
-          ...(snapshot.runId !== undefined ? { runId: snapshot.runId } : {}),
+          runId: identity.runId,
         }
       : undefined
 
@@ -2522,6 +2637,7 @@ export class OpenMultiAgent {
       agentResults,
       checkpointForResume,
       options?.coordinator,
+      identity,
     )
   }
 
@@ -2581,6 +2697,7 @@ export class OpenMultiAgent {
     prompt: string,
     options: ConsensusOptions,
   ): Promise<ConsensusResult> {
+    const identity = createRunIdentity(options)
     const proposers = Array.isArray(options.proposer) ? options.proposer : [options.proposer]
     if (proposers.length === 0) {
       throw new Error('runConsensus: at least one proposer is required.')
@@ -2611,24 +2728,51 @@ export class OpenMultiAgent {
 
     // Step 2: run proposer(s); accumulate usage and honour the budget before judging.
     const candidates: string[] = []
+    let firstFailure: AgentRunResult | undefined
     for (const proposerConfig of proposers) {
       const r = await pool.runEphemeral(
         buildAgent(applyConsensusDefaults(proposerConfig, defaults)),
         prompt,
+        {
+          identity,
+          runId: identity.runId,
+          ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
+        },
       )
       usage = addUsage(usage, r.tokenUsage)
       if (r.success && r.output) candidates.push(r.output)
+      if (!r.success && firstFailure === undefined) firstFailure = r
+      if (options.abortSignal?.aborted) {
+        const abortError = new Error('Run cancelled by caller.')
+        abortError.name = 'AbortError'
+        const classified = classifyRunFailure(abortError)
+        return {
+          identity,
+          status: classified.status,
+          errorInfo: classified.errorInfo,
+          answer: candidates.join('\n\n---\n\n'),
+          verdict: 'rejected',
+          dissent: [],
+          rounds: 0,
+          tokenUsage: usage,
+        }
+      }
       if (budget !== undefined && usage.input_tokens + usage.output_tokens > budget) {
+        const budgetError = new TokenBudgetExceededError(
+          proposerConfig.name,
+          usage.input_tokens + usage.output_tokens,
+          budget,
+        )
         this.config.onProgress?.({
           type: 'budget_exceeded',
           agent: proposerConfig.name,
-          data: new TokenBudgetExceededError(
-            proposerConfig.name,
-            usage.input_tokens + usage.output_tokens,
-            budget,
-          ),
+          data: budgetError,
         })
+        const classified = classifyRunFailure(budgetError)
         return {
+          identity,
+          status: classified.status,
+          errorInfo: classified.errorInfo,
           answer: candidates.join('\n\n---\n\n'),
           verdict: 'rejected',
           dissent: [],
@@ -2641,10 +2785,16 @@ export class OpenMultiAgent {
     // Every proposer failed or returned empty output: there is nothing to judge.
     // Bail with a rejected verdict so an empty answer can never come back accepted.
     if (candidates.length === 0) {
-      return { answer: '', verdict: 'rejected', dissent: [], rounds: 0, tokenUsage: usage }
+      const status = firstFailure?.status ?? statusOnly('error', 'All consensus proposers failed.')
+      return {
+        identity,
+        status,
+        ...(firstFailure?.errorInfo ? { errorInfo: firstFailure.errorInfo } : {}),
+        answer: '', verdict: 'rejected', dissent: [], rounds: 0, tokenUsage: usage,
+      }
     }
 
-    return runConsensusCore({
+    const result = await runConsensusCore({
       team,
       prompt,
       initialAnswer: candidates.join('\n\n---\n\n'),
@@ -2661,9 +2811,27 @@ export class OpenMultiAgent {
       reviseProposer: proposers[0],
       defaults,
       onTrace: this.config.onTrace,
-      runId: this.config.onTrace ? generateRunId() : undefined,
+      runId: identity.runId,
+      identity,
+      abortSignal: options.abortSignal,
       pool,
     })
+    if (options.abortSignal?.aborted) {
+      const abortError = new Error('Run cancelled by caller.')
+      abortError.name = 'AbortError'
+      const classified = classifyRunFailure(abortError)
+      return { ...result, identity, status: classified.status, errorInfo: classified.errorInfo }
+    }
+    if (budget !== undefined && result.tokenUsage.input_tokens + result.tokenUsage.output_tokens > budget) {
+      const budgetError = new TokenBudgetExceededError(
+        proposers[0]!.name,
+        result.tokenUsage.input_tokens + result.tokenUsage.output_tokens,
+        budget,
+      )
+      const classified = classifyRunFailure(budgetError)
+      return { ...result, identity, status: classified.status, errorInfo: classified.errorInfo }
+    }
+    return { ...result, identity, status: result.status ?? statusOnly('ok') }
   }
 
   // -------------------------------------------------------------------------
@@ -2874,6 +3042,7 @@ export class OpenMultiAgent {
     goal: string,
     coordinatorBaseConfig: AgentConfig,
     opts: {
+      readonly identity: RunIdentity
       readonly modelRouting?: ModelRoutingPolicy
       readonly runId?: string
       readonly abortSignal?: AbortSignal
@@ -2905,10 +3074,15 @@ export class OpenMultiAgent {
       routeMatches(opts.modelRouting, { phase: 'synthesis', agent: 'coordinator' }),
     )
     const synthesisAgent = buildAgent(synthesisConfig)
-    const synthTraceOptions: Partial<RunOptions> | undefined = this.config.onTrace
-      ? { onTrace: this.config.onTrace, runId: opts.runId ?? '', traceAgent: 'coordinator' }
-      : undefined
-    const result = await synthesisAgent.run(synthesisPrompt, synthTraceOptions)
+    const synthTraceOptions: Partial<RunOptions> = {
+      identity: opts.identity,
+      runId: opts.identity.runId,
+      ...(this.config.onTrace
+        ? { onTrace: this.config.onTrace, traceAgent: 'coordinator' }
+        : {}),
+      ...(opts.abortSignal ? { abortSignal: opts.abortSignal } : {}),
+    }
+    let result = await synthesisAgent.run(synthesisPrompt, synthTraceOptions)
     const accounting = applyBudgetAccounting({
       currentUsage: opts.cumulativeUsage,
       currentCost: opts.cumulativeCost,
@@ -2926,6 +3100,12 @@ export class OpenMultiAgent {
 
     if (accounting.exceeded) {
       emitBudgetExceeded(this.config, accounting.exceeded, 'coordinator')
+      result = {
+        ...result,
+        success: false,
+        budgetExceeded: true,
+        ...classifyRunFailure(accounting.exceeded),
+      }
     }
 
     this.config.onProgress?.({
@@ -3014,7 +3194,9 @@ export class OpenMultiAgent {
     initialAgentResults?: Map<string, AgentRunResult>,
     activeCheckpoint?: ActiveCheckpoint,
     coordinatorForSynthesis?: CoordinatorConfig,
+    identity?: RunIdentity,
   ): Promise<TeamRunResult> {
+    const runIdentity = identity ?? createRunIdentity(identityOptionsForRun(options))
     const agentConfigs = team.getAgents()
     const scheduler = new Scheduler('dependency-first')
     scheduler.autoAssign(queue, agentConfigs)
@@ -3034,7 +3216,8 @@ export class OpenMultiAgent {
       agentResults,
       config: this.config,
       ...(checkpoint ? { checkpoint } : {}),
-      runId: this.config.onTrace ? generateRunId() : undefined,
+      identity: runIdentity,
+      runId: runIdentity.runId,
       abortSignal: options?.abortSignal,
       cumulativeUsage: ZERO_USAGE,
       cumulativeCost: 0,
@@ -3050,6 +3233,9 @@ export class OpenMultiAgent {
     }
 
     await executeQueue(queue, ctx)
+    if (queue.list().every((task) => task.status === 'completed')) {
+      await saveRunCheckpoint(queue, ctx)
+    }
 
     // A resumed `runTeam` re-runs the coordinator synthesis so the restored
     // result matches a fresh `runTeam` (a synthesized final answer, not raw
@@ -3060,6 +3246,7 @@ export class OpenMultiAgent {
       try {
         const coordinatorBaseConfig = this.buildCoordinatorBaseConfig(coordinatorForSynthesis, agentConfigs, false)
         const synthesis = await this.runCoordinatorSynthesis(team, queue, goal, coordinatorBaseConfig, {
+          identity: runIdentity,
           modelRouting: options?.modelRouting,
           runId: ctx.runId,
           abortSignal: options?.abortSignal,
@@ -3084,12 +3271,23 @@ export class OpenMultiAgent {
               error: new Error(synthesis.result.output || 'coordinator synthesis failed'),
             },
           })
+          ctx.outcomeStatus = synthesis.result.status ?? statusOnly('error', synthesis.result.output)
+          ctx.outcomeErrorInfo = synthesis.result.errorInfo
+        } else if (options?.abortSignal?.aborted && ctx.outcomeStatus === undefined) {
+          const abortError = new Error('Run cancelled by caller.')
+          abortError.name = 'AbortError'
+          const classified = classifyRunFailure(abortError)
+          ctx.outcomeStatus = classified.status
+          ctx.outcomeErrorInfo = classified.errorInfo
         }
       } catch (error) {
         this.config.onProgress?.({
           type: 'error',
           data: { kind: 'synthesis_failed', error },
         })
+        const classified = classifyRunFailure(error)
+        ctx.outcomeStatus = classified.status
+        ctx.outcomeErrorInfo = classified.errorInfo
       }
     }
 
@@ -3108,7 +3306,14 @@ export class OpenMultiAgent {
       metrics: ctx.taskMetrics.get(task.id),
     }))
 
-    return this.buildTeamRunResult(agentResults, goal, taskRecords)
+    return this.buildTeamRunResult(
+      agentResults,
+      runIdentity,
+      goal,
+      taskRecords,
+      ctx.outcomeStatus,
+      ctx.outcomeErrorInfo,
+    )
   }
 
   private createActiveCheckpoint(
@@ -3295,8 +3500,11 @@ export class OpenMultiAgent {
    */
   private buildTeamRunResult(
     agentResults: Map<string, AgentRunResult>,
+    identity: RunIdentity,
     goal?: string,
     tasks?: readonly TaskExecutionRecord[],
+    forcedStatus?: RunStatus,
+    forcedErrorInfo?: StructuredTraceError,
   ): TeamRunResult {
     let totalUsage: TokenUsage = ZERO_USAGE
     let overallSuccess = true
@@ -3317,6 +3525,13 @@ export class OpenMultiAgent {
         // Keep the latest `structured` value (last completed task wins).
         collapsed.set(agentName, {
           success: existing.success && result.success,
+          identity,
+          status: existing.success && result.success
+            ? statusOnly('ok')
+            : result.status ?? existing.status ?? statusOnly('error'),
+          ...(result.errorInfo ?? existing.errorInfo
+            ? { errorInfo: result.errorInfo ?? existing.errorInfo }
+            : {}),
           output: [existing.output, result.output].filter(Boolean).join('\n\n---\n\n'),
           messages: [...existing.messages, ...result.messages],
           tokenUsage: addUsage(existing.tokenUsage, result.tokenUsage),
@@ -3334,8 +3549,25 @@ export class OpenMultiAgent {
 
     const metrics = computeRunMetrics(tasks)
 
+    const statuses = [...agentResults.values()]
+      .map((result) => result.status)
+      .filter((status): status is RunStatus => status !== undefined)
+    const firstStatus = (code: RunStatus['code']) => statuses.find((status) => status.code === code)
+    const taskFailed = tasks?.some((task) => task.status === 'failed') ?? false
+    const status = forcedStatus
+      ?? firstStatus('budget_exhausted')
+      ?? firstStatus('timeout')
+      ?? firstStatus('cancelled')
+      ?? (overallSuccess && !taskFailed ? statusOnly('ok') : statusOnly('error'))
+    const errorInfo = forcedErrorInfo ?? [...agentResults.values()]
+      .find((result) => result.status?.code === status.code && result.errorInfo !== undefined)
+      ?.errorInfo
+
     return {
-      success: overallSuccess,
+      success: status.code === 'ok',
+      identity,
+      status,
+      ...(errorInfo !== undefined ? { errorInfo } : {}),
       goal,
       tasks,
       agentResults: collapsed,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -157,6 +157,98 @@ export interface TokenUsage {
   readonly output_tokens: number
 }
 
+// ---------------------------------------------------------------------------
+// Run identity and outcome
+// ---------------------------------------------------------------------------
+
+/** Stable identity for one logical run and its current execution attempt. */
+export interface RunIdentity {
+  /** Logical run identifier. Preserved across checkpoint restore. */
+  readonly runId: string
+  /** One-based execution attempt. Incremented by each restore. */
+  readonly attempt: number
+  /** W3C-compatible 32-character lowercase hexadecimal trace identifier. */
+  readonly traceId: string
+  /** W3C-compatible 16-character lowercase hexadecimal root span identifier. */
+  readonly rootSpanId: string
+  /** Continuation links, currently used by checkpoint restore. */
+  readonly links?: readonly TraceLink[]
+}
+
+/** A relationship from this execution attempt to an earlier trace. */
+export interface TraceLink {
+  readonly traceId: string
+  readonly spanId: string
+  readonly relation: 'continued_from'
+}
+
+/** Backwards-compatible identity-specific alias for {@link TraceLink}. */
+export type RunIdentityLink = TraceLink
+
+/** Caller-provided identity controls shared by all top-level execution APIs. */
+export interface RunIdentityOptions {
+  /** Optional logical run identifier (1-128 characters). */
+  readonly runId?: string
+}
+
+/** Per-call options for {@link OpenMultiAgent.runAgent}. */
+export interface RunAgentOptions extends RunIdentityOptions {
+  readonly abortSignal?: AbortSignal
+}
+
+export type RunStatusCode =
+  | 'ok'
+  | 'error'
+  | 'cancelled'
+  | 'timeout'
+  | 'budget_exhausted'
+  | 'rejected'
+  | 'skipped'
+
+/** Normalised top-level outcome. */
+export interface RunStatus {
+  readonly code: RunStatusCode
+  readonly message?: string
+}
+
+export type TraceErrorKind =
+  | 'provider'
+  | 'tool'
+  | 'framework'
+  | 'callback'
+  | 'validation'
+  | 'timeout'
+  | 'cancellation'
+  | 'budget'
+  | 'store'
+  | 'exporter'
+  | 'unknown'
+
+/** JSON-safe, redacted error details for results and future trace records. */
+export interface StructuredTraceError {
+  readonly kind: TraceErrorKind
+  readonly code?: string
+  readonly name?: string
+  readonly message?: string
+  readonly retryable?: boolean
+  readonly httpStatus?: number
+  readonly provider?: string
+  readonly attempt?: number
+}
+
+/** Additive result fields introduced by Observability v2. */
+export interface RunOutcomeFields {
+  /**
+   * Runtime results always include this field. It is optional in the first
+   * compatible 1.x type release so existing hand-written result fixtures keep
+   * compiling; it can become required in a later compatibility window.
+   */
+  readonly identity?: RunIdentity
+  /** Runtime results always include this field; see {@link identity}. */
+  readonly status?: RunStatus
+  readonly errorInfo?: StructuredTraceError
+}
+
 /** Context passed to user-supplied cost estimators. */
 export interface CostEstimateContext {
   /** Agent whose LLM usage is being costed. */
@@ -786,7 +878,7 @@ export interface ToolCallRecord {
 }
 
 /** The final result produced when an agent run completes (or fails). */
-export interface AgentRunResult {
+export interface AgentRunResult extends RunOutcomeFields {
   readonly success: boolean
   readonly output: string
   readonly messages: LLMMessage[]
@@ -890,7 +982,7 @@ export interface RunTaskSpec {
 }
 
 /** Per-call options for {@link OpenMultiAgent.runTasks}. */
-export interface RunTasksOptions {
+export interface RunTasksOptions extends RunIdentityOptions {
   readonly abortSignal?: AbortSignal
   /**
    * Opt-in durable task checkpointing. When enabled, the orchestrator writes a
@@ -976,7 +1068,7 @@ export interface RunMetrics {
 }
 
 /** Aggregated result for a full team run. */
-export interface TeamRunResult {
+export interface TeamRunResult extends RunOutcomeFields {
   readonly success: boolean
   readonly goal?: string
   readonly tasks?: readonly TaskExecutionRecord[]
@@ -1044,13 +1136,14 @@ export interface ConsensusVerifyOptions {
 }
 
 /** Options for {@link OpenMultiAgent.runConsensus}. */
-export interface ConsensusOptions extends ConsensusVerifyOptions {
+export interface ConsensusOptions extends ConsensusVerifyOptions, RunIdentityOptions {
   /** Proposer agent(s). An array runs all (N-best); usage counts against the parent budget. */
   readonly proposer: AgentConfig | readonly AgentConfig[]
+  readonly abortSignal?: AbortSignal
 }
 
 /** Result of a consensus run (or per-task `verify` hook). */
-export interface ConsensusResult {
+export interface ConsensusResult extends RunOutcomeFields {
   readonly answer: string
   /** `accepted` when quorum was reached (or `onDissent: 'keep'`); else `rejected`. */
   readonly verdict: 'accepted' | 'rejected'
@@ -1387,12 +1480,9 @@ export interface CompletedTaskCheckpoint {
   readonly result?: string
 }
 
-/** Full persisted checkpoint for a task-based run. */
-export interface CheckpointSnapshot {
-  readonly version: 1
+interface CheckpointSnapshotBase {
   readonly mode: 'runTeam' | 'runTasks'
   readonly createdAt: string
-  readonly runId?: string
   readonly goal?: string
   readonly queue: TaskQueueSnapshot
   readonly sharedMemory?: SharedMemorySnapshot
@@ -1405,6 +1495,29 @@ export interface CheckpointSnapshot {
   readonly turnCount?: number
   readonly completedTaskResults: readonly CompletedTaskCheckpoint[]
 }
+
+/** Legacy checkpoint schema, retained for read compatibility. */
+export interface CheckpointSnapshotV1 extends CheckpointSnapshotBase {
+  readonly version: 1
+  readonly runId?: string
+}
+
+/** Identity persisted by checkpoint schema v2. */
+export interface CheckpointRunIdentity {
+  readonly runId: string
+  readonly attempt: number
+  readonly lastTraceId: string
+  readonly lastRootSpanId: string
+}
+
+/** Current checkpoint schema. */
+export interface CheckpointSnapshotV2 extends CheckpointSnapshotBase {
+  readonly version: 2
+  readonly identity: CheckpointRunIdentity
+}
+
+/** Full persisted checkpoint for a task-based run. */
+export type CheckpointSnapshot = CheckpointSnapshotV1 | CheckpointSnapshotV2
 
 /**
  * Optional overrides for the temporary coordinator agent created by `runTeam`.

--- a/packages/core/tests/observability-v2-identity.test.ts
+++ b/packages/core/tests/observability-v2-identity.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from 'vitest'
+import { Checkpoint } from '../src/memory/checkpoint.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { classifyRunFailure } from '../src/observability/status.js'
+import { TaskQueue } from '../src/task/queue.js'
+import { createTask } from '../src/task/task.js'
+import { Team } from '../src/team/team.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMChatOptions,
+  LLMMessage,
+  LLMResponse,
+  RunIdentity,
+} from '../src/types.js'
+
+function response(text: string, usage = { input_tokens: 1, output_tokens: 1 }): LLMResponse {
+  return {
+    id: `response-${text}`,
+    content: [{ type: 'text', text }],
+    model: 'test-model',
+    stop_reason: 'end_turn',
+    usage,
+  }
+}
+
+function adapter(
+  chat: (messages: LLMMessage[], options: LLMChatOptions) => Promise<LLMResponse>,
+): LLMAdapter {
+  return {
+    name: 'obs-1a-test',
+    chat,
+    async *stream() { /* unused */ },
+  }
+}
+
+function staticAdapter(text = 'ok', usage?: { input_tokens: number; output_tokens: number }): LLMAdapter {
+  return adapter(async () => response(text, usage))
+}
+
+function agentConfig(name = 'worker', llm: LLMAdapter = staticAdapter()): AgentConfig {
+  return { name, model: 'test-model', adapter: llm }
+}
+
+function teamWith(llm: LLMAdapter = staticAdapter()): Team {
+  return new Team({ name: 'team', agents: [agentConfig('worker', llm)] })
+}
+
+function expectIdentity(identity: RunIdentity | undefined, attempt = 1): RunIdentity {
+  expect(identity).toBeDefined()
+  expect(identity!.runId.length).toBeGreaterThan(0)
+  expect(identity!.attempt).toBe(attempt)
+  expect(identity!.traceId).toMatch(/^[0-9a-f]{32}$/)
+  expect(identity!.traceId).not.toMatch(/^0+$/)
+  expect(identity!.rootSpanId).toMatch(/^[0-9a-f]{16}$/)
+  expect(identity!.rootSpanId).not.toMatch(/^0+$/)
+  return identity!
+}
+
+describe('OBS-1A run identity', () => {
+  it('returns unique identity without onTrace from every top-level entry', async () => {
+    const oma = new OpenMultiAgent({ defaultModel: 'test-model' })
+    const runAgent = await oma.runAgent(agentConfig(), 'hello')
+    const runTeam = await oma.runTeam(teamWith(), 'Say hello')
+    const runTasks = await oma.runTasks(teamWith(), [
+      { title: 'task', description: 'work', assignee: 'worker' },
+    ])
+    const runFromPlan = await oma.runFromPlan(teamWith(), {
+      version: 1,
+      tasks: [{ id: 'planned', title: 'planned', description: 'work', assignee: 'worker' }],
+    })
+
+    let consensusCall = 0
+    const consensusAdapter = adapter(async () => response(
+      consensusCall++ === 0 ? 'answer' : '{"accept":true,"critique":""}',
+    ))
+    const runConsensus = await oma.runConsensus(teamWith(), 'question', {
+      proposer: agentConfig('proposer', consensusAdapter),
+      judges: [agentConfig('judge', consensusAdapter)],
+      maxRounds: 1,
+    })
+
+    const identities = [
+      runAgent.identity,
+      runTeam.identity,
+      runTasks.identity,
+      runFromPlan.identity,
+      runConsensus.identity,
+    ].map((identity) => expectIdentity(identity))
+
+    expect(new Set(identities.map((identity) => identity.runId)).size).toBe(5)
+    expect(new Set(identities.map((identity) => identity.traceId)).size).toBe(5)
+    expect(runAgent.status?.code).toBe('ok')
+    expect(runTeam.status?.code).toBe('ok')
+    expect(runTasks.status?.code).toBe('ok')
+    expect(runFromPlan.status?.code).toBe('ok')
+    expect(runConsensus.status?.code).toBe('ok')
+  })
+
+  it('uses a caller runId and keeps it stable through nested results', async () => {
+    const oma = new OpenMultiAgent({ defaultModel: 'test-model' })
+    const result = await oma.runTasks(teamWith(), [
+      { title: 'task', description: 'work', assignee: 'worker' },
+    ], { runId: 'customer-run-42' })
+
+    expect(result.identity?.runId).toBe('customer-run-42')
+    expect(result.agentResults.get('worker')?.identity).toEqual(result.identity)
+  })
+
+  it('rejects empty, overlong, and conflicting run IDs', async () => {
+    const oma = new OpenMultiAgent({ defaultModel: 'test-model' })
+    await expect(oma.runAgent(agentConfig(), 'hello', { runId: '' })).rejects.toThrow(/1 and 128/)
+    await expect(oma.runAgent(agentConfig(), 'hello', { runId: 'x'.repeat(129) })).rejects.toThrow(/1 and 128/)
+    await expect(oma.runTasks(teamWith(), [], {
+      runId: 'one',
+      checkpoint: { store: new InMemoryStore(), runId: 'two' },
+    })).rejects.toThrow(/runId conflict/)
+  })
+})
+
+describe('OBS-1A outcome semantics', () => {
+  it('maps success and provider execution failure', async () => {
+    const ok = await new OpenMultiAgent().runAgent(agentConfig(), 'hello')
+    expect(ok.success).toBe(true)
+    expect(ok.status?.code).toBe('ok')
+    expect(ok.errorInfo).toBeUndefined()
+
+    const providerError = Object.assign(new Error('provider unavailable'), { status: 503 })
+    const failed = await new OpenMultiAgent().runAgent(
+      agentConfig('worker', adapter(async () => { throw providerError })),
+      'hello',
+    )
+    expect(failed.success).toBe(false)
+    expect(failed.status?.code).toBe('error')
+    expect(failed.errorInfo).toMatchObject({ kind: 'provider', httpStatus: 503, retryable: true })
+    expect(failed.error).toBe(providerError)
+  })
+
+  it('classifies provider 401/429/500 retryability', () => {
+    const classified = (status: number) => classifyRunFailure(
+      Object.assign(new Error(`HTTP ${status}`), { status }),
+    ).errorInfo
+    expect(classified(401)).toMatchObject({ kind: 'provider', httpStatus: 401, retryable: false })
+    expect(classified(429)).toMatchObject({ kind: 'provider', httpStatus: 429, retryable: true })
+    expect(classified(500)).toMatchObject({ kind: 'provider', httpStatus: 500, retryable: true })
+  })
+
+  it('maps caller abort and whole-run timeout without reporting success', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const cancelled = await new OpenMultiAgent().runAgent(
+      agentConfig('worker', staticAdapter()),
+      'hello',
+      { abortSignal: controller.signal },
+    )
+    expect(cancelled.success).toBe(false)
+    expect(cancelled.status?.code).toBe('cancelled')
+    expect(cancelled.errorInfo?.kind).toBe('cancellation')
+
+    const waitsForAbort = adapter(async (_messages, options) => {
+      await new Promise<void>((resolve) => {
+        if (options.abortSignal?.aborted) resolve()
+        else options.abortSignal?.addEventListener('abort', () => resolve(), { once: true })
+      })
+      return response('late')
+    })
+    const timedOut = await new OpenMultiAgent().runAgent(
+      { ...agentConfig('worker', waitsForAbort), timeoutMs: 5 },
+      'hello',
+    )
+    expect(timedOut.success).toBe(false)
+    expect(timedOut.status?.code).toBe('timeout')
+    expect(timedOut.errorInfo?.kind).toBe('timeout')
+  })
+
+  it('maps token budget exhaustion', async () => {
+    const result = await new OpenMultiAgent().runAgent(
+      { ...agentConfig('worker', staticAdapter('large', { input_tokens: 8, output_tokens: 8 })), maxTokenBudget: 10 },
+      'hello',
+    )
+    expect(result.success).toBe(false)
+    expect(result.status?.code).toBe('budget_exhausted')
+    expect(result.errorInfo?.kind).toBe('budget')
+  })
+
+  it('maps pre-aborted task runs, plan-only, plan rejection, and callback failure', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const cancelled = await new OpenMultiAgent({ defaultModel: 'test-model' }).runTasks(
+      teamWith(),
+      [{ title: 'task', description: 'work', assignee: 'worker' }],
+      { abortSignal: controller.signal },
+    )
+    expect(cancelled.success).toBe(false)
+    expect(cancelled.status?.code).toBe('cancelled')
+    expect(cancelled.tasks?.[0]?.status).toBe('skipped')
+
+    const taskJson = '```json\n[{"title":"task","description":"work","assignee":"worker"}]\n```'
+    const planOnly = await new OpenMultiAgent({ defaultModel: 'test-model' }).runTeam(
+      teamWith(staticAdapter(taskJson)),
+      'First plan the work, then execute it',
+      { planOnly: true, coordinator: { adapter: staticAdapter(taskJson) } },
+    )
+    expect(planOnly.success).toBe(true)
+    expect(planOnly.status?.code).toBe('ok')
+    expect(planOnly.planOnly).toBe(true)
+
+    const rejected = await new OpenMultiAgent({
+      defaultModel: 'test-model',
+      onPlanReady: async () => false,
+    }).runTeam(teamWith(), 'First plan the work, then execute it', {
+      coordinator: { adapter: staticAdapter(taskJson) },
+    })
+    expect(rejected.success).toBe(false)
+    expect(rejected.status?.code).toBe('rejected')
+    expect(rejected.errorInfo).toBeUndefined()
+
+    const callbackError = await new OpenMultiAgent({
+      defaultModel: 'test-model',
+      onPlanReady: async () => { throw new Error('gate failed') },
+    }).runTeam(teamWith(), 'First plan the work, then execute it', {
+      coordinator: { adapter: staticAdapter(taskJson) },
+    })
+    expect(callbackError.success).toBe(false)
+    expect(callbackError.status?.code).toBe('error')
+    expect(callbackError.errorInfo?.kind).toBe('callback')
+  })
+
+  it('keeps a rejected consensus verdict as an ok execution outcome', async () => {
+    let call = 0
+    const llm = adapter(async () => response(
+      call++ === 0 ? 'answer' : '{"accept":false,"critique":"not enough"}',
+    ))
+    const result = await new OpenMultiAgent().runConsensus(teamWith(), 'question', {
+      proposer: agentConfig('proposer', llm),
+      judges: [agentConfig('judge', llm)],
+      maxRounds: 1,
+      onDissent: 'reject',
+    })
+    expect(result.verdict).toBe('rejected')
+    expect(result.status?.code).toBe('ok')
+  })
+
+  it('reports a judge execution failure as an error outcome', async () => {
+    const proposer = staticAdapter('answer')
+    const judgeError = Object.assign(new Error('judge provider failed'), { status: 500 })
+    const judge = adapter(async () => { throw judgeError })
+    const result = await new OpenMultiAgent().runConsensus(teamWith(), 'question', {
+      proposer: agentConfig('proposer', proposer),
+      judges: [agentConfig('judge', judge)],
+      maxRounds: 1,
+      onDissent: 'reject',
+    })
+    expect(result.verdict).toBe('rejected')
+    expect(result.status?.code).toBe('error')
+    expect(result.errorInfo).toMatchObject({ kind: 'provider', httpStatus: 500 })
+  })
+
+  it('maps between-round approval rejection to rejected', async () => {
+    const oma = new OpenMultiAgent({
+      defaultModel: 'test-model',
+      onApproval: async () => false,
+    })
+    const result = await oma.runTasks(teamWith(), [
+      { title: 'first', description: 'work', assignee: 'worker' },
+      { title: 'second', description: 'work', assignee: 'worker', dependsOn: ['first'] },
+    ])
+    expect(result.success).toBe(false)
+    expect(result.status?.code).toBe('rejected')
+    expect(result.tasks?.map((task) => task.status)).toEqual(['completed', 'skipped'])
+  })
+})
+
+describe('OBS-1A checkpoint v2 restore', () => {
+  it('writes v2 and restores with the same runId, incremented attempt, and a new trace link', async () => {
+    const store = new InMemoryStore()
+    const oma = new OpenMultiAgent({ defaultModel: 'test-model' })
+    const initial = await oma.runTasks(teamWith(), [
+      { title: 'task', description: 'work', assignee: 'worker' },
+    ], { checkpoint: { store, runId: 'logical-run' } })
+    const stored = await new Checkpoint(store, { runId: 'logical-run' }).loadLatest()
+
+    expect(stored?.version).toBe(2)
+    if (stored?.version !== 2) throw new Error('expected checkpoint v2')
+    expect(stored.identity).toEqual({
+      runId: initial.identity?.runId,
+      attempt: 1,
+      lastTraceId: initial.identity?.traceId,
+      lastRootSpanId: initial.identity?.rootSpanId,
+    })
+
+    const restored = await oma.restore(teamWith(), {
+      checkpoint: { store, runId: 'logical-run' },
+    })
+    const restoredIdentity = expectIdentity(restored.identity, 2)
+    expect(restoredIdentity.runId).toBe(initial.identity?.runId)
+    expect(restoredIdentity.traceId).not.toBe(initial.identity?.traceId)
+    expect(restoredIdentity.rootSpanId).not.toBe(initial.identity?.rootSpanId)
+    expect(restoredIdentity.links).toEqual([{
+      traceId: initial.identity?.traceId,
+      spanId: initial.identity?.rootSpanId,
+      relation: 'continued_from',
+    }])
+
+    const restoredAgain = await oma.restore(teamWith(), {
+      checkpoint: { store, runId: 'logical-run' },
+    })
+    expectIdentity(restoredAgain.identity, 3)
+    expect(restoredAgain.identity?.links?.[0]).toMatchObject({
+      traceId: restored.identity?.traceId,
+      spanId: restored.identity?.rootSpanId,
+      relation: 'continued_from',
+    })
+  })
+
+  it('reads v1, treats it as attempt 1, and rejects a conflicting restore runId', async () => {
+    const store = new InMemoryStore()
+    const queue = new TaskQueue()
+    const completed = { ...createTask({ title: 'task', description: 'work', assignee: 'worker' }), id: 'task' }
+    queue.add(completed)
+    queue.complete('task', 'done')
+    await new Checkpoint(store, { runId: 'legacy-run' }).save({
+      version: 1,
+      mode: 'runTasks',
+      createdAt: new Date().toISOString(),
+      runId: 'legacy-run',
+      queue: queue.snapshot(),
+      completedTaskResults: [{ taskId: 'task', assignee: 'worker', result: 'done' }],
+    })
+
+    const oma = new OpenMultiAgent({ defaultModel: 'test-model' })
+    const restored = await oma.restore(teamWith(), {
+      checkpoint: { store, runId: 'legacy-run' },
+    })
+    expectIdentity(restored.identity, 2)
+    expect(restored.identity?.runId).toBe('legacy-run')
+    expect(restored.identity?.links).toBeUndefined()
+
+    await expect(oma.restore(teamWith(), {
+      runId: 'different-run',
+      checkpoint: { store, runId: 'legacy-run' },
+    })).rejects.toThrow(/runId conflict/)
+  })
+})

--- a/packages/core/tests/orchestrator.test.ts
+++ b/packages/core/tests/orchestrator.test.ts
@@ -1027,9 +1027,10 @@ describe('OpenMultiAgent', () => {
         { title: 'Second', description: 'Do second', assignee: 'worker', dependsOn: ['First'] },
       ])
 
-      // The first task succeeded; the second was skipped (no agentResult entry).
-      // Overall success is based on agentResults only, so it's true.
-      expect(result.success).toBe(true)
+      // The first task succeeded; the second was skipped after an explicit
+      // approval rejection. OBS-1A reports the top-level run as rejected.
+      expect(result.success).toBe(false)
+      expect(result.status?.code).toBe('rejected')
       // But we should have fewer agent results than tasks
       expect(result.agentResults.size).toBeLessThanOrEqual(1)
     })


### PR DESCRIPTION
## What changed

- add stable `runId`, `attempt`, `traceId`, and `rootSpanId` to every top-level execution result, including no-sink and special paths
- normalize run outcomes and redacted `errorInfo`, while retaining the existing `success` compatibility contract
- add checkpoint schema v2 so restore preserves `runId`, increments `attempt`, starts a fresh trace/root span, and links to the previous attempt
- retain checkpoint v1 read compatibility and document the public contract in the root/package READMEs plus the observability/checkpoint guides

## Why

OBS-1A establishes a reliable logical-run identity and terminal outcome contract before later span lifecycle, exporter, store, OTel, or dashboard work. It also fixes cancellation and whole-run timeout paths that could previously be reported as successful.

## Compatibility and impact

- runtime results always include `identity` and `status`
- new result fields remain optional in TypeScript for the first compatible 1.x release, minimizing breakage for handwritten result mocks and custom backends
- `success` remains available and is derived from `status.code === 'ok'`
- no new runtime dependencies; no OBS-1B span lifecycle, sink/exporter, TraceStore, OTel, or dashboard changes

## Checks

- `npm run lint`
- `npm test` (1,181 core tests + 26 create-oma-app tests)
- `npm run build`
- `npm --workspace @open-multi-agent/core test -- tests/observability-v2-identity.test.ts` (13 tests)
- `git diff --check`
- built-package root import smoke test
- `npm pack --dry-run -w @open-multi-agent/core`
