### PR TITLE
feat(core): add OBS-1B span lifecycle and hierarchy

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -33,6 +33,40 @@ For source compatibility in the first 1.x release, the new result fields are
 optional in TypeScript declarations, but every runtime result from these APIs
 includes `identity` and `status`.
 
+## TraceRecord schema v2
+
+The core package exports the `TraceRecord` schema used by the internal
+OBS-1B runtime. A span produces `span_start`, zero or more `span_event`
+records, and exactly one self-contained `span_end`. Records carry
+`schemaVersion: 2`, a unique `recordId`, a per-trace strictly increasing
+`sequence`, the run identity, W3C-compatible trace/span IDs, timestamps,
+status, safe attributes, and optional links.
+
+The hierarchy uses parent relationships for lifecycle containment and links
+for non-tree relationships:
+
+- the run root contains coordinator, task, consensus, checkpoint, and callback operations;
+- task attempts are agent children, with LLM and tool calls below the agent;
+- DAG prerequisites use `depends_on` links;
+- delegated agents are children of the `delegate_to_agent` tool and link back to the task;
+- coordinator synthesis uses `consumed` links to task spans;
+- checkpoint restore starts a new trace whose root links `continued_from` the prior root.
+
+`span_end` repeats the span kind, name, start time, final attributes, links,
+status, and structured error so it remains useful if a start/event record is
+lost later in the delivery pipeline. Close is idempotent and the first end
+wins.
+
+OBS-1B does not add a public sink/exporter lifecycle. The runtime is activated
+by the existing `onTrace` path and converts completed v2 operations back to
+the unchanged seven-member `TraceEvent` union. Without `onTrace`, no child
+TraceRecord objects are constructed; top-level identity/status still exist.
+
+Streaming notifications are span events rather than zero-duration child
+spans in v2. TTFT is recorded only by a genuinely streaming provider path;
+the current aggregated `chat()` path never substitutes total latency for
+TTFT. Legacy `agent_stream` callback events remain unchanged.
+
 ## Progress Events
 
 Use `onProgress` when you need lightweight lifecycle events for logs, terminal output, or a live UI.

--- a/packages/core/benchmarks/observability-no-sink.mjs
+++ b/packages/core/benchmarks/observability-no-sink.mjs
@@ -1,0 +1,69 @@
+import { pathToFileURL } from 'node:url'
+import { performance } from 'node:perf_hooks'
+
+const [baselinePath, candidatePath] = process.argv.slice(2)
+if (!baselinePath || !candidatePath) {
+  throw new Error('Usage: node observability-no-sink.mjs <baseline-index.js> <candidate-index.js>')
+}
+
+const iterations = Number(process.env.OMA_BENCH_ITERATIONS ?? 2_000)
+const rounds = Number(process.env.OMA_BENCH_ROUNDS ?? 9)
+
+async function load(indexPath, label) {
+  const { OpenMultiAgent } = await import(`${pathToFileURL(indexPath).href}?label=${label}`)
+  const adapter = {
+    name: `benchmark-${label}`,
+    async chat() {
+      return {
+        id: 'benchmark-response',
+        content: [{ type: 'text', text: 'ok' }],
+        model: 'benchmark-model',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }
+    },
+    async *stream() {},
+  }
+  const oma = new OpenMultiAgent({ defaultModel: 'benchmark-model' })
+  const agent = { name: 'benchmark', model: 'benchmark-model', adapter }
+  return async (count) => {
+    const start = performance.now()
+    for (let index = 0; index < count; index++) {
+      await oma.runAgent(agent, 'ping')
+    }
+    return performance.now() - start
+  }
+}
+
+const baseline = await load(baselinePath, 'baseline')
+const candidate = await load(candidatePath, 'candidate')
+await baseline(200)
+await candidate(200)
+
+const baselineMs = []
+const candidateMs = []
+for (let round = 0; round < rounds; round++) {
+  if (round % 2 === 0) {
+    baselineMs.push(await baseline(iterations))
+    candidateMs.push(await candidate(iterations))
+  } else {
+    candidateMs.push(await candidate(iterations))
+    baselineMs.push(await baseline(iterations))
+  }
+}
+
+const median = (values) => [...values].sort((a, b) => a - b)[Math.floor(values.length / 2)]
+const baselineMedianMs = median(baselineMs)
+const candidateMedianMs = median(candidateMs)
+const regressionPercent = ((candidateMedianMs / baselineMedianMs) - 1) * 100
+
+console.log(JSON.stringify({
+  iterations,
+  rounds,
+  baselineMedianMs,
+  candidateMedianMs,
+  regressionPercent,
+  baselineSamplesMs: baselineMs,
+  candidateSamplesMs: candidateMs,
+}, null, 2))
+

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -54,6 +54,7 @@ import { emitTrace, generateSpanId } from '../utils/trace.js'
 import { mergeAbortSignals } from '../utils/abort.js'
 import { createRunIdentity } from '../observability/identity.js'
 import { classifyRunFailure, statusOnly } from '../observability/status.js'
+import { createTraceRuntime } from '../observability/runtime.js'
 import { TokenBudgetExceededError } from '../errors.js'
 import type { ToolDefinition as FrameworkToolDefinition, ToolRegistry } from '../tool/framework.js'
 import type { ToolExecutor } from '../tool/executor.js'
@@ -376,6 +377,23 @@ export class Agent {
     const identity = callerOptions?.identity ?? createRunIdentity(
       callerOptions?.runId !== undefined ? { runId: callerOptions.runId } : {},
     )
+    const traceRuntime = callerOptions?.traceRuntime
+      ?? createTraceRuntime(identity, callerOptions?.onTrace)
+    const traceRuntimeOwner = traceRuntime !== undefined && callerOptions?.traceRuntime === undefined
+    const traceSpan = traceRuntime?.startSpan({
+      kind: 'agent',
+      name: 'invoke_agent',
+      parent: callerOptions?.traceSpan ?? traceRuntime.root,
+      links: callerOptions?.traceLinks,
+      attributes: {
+        'oma.agent.name': callerOptions?.traceAgent ?? this.name,
+        ...(callerOptions?.tracePhase ? { 'oma.phase': callerOptions.tracePhase } : {}),
+        ...(callerOptions?.traceAgentAttempt !== undefined
+          ? { 'oma.agent.attempt': callerOptions.traceAgentAttempt }
+          : {}),
+        ...(callerOptions?.taskId ? { 'oma.task.id': callerOptions.taskId } : {}),
+      },
+    })
     let timeoutSignal: AbortSignal | undefined
     let callerAbort: AbortSignal | undefined
     let failureKind: TraceErrorKind | undefined
@@ -414,6 +432,9 @@ export class Agent {
       const runOptions: RunOptions = {
         ...callerOptions,
         identity,
+        ...(traceRuntime ? { traceRuntime } : {}),
+        ...(traceSpan ? { traceSpan } : {}),
+        ...(traceRuntimeOwner ? { traceRuntimeOwner: true } : {}),
         onMessage: internalOnMessage,
         ...(effectiveRunId ? { runId: effectiveRunId } : undefined),
         ...(effectiveSpanId ? { traceSpanId: effectiveSpanId } : undefined),
@@ -546,9 +567,8 @@ export class Agent {
     startMs: number,
     result: AgentRunResult,
   ): void {
-    if (!options?.onTrace) return
     const endMs = Date.now()
-    emitTrace(options.onTrace, {
+    const legacyEvent = options?.onTrace ? {
       type: 'agent',
       runId: options.runId ?? '',
       spanId: options.traceSpanId ?? generateSpanId(),
@@ -561,7 +581,29 @@ export class Agent {
       startMs,
       endMs,
       durationMs: endMs - startMs,
-    })
+    } as const : undefined
+    if (options?.traceSpan) {
+      options.traceSpan.end({
+        status: result.status ?? statusOnly(result.success ? 'ok' : 'error'),
+        ...(result.errorInfo ? { error: result.errorInfo } : {}),
+        attributes: {
+          'oma.agent.name': options.traceAgent ?? this.name,
+          'oma.agent.turns': result.messages.filter(m => m.role === 'assistant').length,
+          'oma.agent.tool_calls': result.toolCalls.length,
+          'oma.usage.input_tokens': result.tokenUsage.input_tokens,
+          'oma.usage.output_tokens': result.tokenUsage.output_tokens,
+        },
+        ...(legacyEvent ? { legacyEvent } : {}),
+      })
+      if (options.traceRuntimeOwner) {
+        options.traceRuntime?.close({
+          status: result.status ?? statusOnly(result.success ? 'ok' : 'error'),
+          ...(result.errorInfo ? { error: result.errorInfo } : {}),
+        })
+      }
+    } else if (legacyEvent) {
+      emitTrace(options?.onTrace, legacyEvent)
+    }
   }
 
   /**
@@ -667,6 +709,23 @@ export class Agent {
     const identity = callerOptions?.identity ?? createRunIdentity(
       callerOptions?.runId !== undefined ? { runId: callerOptions.runId } : {},
     )
+    const traceRuntime = callerOptions?.traceRuntime
+      ?? createTraceRuntime(identity, callerOptions?.onTrace)
+    const traceRuntimeOwner = traceRuntime !== undefined && callerOptions?.traceRuntime === undefined
+    const traceSpan = traceRuntime?.startSpan({
+      kind: 'agent',
+      name: 'invoke_agent',
+      parent: callerOptions?.traceSpan ?? traceRuntime.root,
+      links: callerOptions?.traceLinks,
+      attributes: {
+        'oma.agent.name': callerOptions?.traceAgent ?? this.name,
+        ...(callerOptions?.tracePhase ? { 'oma.phase': callerOptions.tracePhase } : {}),
+        ...(callerOptions?.traceAgentAttempt !== undefined
+          ? { 'oma.agent.attempt': callerOptions.traceAgentAttempt }
+          : {}),
+        ...(callerOptions?.taskId ? { 'oma.task.id': callerOptions.taskId } : {}),
+      },
+    })
     let agentTraceEmitted = false
     let effectiveTraceOptions: Partial<RunOptions> | undefined = callerOptions
 
@@ -694,6 +753,9 @@ export class Agent {
       const runOptions: RunOptions = {
         ...callerOptions,
         identity,
+        ...(traceRuntime ? { traceRuntime } : {}),
+        ...(traceSpan ? { traceSpan } : {}),
+        ...(traceRuntimeOwner ? { traceRuntimeOwner: true } : {}),
         ...(effectiveRunId ? { runId: effectiveRunId } : undefined),
         ...(effectiveSpanId ? { traceSpanId: effectiveSpanId } : undefined),
         ...(effectiveAbort ? { abortSignal: effectiveAbort } : undefined),
@@ -705,7 +767,13 @@ export class Agent {
           const result = event.data as RunResult
           this.state.tokenUsage = addUsage(this.state.tokenUsage, result.tokenUsage)
 
-          const status = result.budgetExceeded ? statusOnly('budget_exhausted') : statusOnly('ok')
+          const status = result.budgetExceeded
+            ? statusOnly('budget_exhausted')
+            : timeoutSignal?.aborted
+              ? statusOnly('timeout')
+              : callerAbort?.aborted && result.aborted
+                ? statusOnly('cancelled')
+                : statusOnly('ok')
           let agentResult = this.toAgentRunResult(
             result, !result.budgetExceeded, undefined, identity, status,
           )

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -41,6 +41,8 @@ import { emitTrace, generateSpanId } from '../utils/trace.js'
 import { mergeAbortSignals } from '../utils/abort.js'
 import { estimateTokens } from '../utils/tokens.js'
 import { redactSensitiveObject, redactSensitiveText } from '../utils/redaction.js'
+import type { TraceRuntime, TraceSpan } from '../observability/runtime.js'
+import { classifyRunFailure } from '../observability/status.js'
 import type { ToolRegistry } from '../tool/framework.js'
 import type { ToolExecutor } from '../tool/executor.js'
 import { defaultWorkspaceDir } from '../tool/built-in/path-safety.js'
@@ -168,6 +170,18 @@ export interface RunnerOptions {
 export interface RunOptions {
   /** Top-level run identity. Optional for custom backend compatibility. */
   readonly identity?: RunIdentity
+  /** Internal OBS-1B runtime; public sink configuration arrives in OBS-2. */
+  readonly traceRuntime?: TraceRuntime
+  /** Current v2 agent span used as parent for LLM/tool operations. */
+  readonly traceSpan?: TraceSpan
+  /** One-based task attempt number for v2 agent hierarchy. */
+  readonly traceAgentAttempt?: number
+  /** Non-parent relationships attached to the v2 agent span. */
+  readonly traceLinks?: readonly import('../types.js').TraceLink[]
+  /** Stable low-cardinality phase attribute for agent operations. */
+  readonly tracePhase?: string
+  /** True when the current Agent created and therefore closes traceRuntime.root. */
+  readonly traceRuntimeOwner?: boolean
   /** Fired just before each tool is dispatched. */
   readonly onToolCall?: (name: string, input: Record<string, unknown>) => void
   /** Fired after each tool result is received. */
@@ -515,6 +529,104 @@ export class AgentRunner implements AgentBackend {
     }
   }
 
+  /** Execute one model call with OBS-1B closure and legacy completion mapping. */
+  private async tracedChat(
+    messages: LLMMessage[],
+    chatOptions: LLMChatOptions,
+    options: RunOptions,
+    phase: 'turn' | 'summary',
+    turn: number,
+  ): Promise<LLMResponse> {
+    if (!options.traceRuntime || !options.traceSpan) {
+      const startMs = options.onTrace ? Date.now() : 0
+      const response = await this.chatWithCallTimeout(messages, chatOptions)
+      if (options.onTrace) {
+        const endMs = Date.now()
+        emitTrace(options.onTrace, {
+          type: 'llm_call',
+          runId: options.runId ?? '',
+          spanId: generateSpanId(),
+          ...(options.traceSpanId ? { parentId: options.traceSpanId } : {}),
+          taskId: options.taskId,
+          agent: options.traceAgent ?? this.options.agentName ?? 'unknown',
+          model: chatOptions.model,
+          phase,
+          turn,
+          tokens: response.usage,
+          startMs,
+          endMs,
+          durationMs: endMs - startMs,
+        })
+      }
+      return response
+    }
+
+    const span = options.traceRuntime.startSpan({
+      kind: 'llm',
+      name: 'chat',
+      parent: options.traceSpan,
+      attributes: {
+        'oma.agent.name': options.traceAgent ?? this.options.agentName ?? 'unknown',
+        'oma.llm.model': chatOptions.model,
+        'oma.phase': phase,
+        'oma.llm.turn': turn,
+        ...(options.taskId ? { 'oma.task.id': options.taskId } : {}),
+      },
+    })
+    const classifyCallFailure = (error: unknown) => {
+      const reason = chatOptions.abortSignal?.reason
+      const timedOut = chatOptions.abortSignal?.aborted
+        && reason instanceof Error
+        && reason.name === 'TimeoutError'
+      const cancelled = chatOptions.abortSignal?.aborted && !timedOut
+      return classifyRunFailure(error, {
+        provider: this.adapter.name,
+        ...(timedOut ? { kind: 'timeout' as const, statusCode: 'timeout' as const } : {}),
+        ...(cancelled ? { kind: 'cancellation' as const, statusCode: 'cancelled' as const } : {}),
+      })
+    }
+    try {
+      const response = await this.chatWithCallTimeout(messages, chatOptions)
+      if (chatOptions.abortSignal?.aborted) {
+        const reason = chatOptions.abortSignal.reason ?? new Error('Model call aborted.')
+        const classified = classifyCallFailure(reason)
+        span.end({ status: classified.status, error: classified.errorInfo })
+        return response
+      }
+      const endMs = Date.now()
+      const legacyEvent: TraceEvent | undefined = options.onTrace ? {
+        type: 'llm_call',
+        runId: options.runId ?? '',
+        spanId: generateSpanId(),
+        ...(options.traceSpanId ? { parentId: options.traceSpanId } : {}),
+        taskId: options.taskId,
+        agent: options.traceAgent ?? this.options.agentName ?? 'unknown',
+        model: chatOptions.model,
+        phase,
+        turn,
+        tokens: response.usage,
+        startMs: span.startUnixMs,
+        endMs,
+        durationMs: Math.max(0, endMs - span.startUnixMs),
+      } : undefined
+      span.end({
+        status: { code: 'ok' },
+        attributes: {
+          'oma.usage.input_tokens': response.usage.input_tokens,
+          'oma.usage.output_tokens': response.usage.output_tokens,
+        },
+        ...(legacyEvent ? { legacyEvent } : {}),
+      })
+      return response
+    } catch (error) {
+      const classified = classifyCallFailure(error)
+      span.end({ status: classified.status, error: classified.errorInfo })
+      throw error
+    } finally {
+      span.ensureEnded()
+    }
+  }
+
   private async summarizeMessages(
     messages: LLMMessage[],
     maxTokens: number,
@@ -585,26 +697,9 @@ export class AgentRunner implements AgentBackend {
       tools: undefined,
     }
 
-    const summaryStartMs = Date.now()
-    const summaryResponse = await this.chatWithCallTimeout(summaryInput, summaryOptions)
-    if (options.onTrace) {
-      const summaryEndMs = Date.now()
-      emitTrace(options.onTrace, {
-        type: 'llm_call',
-        runId: options.runId ?? '',
-        spanId: generateSpanId(),
-        ...(options.traceSpanId ? { parentId: options.traceSpanId } : {}),
-        taskId: options.taskId,
-        agent: options.traceAgent ?? this.options.agentName ?? 'unknown',
-        model: summaryOptions.model,
-        phase: 'summary',
-        turn: turns,
-        tokens: summaryResponse.usage,
-        startMs: summaryStartMs,
-        endMs: summaryEndMs,
-        durationMs: summaryEndMs - summaryStartMs,
-      })
-    }
+    const summaryResponse = await this.tracedChat(
+      summaryInput, summaryOptions, options, 'summary', turns,
+    )
 
     const summaryText = extractText(summaryResponse.content).trim()
     const summaryPrefix = summaryText.length > 0
@@ -891,26 +986,9 @@ export class AgentRunner implements AgentBackend {
         // ------------------------------------------------------------------
         // Step 1: Call the LLM and collect the full response for this turn.
         // ------------------------------------------------------------------
-        const llmStartMs = Date.now()
-        const response = await this.chatWithCallTimeout(conversationMessages, baseChatOptions)
-        if (options.onTrace) {
-          const llmEndMs = Date.now()
-          emitTrace(options.onTrace, {
-            type: 'llm_call',
-            runId: options.runId ?? '',
-            spanId: generateSpanId(),
-            ...(options.traceSpanId ? { parentId: options.traceSpanId } : {}),
-            taskId: options.taskId,
-            agent: options.traceAgent ?? this.options.agentName ?? 'unknown',
-            model: this.options.model,
-            phase: 'turn',
-            turn: turns,
-            tokens: response.usage,
-            startMs: llmStartMs,
-            endMs: llmEndMs,
-            durationMs: llmEndMs - llmStartMs,
-          })
-        }
+        const response = await this.tracedChat(
+          conversationMessages, baseChatOptions, options, 'turn', turns,
+        )
 
         totalUsage = addTokenUsage(totalUsage, response.usage)
 
@@ -1052,7 +1130,19 @@ export class AgentRunner implements AgentBackend {
         }> => {
           options.onToolCall?.(block.name, block.input)
 
-          const startTime = Date.now()
+          const toolSpan = options.traceRuntime && options.traceSpan
+            ? options.traceRuntime.startSpan({
+                kind: 'tool',
+                name: 'execute_tool',
+                parent: options.traceSpan,
+                attributes: {
+                  'oma.agent.name': options.traceAgent ?? this.options.agentName ?? 'unknown',
+                  'oma.tool.name': block.name,
+                  ...(options.taskId ? { 'oma.task.id': options.taskId } : {}),
+                },
+              })
+            : undefined
+          const startTime = toolSpan?.startUnixMs ?? Date.now()
           let result: ToolResult
 
           if (!grantedToolNames.has(block.name)) {
@@ -1069,10 +1159,20 @@ export class AgentRunner implements AgentBackend {
             }
           } else {
             try {
+              const executionContext: ToolUseContext = toolSpan && toolContext.team?.runDelegatedAgent
+                ? {
+                    ...toolContext,
+                    team: {
+                      ...toolContext.team,
+                      runDelegatedAgent: (targetAgent, prompt) =>
+                        toolContext.team!.runDelegatedAgent!(targetAgent, prompt, toolSpan),
+                    },
+                  }
+                : toolContext
               result = await this.toolExecutor.execute(
                 block.name,
                 block.input,
-                toolContext,
+                executionContext,
               )
             } catch (err) {
               // Tool executor errors become error results — the loop continues.
@@ -1084,10 +1184,7 @@ export class AgentRunner implements AgentBackend {
           const endTime = Date.now()
           const duration = endTime - startTime
 
-          options.onToolResult?.(block.name, result)
-
-          if (options.onTrace) {
-            emitTrace(options.onTrace, {
+          const legacyEvent: TraceEvent | undefined = options.onTrace ? {
               type: 'tool_call',
               runId: options.runId ?? '',
               spanId: generateSpanId(),
@@ -1101,8 +1198,24 @@ export class AgentRunner implements AgentBackend {
               startMs: startTime,
               endMs: endTime,
               durationMs: duration,
+            } : undefined
+          if (toolSpan) {
+            const isError = result.isError ?? false
+            const classified = isError
+              ? classifyRunFailure(new Error(result.data), { kind: 'tool' })
+              : undefined
+            toolSpan.end({
+              status: classified?.status ?? { code: 'ok' },
+              ...(classified ? { error: classified.errorInfo } : {}),
+              attributes: { 'oma.tool.is_error': isError },
+              ...(legacyEvent ? { legacyEvent } : {}),
             })
+            toolSpan.ensureEnded()
+          } else if (legacyEvent) {
+            emitTrace(options.onTrace, legacyEvent)
           }
+
+          options.onToolResult?.(block.name, result)
 
           const record: ToolCallRecord = {
             toolName: block.name,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,6 +119,15 @@ export type { SupportedProvider } from './llm/adapter.js'
 export { TokenBudgetExceededError, CostBudgetExceededError, InvalidMessageError, LLMCallTimeoutError, isRetryableError } from './errors.js'
 export { createRunIdentity, createRestoreIdentity, validateRunId } from './observability/identity.js'
 export { classifyRunFailure } from './observability/status.js'
+export type {
+  SpanEndRecord,
+  SpanEventName,
+  SpanEventRecord,
+  SpanKind,
+  SpanStartRecord,
+  TraceRecord,
+  TraceRecordBase,
+} from './observability/records.js'
 
 // ---------------------------------------------------------------------------
 // Memory
@@ -176,6 +185,7 @@ export type {
   RunIdentity,
   RunIdentityLink,
   TraceLink,
+  TraceAttributeValue,
   RunIdentityOptions,
   RunStatus,
   RunStatusCode,

--- a/packages/core/src/observability/records.ts
+++ b/packages/core/src/observability/records.ts
@@ -1,0 +1,74 @@
+import type {
+  RunStatus,
+  StructuredTraceError,
+  TraceAttributeValue,
+  TraceLink,
+} from '../types.js'
+
+/** Stable operation categories used by TraceRecord schema v2. */
+export type SpanKind =
+  | 'run'
+  | 'agent'
+  | 'task'
+  | 'llm'
+  | 'tool'
+  | 'plan'
+  | 'consensus'
+  | 'checkpoint'
+  | 'callback'
+
+/** Event names emitted by the OBS-1B runtime. */
+export type SpanEventName =
+  | 'retry_scheduled'
+  | 'budget_exhausted'
+  | 'first_chunk'
+  | 'approval_decision'
+  | 'checkpoint_failed'
+  | 'telemetry_diagnostic'
+  | 'loop_detected'
+  | 'stream_chunk'
+  | 'consensus_verdict'
+
+export interface TraceRecordBase {
+  readonly schemaVersion: 2
+  readonly recordId: string
+  /** Strictly increasing and unique within one traceId. */
+  readonly sequence: number
+  readonly timestampUnixMs: number
+  readonly runId: string
+  readonly attempt: number
+  readonly traceId: string
+  readonly spanId: string
+  readonly parentSpanId?: string
+}
+
+export interface SpanStartRecord extends TraceRecordBase {
+  readonly recordType: 'span_start'
+  readonly kind: SpanKind
+  readonly name: string
+  readonly startUnixMs: number
+  readonly links?: readonly TraceLink[]
+  readonly attributes: Readonly<Record<string, TraceAttributeValue>>
+}
+
+export interface SpanEventRecord extends TraceRecordBase {
+  readonly recordType: 'span_event'
+  readonly name: SpanEventName
+  readonly attributes: Readonly<Record<string, TraceAttributeValue>>
+}
+
+export interface SpanEndRecord extends TraceRecordBase {
+  readonly recordType: 'span_end'
+  readonly kind: SpanKind
+  readonly name: string
+  readonly startUnixMs: number
+  readonly endUnixMs: number
+  readonly durationMs: number
+  readonly status: RunStatus
+  readonly error?: StructuredTraceError
+  readonly links?: readonly TraceLink[]
+  /** Complete final snapshot; usable even if the matching start was dropped. */
+  readonly attributes: Readonly<Record<string, TraceAttributeValue>>
+}
+
+export type TraceRecord = SpanStartRecord | SpanEventRecord | SpanEndRecord

--- a/packages/core/src/observability/runtime.ts
+++ b/packages/core/src/observability/runtime.ts
@@ -1,0 +1,231 @@
+import { randomBytes, randomUUID } from 'node:crypto'
+import type {
+  RunIdentity,
+  RunStatus,
+  StructuredTraceError,
+  TraceAttributeValue,
+  TraceEvent,
+  TraceLink,
+} from '../types.js'
+import type {
+  SpanEndRecord,
+  SpanEventName,
+  SpanEventRecord,
+  SpanKind,
+  SpanStartRecord,
+  TraceRecord,
+} from './records.js'
+import { emitTrace } from '../utils/trace.js'
+
+export type TraceRecordObserver = (record: TraceRecord) => void
+
+/** Internal-only hook used by contract tests until OBS-2 introduces TraceSink. */
+export const TRACE_RECORD_OBSERVER = Symbol('oma.traceRecordObserver')
+
+export interface InternalTraceRecordConfig {
+  readonly [TRACE_RECORD_OBSERVER]?: TraceRecordObserver
+}
+
+export interface StartSpanOptions {
+  readonly kind: SpanKind
+  readonly name: string
+  readonly parent?: TraceSpan | string
+  readonly spanId?: string
+  readonly links?: readonly TraceLink[]
+  readonly attributes?: Readonly<Record<string, TraceAttributeValue>>
+}
+
+export interface EndSpanOptions {
+  readonly status: RunStatus
+  readonly error?: StructuredTraceError
+  readonly links?: readonly TraceLink[]
+  readonly attributes?: Readonly<Record<string, TraceAttributeValue>>
+  /** Exact legacy completion event emitted after the v2 end record. */
+  readonly legacyEvent?: TraceEvent
+}
+
+function w3cSpanId(): string {
+  let id = randomBytes(8).toString('hex')
+  while (/^0+$/.test(id)) id = randomBytes(8).toString('hex')
+  return id
+}
+
+function safeObserve(observer: TraceRecordObserver | undefined, record: TraceRecord): void {
+  if (!observer) return
+  try {
+    observer(record)
+  } catch {
+    // Telemetry must never change execution semantics.
+  }
+}
+
+/** One top-level attempt's synchronous record runtime. */
+export class TraceRuntime {
+  readonly identity: RunIdentity
+  readonly root: TraceSpan
+  private sequence = 0
+
+  constructor(
+    identity: RunIdentity,
+    private readonly observer?: TraceRecordObserver,
+    private readonly legacyCallback?: (event: TraceEvent) => void | Promise<void>,
+  ) {
+    this.identity = identity
+    this.root = this.startSpan({
+      kind: 'run',
+      name: 'oma.run',
+      spanId: identity.rootSpanId,
+      links: identity.links,
+      attributes: {
+        'oma.run.id': identity.runId,
+        'oma.run.attempt': identity.attempt,
+      },
+    })
+  }
+
+  startSpan(options: StartSpanOptions): TraceSpan {
+    return new TraceSpan(this, {
+      ...options,
+      spanId: options.spanId ?? w3cSpanId(),
+      parentSpanId: typeof options.parent === 'string'
+        ? options.parent
+        : options.parent?.spanId,
+      startUnixMs: Date.now(),
+    })
+  }
+
+  close(options: EndSpanOptions): boolean {
+    return this.root.end(options)
+  }
+
+  emitStart(span: TraceSpan): void {
+    const record: SpanStartRecord = {
+      ...this.base(span),
+      recordType: 'span_start',
+      kind: span.kind,
+      name: span.name,
+      startUnixMs: span.startUnixMs,
+      ...(span.links.length > 0 ? { links: span.links } : {}),
+      attributes: span.attributes,
+    }
+    safeObserve(this.observer, record)
+  }
+
+  emitEvent(
+    span: TraceSpan,
+    name: SpanEventName,
+    attributes: Readonly<Record<string, TraceAttributeValue>>,
+    legacyEvent?: TraceEvent,
+  ): void {
+    if (span.ended) return
+    const record: SpanEventRecord = {
+      ...this.base(span),
+      recordType: 'span_event',
+      name,
+      attributes,
+    }
+    safeObserve(this.observer, record)
+    if (legacyEvent) emitTrace(this.legacyCallback, legacyEvent)
+  }
+
+  emitEnd(span: TraceSpan, options: EndSpanOptions, endUnixMs: number): void {
+    const links = [...span.links, ...(options.links ?? [])]
+    const attributes = { ...span.attributes, ...options.attributes, 'oma.status': options.status.code }
+    const record: SpanEndRecord = {
+      ...this.base(span),
+      recordType: 'span_end',
+      kind: span.kind,
+      name: span.name,
+      startUnixMs: span.startUnixMs,
+      endUnixMs,
+      durationMs: Math.max(0, endUnixMs - span.startUnixMs),
+      status: options.status,
+      ...(options.error ? { error: options.error } : {}),
+      ...(links.length > 0 ? { links } : {}),
+      attributes,
+    }
+    safeObserve(this.observer, record)
+    if (options.legacyEvent) emitTrace(this.legacyCallback, options.legacyEvent)
+  }
+
+  private base(span: TraceSpan) {
+    return {
+      schemaVersion: 2 as const,
+      recordId: randomUUID(),
+      sequence: ++this.sequence,
+      timestampUnixMs: Date.now(),
+      runId: this.identity.runId,
+      attempt: this.identity.attempt,
+      traceId: this.identity.traceId,
+      spanId: span.spanId,
+      ...(span.parentSpanId ? { parentSpanId: span.parentSpanId } : {}),
+    }
+  }
+}
+
+/** Idempotently closable span handle. */
+export class TraceSpan {
+  readonly spanId: string
+  readonly parentSpanId?: string
+  readonly kind: SpanKind
+  readonly name: string
+  readonly startUnixMs: number
+  readonly links: readonly TraceLink[]
+  readonly attributes: Readonly<Record<string, TraceAttributeValue>>
+  private closed = false
+
+  constructor(
+    private readonly runtime: TraceRuntime,
+    options: StartSpanOptions & {
+      readonly spanId: string
+      readonly parentSpanId?: string
+      readonly startUnixMs: number
+    },
+  ) {
+    this.spanId = options.spanId
+    this.parentSpanId = options.parentSpanId
+    this.kind = options.kind
+    this.name = options.name
+    this.startUnixMs = options.startUnixMs
+    this.links = options.links ?? []
+    this.attributes = options.attributes ?? {}
+    runtime.emitStart(this)
+  }
+
+  get ended(): boolean { return this.closed }
+
+  event(
+    name: SpanEventName,
+    attributes: Readonly<Record<string, TraceAttributeValue>> = {},
+    legacyEvent?: TraceEvent,
+  ): void {
+    this.runtime.emitEvent(this, name, attributes, legacyEvent)
+  }
+
+  end(options: EndSpanOptions): boolean {
+    if (this.closed) return false
+    this.closed = true
+    this.runtime.emitEnd(this, options, Date.now())
+    return true
+  }
+
+  ensureEnded(options?: EndSpanOptions): boolean {
+    return this.end(options ?? {
+      status: { code: 'error', message: 'Span exited without an explicit outcome.' },
+      error: { kind: 'framework', code: 'SPAN_NOT_CLOSED', message: 'Span exited without an explicit outcome.' },
+    })
+  }
+}
+
+export function traceRecordObserverFrom(config: unknown): TraceRecordObserver | undefined {
+  return (config as InternalTraceRecordConfig | undefined)?.[TRACE_RECORD_OBSERVER]
+}
+
+export function createTraceRuntime(
+  identity: RunIdentity,
+  legacyCallback?: (event: TraceEvent) => void | Promise<void>,
+  observer?: TraceRecordObserver,
+): TraceRuntime | undefined {
+  return legacyCallback || observer ? new TraceRuntime(identity, observer, legacyCallback) : undefined
+}
+

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -96,6 +96,13 @@ import { CostBudgetExceededError, TokenBudgetExceededError, isRetryableError } f
 import { abortableDelay } from '../utils/abort.js'
 import { createRestoreIdentity, createRunIdentity } from '../observability/identity.js'
 import { classifyRunFailure, statusOnly } from '../observability/status.js'
+import {
+  createTraceRuntime,
+  traceRecordObserverFrom,
+  type TraceRecordObserver,
+  type TraceRuntime,
+  type TraceSpan,
+} from '../observability/runtime.js'
 import { extractKeywords, keywordScore } from '../utils/keywords.js'
 
 // ---------------------------------------------------------------------------
@@ -530,7 +537,7 @@ export function computeRetryDelay(
  * @returns The final {@link AgentRunResult} from the last attempt.
  */
 export async function executeWithRetry(
-  run: () => Promise<AgentRunResult>,
+  run: (attempt: number) => Promise<AgentRunResult>,
   task: Task,
   onRetry?: (data: { attempt: number; maxAttempts: number; error: string; nextDelayMs: number }) => void,
   delayFn: (ms: number, signal?: AbortSignal) => Promise<void> = abortableDelay,
@@ -575,7 +582,7 @@ export async function executeWithRetry(
     }
 
     try {
-      const result = await run()
+      const result = await run(attempt)
       totalUsage = {
         input_tokens: totalUsage.input_tokens + result.tokenUsage.input_tokens,
         output_tokens: totalUsage.output_tokens + result.tokenUsage.output_tokens,
@@ -848,6 +855,8 @@ interface RunContext {
   readonly identity: RunIdentity
   /** Legacy trace correlation alias. */
   readonly runId: string
+  readonly traceRuntime?: TraceRuntime
+  readonly taskSpans: Map<string, TraceSpan>
   /** AbortSignal for run-level cancellation. Checked between task dispatch rounds. */
   readonly abortSignal?: AbortSignal
   cumulativeUsage: TokenUsage
@@ -907,7 +916,11 @@ function buildTaskAgentTeamInfo(
   const agentConfigs = ctx.team.getAgents()
   const agentNames = agentConfigs.map((a) => a.name)
 
-  const runDelegatedAgent = async (targetAgent: string, prompt: string): Promise<AgentRunResult> => {
+  const runDelegatedAgent = async (
+    targetAgent: string,
+    prompt: string,
+    delegatedParent?: unknown,
+  ): Promise<AgentRunResult> => {
     const pool = ctx.pool
     if (pool.availableRunSlots < 1) {
       return {
@@ -956,6 +969,16 @@ function buildTaskAgentTeamInfo(
       ...traceBase,
       traceAgent: targetAgent,
       taskId,
+      ...(ctx.traceRuntime && delegatedParent ? {
+        traceRuntime: ctx.traceRuntime,
+        traceSpan: delegatedParent as TraceSpan,
+        tracePhase: 'delegated',
+        traceLinks: ctx.taskSpans.get(taskId) ? [{
+          traceId: ctx.identity.traceId,
+          spanId: ctx.taskSpans.get(taskId)!.spanId,
+          relation: 'delegated_from' as const,
+        }] : [],
+      } : {}),
       ...(delegatedParentId ? { traceParentId: delegatedParentId } : {}),
       ...(delegatedSpanId ? { traceSpanId: delegatedSpanId } : {}),
     }
@@ -992,6 +1015,12 @@ function buildTaskAgentTeamInfo(
 async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Promise<void> {
   const active = ctx.checkpoint
   if (!active) return
+  const checkpointSpan = ctx.traceRuntime?.startSpan({
+    kind: 'checkpoint',
+    name: 'save_checkpoint',
+    parent: ctx.traceRuntime.root,
+    attributes: { 'oma.checkpoint.mode': active.mode },
+  })
 
   // Best-effort: a checkpoint write must never take down the run it protects.
   // Both snapshot construction and the store write are guarded, so a failing
@@ -1038,7 +1067,11 @@ async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Promise<voi
   active.saveChain = nextSave.catch(() => undefined)
   try {
     await nextSave
+    checkpointSpan?.end({ status: statusOnly('ok') })
   } catch (error) {
+    const classified = classifyRunFailure(error, { kind: 'store' })
+    checkpointSpan?.event('checkpoint_failed', {})
+    checkpointSpan?.end({ status: classified.status, error: classified.errorInfo })
     ctx.config.onProgress?.({
       type: 'error',
       data: { kind: 'checkpoint_save_failed', error },
@@ -1106,255 +1139,317 @@ async function executeQueue(
       // Mark in-progress
       queue.update(task.id, { status: 'in_progress' as TaskStatus })
 
-      const assignee = task.assignee
-      if (!assignee) {
-        // No assignee — mark failed and continue
-        const msg = `Task "${task.title}" has no assignee.`
-        queue.fail(task.id, msg)
-        config.onProgress?.({
-          type: 'error',
-          task: task.id,
-          data: msg,
-        } satisfies OrchestratorEvent)
-        return
-      }
-
-      const agentConfig = team.getAgent(assignee)
-      if (!agentConfig) {
-        const msg = `Agent "${assignee}" not found in team for task "${task.title}".`
-        queue.fail(task.id, msg)
-        config.onProgress?.({
-          type: 'error',
-          task: task.id,
-          agent: assignee,
-          data: msg,
-        } satisfies OrchestratorEvent)
-        return
-      }
-
-      const agent = pool.get(assignee)
-      if (!agent) {
-        const msg = `Agent "${assignee}" not found in pool for task "${task.title}".`
-        queue.fail(task.id, msg)
-        config.onProgress?.({
-          type: 'error',
-          task: task.id,
-          agent: assignee,
-          data: msg,
-        } satisfies OrchestratorEvent)
-        return
-      }
-
-      config.onProgress?.({
-        type: 'task_start',
-        task: task.id,
-        agent: assignee,
-        data: task,
-      } satisfies OrchestratorEvent)
-
-      config.onProgress?.({
-        type: 'agent_start',
-        agent: assignee,
-        task: task.id,
-        data: task,
-      } satisfies OrchestratorEvent)
-
-      // Build the prompt: task description + dependency-only context by default.
-      const prompt = await buildTaskPrompt(task, team, queue, ctx.revealCoordinatorContext)
-
-      // Trace + abort + team tool context (delegate_to_agent)
-      const taskSpanId = config.onTrace ? generateSpanId() : undefined
-      const agentSpanId = config.onTrace ? generateSpanId() : undefined
-      const traceBase: Partial<RunOptions> = {
-        identity: ctx.identity,
-        runId: ctx.runId,
-        ...(config.onTrace
-          ? {
-              onTrace: config.onTrace,
-              taskId: task.id,
-              traceAgent: assignee,
-              ...(taskSpanId ? { traceParentId: taskSpanId } : {}),
-              ...(agentSpanId ? { traceSpanId: agentSpanId } : {}),
-            }
-          : {}),
-        ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
-      }
-      const runOptions: Partial<RunOptions> = {
-        ...traceBase,
-        team: buildTaskAgentTeamInfo(ctx, task.id, traceBase, 0, [assignee]),
-      }
-      const workerRoute = routeMatches(ctx.modelRouting, {
-        phase: 'worker',
-        agent: assignee,
-        task,
-        leaf: ctx.taskLeafById.get(task.id),
+      const dependencyLinks = (task.dependsOn ?? []).flatMap((dependencyId) => {
+        const dependencySpan = ctx.taskSpans.get(dependencyId)
+        return dependencySpan ? [{
+          traceId: ctx.identity.traceId,
+          spanId: dependencySpan.spanId,
+          relation: 'depends_on' as const,
+        }] : []
       })
-      const workerEffectiveConfig = withModelRoute(applyDefaultToolPreset({
-        ...agentConfig,
-        model: agentConfig.model ?? config.defaultModel,
-        provider: agentConfig.provider ?? config.defaultProvider,
-        baseURL: agentConfig.baseURL ?? config.defaultBaseURL,
-        apiKey: agentConfig.apiKey ?? config.defaultApiKey,
-        cwd: agentConfig.cwd === undefined ? config.defaultCwd : agentConfig.cwd,
-      }, config.defaultToolPreset), workerRoute)
-      const routedAgent = workerRoute
-        ? buildAgent(workerEffectiveConfig, { includeDelegateTool: true })
-        : undefined
-      const streamCallback = config.onAgentStream
-        ? (event: StreamEvent) => {
-            if (config.onTrace) {
-              const streamMs = Date.now()
-              emitTrace(config.onTrace, {
-                type: 'agent_stream',
-                runId: ctx.runId ?? '',
-                spanId: generateSpanId(),
-                ...(agentSpanId ? { parentId: agentSpanId } : {}),
-                taskId: task.id,
-                agent: assignee,
-                streamType: event.type,
-                startMs: streamMs,
-                endMs: streamMs,
-                durationMs: 0,
-              })
-            }
-            config.onAgentStream!(assignee, event)
-          }
-        : undefined
+      const taskSpan = ctx.traceRuntime?.startSpan({
+        kind: 'task',
+        name: 'execute_task',
+        parent: ctx.traceRuntime.root,
+        links: dependencyLinks,
+        attributes: {
+          'oma.task.id': task.id,
+          'oma.task.title': task.title,
+          ...(task.assignee ? { 'oma.agent.name': task.assignee } : {}),
+        },
+      })
+      if (taskSpan) ctx.taskSpans.set(task.id, taskSpan)
 
-      const taskStartMs = Date.now()
-      let retryCount = 0
-
-      const result = await executeWithRetry(
-        () => routedAgent
-          ? pool.runEphemeral(
-              routedAgent,
-              prompt,
-              runOptions,
-              streamCallback,
-            )
-          : pool.run(
-              assignee,
-              prompt,
-              runOptions,
-              streamCallback,
-            ),
-        task,
-        (retryData) => {
-          retryCount++
+      try {
+        const assignee = task.assignee
+        if (!assignee) {
+          // No assignee — mark failed and continue
+          const msg = `Task "${task.title}" has no assignee.`
+          queue.fail(task.id, msg)
+          const classified = classifyRunFailure(new Error(msg), { kind: 'framework' })
+          taskSpan?.end({ status: classified.status, error: classified.errorInfo })
           config.onProgress?.({
-            type: 'task_retry',
+            type: 'error',
+            task: task.id,
+            data: msg,
+          } satisfies OrchestratorEvent)
+          return
+        }
+
+        const agentConfig = team.getAgent(assignee)
+        if (!agentConfig) {
+          const msg = `Agent "${assignee}" not found in team for task "${task.title}".`
+          queue.fail(task.id, msg)
+          const classified = classifyRunFailure(new Error(msg), { kind: 'framework' })
+          taskSpan?.end({ status: classified.status, error: classified.errorInfo })
+          config.onProgress?.({
+            type: 'error',
             task: task.id,
             agent: assignee,
-            data: retryData,
+            data: msg,
           } satisfies OrchestratorEvent)
-        },
-        undefined,
-        { abortSignal: ctx.abortSignal },
-      )
+          return
+        }
 
-      const taskEndMs = Date.now()
+        const agent = pool.get(assignee)
+        if (!agent) {
+          const msg = `Agent "${assignee}" not found in pool for task "${task.title}".`
+          queue.fail(task.id, msg)
+          const classified = classifyRunFailure(new Error(msg), { kind: 'framework' })
+          taskSpan?.end({ status: classified.status, error: classified.errorInfo })
+          config.onProgress?.({
+            type: 'error',
+            task: task.id,
+            agent: assignee,
+            data: msg,
+          } satisfies OrchestratorEvent)
+          return
+        }
 
-      // Emit task trace
-      if (config.onTrace) {
-        emitTrace(config.onTrace, {
-          type: 'task',
-          runId: ctx.runId ?? '',
-          spanId: taskSpanId ?? generateSpanId(),
-          taskId: task.id,
-          taskTitle: task.title,
+        config.onProgress?.({
+          type: 'task_start',
+          task: task.id,
           agent: assignee,
-          success: result.success,
-          retries: retryCount,
+          data: task,
+        } satisfies OrchestratorEvent)
+
+        config.onProgress?.({
+          type: 'agent_start',
+          agent: assignee,
+          task: task.id,
+          data: task,
+        } satisfies OrchestratorEvent)
+
+        // Build the prompt: task description + dependency-only context by default.
+        const prompt = await buildTaskPrompt(task, team, queue, ctx.revealCoordinatorContext)
+
+        // Trace + abort + team tool context (delegate_to_agent)
+        const taskSpanId = config.onTrace ? generateSpanId() : undefined
+        const agentSpanId = config.onTrace ? generateSpanId() : undefined
+        const traceBase: Partial<RunOptions> = {
+          identity: ctx.identity,
+          runId: ctx.runId,
+          ...(ctx.traceRuntime ? {
+            traceRuntime: ctx.traceRuntime,
+            traceSpan: taskSpan ?? ctx.traceRuntime.root,
+          } : {}),
+          ...(config.onTrace
+            ? {
+                onTrace: config.onTrace,
+                taskId: task.id,
+                traceAgent: assignee,
+                ...(taskSpanId ? { traceParentId: taskSpanId } : {}),
+                ...(agentSpanId ? { traceSpanId: agentSpanId } : {}),
+              }
+            : {}),
+          ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
+        }
+        const runOptions: Partial<RunOptions> = {
+          ...traceBase,
+          team: buildTaskAgentTeamInfo(ctx, task.id, traceBase, 0, [assignee]),
+        }
+        const workerRoute = routeMatches(ctx.modelRouting, {
+          phase: 'worker',
+          agent: assignee,
+          task,
+          leaf: ctx.taskLeafById.get(task.id),
+        })
+        const workerEffectiveConfig = withModelRoute(applyDefaultToolPreset({
+          ...agentConfig,
+          model: agentConfig.model ?? config.defaultModel,
+          provider: agentConfig.provider ?? config.defaultProvider,
+          baseURL: agentConfig.baseURL ?? config.defaultBaseURL,
+          apiKey: agentConfig.apiKey ?? config.defaultApiKey,
+          cwd: agentConfig.cwd === undefined ? config.defaultCwd : agentConfig.cwd,
+        }, config.defaultToolPreset), workerRoute)
+        const routedAgent = workerRoute
+          ? buildAgent(workerEffectiveConfig, { includeDelegateTool: true })
+          : undefined
+        const streamCallback = config.onAgentStream
+          ? (event: StreamEvent) => {
+              const streamMs = Date.now()
+              const legacyEvent = config.onTrace ? {
+                  type: 'agent_stream',
+                  runId: ctx.runId ?? '',
+                  spanId: generateSpanId(),
+                  ...(agentSpanId ? { parentId: agentSpanId } : {}),
+                  taskId: task.id,
+                  agent: assignee,
+                  streamType: event.type,
+                  startMs: streamMs,
+                  endMs: streamMs,
+                  durationMs: 0,
+                } as const : undefined
+              if (taskSpan) {
+                taskSpan.event('stream_chunk', { 'oma.stream.type': event.type }, legacyEvent)
+              } else if (legacyEvent) {
+                emitTrace(config.onTrace, legacyEvent)
+              }
+              config.onAgentStream!(assignee, event)
+            }
+          : undefined
+
+        const taskStartMs = taskSpan?.startUnixMs ?? Date.now()
+        let retryCount = 0
+
+        const result = await executeWithRetry(
+          (attempt) => routedAgent
+            ? pool.runEphemeral(
+                routedAgent,
+                prompt,
+                { ...runOptions, traceAgentAttempt: attempt },
+                streamCallback,
+              )
+            : pool.run(
+                assignee,
+                prompt,
+                { ...runOptions, traceAgentAttempt: attempt },
+                streamCallback,
+              ),
+          task,
+          (retryData) => {
+            retryCount++
+            taskSpan?.event('retry_scheduled', {
+              'oma.retry.attempt': retryData.attempt,
+              'oma.retry.max_attempts': retryData.maxAttempts,
+              'oma.retry.delay_ms': retryData.nextDelayMs,
+            })
+            config.onProgress?.({
+              type: 'task_retry',
+              task: task.id,
+              agent: assignee,
+              data: retryData,
+            } satisfies OrchestratorEvent)
+          },
+          undefined,
+          { abortSignal: ctx.abortSignal },
+        )
+
+        const taskEndMs = Date.now()
+
+        const taskLegacyEvent = config.onTrace ? {
+            type: 'task',
+            runId: ctx.runId ?? '',
+            spanId: taskSpanId ?? generateSpanId(),
+            taskId: task.id,
+            taskTitle: task.title,
+            agent: assignee,
+            success: result.success,
+            retries: retryCount,
+            startMs: taskStartMs,
+            endMs: taskEndMs,
+            durationMs: taskEndMs - taskStartMs,
+          } as const : undefined
+
+        ctx.agentResults.set(`${assignee}:${task.id}`, result)
+
+        ctx.taskMetrics.set(task.id, {
           startMs: taskStartMs,
           endMs: taskEndMs,
-          durationMs: taskEndMs - taskStartMs,
+          durationMs: Math.max(0, taskEndMs - taskStartMs),
+          tokenUsage: result.tokenUsage,
+          toolCalls: result.toolCalls,
+          retries: retryCount,
         })
-      }
-
-      ctx.agentResults.set(`${assignee}:${task.id}`, result)
-
-      ctx.taskMetrics.set(task.id, {
-        startMs: taskStartMs,
-        endMs: taskEndMs,
-        durationMs: Math.max(0, taskEndMs - taskStartMs),
-        tokenUsage: result.tokenUsage,
-        toolCalls: result.toolCalls,
-        retries: retryCount,
-      })
-      try {
-        recordRunUsage(ctx, result.tokenUsage, buildCostEstimateContext({
-          agentName: assignee,
-          model: workerEffectiveConfig.model ?? config.defaultModel ?? DEFAULT_MODEL,
-          provider: workerEffectiveConfig.provider,
-          phase: 'worker',
-          taskId: task.id,
-        }), assignee, task.id)
-      } catch (error) {
-        const message = errorMessage(error)
-        ctx.agentResults.set(`${assignee}:${task.id}`, {
-          ...result,
-          success: false,
-          output: message,
-          error,
-        })
-        queue.fail(task.id, message)
-        config.onProgress?.({
-          type: 'error',
-          task: task.id,
-          agent: assignee,
-          data: message,
-        } satisfies OrchestratorEvent)
-        return
-      }
-
-      if (result.success) {
-        const sharedMem = team.getSharedMemoryInstance()
-
-        // Opt-in consensus verification runs *before* the task is finalised so the
-        // verified outcome (accepted → revised, rejected → original) flows into the
-        // queue, shared memory, progress events, and agentResults as one consistent
-        // result. Judge usage is charged to the same parent budget as the rest of the run.
-        let effective = result
-        if (task.verify && !ctx.budgetExceededTriggered) {
-          effective = await runTaskVerify(task, assignee, result, sharedMem, ctx)
+        try {
+          const budgetError = recordRunUsage(ctx, result.tokenUsage, buildCostEstimateContext({
+            agentName: assignee,
+            model: workerEffectiveConfig.model ?? config.defaultModel ?? DEFAULT_MODEL,
+            provider: workerEffectiveConfig.provider,
+            phase: 'worker',
+            taskId: task.id,
+          }), assignee, task.id)
+          if (budgetError) {
+            taskSpan?.event('budget_exhausted', {})
+          }
+        } catch (error) {
+          const message = errorMessage(error)
+          ctx.agentResults.set(`${assignee}:${task.id}`, {
+            ...result,
+            success: false,
+            output: message,
+            error,
+          })
+          queue.fail(task.id, message)
+          const classified = classifyRunFailure(error, { kind: 'budget' })
+          taskSpan?.event('budget_exhausted', {})
+          taskSpan?.end({
+            status: classified.status,
+            error: classified.errorInfo,
+            ...(taskLegacyEvent ? { legacyEvent: taskLegacyEvent } : {}),
+          })
+          config.onProgress?.({
+            type: 'error',
+            task: task.id,
+            agent: assignee,
+            data: message,
+          } satisfies OrchestratorEvent)
+          return
         }
 
-        // Reflect the verified result in the per-task record the caller receives.
-        ctx.agentResults.set(`${assignee}:${task.id}`, effective)
+        if (result.success) {
+          const sharedMem = team.getSharedMemoryInstance()
 
-        // Persist result into shared memory so other agents can read it
-        if (sharedMem) {
-          await sharedMem.write(assignee, `task:${task.id}:result`, effective.output)
-          // Advance the turn counter so any TTL-tagged entries written during
-          // this task can be expired by subsequent reads.
-          sharedMem.advanceTurn()
+          // Opt-in consensus verification runs *before* the task is finalised so the
+          // verified outcome (accepted → revised, rejected → original) flows into the
+          // queue, shared memory, progress events, and agentResults as one consistent
+          // result. Judge usage is charged to the same parent budget as the rest of the run.
+          let effective = result
+          if (task.verify && !ctx.budgetExceededTriggered) {
+            effective = await runTaskVerify(task, assignee, result, sharedMem, ctx)
+          }
+
+          // Reflect the verified result in the per-task record the caller receives.
+          ctx.agentResults.set(`${assignee}:${task.id}`, effective)
+
+          // Persist result into shared memory so other agents can read it
+          if (sharedMem) {
+            await sharedMem.write(assignee, `task:${task.id}:result`, effective.output)
+            // Advance the turn counter so any TTL-tagged entries written during
+            // this task can be expired by subsequent reads.
+            sharedMem.advanceTurn()
+          }
+
+          const completedTask = queue.complete(task.id, effective.output)
+          completedThisRound.push(completedTask)
+          await saveRunCheckpoint(queue, ctx)
+
+          config.onProgress?.({
+            type: 'task_complete',
+            task: task.id,
+            agent: assignee,
+            data: effective,
+          } satisfies OrchestratorEvent)
+
+          config.onProgress?.({
+            type: 'agent_complete',
+            agent: assignee,
+            task: task.id,
+            data: effective,
+          } satisfies OrchestratorEvent)
+          taskSpan?.end({
+            status: effective.status ?? statusOnly(effective.success ? 'ok' : 'error'),
+            ...(effective.errorInfo ? { error: effective.errorInfo } : {}),
+            attributes: { 'oma.task.retries': retryCount },
+            ...(taskLegacyEvent ? { legacyEvent: { ...taskLegacyEvent, success: effective.success } } : {}),
+          })
+        } else {
+          queue.fail(task.id, result.output)
+          taskSpan?.end({
+            status: result.status ?? statusOnly('error', result.output),
+            ...(result.errorInfo ? { error: result.errorInfo } : {}),
+            attributes: { 'oma.task.retries': retryCount },
+            ...(taskLegacyEvent ? { legacyEvent: taskLegacyEvent } : {}),
+          })
+          config.onProgress?.({
+            type: 'error',
+            task: task.id,
+            agent: assignee,
+            data: result,
+          } satisfies OrchestratorEvent)
         }
-
-        const completedTask = queue.complete(task.id, effective.output)
-        completedThisRound.push(completedTask)
-        await saveRunCheckpoint(queue, ctx)
-
-        config.onProgress?.({
-          type: 'task_complete',
-          task: task.id,
-          agent: assignee,
-          data: effective,
-        } satisfies OrchestratorEvent)
-
-        config.onProgress?.({
-          type: 'agent_complete',
-          agent: assignee,
-          task: task.id,
-          data: effective,
-        } satisfies OrchestratorEvent)
-      } else {
-        queue.fail(task.id, result.output)
-        config.onProgress?.({
-          type: 'error',
-          task: task.id,
-          agent: assignee,
-          data: result,
-        } satisfies OrchestratorEvent)
+      } finally {
+        taskSpan?.ensureEnded()
       }
     })
 
@@ -1373,6 +1468,12 @@ async function executeQueue(
       const nextPending = queue.getByStatus('pending')
 
       if (nextPending.length > 0) {
+        const approvalSpan = ctx.traceRuntime?.startSpan({
+          kind: 'callback',
+          name: 'approval_callback',
+          parent: ctx.traceRuntime.root,
+          attributes: { 'oma.callback.name': 'onApproval' },
+        })
         let approved: boolean
         try {
           approved = await config.onApproval(completedThisRound, nextPending)
@@ -1380,15 +1481,20 @@ async function executeQueue(
           const reason = `Skipped: approval callback error — ${err instanceof Error ? err.message : String(err)}`
           queue.skipRemaining(reason)
           const classified = classifyRunFailure(err, { kind: 'callback' })
+          approvalSpan?.end({ status: classified.status, error: classified.errorInfo })
           ctx.outcomeStatus = classified.status
           ctx.outcomeErrorInfo = classified.errorInfo
           break
         }
         if (!approved) {
+          approvalSpan?.event('approval_decision', { 'oma.approval.approved': false })
+          approvalSpan?.end({ status: statusOnly('rejected') })
           queue.skipRemaining('Skipped: approval rejected.')
           ctx.outcomeStatus = statusOnly('rejected', 'Approval rejected.')
           break
         }
+        approvalSpan?.event('approval_decision', { 'oma.approval.approved': true })
+        approvalSpan?.end({ status: statusOnly('ok') })
       }
     }
   }
@@ -1617,6 +1723,8 @@ interface ConsensusCoreParams {
   readonly shouldStop?: () => boolean
   /** Existing pool to reuse; a fresh one is created when omitted. */
   readonly pool?: AgentPool
+  readonly traceRuntime?: TraceRuntime
+  readonly consensusSpan?: TraceSpan
 }
 
 /**
@@ -1643,10 +1751,19 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
   const overBudget = (): boolean =>
     budget !== undefined && budgetBaseTokens + usage.input_tokens + usage.output_tokens > budget
 
-  const runEphemeral = async (config: AgentConfig, text: string): Promise<AgentRunResult> => {
+  const runEphemeral = async (
+    config: AgentConfig,
+    text: string,
+    phase: 'judge' | 'revision',
+  ): Promise<AgentRunResult> => {
     const effective = applyConsensusDefaults(config, defaults)
     const result = await pool.runEphemeral(buildAgent(effective), text, {
       ...(params.identity ? { identity: params.identity, runId: params.identity.runId } : {}),
+      ...(params.traceRuntime && params.consensusSpan ? {
+        traceRuntime: params.traceRuntime,
+        traceSpan: params.consensusSpan,
+        tracePhase: phase,
+      } : {}),
       ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
     })
     params.onUsage?.(result.tokenUsage, effective)
@@ -1667,7 +1784,7 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
     for (let j = 0; j < judges.length; j++) {
       const judge = judges[j]!
       const judgeText = buildJudgePrompt({ judge: judge.name, answer, prompt, mode, judgeIndex: j, judgePrompt })
-      const r = await runEphemeral(judge, judgeText)
+      const r = await runEphemeral(judge, judgeText, 'judge')
       usage = addUsage(usage, r.tokenUsage)
       if (!r.success && executionFailure === undefined) executionFailure = r
       if (overBudget() || params.shouldStop?.()) { budgetHit = true; break }
@@ -1675,9 +1792,8 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
       const verdict = parseJudgeVerdict(r.output, verdictSchema)
 
       // Trace every verdict (accept or dissent); shared memory records dissent only.
-      if (onTrace) {
-        const now = Date.now()
-        emitTrace(onTrace, {
+      const now = Date.now()
+      const legacyEvent = onTrace ? {
           type: 'consensus',
           runId: runId ?? '',
           spanId: generateSpanId(),
@@ -1688,7 +1804,15 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
           startMs: now,
           endMs: now,
           durationMs: 0,
-        })
+        } as const : undefined
+      if (params.consensusSpan) {
+        params.consensusSpan.event('consensus_verdict', {
+          'oma.consensus.round': round,
+          'oma.consensus.accepted': verdict.accept,
+          'oma.agent.name': judge.name,
+        }, legacyEvent)
+      } else if (legacyEvent) {
+        emitTrace(onTrace, legacyEvent)
       }
 
       if (verdict.accept) {
@@ -1708,7 +1832,11 @@ async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusR
 
     // Round missed quorum. Revise (if rounds remain) or stop.
     if (onDissent === 'revise' && round < maxRounds && reviseProposer) {
-      const r = await runEphemeral(reviseProposer, buildRevisePrompt(prompt, answer, roundDissent))
+      const r = await runEphemeral(
+        reviseProposer,
+        buildRevisePrompt(prompt, answer, roundDissent),
+        'revision',
+      )
       usage = addUsage(usage, r.tokenUsage)
       if (!r.success && executionFailure === undefined) executionFailure = r
       if (r.success && r.output) answer = r.output
@@ -1749,6 +1877,15 @@ async function runTaskVerify(
   const verify = task.verify!
   const { team, config } = ctx
   const assigneeConfig = team.getAgents().find((a) => a.name === assignee)
+  const consensusSpan = ctx.traceRuntime?.startSpan({
+    kind: 'consensus',
+    name: 'verify_consensus',
+    parent: ctx.taskSpans.get(task.id) ?? ctx.traceRuntime.root,
+    attributes: {
+      'oma.consensus.scope': 'task',
+      'oma.task.id': task.id,
+    },
+  })
 
   const consensus = await runConsensusCore({
     team,
@@ -1790,6 +1927,19 @@ async function runTaskVerify(
       }), assignee, task.id)
     },
     shouldStop: () => ctx.budgetExceededTriggered,
+    ...(ctx.traceRuntime && consensusSpan ? {
+      traceRuntime: ctx.traceRuntime,
+      consensusSpan,
+    } : {}),
+  })
+
+  consensusSpan?.end({
+    status: consensus.status ?? statusOnly('ok'),
+    ...(consensus.errorInfo ? { error: consensus.errorInfo } : {}),
+    attributes: {
+      'oma.consensus.verdict': consensus.verdict,
+      'oma.consensus.rounds': consensus.rounds,
+    },
   })
 
   if (consensus.status && consensus.status.code !== 'ok') {
@@ -1836,6 +1986,7 @@ export class OpenMultiAgent {
   private readonly teams: Map<string, Team> = new Map()
   private readonly fallbackCheckpointStore = new InMemoryStore()
   private completedTaskCount = 0
+  private readonly traceRecordObserver?: TraceRecordObserver
 
   /**
    * @param config - Optional top-level configuration.
@@ -1851,6 +2002,7 @@ export class OpenMultiAgent {
       throw new Error('maxCostBudget requires estimateCost so cost caps cannot be silently ignored.')
     }
 
+    this.traceRecordObserver = traceRecordObserverFrom(config)
     this.config = {
       maxConcurrency: config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
       maxDelegationDepth: config.maxDelegationDepth ?? DEFAULT_MAX_DELEGATION_DEPTH,
@@ -1873,6 +2025,10 @@ export class OpenMultiAgent {
       onProgress: config.onProgress,
       onTrace: config.onTrace,
     }
+  }
+
+  private startTrace(identity: RunIdentity): TraceRuntime | undefined {
+    return createTraceRuntime(identity, this.config.onTrace, this.traceRecordObserver)
   }
 
   // -------------------------------------------------------------------------
@@ -1921,6 +2077,7 @@ export class OpenMultiAgent {
     options?: RunAgentOptions,
   ): Promise<AgentRunResult> {
     const identity = createRunIdentity(options)
+    const traceRuntime = this.startTrace(identity)
     const effectiveBudget = resolveTokenBudget(config.maxTokenBudget, this.config.maxTokenBudget)
     const effective: AgentConfig = applyDefaultToolPreset({
       ...config,
@@ -1949,8 +2106,20 @@ export class OpenMultiAgent {
     const abortFields = options?.abortSignal ? { abortSignal: options.abortSignal } : null
     const runOptions: Partial<RunOptions> | undefined =
       traceFields || abortFields
-        ? { identity, runId: identity.runId, ...(traceFields ?? {}), ...(abortFields ?? {}) }
-        : { identity, runId: identity.runId }
+        ? {
+            identity,
+            runId: identity.runId,
+            ...(traceRuntime ? { traceRuntime, traceSpan: traceRuntime.root } : {}),
+            tracePhase: 'agent',
+            ...(traceFields ?? {}),
+            ...(abortFields ?? {}),
+          }
+        : {
+            identity,
+            runId: identity.runId,
+            ...(traceRuntime ? { traceRuntime, traceSpan: traceRuntime.root } : {}),
+            tracePhase: 'agent',
+          }
 
     const result = await agent.run(prompt, runOptions)
     let finalResult = result
@@ -2006,6 +2175,10 @@ export class OpenMultiAgent {
       this.completedTaskCount++
     }
 
+    traceRuntime?.close({
+      status: finalResult.status ?? statusOnly(finalResult.success ? 'ok' : 'error'),
+      ...(finalResult.errorInfo ? { error: finalResult.errorInfo } : {}),
+    })
     return finalResult
   }
 
@@ -2040,6 +2213,14 @@ export class OpenMultiAgent {
     options?: RunTeamOptions,
   ): Promise<TeamRunResult> {
     const identity = createRunIdentity(identityOptionsForRun(options))
+    const traceRuntime = this.startTrace(identity)
+    const finish = (result: TeamRunResult): TeamRunResult => {
+      traceRuntime?.close({
+        status: result.status ?? statusOnly(result.success ? 'ok' : 'error'),
+        ...(result.errorInfo ? { error: result.errorInfo } : {}),
+      })
+      return result
+    }
     const agentConfigs = team.getAgents()
     const coordinatorOverrides = options?.coordinator
 
@@ -2083,8 +2264,20 @@ export class OpenMultiAgent {
       const abortFields = options?.abortSignal ? { abortSignal: options.abortSignal } : null
       const runOptions: Partial<RunOptions> | undefined =
         traceFields || abortFields
-          ? { identity, runId: identity.runId, ...(traceFields ?? {}), ...(abortFields ?? {}) }
-          : { identity, runId: identity.runId }
+          ? {
+              identity,
+              runId: identity.runId,
+              ...(traceRuntime ? { traceRuntime, traceSpan: traceRuntime.root } : {}),
+              tracePhase: 'short-circuit',
+              ...(traceFields ?? {}),
+              ...(abortFields ?? {}),
+            }
+          : {
+              identity,
+              runId: identity.runId,
+              ...(traceRuntime ? { traceRuntime, traceSpan: traceRuntime.root } : {}),
+              tracePhase: 'short-circuit',
+            }
 
       const scStartMs = Date.now()
       const result = await agent.run(goal, runOptions)
@@ -2157,7 +2350,7 @@ export class OpenMultiAgent {
           retries: 0,
         },
       }]
-      return this.buildTeamRunResult(agentResults, identity, goal, tasks)
+      return finish(this.buildTeamRunResult(agentResults, identity, goal, tasks))
     }
 
     // ------------------------------------------------------------------
@@ -2187,6 +2380,8 @@ export class OpenMultiAgent {
     const decompTraceOptions: Partial<RunOptions> | undefined = this.config.onTrace
       ? {
           identity,
+          ...(traceRuntime ? { traceRuntime, traceSpan: traceRuntime.root } : {}),
+          tracePhase: 'decomposition',
           onTrace: this.config.onTrace,
           runId,
           traceAgent: 'coordinator',
@@ -2196,6 +2391,8 @@ export class OpenMultiAgent {
       : {
           identity,
           runId,
+          ...(traceRuntime ? { traceRuntime, traceSpan: traceRuntime.root } : {}),
+          tracePhase: 'decomposition',
           ...(options?.abortSignal ? { abortSignal: options.abortSignal } : {}),
         }
     const decompositionResult = await coordinatorAgent.run(decompositionPrompt, decompTraceOptions)
@@ -2223,9 +2420,9 @@ export class OpenMultiAgent {
     if (decompositionBudget.exceeded) {
       emitBudgetExceeded(this.config, decompositionBudget.exceeded, 'coordinator')
       const classified = classifyRunFailure(decompositionBudget.exceeded)
-      return this.buildTeamRunResult(
+      return finish(this.buildTeamRunResult(
         agentResults, identity, goal, [], classified.status, classified.errorInfo,
-      )
+      ))
     }
 
     // ------------------------------------------------------------------
@@ -2278,6 +2475,8 @@ export class OpenMultiAgent {
       ...(activeCheckpoint ? { checkpoint: activeCheckpoint } : {}),
       runId,
       identity,
+      ...(traceRuntime ? { traceRuntime } : {}),
+      taskSpans: new Map(),
       abortSignal: options?.abortSignal,
       cumulativeUsage,
       cumulativeCost,
@@ -2301,7 +2500,13 @@ export class OpenMultiAgent {
     }
 
     const planTasks = queue.list()
-    const planReadyStartMs = Date.now()
+    const planSpan = traceRuntime?.startSpan({
+      kind: 'plan',
+      name: 'prepare_plan',
+      parent: traceRuntime.root,
+      attributes: { 'oma.plan.task_count': planTasks.length },
+    })
+    const planReadyStartMs = planSpan?.startUnixMs ?? Date.now()
     let approved = true
     let planApprovalError: unknown
     if (this.config.onPlanReady) {
@@ -2312,9 +2517,8 @@ export class OpenMultiAgent {
         planApprovalError = error
       }
     }
-    if (this.config.onTrace) {
-      const planReadyEndMs = Date.now()
-      emitTrace(this.config.onTrace, {
+    const planReadyEndMs = Date.now()
+    const planLegacyEvent = this.config.onTrace ? {
         type: 'plan_ready',
         runId: runId ?? '',
         spanId: generateSpanId(),
@@ -2325,22 +2529,34 @@ export class OpenMultiAgent {
         startMs: planReadyStartMs,
         endMs: planReadyEndMs,
         durationMs: planReadyEndMs - planReadyStartMs,
+      } as const : undefined
+    if (planSpan) {
+      const planStatus = planApprovalError !== undefined
+        ? classifyRunFailure(planApprovalError, { kind: 'callback' })
+        : undefined
+      planSpan.end({
+        status: planStatus?.status ?? statusOnly(approved ? 'ok' : 'rejected'),
+        ...(planStatus ? { error: planStatus.errorInfo } : {}),
+        attributes: { 'oma.plan.approved': approved },
+        ...(planLegacyEvent ? { legacyEvent: planLegacyEvent } : {}),
       })
+    } else if (planLegacyEvent) {
+      emitTrace(this.config.onTrace, planLegacyEvent)
     }
     if (!approved) {
       if (planApprovalError !== undefined) {
         const classified = classifyRunFailure(planApprovalError, { kind: 'callback' })
-        return this.buildTeamRunResult(
+        return finish(this.buildTeamRunResult(
           agentResults, identity, goal, [], classified.status, classified.errorInfo,
-        )
+        ))
       }
-      return this.buildTeamRunResult(
+      return finish(this.buildTeamRunResult(
         agentResults,
         identity,
         goal,
         [],
         statusOnly('rejected', 'Plan approval rejected.'),
-      )
+      ))
     }
 
     if (options?.planOnly) {
@@ -2363,10 +2579,10 @@ export class OpenMultiAgent {
         agent: 'coordinator',
         data: decompositionResult,
       })
-      return {
+      return finish({
         ...this.buildTeamRunResult(agentResults, identity, goal, planOnlyTasks),
         planOnly: true,
-      }
+      })
     }
 
     await executeQueue(queue, ctx)
@@ -2403,6 +2619,7 @@ export class OpenMultiAgent {
       maxTokenBudget,
       maxCostBudget,
       estimateCost: this.config.estimateCost,
+      ...(traceRuntime ? { traceRuntime, consumedTaskSpans: [...ctx.taskSpans.values()] } : {}),
     })
     if (synthesis === null) {
       // Aborted or already over budget — return raw task outputs, no synthesis.
@@ -2413,9 +2630,9 @@ export class OpenMultiAgent {
         ctx.outcomeStatus = classified.status
         ctx.outcomeErrorInfo = classified.errorInfo
       }
-      return this.buildTeamRunResult(
+      return finish(this.buildTeamRunResult(
         agentResults, identity, goal, taskRecords, ctx.outcomeStatus, ctx.outcomeErrorInfo,
-      )
+      ))
     }
     agentResults.set('coordinator', synthesis.result)
     cumulativeUsage = synthesis.cumulativeUsage
@@ -2425,9 +2642,9 @@ export class OpenMultiAgent {
     // Only actual user tasks (non-coordinator keys) are counted in
     // buildTeamRunResult, so we do not increment completedTaskCount here.
 
-    return this.buildTeamRunResult(
+    return finish(this.buildTeamRunResult(
       agentResults, identity, goal, taskRecords, ctx.outcomeStatus, ctx.outcomeErrorInfo,
-    )
+    ))
   }
 
   // -------------------------------------------------------------------------
@@ -2706,6 +2923,30 @@ export class OpenMultiAgent {
       throw new Error('runConsensus: at least one judge is required.')
     }
 
+    const traceRuntime = this.startTrace(identity)
+    const consensusSpan = traceRuntime?.startSpan({
+      kind: 'consensus',
+      name: 'verify_consensus',
+      parent: traceRuntime.root,
+      attributes: { 'oma.consensus.scope': 'top_level' },
+    })
+    const finish = (result: ConsensusResult): ConsensusResult => {
+      const status = result.status ?? statusOnly('ok')
+      consensusSpan?.end({
+        status,
+        ...(result.errorInfo ? { error: result.errorInfo } : {}),
+        attributes: {
+          'oma.consensus.verdict': result.verdict,
+          'oma.consensus.rounds': result.rounds,
+        },
+      })
+      traceRuntime?.close({
+        status,
+        ...(result.errorInfo ? { error: result.errorInfo } : {}),
+      })
+      return result
+    }
+
     const mode = options.mode ?? 'refute'
     const maxRounds = Math.max(1, options.maxRounds ?? 2)
     const quorum = Math.min(
@@ -2736,6 +2977,12 @@ export class OpenMultiAgent {
         {
           identity,
           runId: identity.runId,
+          ...(traceRuntime && consensusSpan ? {
+            traceRuntime,
+            traceSpan: consensusSpan,
+            tracePhase: 'proposer',
+          } : {}),
+          ...(this.config.onTrace ? { onTrace: this.config.onTrace, traceAgent: proposerConfig.name } : {}),
           ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
         },
       )
@@ -2746,7 +2993,7 @@ export class OpenMultiAgent {
         const abortError = new Error('Run cancelled by caller.')
         abortError.name = 'AbortError'
         const classified = classifyRunFailure(abortError)
-        return {
+        return finish({
           identity,
           status: classified.status,
           errorInfo: classified.errorInfo,
@@ -2755,7 +3002,7 @@ export class OpenMultiAgent {
           dissent: [],
           rounds: 0,
           tokenUsage: usage,
-        }
+        })
       }
       if (budget !== undefined && usage.input_tokens + usage.output_tokens > budget) {
         const budgetError = new TokenBudgetExceededError(
@@ -2769,7 +3016,8 @@ export class OpenMultiAgent {
           data: budgetError,
         })
         const classified = classifyRunFailure(budgetError)
-        return {
+        consensusSpan?.event('budget_exhausted', {})
+        return finish({
           identity,
           status: classified.status,
           errorInfo: classified.errorInfo,
@@ -2778,7 +3026,7 @@ export class OpenMultiAgent {
           dissent: [],
           rounds: 0,
           tokenUsage: usage,
-        }
+        })
       }
     }
 
@@ -2786,12 +3034,12 @@ export class OpenMultiAgent {
     // Bail with a rejected verdict so an empty answer can never come back accepted.
     if (candidates.length === 0) {
       const status = firstFailure?.status ?? statusOnly('error', 'All consensus proposers failed.')
-      return {
+      return finish({
         identity,
         status,
         ...(firstFailure?.errorInfo ? { errorInfo: firstFailure.errorInfo } : {}),
         answer: '', verdict: 'rejected', dissent: [], rounds: 0, tokenUsage: usage,
-      }
+      })
     }
 
     const result = await runConsensusCore({
@@ -2815,12 +3063,13 @@ export class OpenMultiAgent {
       identity,
       abortSignal: options.abortSignal,
       pool,
+      ...(traceRuntime && consensusSpan ? { traceRuntime, consensusSpan } : {}),
     })
     if (options.abortSignal?.aborted) {
       const abortError = new Error('Run cancelled by caller.')
       abortError.name = 'AbortError'
       const classified = classifyRunFailure(abortError)
-      return { ...result, identity, status: classified.status, errorInfo: classified.errorInfo }
+      return finish({ ...result, identity, status: classified.status, errorInfo: classified.errorInfo })
     }
     if (budget !== undefined && result.tokenUsage.input_tokens + result.tokenUsage.output_tokens > budget) {
       const budgetError = new TokenBudgetExceededError(
@@ -2829,9 +3078,10 @@ export class OpenMultiAgent {
         budget,
       )
       const classified = classifyRunFailure(budgetError)
-      return { ...result, identity, status: classified.status, errorInfo: classified.errorInfo }
+      consensusSpan?.event('budget_exhausted', {})
+      return finish({ ...result, identity, status: classified.status, errorInfo: classified.errorInfo })
     }
-    return { ...result, identity, status: result.status ?? statusOnly('ok') }
+    return finish({ ...result, identity, status: result.status ?? statusOnly('ok') })
   }
 
   // -------------------------------------------------------------------------
@@ -3051,6 +3301,8 @@ export class OpenMultiAgent {
       readonly maxTokenBudget?: number
       readonly maxCostBudget?: number
       readonly estimateCost?: OrchestratorConfig['estimateCost']
+      readonly traceRuntime?: TraceRuntime
+      readonly consumedTaskSpans?: readonly TraceSpan[]
     },
   ): Promise<{ readonly result: AgentRunResult; readonly cumulativeUsage: TokenUsage; readonly cumulativeCost: number } | null> {
     if (opts.abortSignal?.aborted) return null
@@ -3077,6 +3329,16 @@ export class OpenMultiAgent {
     const synthTraceOptions: Partial<RunOptions> = {
       identity: opts.identity,
       runId: opts.identity.runId,
+      ...(opts.traceRuntime ? {
+        traceRuntime: opts.traceRuntime,
+        traceSpan: opts.traceRuntime.root,
+        tracePhase: 'synthesis',
+        traceLinks: (opts.consumedTaskSpans ?? []).map((span) => ({
+          traceId: opts.identity.traceId,
+          spanId: span.spanId,
+          relation: 'consumed' as const,
+        })),
+      } : {}),
       ...(this.config.onTrace
         ? { onTrace: this.config.onTrace, traceAgent: 'coordinator' }
         : {}),
@@ -3197,6 +3459,7 @@ export class OpenMultiAgent {
     identity?: RunIdentity,
   ): Promise<TeamRunResult> {
     const runIdentity = identity ?? createRunIdentity(identityOptionsForRun(options))
+    const traceRuntime = this.startTrace(runIdentity)
     const agentConfigs = team.getAgents()
     const scheduler = new Scheduler('dependency-first')
     scheduler.autoAssign(queue, agentConfigs)
@@ -3218,6 +3481,8 @@ export class OpenMultiAgent {
       ...(checkpoint ? { checkpoint } : {}),
       identity: runIdentity,
       runId: runIdentity.runId,
+      ...(traceRuntime ? { traceRuntime } : {}),
+      taskSpans: new Map(),
       abortSignal: options?.abortSignal,
       cumulativeUsage: ZERO_USAGE,
       cumulativeCost: 0,
@@ -3255,6 +3520,7 @@ export class OpenMultiAgent {
           maxTokenBudget: ctx.maxTokenBudget,
           maxCostBudget: ctx.maxCostBudget,
           estimateCost: ctx.estimateCost,
+          ...(traceRuntime ? { traceRuntime, consumedTaskSpans: [...ctx.taskSpans.values()] } : {}),
         })
         if (synthesis !== null && synthesis.result.success) {
           agentResults.set('coordinator', synthesis.result)
@@ -3306,7 +3572,7 @@ export class OpenMultiAgent {
       metrics: ctx.taskMetrics.get(task.id),
     }))
 
-    return this.buildTeamRunResult(
+    const result = this.buildTeamRunResult(
       agentResults,
       runIdentity,
       goal,
@@ -3314,6 +3580,11 @@ export class OpenMultiAgent {
       ctx.outcomeStatus,
       ctx.outcomeErrorInfo,
     )
+    traceRuntime?.close({
+      status: result.status ?? statusOnly(result.success ? 'ok' : 'error'),
+      ...(result.errorInfo ? { error: result.errorInfo } : {}),
+    })
+    return result
   }
 
   private createActiveCheckpoint(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -161,6 +161,15 @@ export interface TokenUsage {
 // Run identity and outcome
 // ---------------------------------------------------------------------------
 
+/** Scalar trace attribute values supported by the v2 record schema. */
+export type TraceAttributeValue =
+  | string
+  | number
+  | boolean
+  | readonly string[]
+  | readonly number[]
+  | readonly boolean[]
+
 /** Stable identity for one logical run and its current execution attempt. */
 export interface RunIdentity {
   /** Logical run identifier. Preserved across checkpoint restore. */
@@ -179,7 +188,8 @@ export interface RunIdentity {
 export interface TraceLink {
   readonly traceId: string
   readonly spanId: string
-  readonly relation: 'continued_from'
+  readonly relation: 'continued_from' | 'depends_on' | 'consumed' | 'delegated_from'
+  readonly attributes?: Readonly<Record<string, TraceAttributeValue>>
 }
 
 /** Backwards-compatible identity-specific alias for {@link TraceLink}. */
@@ -395,7 +405,12 @@ export interface TeamInfo {
    * Run another roster agent to completion and return its result.
    * Only set during orchestrated pool execution (`runTeam` / `runTasks`).
    */
-  readonly runDelegatedAgent?: (targetAgent: string, prompt: string) => Promise<AgentRunResult>
+  readonly runDelegatedAgent?: (
+    targetAgent: string,
+    prompt: string,
+    /** Internal OBS-1B parent handle; callers should omit it. */
+    traceParent?: unknown,
+  ) => Promise<AgentRunResult>
 }
 
 /**

--- a/packages/core/tests/observability-v2-spans.test.ts
+++ b/packages/core/tests/observability-v2-spans.test.ts
@@ -1,0 +1,486 @@
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import { createRunIdentity } from '../src/observability/identity.js'
+import { TRACE_RECORD_OBSERVER, TraceRuntime } from '../src/observability/runtime.js'
+import type { SpanEndRecord, TraceRecord } from '../src/observability/records.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { Team } from '../src/team/team.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMChatOptions,
+  LLMMessage,
+  LLMResponse,
+  OrchestratorConfig,
+  TraceEvent,
+} from '../src/types.js'
+
+function ended(records: readonly TraceRecord[]): SpanEndRecord[] {
+  return records.filter((record): record is SpanEndRecord => record.recordType === 'span_end')
+}
+
+function response(text: string, usage = { input_tokens: 1, output_tokens: 1 }): LLMResponse {
+  return {
+    id: `response-${text}`,
+    content: [{ type: 'text', text }],
+    model: 'test-model',
+    stop_reason: 'end_turn',
+    usage,
+  }
+}
+
+function toolResponse(name: string, input: Record<string, unknown>): LLMResponse {
+  return {
+    id: `tool-${name}`,
+    content: [{ type: 'tool_use', id: `call-${name}`, name, input }],
+    model: 'test-model',
+    stop_reason: 'tool_use',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function adapter(
+  chat: (messages: LLMMessage[], options: LLMChatOptions) => Promise<LLMResponse>,
+): LLMAdapter {
+  return { name: 'obs-1b-test', chat, async *stream() { /* unused */ } }
+}
+
+function config(name: string, llm: LLMAdapter, extra: Partial<AgentConfig> = {}): AgentConfig {
+  return { name, model: 'test-model', adapter: llm, ...extra }
+}
+
+function tracedOrchestrator(records: TraceRecord[], extra: OrchestratorConfig = {}): OpenMultiAgent {
+  return new OpenMultiAgent({
+    defaultModel: 'test-model',
+    ...extra,
+    [TRACE_RECORD_OBSERVER]: (record: TraceRecord) => records.push(record),
+  } as OrchestratorConfig & { [TRACE_RECORD_OBSERVER]: (record: TraceRecord) => void })
+}
+
+function expectClosed(records: readonly TraceRecord[]): void {
+  const starts = records.filter((record) => record.recordType === 'span_start')
+  const ends = ended(records)
+  expect(ends).toHaveLength(starts.length)
+  for (const start of starts) {
+    expect(ends.filter((end) => end.spanId === start.spanId)).toHaveLength(1)
+  }
+}
+
+describe('OBS-1B TraceRuntime contract', () => {
+  it('emits schema-v2 start/event/self-contained end records in strict sequence', () => {
+    const records: TraceRecord[] = []
+    const identity = createRunIdentity({ runId: 'contract-run' })
+    const runtime = new TraceRuntime(identity, (record) => records.push(record))
+    const child = runtime.startSpan({
+      kind: 'llm',
+      name: 'chat',
+      parent: runtime.root,
+      attributes: { 'oma.phase': 'turn', 'oma.agent.name': 'worker' },
+    })
+    child.event('first_chunk', { 'oma.stream.ttft_ms': 4 })
+    child.end({ status: { code: 'ok' }, attributes: { 'oma.usage.input_tokens': 2 } })
+    runtime.close({ status: { code: 'ok' } })
+
+    expect(records.map((record) => record.sequence)).toEqual([1, 2, 3, 4, 5])
+    expect(new Set(records.map((record) => record.recordId)).size).toBe(records.length)
+    expect(records.every((record) => record.schemaVersion === 2)).toBe(true)
+    expect(records.every((record) => record.runId === identity.runId)).toBe(true)
+    expect(records.every((record) => record.attempt === identity.attempt)).toBe(true)
+    expect(records.every((record) => record.traceId === identity.traceId)).toBe(true)
+    expect(child.spanId).toMatch(/^[0-9a-f]{16}$/)
+
+    const childEnd = ended(records).find((record) => record.spanId === child.spanId)!
+    expect(childEnd).toMatchObject({
+      kind: 'llm',
+      name: 'chat',
+      parentSpanId: identity.rootSpanId,
+      status: { code: 'ok' },
+    })
+    expect(childEnd.attributes).toMatchObject({
+      'oma.phase': 'turn',
+      'oma.agent.name': 'worker',
+      'oma.usage.input_tokens': 2,
+      'oma.status': 'ok',
+    })
+  })
+
+  it('closes exactly once and makes close/ensureEnded idempotent', () => {
+    const records: TraceRecord[] = []
+    const runtime = new TraceRuntime(createRunIdentity(), (record) => records.push(record))
+    const span = runtime.startSpan({ kind: 'tool', name: 'execute_tool', parent: runtime.root })
+
+    expect(span.end({ status: { code: 'error' } })).toBe(true)
+    expect(span.end({ status: { code: 'ok' } })).toBe(false)
+    expect(span.ensureEnded()).toBe(false)
+    expect(ended(records).filter((record) => record.spanId === span.spanId)).toHaveLength(1)
+  })
+
+  it('keeps sequence unique and strictly increasing under parallel completions', async () => {
+    const records: TraceRecord[] = []
+    const runtime = new TraceRuntime(createRunIdentity(), (record) => records.push(record))
+    const spans = Array.from({ length: 100 }, (_, index) => runtime.startSpan({
+      kind: 'task',
+      name: 'execute_task',
+      parent: runtime.root,
+      attributes: { 'oma.task.index': index },
+    }))
+
+    await Promise.all(spans.map(async (span, index) => {
+      await Promise.resolve(index)
+      span.end({ status: { code: 'ok' } })
+    }))
+    runtime.close({ status: { code: 'ok' } })
+
+    const sequences = records.map((record) => record.sequence)
+    expect(new Set(sequences).size).toBe(sequences.length)
+    expect(sequences).toEqual(Array.from({ length: sequences.length }, (_, index) => index + 1))
+    expect(ended(records)).toHaveLength(101)
+  })
+
+  it('converts only completed v2 records back to the unchanged legacy callback shape', () => {
+    const legacy = vi.fn<(event: TraceEvent) => void>()
+    const runtime = new TraceRuntime(createRunIdentity({ runId: 'legacy-run' }), undefined, legacy)
+    const span = runtime.startSpan({ kind: 'agent', name: 'invoke_agent', parent: runtime.root })
+    const event: TraceEvent = {
+      type: 'agent',
+      runId: 'legacy-run',
+      spanId: '86012c59-320f-42af-b891-a870ad4ab4dc',
+      agent: 'worker',
+      turns: 1,
+      tokens: { input_tokens: 1, output_tokens: 2 },
+      toolCalls: 0,
+      startMs: 1,
+      endMs: 2,
+      durationMs: 1,
+    }
+
+    expect(legacy).not.toHaveBeenCalled()
+    span.end({ status: { code: 'ok' }, legacyEvent: event })
+    expect(legacy).toHaveBeenCalledOnce()
+    expect(legacy).toHaveBeenCalledWith(event)
+  })
+})
+
+describe('OBS-1B runtime integration', () => {
+  it('closes LLM/agent/root spans for success, provider error, timeout, cancellation, and budget', async () => {
+    const cases: Array<{
+      expected: string
+      agent: AgentConfig
+      abort?: AbortSignal
+    }> = [
+      { expected: 'ok', agent: config('ok', adapter(async () => response('ok'))) },
+      {
+        expected: 'error',
+        agent: config('error', adapter(async () => {
+          throw Object.assign(new Error('provider failed'), { status: 503 })
+        })),
+      },
+      {
+        expected: 'timeout',
+        agent: config('timeout', adapter(async (_messages, options) => {
+          await new Promise<void>((resolve) => {
+            if (options.abortSignal?.aborted) resolve()
+            else options.abortSignal?.addEventListener('abort', () => resolve(), { once: true })
+          })
+          return response('late')
+        }), { timeoutMs: 5 }),
+      },
+      {
+        expected: 'budget_exhausted',
+        agent: config('budget', adapter(async () => response('large', {
+          input_tokens: 10,
+          output_tokens: 10,
+        })), { maxTokenBudget: 5 }),
+      },
+    ]
+
+    for (const testCase of cases) {
+      const records: TraceRecord[] = []
+      const result = await tracedOrchestrator(records).runAgent(testCase.agent, 'hello')
+      expect(result.status?.code).toBe(testCase.expected)
+      expectClosed(records)
+      expect(ended(records).find((record) => record.kind === 'run')?.status.code)
+        .toBe(testCase.expected)
+      if (testCase.expected !== 'budget_exhausted') {
+        expect(ended(records).find((record) => record.kind === 'llm')?.status.code)
+          .toBe(testCase.expected)
+      }
+    }
+
+    const controller = new AbortController()
+    controller.abort()
+    const cancelledRecords: TraceRecord[] = []
+    const cancelled = await tracedOrchestrator(cancelledRecords).runAgent(
+      config('cancelled', adapter(async () => response('unused'))),
+      'hello',
+      { abortSignal: controller.signal },
+    )
+    expect(cancelled.status?.code).toBe('cancelled')
+    expectClosed(cancelledRecords)
+    expect(ended(cancelledRecords).some((record) => record.kind === 'llm')).toBe(false)
+
+    const inFlightController = new AbortController()
+    const inFlightRecords: TraceRecord[] = []
+    let markStarted!: () => void
+    const started = new Promise<void>((resolve) => { markStarted = resolve })
+    const inFlight = tracedOrchestrator(inFlightRecords).runAgent(
+      config('in-flight', adapter(async (_messages, options) => {
+        markStarted()
+        await new Promise<void>((resolve) => {
+          if (options.abortSignal?.aborted) resolve()
+          else options.abortSignal?.addEventListener('abort', () => resolve(), { once: true })
+        })
+        const error = new Error('aborted in flight')
+        error.name = 'AbortError'
+        throw error
+      })),
+      'hello',
+      { abortSignal: inFlightController.signal },
+    )
+    await started
+    inFlightController.abort()
+    const inFlightResult = await inFlight
+    expect(inFlightResult.status?.code).toBe('cancelled')
+    expect(ended(inFlightRecords).find((record) => record.kind === 'llm')?.status.code)
+      .toBe('cancelled')
+    expectClosed(inFlightRecords)
+  })
+
+  it('closes the structured-output retry when its second LLM call fails', async () => {
+    const records: TraceRecord[] = []
+    let calls = 0
+    const llm = adapter(async () => {
+      if (calls++ === 0) return response('not-json')
+      throw Object.assign(new Error('retry failed'), { status: 500 })
+    })
+    const result = await tracedOrchestrator(records).runAgent(config('structured', llm, {
+      outputSchema: z.object({ value: z.string() }),
+    }), 'return json')
+
+    expect(result.success).toBe(false)
+    expect(ended(records).filter((record) => record.kind === 'llm').map((record) => record.status.code))
+      .toEqual(['ok', 'error'])
+    expectClosed(records)
+  })
+
+  it('closes a failing context-summary LLM call', async () => {
+    const records: TraceRecord[] = []
+    let mainCalls = 0
+    const llm = adapter(async (_messages, options) => {
+      if (options.model === 'summary-model') {
+        throw Object.assign(new Error('summary provider failed'), { status: 500 })
+      }
+      return mainCalls++ < 2 ? toolResponse('echo', { value: 'x'.repeat(200) }) : response('done')
+    })
+    const result = await tracedOrchestrator(records).runAgent(config('summary', llm, {
+      customTools: [{
+        name: 'echo',
+        description: 'echo',
+        inputSchema: z.object({ value: z.string() }),
+        execute: async ({ value }) => ({ data: value }),
+      }],
+      tools: ['echo'],
+      contextStrategy: { type: 'summarize', maxTokens: 1, summaryModel: 'summary-model' },
+    }), 'start')
+
+    expect(result.success).toBe(false)
+    const llmEnds = ended(records).filter((record) => record.kind === 'llm')
+    expect(llmEnds.map((record) => record.attributes['oma.phase'])).toEqual(['turn', 'turn', 'summary'])
+    expect(llmEnds.map((record) => record.status.code)).toEqual(['ok', 'ok', 'error'])
+    expectClosed(records)
+  })
+
+  it('models retry attempts and DAG dependencies without turning the DAG into a parent chain', async () => {
+    const records: TraceRecord[] = []
+    let calls = 0
+    const llm = adapter(async () => {
+      if (calls++ === 0) throw Object.assign(new Error('transient'), { status: 500 })
+      return response('ok')
+    })
+    const team = new Team({ name: 'team', agents: [config('worker', llm)] })
+    const result = await tracedOrchestrator(records).runTasks(team, [
+      { title: 'first', description: 'first', assignee: 'worker', maxRetries: 1, retryDelayMs: 0 },
+      { title: 'second', description: 'second', assignee: 'worker', dependsOn: ['first'] },
+    ])
+
+    expect(result.success).toBe(true)
+    expectClosed(records)
+    const taskEnds = ended(records).filter((record) => record.kind === 'task')
+    expect(taskEnds).toHaveLength(2)
+    expect(taskEnds.every((record) => record.parentSpanId === result.identity?.rootSpanId)).toBe(true)
+    expect(taskEnds[1]!.links).toContainEqual(expect.objectContaining({
+      relation: 'depends_on',
+      spanId: taskEnds[0]!.spanId,
+    }))
+    const attempts = ended(records).filter((record) => record.kind === 'agent')
+    expect(attempts.map((record) => record.status.code)).toEqual(['error', 'ok', 'ok'])
+    expect(records.some((record) => record.recordType === 'span_event' && record.name === 'retry_scheduled'))
+      .toBe(true)
+  })
+
+  it('keeps an agent/task/run ok when a tool error is handled by the next LLM turn', async () => {
+    const records: TraceRecord[] = []
+    let calls = 0
+    const llm = adapter(async () => calls++ === 0
+      ? toolResponse('boom', {})
+      : response('handled'))
+    const team = new Team({ name: 'team', agents: [config('worker', llm, {
+      customTools: [{
+        name: 'boom',
+        description: 'fails',
+        inputSchema: z.object({}),
+        execute: async () => { throw new Error('tool failed') },
+      }],
+      tools: ['boom'],
+    })] })
+    const result = await tracedOrchestrator(records).runTasks(team, [
+      { title: 'tool task', description: 'use tool', assignee: 'worker' },
+    ])
+
+    expect(result.success).toBe(true)
+    expect(ended(records).find((record) => record.kind === 'tool')?.status.code).toBe('error')
+    expect(ended(records).find((record) => record.kind === 'agent')?.status.code).toBe('ok')
+    expect(ended(records).find((record) => record.kind === 'task')?.status.code).toBe('ok')
+    expect(ended(records).find((record) => record.kind === 'run')?.status.code).toBe('ok')
+    expectClosed(records)
+  })
+
+  it('parents a delegated agent under the delegate tool and links it back to the task', async () => {
+    const records: TraceRecord[] = []
+    let callerTurns = 0
+    const caller = adapter(async () => callerTurns++ === 0
+      ? toolResponse('delegate_to_agent', { target_agent: 'helper', prompt: 'help' })
+      : response('done'))
+    const helper = adapter(async () => response('helped'))
+    const team = new Team({ name: 'team', agents: [
+      config('caller', caller, { tools: ['delegate_to_agent'] }),
+      config('helper', helper),
+    ] })
+    const result = await tracedOrchestrator(records, { maxConcurrency: 2 }).runTasks(team, [
+      { title: 'delegate', description: 'delegate work', assignee: 'caller' },
+    ])
+
+    expect(result.success).toBe(true)
+    expectClosed(records)
+    const tool = ended(records).find((record) =>
+      record.kind === 'tool' && record.attributes['oma.tool.name'] === 'delegate_to_agent')!
+    const task = ended(records).find((record) => record.kind === 'task')!
+    const delegated = ended(records).find((record) =>
+      record.kind === 'agent' && record.attributes['oma.phase'] === 'delegated')!
+    expect(delegated.parentSpanId).toBe(tool.spanId)
+    expect(delegated.links).toContainEqual(expect.objectContaining({
+      relation: 'delegated_from',
+      spanId: task.spanId,
+    }))
+  })
+
+  it('links coordinator synthesis to every consumed task span', async () => {
+    const records: TraceRecord[] = []
+    let coordinatorCalls = 0
+    const coordinator = adapter(async () => response(coordinatorCalls++ === 0
+      ? '```json\n[{"title":"work","description":"do work","assignee":"worker"}]\n```'
+      : 'synthesized'))
+    const team = new Team({
+      name: 'team',
+      agents: [config('worker', adapter(async () => response('task output')))],
+    })
+    const result = await tracedOrchestrator(records).runTeam(
+      team,
+      'First do the work, then synthesize the result',
+      { coordinator: { adapter: coordinator } },
+    )
+
+    expect(result.success).toBe(true)
+    expectClosed(records)
+    const task = ended(records).find((record) => record.kind === 'task')!
+    const synthesis = ended(records).find((record) =>
+      record.kind === 'agent' && record.attributes['oma.phase'] === 'synthesis')!
+    expect(synthesis.parentSpanId).toBe(result.identity?.rootSpanId)
+    expect(synthesis.links).toContainEqual(expect.objectContaining({
+      relation: 'consumed',
+      spanId: task.spanId,
+    }))
+  })
+
+  it('closes approval rejection and callback-throw paths distinctly', async () => {
+    for (const throws of [false, true]) {
+      const records: TraceRecord[] = []
+      const oma = tracedOrchestrator(records, {
+        onApproval: async () => {
+          if (throws) throw new Error('approval failed')
+          return false
+        },
+      })
+      const team = new Team({
+        name: 'team',
+        agents: [config('worker', adapter(async () => response('ok')))],
+      })
+      const result = await oma.runTasks(team, [
+        { title: 'first', description: 'first', assignee: 'worker' },
+        { title: 'second', description: 'second', assignee: 'worker', dependsOn: ['first'] },
+      ])
+
+      expect(result.status?.code).toBe(throws ? 'error' : 'rejected')
+      const callback = ended(records).find((record) => record.kind === 'callback')!
+      expect(callback.status.code).toBe(throws ? 'error' : 'rejected')
+      expect(callback.error?.kind).toBe(throws ? 'callback' : undefined)
+      expectClosed(records)
+    }
+  })
+
+  it('builds top-level consensus proposer/judge/revision hierarchy', async () => {
+    const records: TraceRecord[] = []
+    let proposerCalls = 0
+    const proposer = adapter(async () => response(proposerCalls++ === 0 ? 'answer' : 'revised answer'))
+    let judgeCalls = 0
+    const judge = adapter(async () => response(judgeCalls++ === 0
+      ? '{"accept":false,"critique":"revise"}'
+      : '{"accept":true,"critique":""}'))
+    const result = await tracedOrchestrator(records).runConsensus(
+      new Team({ name: 'team', agents: [] }),
+      'question',
+      {
+        proposer: config('proposer', proposer),
+        judges: [config('judge', judge)],
+        maxRounds: 2,
+      },
+    )
+
+    expect(result.verdict).toBe('accepted')
+    expectClosed(records)
+    const consensus = ended(records).find((record) => record.kind === 'consensus')!
+    const agents = ended(records).filter((record) => record.kind === 'agent')
+    expect(agents).toHaveLength(4)
+    expect(agents.every((record) => record.parentSpanId === consensus.spanId)).toBe(true)
+    expect(agents.map((record) => record.attributes['oma.phase']))
+      .toEqual(['proposer', 'judge', 'revision', 'judge'])
+  })
+
+  it('puts checkpoint restore on a new trace linked to the previous root', async () => {
+    const records: TraceRecord[] = []
+    const store = new InMemoryStore()
+    const oma = tracedOrchestrator(records)
+    const makeTeam = () => new Team({
+      name: 'team',
+      agents: [config('worker', adapter(async () => response('ok')))],
+    })
+    const initial = await oma.runTasks(makeTeam(), [
+      { title: 'task', description: 'work', assignee: 'worker' },
+    ], { checkpoint: { store, runId: 'continued-run' } })
+    const restored = await oma.restore(makeTeam(), {
+      checkpoint: { store, runId: 'continued-run' },
+    })
+
+    expect(restored.identity?.attempt).toBe(2)
+    const restoredRoot = records.find((record) =>
+      record.recordType === 'span_start'
+      && record.spanId === restored.identity?.rootSpanId)
+    expect(restoredRoot?.links).toContainEqual({
+      traceId: initial.identity?.traceId,
+      spanId: initial.identity?.rootSpanId,
+      relation: 'continued_from',
+    })
+    expectClosed(records)
+  })
+})


### PR DESCRIPTION
## Summary

- add public TraceRecord schema v2 types and an internal synchronous runtime for start/event/end records
- guarantee idempotent, exactly-once span closure across success, failure, timeout, cancellation, budget, approval, callback, retry, and checkpoint paths
- model run/coordinator/task/agent/LLM/tool/retry/delegation/consensus/checkpoint hierarchy, with DAG, synthesis, delegation, and restore relationships represented as links
- preserve the existing seven-member TraceEvent callback shape and legacy UUID parent tree behavior
- add OBS-1B contract/integration coverage and a reproducible no-sink benchmark

## Scope

This PR is limited to OBS-1B. It does not add TraceSink/TraceExporter lifecycle, batching/queue/flush/shutdown, TraceStore, OpenTelemetry packaging, or dashboard changes.

## Test Coverage

- TraceRecord v2 schema, strict per-trace sequence, start/end pairing, self-contained end records, and double-close idempotency
- LLM success/error/timeout/pre-abort/in-flight cancellation and structured-output/summary failure closure
- retry failure then success, handled tool errors, whole-run budget exhaustion, approval rejection, callback errors
- DAG dependency links, delegation parent/link behavior, synthesis consumed links, consensus hierarchy, and restore continuation
- existing legacy trace compatibility suite

## Pre-Landing Review

No blocking issues found in the data/concurrency, LLM trust-boundary, enum-completeness, compatibility, or test-gap passes.

## Performance

No-sink benchmark, 20,000 iterations x 11 alternating rounds against PR #371 baseline: 167.279 ms baseline median vs 167.601 ms candidate median (+0.192%).

## Validation

- [x] Targeted OBS-1B tests: 14 passed
- [x] Compatibility-focused tests: 216 passed
- [x] `npm run lint`
- [x] `npm test`: core 1195 passed; create-oma-app 26 passed
- [x] `npm run build`
- [x] `git diff --check`
- [x] direct root and package-name import smoke tests
- [x] `npm pack --dry-run --workspace @open-multi-agent/core`

## Documentation

- `docs/observability.md`: documents TraceRecord v2 lifecycle, hierarchy/link mapping, compatibility, and streaming semantics.
