### PR TITLE
feat(core): add OBS-2 trace sink lifecycle

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -57,15 +57,124 @@ status, and structured error so it remains useful if a start/event record is
 lost later in the delivery pipeline. Close is idempotent and the first end
 wins.
 
-OBS-1B does not add a public sink/exporter lifecycle. The runtime is activated
-by the existing `onTrace` path and converts completed v2 operations back to
-the unchanged seven-member `TraceEvent` union. Without `onTrace`, no child
-TraceRecord objects are constructed; top-level identity/status still exist.
+OBS-2 adds a public sink/exporter lifecycle. The runtime is activated by either
+`observability.sinks` or the existing `onTrace` path. Without either option, no
+child `TraceRecord` objects or attributes are constructed; top-level
+identity/status still exist.
 
 Streaming notifications are span events rather than zero-duration child
 spans in v2. TTFT is recorded only by a genuinely streaming provider path;
 the current aggregated `chat()` path never substitutes total latency for
 TTFT. Legacy `agent_stream` callback events remain unchanged.
+
+## Sinks, exporters, and ownership
+
+`TraceSink` is the synchronous hot-path contract. Its `emit(record): void`
+method accepts a record quickly and is never awaited by Agent, Task, or Run
+execution. `TraceExporter` is the asynchronous batch-delivery contract used by
+`BatchingTraceSink`; network or storage I/O belongs there. A sink or exporter
+failure changes observability statistics and diagnostics, never the business
+result.
+
+```typescript
+import {
+  BatchingTraceSink,
+  OpenMultiAgent,
+  type TraceExporter,
+} from '@open-multi-agent/core'
+
+const exporter: TraceExporter = {
+  async export(records, signal) {
+    // Send the batch using `signal`; return a delivered prefix count.
+    return { status: 'success', exported: records.length }
+  },
+}
+
+const sink = new BatchingTraceSink(exporter)
+const orchestrator = new OpenMultiAgent({
+  observability: { sinks: [sink] },
+})
+```
+
+An exporter result has `success`, `retryable`, or permanent `failure` status.
+`exported` is the successfully delivered prefix of the supplied batch. A short
+`success` is a permanent partial result; a short `retryable` result retries only
+the unexported suffix. Rejected or timed-out exporter promises are contained by
+the batching sink.
+
+Core also exports `CompositeSink`, `FilteringSink`,
+`SensitiveDataProcessor`, and `LegacyCallbackTraceSink`, both from the package
+root and the explicit `@open-multi-agent/core/observability` subpath.
+
+## Flush and shutdown
+
+`forceFlush({ timeoutMs })` captures an acceptance watermark. It promises that
+records accepted before that call have been exported or explicitly counted as
+failed/dropped; records accepted afterward do not delay that call. It then
+delegates to the exporter's optional `forceFlush`. Results are `ok`, `partial`,
+`timeout`, or `error` and include cumulative accepted/exported/dropped/failed
+counts.
+
+`shutdown({ timeoutMs })` atomically stops acceptance, flushes the cutoff, then
+shuts down the exporter. It is idempotent: concurrent and repeated calls share
+the first result. An `emit` after the cutoff is dropped and diagnosed. Timeout
+is a total lifecycle deadline, not an exception thrown into Agent execution.
+
+The creator of a sink owns its lifecycle. OMA does **not** automatically shut
+down injected sinks, install process signal handlers, call `process.exit()`, or
+assume that a sink is exclusive to one orchestrator.
+
+```typescript
+// Serverless/FaaS: flush this invocation, keep a shared singleton usable.
+const result = await orchestrator.runAgent(agent, prompt)
+const telemetry = await sink.forceFlush({ timeoutMs: 1_500 })
+return { result, telemetry: telemetry.status }
+
+// Short-lived CLI: finish delivery before natural process exit.
+try {
+  await main()
+  await sink.forceFlush({ timeoutMs: 5_000 })
+} finally {
+  await sink.shutdown({ timeoutMs: 5_000 })
+}
+
+// Long-lived server: application-owned graceful shutdown.
+async function stopServer() {
+  await sink.shutdown({ timeoutMs: 10_000 })
+  await server.close()
+}
+// Register stopServer with your server/process framework if desired.
+```
+
+## Queue, retry, drop, and diagnostics
+
+`BatchingTraceSink` defaults are bounded:
+
+| Setting | Default |
+|---|---:|
+| queued records | 2,048 |
+| queued bytes | 16 MiB |
+| one record | 256 KiB |
+| batch records | 512 |
+| scheduled delay | 5 seconds |
+| export timeout | 30 seconds |
+| retries after the first attempt | 3 |
+| retry backoff | 1 second, exponential ×2, equal jitter, capped at 30 seconds |
+
+Only `retryable` results, rejected exporter promises, and export timeouts are
+retried. Retry/backoff happens in the transport worker and never blocks
+business execution. Queue admission is non-blocking. When capacity is needed,
+the sink drops oldest records in this priority order: `stream_chunk`, other
+events, `span_start`, then self-contained `span_end`. Oversize records are
+rejected before acceptance.
+
+`getStats()` reports accepted, exported, retried, failed, dropped, queued record
+count/bytes, and a payload-free last error code. Built-in diagnostics never
+include a record, prompt, tool payload, or raw exception. They default to one
+`console.warn` per sink+code per 60 seconds; pass `diagnostics: 'silent'`
+explicitly to a built-in sink to disable warnings, or use `onDiagnostic`.
+Diagnostic handler throws are swallowed without recursively producing another
+diagnostic.
 
 ## Progress Events
 
@@ -83,7 +192,9 @@ Common event types include `task_start`, `task_complete`, `task_retry`, `task_sk
 
 ## Trace Spans
 
-Use `onTrace` when you need structured spans for LLM calls, tool executions, and tasks. Each span carries a `runId`, its own `spanId`, an optional `parentId`, durations, token counts, and best-effort-redacted tool I/O.
+`onTrace` remains source- and runtime-compatible for existing users. Each event
+still carries its UUID `spanId`, optional UUID `parentId`, duration, token
+counts, and the same best-effort-redacted legacy tool I/O.
 
 ```typescript
 const orchestrator = new OpenMultiAgent({
@@ -94,6 +205,13 @@ const orchestrator = new OpenMultiAgent({
 ```
 
 Forward trace spans to OpenTelemetry, Datadog, Honeycomb, Langfuse, or your own run database only after deciding what data is safe for that sink. See [`integrations/trace-observability`](../packages/core/examples/integrations/trace-observability.ts) for a runnable example.
+
+The seven-member `TraceEvent` union and completion/event timing are unchanged.
+Internally, `LegacyCallbackTraceSink` maps v2 records back to the exact legacy
+event object. Synchronous callback throws and asynchronous rejections remain
+isolated and cannot become unhandled rejections. `onTrace` is not marked
+deprecated in this release; the 1.x compatibility window remains open while
+users can migrate transport code to `observability.sinks` at their own pace.
 
 Span parentage is best-effort and uses the causal structure known to the runtime. In team runs, worker agent spans point to their task span, and LLM/tool/stream spans point to the agent span. Root spans such as top-level agent runs omit `parentId`.
 
@@ -124,3 +242,17 @@ For production runs, persist enough data to reconstruct a failure without replay
 - The rendered dashboard HTML when you need a shareable post-mortem artifact.
 
 > **Redaction scope.** The redaction noted above applies to *telemetry* — trace spans and the dashboard payload. It does **not** cover persisted run state: shared-memory writes and checkpoint saves store agent output verbatim. To scrub secrets there, wrap the durable store with [`RedactingStore`](shared-memory.md#redacting-persisted-secrets).
+
+## Default privacy boundary
+
+The v2 instrumentation does not collect prompts, completions, tool arguments,
+or tool results by default. `OpenMultiAgent` wraps configured v2 sinks in a
+`SensitiveDataProcessor`; its optional `observability.capture` policy is the
+only core-controlled content opt-in. Structured credential fields are removed
+even when content capture is enabled. Chain-of-thought/reasoning content,
+signed reasoning blocks, and `<thinking>` text are never captured by OMA
+instrumentation; numeric reasoning-token counts may be recorded.
+
+Legacy `onTrace` keeps its existing redacted tool input/output fields for
+compatibility, so its privacy surface is intentionally broader than the v2
+default. Trace processing does not redact checkpoints or shared memory.

--- a/packages/core/benchmarks/observability-sinks.mjs
+++ b/packages/core/benchmarks/observability-sinks.mjs
@@ -1,0 +1,135 @@
+import { pathToFileURL } from 'node:url'
+import { performance } from 'node:perf_hooks'
+
+const [candidatePath] = process.argv.slice(2)
+if (!candidatePath) {
+  throw new Error('Usage: node observability-sinks.mjs <candidate-index.js>')
+}
+
+const iterations = Number(process.env.OMA_BENCH_ITERATIONS ?? 2_000)
+const rounds = Number(process.env.OMA_BENCH_ROUNDS ?? 9)
+const core = await import(`${pathToFileURL(candidatePath).href}?obs2-benchmark`)
+
+const adapter = {
+  name: 'obs2-benchmark',
+  async chat() {
+    return {
+      id: 'benchmark-response',
+      content: [{ type: 'text', text: 'ok' }],
+      model: 'benchmark-model',
+      stop_reason: 'end_turn',
+      usage: { input_tokens: 1, output_tokens: 1 },
+    }
+  },
+  async *stream() {},
+}
+const agent = { name: 'benchmark', model: 'benchmark-model', adapter }
+
+function makeBatchSink(options = {}) {
+  return new core.BatchingTraceSink({
+    async export(records) { return { status: 'success', exported: records.length } },
+  }, { diagnostics: 'silent', ...options })
+}
+
+const batchSink = makeBatchSink()
+const runners = {
+  noSink: new core.OpenMultiAgent({ defaultModel: 'benchmark-model' }),
+  syncCallback: new core.OpenMultiAgent({ defaultModel: 'benchmark-model', onTrace() {} }),
+  batchSink: new core.OpenMultiAgent({
+    defaultModel: 'benchmark-model',
+    observability: { sinks: [batchSink] },
+  }),
+}
+
+async function measure(oma, count) {
+  const start = performance.now()
+  for (let index = 0; index < count; index++) await oma.runAgent(agent, 'ping')
+  return performance.now() - start
+}
+
+for (const oma of Object.values(runners)) await measure(oma, 200)
+await batchSink.forceFlush({ timeoutMs: 5_000 })
+
+const samples = { noSink: [], syncCallback: [], batchSink: [] }
+const names = Object.keys(runners)
+for (let round = 0; round < rounds; round++) {
+  const order = round % 2 === 0 ? names : [...names].reverse()
+  for (const name of order) samples[name].push(await measure(runners[name], iterations))
+  await batchSink.forceFlush({ timeoutMs: 5_000 })
+}
+
+const median = (values) => [...values].sort((a, b) => a - b)[Math.floor(values.length / 2)]
+const medians = Object.fromEntries(Object.entries(samples).map(([name, values]) => [name, median(values)]))
+
+const sampleRecord = {
+  schemaVersion: 2,
+  recordId: '00000000-0000-4000-8000-000000000000',
+  sequence: 1,
+  timestampUnixMs: Date.now(),
+  runId: 'benchmark-run',
+  attempt: 1,
+  traceId: '1'.repeat(32),
+  spanId: '2'.repeat(16),
+  recordType: 'span_end',
+  kind: 'agent',
+  name: 'invoke_agent',
+  startUnixMs: Date.now(),
+  endUnixMs: Date.now(),
+  durationMs: 1,
+  status: { code: 'ok' },
+  attributes: {
+    'oma.agent.name': 'benchmark-agent',
+    'oma.usage.input_tokens': 100,
+    'oma.usage.output_tokens': 20,
+    'oma.status': 'ok',
+  },
+}
+const representativeRecords = Array.from({ length: 402 }, (_, index) => ({
+  ...sampleRecord,
+  recordId: `${index}`.padStart(36, '0'),
+  sequence: index + 1,
+}))
+const representativeBytes = representativeRecords.reduce(
+  (sum, record) => sum + Buffer.byteLength(JSON.stringify(record), 'utf8'),
+  0,
+)
+
+const emitIterations = 10_000
+const emitSink = makeBatchSink({
+  maxQueueRecords: emitIterations + 1,
+  maxQueueBytes: 64 * 1024 * 1024,
+  maxBatchRecords: emitIterations + 1,
+  scheduledDelayMs: 60_000,
+})
+const emitMicros = []
+for (let index = 0; index < emitIterations; index++) {
+  const started = performance.now()
+  emitSink.emit({ ...sampleRecord, sequence: index + 1 })
+  emitMicros.push((performance.now() - started) * 1_000)
+}
+emitMicros.sort((a, b) => a - b)
+const emitP95Micros = emitMicros[Math.floor(emitMicros.length * 0.95)]
+await emitSink.shutdown({ timeoutMs: 5_000 })
+
+console.log(JSON.stringify({
+  iterations,
+  rounds,
+  mediansMs: medians,
+  overheadVsNoSinkPercent: {
+    syncCallback: ((medians.syncCallback / medians.noSink) - 1) * 100,
+    batchSink: ((medians.batchSink / medians.noSink) - 1) * 100,
+  },
+  medianMicrosPerRun: Object.fromEntries(
+    Object.entries(medians).map(([name, value]) => [name, value * 1_000 / iterations]),
+  ),
+  batchEmitP95Micros: emitP95Micros,
+  samplesMs: samples,
+  representative100AgentEnvelope: {
+    records: representativeRecords.length,
+    bytes: representativeBytes,
+    fractionOfDefaultQueueBytes: representativeBytes / core.DEFAULT_BATCHING_OPTIONS.maxQueueBytes,
+  },
+  defaults: core.DEFAULT_BATCHING_OPTIONS,
+}, null, 2))
+
+await batchSink.shutdown({ timeoutMs: 5_000 })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./observability": {
+      "types": "./dist/observability/index.d.ts",
+      "import": "./dist/observability/index.js"
+    },
     "./acp": {
       "types": "./dist/acp.d.ts",
       "import": "./dist/acp.js"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -128,6 +128,34 @@ export type {
   TraceRecord,
   TraceRecordBase,
 } from './observability/records.js'
+export {
+  BatchingTraceSink,
+  CompositeSink,
+  DEFAULT_BATCHING_OPTIONS,
+  DiagnosticReporter,
+  FilteringSink,
+  LegacyCallbackTraceSink,
+  SensitiveDataProcessor,
+  emptyTraceSinkStats,
+} from './observability/index.js'
+export type {
+  BatchingTraceSinkOptions,
+  DiagnosticMode,
+  DiagnosticOptions,
+  ExportResult,
+  FlushOptions,
+  FlushResult,
+  ObservabilityConfig,
+  ObservabilityResource,
+  SensitiveDataProcessorOptions,
+  TelemetryDiagnostic,
+  TelemetryDiagnosticCode,
+  TraceCapturePolicy,
+  TraceExporter,
+  TraceFilter,
+  TraceSink,
+  TraceSinkStats,
+} from './observability/index.js'
 
 // ---------------------------------------------------------------------------
 // Memory

--- a/packages/core/src/observability/batching.ts
+++ b/packages/core/src/observability/batching.ts
@@ -1,0 +1,520 @@
+import type { TraceRecord } from './records.js'
+import {
+  DiagnosticReporter,
+  statsFlushResult,
+  type DiagnosticOptions,
+  type ExportResult,
+  type FlushOptions,
+  type FlushResult,
+  type TraceExporter,
+  type TraceSink,
+  type TraceSinkStats,
+} from './sink.js'
+
+export const DEFAULT_BATCHING_OPTIONS = Object.freeze({
+  maxQueueRecords: 2_048,
+  maxQueueBytes: 16 * 1024 * 1024,
+  maxRecordBytes: 256 * 1024,
+  maxBatchRecords: 512,
+  scheduledDelayMs: 5_000,
+  exportTimeoutMs: 30_000,
+  maxRetries: 3,
+  retryDelayMs: 1_000,
+  retryBackoff: 2,
+  maxRetryDelayMs: 30_000,
+})
+
+export interface BatchingTraceSinkOptions extends DiagnosticOptions {
+  readonly maxQueueRecords?: number
+  readonly maxQueueBytes?: number
+  readonly maxRecordBytes?: number
+  readonly maxBatchRecords?: number
+  readonly scheduledDelayMs?: number
+  readonly exportTimeoutMs?: number
+  /** Number of retries after the initial export attempt. */
+  readonly maxRetries?: number
+  readonly retryDelayMs?: number
+  readonly retryBackoff?: number
+  readonly maxRetryDelayMs?: number
+  /** Disable equal jitter only for deterministic tests/benchmarks. */
+  readonly retryJitter?: boolean
+}
+
+interface QueueEntry {
+  readonly id: number
+  readonly record: TraceRecord
+  readonly bytes: number
+  readonly priority: number
+}
+
+interface MutableStats {
+  accepted: number
+  exported: number
+  retried: number
+  failed: number
+  dropped: number
+  queuedRecords: number
+  queuedBytes: number
+  lastError?: string
+}
+
+type TimeoutResult<T> = { readonly kind: 'value'; readonly value: T } | { readonly kind: 'timeout' }
+
+function positiveInt(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : fallback
+}
+
+function nonNegativeInt(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : fallback
+}
+
+function recordPriority(record: TraceRecord): number {
+  if (record.recordType === 'span_end') return 3
+  if (record.recordType === 'span_start') return 2
+  if (record.name === 'stream_chunk') return 0
+  return 1
+}
+
+function normalizeExportResult(value: unknown): ExportResult {
+  try {
+    if (typeof value !== 'object' || value === null) {
+      return { status: 'failure', exported: 0, code: 'INVALID_EXPORT_RESULT' }
+    }
+    const candidate = value as Partial<ExportResult>
+    if (
+      candidate.status !== 'success'
+      && candidate.status !== 'retryable'
+      && candidate.status !== 'failure'
+    ) {
+      return { status: 'failure', exported: 0, code: 'INVALID_EXPORT_RESULT' }
+    }
+    if (typeof candidate.exported !== 'number' || !Number.isFinite(candidate.exported)) {
+      return { status: 'failure', exported: 0, code: 'INVALID_EXPORT_RESULT' }
+    }
+    return {
+      status: candidate.status,
+      exported: candidate.exported,
+      ...(typeof candidate.retryAfterMs === 'number' && Number.isFinite(candidate.retryAfterMs)
+        ? { retryAfterMs: Math.max(0, candidate.retryAfterMs) }
+        : {}),
+      ...(typeof candidate.code === 'string' ? { code: candidate.code.slice(0, 128) } : {}),
+    }
+  } catch {
+    return { status: 'failure', exported: 0, code: 'INVALID_EXPORT_RESULT' }
+  }
+}
+
+function byteSize(record: TraceRecord): number | undefined {
+  try {
+    return Buffer.byteLength(JSON.stringify(record), 'utf8')
+  } catch {
+    return undefined
+  }
+}
+
+function unrefTimer(callback: () => void, delayMs: number): ReturnType<typeof setTimeout> {
+  const timer = setTimeout(callback, delayMs)
+  timer.unref?.()
+  return timer
+}
+
+async function withTimeout<T>(
+  timeoutMs: number,
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<TimeoutResult<T>> {
+  const controller = new AbortController()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<TimeoutResult<T>>((resolve) => {
+    timer = unrefTimer(() => {
+      controller.abort(new Error('Telemetry operation timed out.'))
+      resolve({ kind: 'timeout' })
+    }, timeoutMs)
+  })
+  const value = Promise.resolve()
+    .then(() => operation(controller.signal))
+    .then<TimeoutResult<T>>((result) => ({ kind: 'value', value: result }))
+  try {
+    return await Promise.race([value, timeout])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+function abortableDelay(delayMs: number, signal?: AbortSignal): Promise<boolean> {
+  if (delayMs <= 0) return Promise.resolve(true)
+  if (signal?.aborted) return Promise.resolve(false)
+  return new Promise((resolve) => {
+    const timer = unrefTimer(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve(true)
+    }, delayMs)
+    const onAbort = () => {
+      clearTimeout(timer)
+      resolve(false)
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+/** Zero-dependency, bounded asynchronous transport for TraceRecord batches. */
+export class BatchingTraceSink implements TraceSink {
+  private readonly options: Required<Omit<BatchingTraceSinkOptions, keyof DiagnosticOptions>>
+  private readonly diagnostics: DiagnosticReporter
+  private readonly queue: QueueEntry[] = []
+  private readonly mutable: MutableStats = {
+    accepted: 0,
+    exported: 0,
+    retried: 0,
+    failed: 0,
+    dropped: 0,
+    queuedRecords: 0,
+    queuedBytes: 0,
+  }
+  private nextId = 0
+  private settledThrough = 0
+  private readonly settledOutOfOrder = new Set<number>()
+  private timer?: ReturnType<typeof setTimeout>
+  private worker?: Promise<void>
+  private wakeWorker = false
+  private closing = false
+  private shutdownPromise?: Promise<FlushResult>
+  private exporterFlush?: Promise<'ok' | 'timeout' | 'error'>
+  private readonly waiters = new Set<() => void>()
+
+  constructor(
+    private readonly exporter: TraceExporter,
+    options: BatchingTraceSinkOptions = {},
+  ) {
+    this.options = {
+      maxQueueRecords: positiveInt(options.maxQueueRecords, DEFAULT_BATCHING_OPTIONS.maxQueueRecords),
+      maxQueueBytes: positiveInt(options.maxQueueBytes, DEFAULT_BATCHING_OPTIONS.maxQueueBytes),
+      maxRecordBytes: positiveInt(options.maxRecordBytes, DEFAULT_BATCHING_OPTIONS.maxRecordBytes),
+      maxBatchRecords: positiveInt(options.maxBatchRecords, DEFAULT_BATCHING_OPTIONS.maxBatchRecords),
+      scheduledDelayMs: positiveInt(options.scheduledDelayMs, DEFAULT_BATCHING_OPTIONS.scheduledDelayMs),
+      exportTimeoutMs: positiveInt(options.exportTimeoutMs, DEFAULT_BATCHING_OPTIONS.exportTimeoutMs),
+      maxRetries: nonNegativeInt(options.maxRetries, DEFAULT_BATCHING_OPTIONS.maxRetries),
+      retryDelayMs: nonNegativeInt(options.retryDelayMs, DEFAULT_BATCHING_OPTIONS.retryDelayMs),
+      retryBackoff: options.retryBackoff !== undefined && options.retryBackoff >= 1
+        ? options.retryBackoff
+        : DEFAULT_BATCHING_OPTIONS.retryBackoff,
+      maxRetryDelayMs: positiveInt(options.maxRetryDelayMs, DEFAULT_BATCHING_OPTIONS.maxRetryDelayMs),
+      retryJitter: options.retryJitter ?? true,
+    }
+    this.diagnostics = new DiagnosticReporter({ ...options, sinkName: options.sinkName ?? 'BatchingTraceSink' })
+  }
+
+  emit(record: TraceRecord): void {
+    if (this.closing) {
+      this.mutable.dropped++
+      this.diagnostics.report('emit_after_shutdown', 'Trace record rejected after sink shutdown began.')
+      return
+    }
+    const bytes = byteSize(record)
+    if (bytes === undefined || bytes > this.options.maxRecordBytes) {
+      this.mutable.dropped++
+      this.diagnostics.report('record_too_large', 'Trace record exceeded the configured size limit or was not serializable.')
+      return
+    }
+
+    const incoming: QueueEntry = {
+      id: this.nextId + 1,
+      record,
+      bytes,
+      priority: recordPriority(record),
+    }
+    if (!this.makeRoom(incoming)) {
+      this.mutable.dropped++
+      this.diagnostics.report('queue_full', 'Trace record dropped because the bounded queue is full.')
+      return
+    }
+
+    this.nextId = incoming.id
+    this.mutable.accepted++
+    this.queue.push(incoming)
+    this.mutable.queuedRecords++
+    this.mutable.queuedBytes += bytes
+    if (this.queue.length >= this.options.maxBatchRecords) this.startWorker()
+    else this.schedule()
+  }
+
+  async forceFlush(options: FlushOptions = {}): Promise<FlushResult> {
+    const startedAt = Date.now()
+    const timeoutMs = options.timeoutMs ?? this.options.exportTimeoutMs
+    const target = this.nextId
+    const before = this.getStats()
+    let completed = target <= this.settledThrough
+    if (!completed) {
+      this.clearTimer()
+      this.startWorker()
+      completed = await this.waitForWatermark(target, timeoutMs)
+    }
+    const stats = this.getStats()
+    if (!completed) {
+      this.diagnostics.report('flush_timeout', 'Trace flush timed out before its acceptance watermark settled.')
+      return statsFlushResult(stats, 'timeout')
+    }
+    const remainingMs = Math.max(0, timeoutMs - (Date.now() - startedAt))
+    const exporterStatus = await this.flushExporter(remainingMs)
+    if (exporterStatus === 'timeout') {
+      this.diagnostics.report('flush_timeout', 'Trace exporter forceFlush timed out.')
+      return statsFlushResult(this.getStats(), 'timeout')
+    }
+    if (exporterStatus === 'error') {
+      this.mutable.lastError = 'EXPORTER_FLUSH_FAILED'
+      this.diagnostics.report('export_failed', 'Trace exporter forceFlush failed.', 'error')
+      return statsFlushResult(this.getStats(), stats.exported > 0 ? 'partial' : 'error')
+    }
+    return statsFlushResult(stats, this.resultStatus(stats))
+  }
+
+  shutdown(options: FlushOptions = {}): Promise<FlushResult> {
+    if (this.shutdownPromise) return this.shutdownPromise
+    this.closing = true
+    this.clearTimer()
+    this.shutdownPromise = this.performShutdown(options)
+    return this.shutdownPromise
+  }
+
+  getStats(): TraceSinkStats {
+    return {
+      ...this.mutable,
+      queued: this.mutable.queuedRecords,
+      ...(this.mutable.lastError ? { lastFailureCode: this.mutable.lastError } : {}),
+    }
+  }
+
+  private makeRoom(incoming: QueueEntry): boolean {
+    const wouldOverflow = () =>
+      this.mutable.queuedRecords + 1 > this.options.maxQueueRecords
+      || this.mutable.queuedBytes + incoming.bytes > this.options.maxQueueBytes
+
+    while (wouldOverflow()) {
+      let candidateIndex = -1
+      let candidatePriority = Infinity
+      for (let index = 0; index < this.queue.length; index++) {
+        const priority = this.queue[index]!.priority
+        if (priority < candidatePriority) {
+          candidatePriority = priority
+          candidateIndex = index
+        }
+      }
+      if (candidateIndex < 0 || candidatePriority > incoming.priority) return false
+      const [dropped] = this.queue.splice(candidateIndex, 1)
+      if (!dropped) return false
+      this.mutable.queuedRecords--
+      this.mutable.queuedBytes -= dropped.bytes
+      this.mutable.dropped++
+      this.settle(dropped.id)
+      this.diagnostics.report('queue_full', 'A lower-priority queued trace record was dropped to preserve bounded memory.')
+    }
+    return true
+  }
+
+  private schedule(): void {
+    if (this.timer || this.worker || this.queue.length === 0) return
+    this.timer = unrefTimer(() => {
+      this.timer = undefined
+      this.startWorker()
+    }, this.options.scheduledDelayMs)
+  }
+
+  private clearTimer(): void {
+    if (this.timer) clearTimeout(this.timer)
+    this.timer = undefined
+  }
+
+  private startWorker(): void {
+    this.wakeWorker = true
+    if (this.worker) return
+    this.worker = this.drain().finally(() => {
+      this.worker = undefined
+      if (this.queue.length > 0) {
+        if (this.wakeWorker || this.closing) this.startWorker()
+        else this.schedule()
+      }
+    })
+  }
+
+  private async drain(): Promise<void> {
+    while (this.queue.length > 0) {
+      this.wakeWorker = false
+      const batch = this.queue.splice(0, this.options.maxBatchRecords)
+      await this.exportBatch(batch)
+      if (!this.wakeWorker && !this.closing && this.queue.length < this.options.maxBatchRecords) break
+    }
+  }
+
+  private async exportBatch(batch: QueueEntry[]): Promise<void> {
+    let remaining = batch
+    let retry = 0
+    while (remaining.length > 0) {
+      let result: ExportResult
+      try {
+        const outcome = await withTimeout(this.options.exportTimeoutMs, (signal) =>
+          this.exporter.export(remaining.map((entry) => entry.record), signal))
+        if (outcome.kind === 'timeout') {
+          result = { status: 'retryable', exported: 0, code: 'EXPORT_TIMEOUT' }
+          this.diagnostics.report('export_timeout', 'Trace exporter exceeded its configured timeout.', 'error')
+        } else {
+          result = normalizeExportResult(outcome.value)
+        }
+      } catch {
+        result = { status: 'retryable', exported: 0, code: 'EXPORT_REJECTED' }
+      }
+
+      const delivered = Math.min(remaining.length, Math.max(0, Math.floor(result.exported)))
+      for (const entry of remaining.slice(0, delivered)) this.markExported(entry)
+      remaining = remaining.slice(delivered)
+      if (remaining.length === 0) return
+
+      if (result.status !== 'success') {
+        this.mutable.lastError = result.code ?? (result.status === 'retryable' ? 'EXPORT_RETRYABLE' : 'EXPORT_FAILED')
+      }
+
+      if (result.status === 'retryable' && retry < this.options.maxRetries) {
+        retry++
+        this.mutable.retried += remaining.length
+        const nominal = result.retryAfterMs ?? Math.min(
+          this.options.retryDelayMs * this.options.retryBackoff ** (retry - 1),
+          this.options.maxRetryDelayMs,
+        )
+        const delay = this.options.retryJitter
+          ? Math.floor(nominal / 2 + Math.random() * nominal / 2)
+          : nominal
+        this.diagnostics.report('export_failed', 'Trace exporter reported a retryable delivery failure.')
+        await abortableDelay(delay)
+        continue
+      }
+
+      const code = result.code ?? (result.status === 'success' ? 'PARTIAL_EXPORT' : 'EXPORT_FAILED')
+      this.mutable.lastError = code
+      for (const entry of remaining) this.markFailed(entry)
+      this.diagnostics.report('export_failed', 'Trace exporter permanently failed to deliver one or more records.', 'error')
+      return
+    }
+  }
+
+  private markExported(entry: QueueEntry): void {
+    this.mutable.exported++
+    this.release(entry)
+    this.settle(entry.id)
+  }
+
+  private markFailed(entry: QueueEntry): void {
+    this.mutable.failed++
+    this.release(entry)
+    this.settle(entry.id)
+  }
+
+  private release(entry: QueueEntry): void {
+    this.mutable.queuedRecords--
+    this.mutable.queuedBytes -= entry.bytes
+  }
+
+  private settle(id: number): void {
+    if (id === this.settledThrough + 1) {
+      this.settledThrough = id
+      while (this.settledOutOfOrder.delete(this.settledThrough + 1)) this.settledThrough++
+    } else if (id > this.settledThrough) {
+      this.settledOutOfOrder.add(id)
+    }
+    for (const wake of this.waiters) wake()
+  }
+
+  private waitForWatermark(target: number, timeoutMs?: number): Promise<boolean> {
+    if (target <= this.settledThrough) return Promise.resolve(true)
+    return new Promise((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const check = () => {
+        if (target > this.settledThrough) return
+        cleanup()
+        resolve(true)
+      }
+      const cleanup = () => {
+        this.waiters.delete(check)
+        if (timer) clearTimeout(timer)
+      }
+      this.waiters.add(check)
+      if (timeoutMs !== undefined) {
+        timer = unrefTimer(() => {
+          cleanup()
+          resolve(false)
+        }, Math.max(0, timeoutMs))
+      }
+      check()
+    })
+  }
+
+  private resultStatus(stats: TraceSinkStats): FlushResult['status'] {
+    if (stats.failed > 0 || stats.dropped > 0) {
+      return stats.exported > 0 ? 'partial' : 'error'
+    }
+    return 'ok'
+  }
+
+  private async performShutdown(options: FlushOptions): Promise<FlushResult> {
+    const startedAt = Date.now()
+    const totalTimeoutMs = options.timeoutMs ?? this.options.exportTimeoutMs
+    const flushed = await this.forceFlush({ timeoutMs: totalTimeoutMs })
+    if (flushed.status === 'timeout') return flushed
+    if (!this.exporter.shutdown) return flushed
+    try {
+      const timeoutMs = Math.max(0, totalTimeoutMs - (Date.now() - startedAt))
+      const outcome = await withTimeout(timeoutMs, (signal) => this.exporter.shutdown!(signal))
+      if (outcome.kind === 'timeout') {
+        this.mutable.lastError = 'SHUTDOWN_TIMEOUT'
+        this.diagnostics.report('shutdown_failed', 'Trace exporter shutdown timed out.', 'error')
+        return statsFlushResult(this.getStats(), 'timeout')
+      }
+      if (outcome.value.status !== 'success') {
+        this.mutable.lastError = outcome.value.code ?? 'SHUTDOWN_FAILED'
+        this.diagnostics.report('shutdown_failed', 'Trace exporter shutdown failed.', 'error')
+        return statsFlushResult(this.getStats(), flushed.status === 'ok' ? 'error' : 'partial')
+      }
+      return flushed
+    } catch {
+      this.mutable.lastError = 'SHUTDOWN_REJECTED'
+      this.diagnostics.report('shutdown_failed', 'Trace exporter shutdown rejected.', 'error')
+      return statsFlushResult(this.getStats(), flushed.status === 'ok' ? 'error' : 'partial')
+    }
+  }
+
+  private flushExporter(timeoutMs: number): Promise<'ok' | 'timeout' | 'error'> {
+    if (!this.exporter.forceFlush) return Promise.resolve('ok')
+    if (this.exporterFlush) return this.waitForExporterFlush(this.exporterFlush, timeoutMs)
+    this.exporterFlush = (async () => {
+      try {
+        const outcome = await withTimeout(timeoutMs, (signal) => this.exporter.forceFlush!(signal))
+        if (outcome.kind === 'timeout') return 'timeout'
+        return outcome.value.status === 'success' ? 'ok' : 'error'
+      } catch {
+        return 'error'
+      }
+    })().finally(() => { this.exporterFlush = undefined })
+    return this.exporterFlush
+  }
+
+  private waitForExporterFlush(
+    work: Promise<'ok' | 'timeout' | 'error'>,
+    timeoutMs: number,
+  ): Promise<'ok' | 'timeout' | 'error'> {
+    return new Promise((resolve) => {
+      let settled = false
+      const timer = unrefTimer(() => {
+        if (settled) return
+        settled = true
+        resolve('timeout')
+      }, timeoutMs)
+      work.then((result) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        resolve(result)
+      })
+    })
+  }
+}

--- a/packages/core/src/observability/composite.ts
+++ b/packages/core/src/observability/composite.ts
@@ -1,0 +1,156 @@
+import type { TraceRecord } from './records.js'
+import {
+  DiagnosticReporter,
+  emptyTraceSinkStats,
+  type DiagnosticOptions,
+  type FlushOptions,
+  type FlushResult,
+  type TraceSink,
+  type TraceSinkStats,
+} from './sink.js'
+
+function combineStatus(results: readonly FlushResult[]): FlushResult['status'] {
+  if (results.length === 0 || results.every((result) => result.status === 'ok')) return 'ok'
+  if (results.every((result) => result.status === 'timeout')) return 'timeout'
+  if (results.every((result) => result.status === 'error')) return 'error'
+  return 'partial'
+}
+
+function combine(results: readonly FlushResult[]): FlushResult {
+  return {
+    status: combineStatus(results),
+    accepted: results.reduce((sum, result) => sum + result.accepted, 0),
+    exported: results.reduce((sum, result) => sum + result.exported, 0),
+    dropped: results.reduce((sum, result) => sum + result.dropped, 0),
+    failed: results.reduce((sum, result) => sum + result.failed, 0),
+  }
+}
+
+function unrefTimer(callback: () => void, delayMs: number): ReturnType<typeof setTimeout> {
+  const timer = setTimeout(callback, delayMs)
+  timer.unref?.()
+  return timer
+}
+
+function safeStats(sink: TraceSink): TraceSinkStats {
+  try {
+    return sink.getStats?.() ?? emptyTraceSinkStats()
+  } catch {
+    return emptyTraceSinkStats()
+  }
+}
+
+/** Fan-out sink. One child failure never prevents delivery to later children. */
+export class CompositeSink implements TraceSink {
+  private readonly diagnostics: DiagnosticReporter
+  private shutdownPromise?: Promise<FlushResult>
+  private closing = false
+  private emitFailures = 0
+
+  constructor(
+    private readonly sinks: readonly TraceSink[],
+    options: DiagnosticOptions = {},
+  ) {
+    this.diagnostics = new DiagnosticReporter({ ...options, sinkName: options.sinkName ?? 'CompositeSink' })
+  }
+
+  emit(record: TraceRecord): void {
+    if (this.closing) {
+      this.diagnostics.report('emit_after_shutdown', 'Trace record rejected after composite shutdown began.')
+      return
+    }
+    for (const sink of this.sinks) {
+      try {
+        sink.emit(record)
+      } catch {
+        this.emitFailures++
+        this.diagnostics.report('sink_emit_failed', 'A child trace sink threw while accepting a record.', 'error')
+      }
+    }
+  }
+
+  async forceFlush(options: FlushOptions = {}): Promise<FlushResult> {
+    const results = await Promise.all(this.sinks.map((sink) =>
+      this.callChild(sink, 'flush', options)))
+    return combine(results)
+  }
+
+  shutdown(options: FlushOptions = {}): Promise<FlushResult> {
+    if (this.shutdownPromise) return this.shutdownPromise
+    this.closing = true
+    this.shutdownPromise = this.performShutdown(options)
+    return this.shutdownPromise
+  }
+
+  getStats(): TraceSinkStats {
+    const stats = this.sinks.map(safeStats)
+    const last = [...stats].reverse().find((value) => value.lastError !== undefined)
+    return {
+      accepted: stats.reduce((sum, value) => sum + value.accepted, 0),
+      exported: stats.reduce((sum, value) => sum + value.exported, 0),
+      retried: stats.reduce((sum, value) => sum + value.retried, 0),
+      failed: stats.reduce((sum, value) => sum + value.failed, this.emitFailures),
+      dropped: stats.reduce((sum, value) => sum + value.dropped, 0),
+      queuedRecords: stats.reduce((sum, value) => sum + value.queuedRecords, 0),
+      queuedBytes: stats.reduce((sum, value) => sum + value.queuedBytes, 0),
+      queued: stats.reduce((sum, value) => sum + value.queuedRecords, 0),
+      ...(last?.lastError ? { lastError: last.lastError, lastFailureCode: last.lastError } : {}),
+    }
+  }
+
+  private async performShutdown(options: FlushOptions): Promise<FlushResult> {
+    const results = await Promise.all(this.sinks.map((sink) =>
+      this.callChild(sink, 'shutdown', options)))
+    return combine(results)
+  }
+
+  private callChild(
+    sink: TraceSink,
+    operation: 'flush' | 'shutdown',
+    options: FlushOptions,
+  ): Promise<FlushResult> {
+    const timeoutMs = options.timeoutMs ?? 30_000
+    return new Promise((resolve) => {
+      let settled = false
+      const finish = (result: FlushResult) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        resolve(result)
+      }
+      const timer = unrefTimer(() => {
+        const stats = safeStats(sink)
+        this.diagnostics.report(
+          operation === 'flush' ? 'flush_timeout' : 'shutdown_failed',
+          `A child trace sink ${operation} operation timed out.`,
+          'error',
+        )
+        finish({
+          status: 'timeout',
+          accepted: stats.accepted,
+          exported: stats.exported,
+          dropped: stats.dropped,
+          failed: stats.failed,
+        })
+      }, Math.max(0, timeoutMs))
+
+      Promise.resolve()
+        .then(() => operation === 'flush' ? sink.forceFlush(options) : sink.shutdown(options))
+        .then(finish, () => {
+          const stats = safeStats(sink)
+          this.diagnostics.report(
+            operation === 'flush' ? 'export_failed' : 'shutdown_failed',
+            `A child trace sink rejected ${operation}.`,
+            'error',
+          )
+          finish({
+            status: 'error',
+            accepted: stats.accepted,
+            exported: stats.exported,
+            dropped: stats.dropped,
+            failed: stats.failed + 1,
+          })
+        })
+    })
+  }
+}

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -1,0 +1,37 @@
+export type {
+  SpanEndRecord,
+  SpanEventName,
+  SpanEventRecord,
+  SpanKind,
+  SpanStartRecord,
+  TraceRecord,
+  TraceRecordBase,
+} from './records.js'
+export {
+  DiagnosticReporter,
+  emptyTraceSinkStats,
+} from './sink.js'
+export type {
+  DiagnosticMode,
+  DiagnosticOptions,
+  ExportResult,
+  FlushOptions,
+  FlushResult,
+  ObservabilityConfig,
+  ObservabilityResource,
+  TelemetryDiagnostic,
+  TelemetryDiagnosticCode,
+  TraceCapturePolicy,
+  TraceExporter,
+  TraceSink,
+  TraceSinkStats,
+} from './sink.js'
+export { BatchingTraceSink, DEFAULT_BATCHING_OPTIONS } from './batching.js'
+export type { BatchingTraceSinkOptions } from './batching.js'
+export { CompositeSink } from './composite.js'
+export { FilteringSink, SensitiveDataProcessor } from './processors.js'
+export type {
+  SensitiveDataProcessorOptions,
+  TraceFilter,
+} from './processors.js'
+export { LegacyCallbackTraceSink } from './legacy-callback.js'

--- a/packages/core/src/observability/legacy-callback.ts
+++ b/packages/core/src/observability/legacy-callback.ts
@@ -1,0 +1,128 @@
+import type { TraceEvent } from '../types.js'
+import type { TraceRecord } from './records.js'
+import {
+  DiagnosticReporter,
+  statsFlushResult,
+  type DiagnosticOptions,
+  type FlushOptions,
+  type FlushResult,
+  type TraceSink,
+  type TraceSinkStats,
+} from './sink.js'
+
+const LEGACY_EVENT = Symbol('oma.legacyTraceEvent')
+
+type RecordWithLegacy = TraceRecord & { readonly [LEGACY_EVENT]?: TraceEvent }
+
+/** Internal non-enumerable metadata used only by the compatibility bridge. */
+export function attachLegacyTraceEvent(record: TraceRecord, event: TraceEvent): void {
+  Object.defineProperty(record, LEGACY_EVENT, { value: event, enumerable: false })
+}
+
+/**
+ * Completion/event bridge for the unchanged seven-member TraceEvent union.
+ * Promise callbacks are tracked so direct users can forceFlush the bridge.
+ */
+export class LegacyCallbackTraceSink implements TraceSink {
+  private readonly diagnostics: DiagnosticReporter
+  private readonly pending = new Map<number, Promise<void>>()
+  private nextId = 0
+  private closing = false
+  private shutdownPromise?: Promise<FlushResult>
+  private mutable = { accepted: 0, exported: 0, failed: 0, dropped: 0 }
+
+  constructor(
+    private readonly callback: (event: TraceEvent) => void | Promise<void>,
+    options: DiagnosticOptions = {},
+  ) {
+    this.diagnostics = new DiagnosticReporter({ ...options, sinkName: options.sinkName ?? 'LegacyCallbackTraceSink' })
+  }
+
+  emit(record: TraceRecord): void {
+    const event = (record as RecordWithLegacy)[LEGACY_EVENT]
+    if (!event) return
+    if (this.closing) {
+      this.mutable.dropped++
+      this.diagnostics.report('emit_after_shutdown', 'Legacy trace event rejected after sink shutdown began.')
+      return
+    }
+
+    const id = ++this.nextId
+    this.mutable.accepted++
+    try {
+      const result = this.callback(event)
+      if (result && typeof (result as Promise<unknown>).then === 'function') {
+        const tracked = Promise.resolve(result).then(
+          () => { this.mutable.exported++ },
+          () => {
+            this.mutable.failed++
+            this.diagnostics.report('export_failed', 'Legacy trace callback rejected.', 'error')
+          },
+        ).finally(() => { this.pending.delete(id) })
+        this.pending.set(id, tracked)
+      } else {
+        this.mutable.exported++
+      }
+    } catch {
+      this.mutable.failed++
+      this.diagnostics.report('sink_emit_failed', 'Legacy trace callback threw synchronously.', 'error')
+    }
+  }
+
+  async forceFlush(options: FlushOptions = {}): Promise<FlushResult> {
+    const watermark = this.nextId
+    const work = [...this.pending.entries()]
+      .filter(([id]) => id <= watermark)
+      .map(([, promise]) => promise)
+    if (work.length === 0) return statsFlushResult(this.getStats(), this.resultStatus())
+
+    const completed = await this.wait(Promise.all(work), options.timeoutMs ?? 30_000)
+    if (!completed) {
+      this.diagnostics.report('flush_timeout', 'Legacy trace callback flush timed out.')
+      return statsFlushResult(this.getStats(), 'timeout')
+    }
+    return statsFlushResult(this.getStats(), this.resultStatus())
+  }
+
+  shutdown(options: FlushOptions = {}): Promise<FlushResult> {
+    if (this.shutdownPromise) return this.shutdownPromise
+    this.closing = true
+    this.shutdownPromise = this.forceFlush(options)
+    return this.shutdownPromise
+  }
+
+  getStats(): TraceSinkStats {
+    return {
+      ...this.mutable,
+      retried: 0,
+      queuedRecords: this.pending.size,
+      queuedBytes: 0,
+      queued: this.pending.size,
+      ...(this.mutable.failed > 0 ? { lastError: 'LEGACY_CALLBACK_FAILED', lastFailureCode: 'LEGACY_CALLBACK_FAILED' } : {}),
+    }
+  }
+
+  private resultStatus(): FlushResult['status'] {
+    if (this.mutable.failed === 0 && this.mutable.dropped === 0) return 'ok'
+    return this.mutable.exported > 0 ? 'partial' : 'error'
+  }
+
+  private wait(work: Promise<unknown>, timeoutMs?: number): Promise<boolean> {
+    if (timeoutMs === undefined) return work.then(() => true)
+    return new Promise((resolve) => {
+      let settled = false
+      const timer = setTimeout(() => {
+        if (settled) return
+        settled = true
+        resolve(false)
+      }, Math.max(0, timeoutMs))
+      timer.unref?.()
+      work.then(() => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        resolve(true)
+      })
+    })
+  }
+}

--- a/packages/core/src/observability/processors.ts
+++ b/packages/core/src/observability/processors.ts
@@ -1,0 +1,131 @@
+import type { TraceAttributeValue } from '../types.js'
+import { redactSensitiveText } from '../utils/redaction.js'
+import type { TraceRecord } from './records.js'
+import type {
+  FlushOptions,
+  FlushResult,
+  TraceCapturePolicy,
+  TraceSink,
+  TraceSinkStats,
+} from './sink.js'
+import { emptyTraceSinkStats } from './sink.js'
+
+export type TraceFilter = (record: TraceRecord) => boolean
+
+abstract class DelegatingSink implements TraceSink {
+  constructor(protected readonly sink: TraceSink) {}
+  abstract emit(record: TraceRecord): void
+  forceFlush(options?: FlushOptions): Promise<FlushResult> { return this.sink.forceFlush(options) }
+  shutdown(options?: FlushOptions): Promise<FlushResult> { return this.sink.shutdown(options) }
+  getStats(): TraceSinkStats { return this.sink.getStats?.() ?? emptyTraceSinkStats() }
+}
+
+/** Synchronous record filter. Predicate failures drop telemetry, never business work. */
+export class FilteringSink extends DelegatingSink {
+  constructor(sink: TraceSink, private readonly filter: TraceFilter) { super(sink) }
+  emit(record: TraceRecord): void {
+    try {
+      if (this.filter(record)) this.sink.emit(record)
+    } catch {
+      // User filters are telemetry code and must remain isolated.
+    }
+  }
+}
+
+export interface SensitiveDataProcessorOptions {
+  /** Optional exact allowlist applied before structural secret removal. */
+  readonly attributeAllowlist?: readonly string[]
+  readonly capture?: TraceCapturePolicy
+}
+
+const STRUCTURED_SECRET = /(^|[._-])(authorization|cookie|set_cookie|api[_-]?key|password|passwd|secret|access[_-]?token|refresh[_-]?token|private[_-]?key)($|[._-])/i
+const REASONING_CONTENT = /(^|[._-])(reasoning|thinking|chain[_-]?of[_-]?thought|signed[_-]?reasoning)[._-](content|text|data)($|[._-])/i
+
+function contentKind(key: string): 'prompt' | 'completion' | 'toolInput' | 'toolOutput' | undefined {
+  const normal = key.toLowerCase().replaceAll('-', '_')
+  if (normal.includes('prompt')) return 'prompt'
+  if (normal.includes('completion')) return 'completion'
+  if (normal.includes('tool.input') || normal.includes('tool_input') || normal.includes('tool.arguments')) return 'toolInput'
+  if (normal.includes('tool.output') || normal.includes('tool_output') || normal.includes('tool.result')) return 'toolOutput'
+  return undefined
+}
+
+function safeValue(value: TraceAttributeValue, maxChars: number): TraceAttributeValue {
+  if (typeof value === 'string') return redactSensitiveText(value).slice(0, maxChars)
+  if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
+    return value.map((item) => redactSensitiveText(item).slice(0, maxChars))
+  }
+  return value
+}
+
+/**
+ * Structured privacy boundary: allowlist, credential removal, redaction, then
+ * truncation. Reasoning content is always removed and has no opt-in.
+ */
+export class SensitiveDataProcessor extends DelegatingSink {
+  private readonly allowlist?: ReadonlySet<string>
+  private readonly capture: Required<Pick<TraceCapturePolicy,
+    'prompt' | 'completion' | 'toolInput' | 'toolOutput' | 'errorMessage' | 'stack' | 'streamEvents' | 'maxContentChars'>>
+
+  constructor(sink: TraceSink, options: SensitiveDataProcessorOptions = {}) {
+    super(sink)
+    this.allowlist = options.attributeAllowlist
+      ? new Set(options.attributeAllowlist)
+      : undefined
+    this.capture = {
+      prompt: options.capture?.prompt ?? 'none',
+      completion: options.capture?.completion ?? 'none',
+      toolInput: options.capture?.toolInput ?? 'none',
+      toolOutput: options.capture?.toolOutput ?? 'none',
+      errorMessage: options.capture?.errorMessage ?? 'redacted',
+      stack: options.capture?.stack ?? false,
+      streamEvents: options.capture?.streamEvents ?? 'first',
+      maxContentChars: options.capture?.maxContentChars ?? 4_096,
+    }
+  }
+
+  emit(record: TraceRecord): void {
+    const attributes: Record<string, TraceAttributeValue> = {}
+    for (const [key, value] of Object.entries(record.attributes)) {
+      if (this.allowlist && !this.allowlist.has(key)) continue
+      if (STRUCTURED_SECRET.test(key) || REASONING_CONTENT.test(key)) continue
+      const kind = contentKind(key)
+      if (kind && this.capture[kind] === 'none') continue
+      attributes[key] = safeValue(value, this.capture.maxContentChars)
+    }
+
+    if (record.recordType === 'span_event') {
+      if (record.name === 'stream_chunk' && this.capture.streamEvents === 'none') return
+      this.sink.emit({ ...record, attributes })
+      return
+    }
+    if (record.recordType === 'span_start') {
+      this.sink.emit({ ...record, attributes })
+      return
+    }
+
+    const message = this.capture.errorMessage === 'code-only'
+      ? undefined
+      : record.error?.message
+    this.sink.emit({
+      ...record,
+      status: {
+        ...record.status,
+        ...(record.status.message
+          ? { message: redactSensitiveText(record.status.message).slice(0, 256) }
+          : {}),
+      },
+      ...(record.error
+        ? {
+            error: {
+              ...record.error,
+              ...(message
+                ? { message: redactSensitiveText(message).slice(0, 1_024) }
+                : { message: undefined }),
+            },
+          }
+        : {}),
+      attributes,
+    })
+  }
+}

--- a/packages/core/src/observability/runtime.ts
+++ b/packages/core/src/observability/runtime.ts
@@ -15,7 +15,9 @@ import type {
   SpanStartRecord,
   TraceRecord,
 } from './records.js'
-import { emitTrace } from '../utils/trace.js'
+import type { TraceSink } from './sink.js'
+import { attachLegacyTraceEvent, LegacyCallbackTraceSink } from './legacy-callback.js'
+import { CompositeSink } from './composite.js'
 
 export type TraceRecordObserver = (record: TraceRecord) => void
 
@@ -59,18 +61,33 @@ function safeObserve(observer: TraceRecordObserver | undefined, record: TraceRec
   }
 }
 
+function safeEmit(sink: TraceSink | undefined, record: TraceRecord): void {
+  if (!sink) return
+  try {
+    sink.emit(record)
+  } catch {
+    // A user-supplied sink must never change execution semantics.
+  }
+}
+
 /** One top-level attempt's synchronous record runtime. */
 export class TraceRuntime {
   readonly identity: RunIdentity
   readonly root: TraceSpan
   private sequence = 0
+  private readonly sink?: TraceSink
 
   constructor(
     identity: RunIdentity,
     private readonly observer?: TraceRecordObserver,
-    private readonly legacyCallback?: (event: TraceEvent) => void | Promise<void>,
+    legacyCallback?: (event: TraceEvent) => void | Promise<void>,
+    sink?: TraceSink,
   ) {
     this.identity = identity
+    const legacySink = legacyCallback ? new LegacyCallbackTraceSink(legacyCallback) : undefined
+    this.sink = sink && legacySink
+      ? new CompositeSink([sink, legacySink], { diagnostics: 'silent' })
+      : sink ?? legacySink
     this.root = this.startSpan({
       kind: 'run',
       name: 'oma.run',
@@ -109,6 +126,7 @@ export class TraceRuntime {
       attributes: span.attributes,
     }
     safeObserve(this.observer, record)
+    safeEmit(this.sink, record)
   }
 
   emitEvent(
@@ -124,8 +142,9 @@ export class TraceRuntime {
       name,
       attributes,
     }
+    if (legacyEvent) attachLegacyTraceEvent(record, legacyEvent)
     safeObserve(this.observer, record)
-    if (legacyEvent) emitTrace(this.legacyCallback, legacyEvent)
+    safeEmit(this.sink, record)
   }
 
   emitEnd(span: TraceSpan, options: EndSpanOptions, endUnixMs: number): void {
@@ -144,8 +163,9 @@ export class TraceRuntime {
       ...(links.length > 0 ? { links } : {}),
       attributes,
     }
+    if (options.legacyEvent) attachLegacyTraceEvent(record, options.legacyEvent)
     safeObserve(this.observer, record)
-    if (options.legacyEvent) emitTrace(this.legacyCallback, options.legacyEvent)
+    safeEmit(this.sink, record)
   }
 
   private base(span: TraceSpan) {
@@ -225,7 +245,9 @@ export function createTraceRuntime(
   identity: RunIdentity,
   legacyCallback?: (event: TraceEvent) => void | Promise<void>,
   observer?: TraceRecordObserver,
+  sink?: TraceSink,
 ): TraceRuntime | undefined {
-  return legacyCallback || observer ? new TraceRuntime(identity, observer, legacyCallback) : undefined
+  return legacyCallback || observer || sink
+    ? new TraceRuntime(identity, observer, legacyCallback, sink)
+    : undefined
 }
-

--- a/packages/core/src/observability/sink.ts
+++ b/packages/core/src/observability/sink.ts
@@ -1,0 +1,174 @@
+import type { TraceRecord } from './records.js'
+
+export interface FlushOptions {
+  readonly timeoutMs?: number
+}
+
+export interface FlushResult {
+  readonly status: 'ok' | 'partial' | 'timeout' | 'error'
+  readonly accepted: number
+  readonly exported: number
+  readonly dropped: number
+  readonly failed: number
+}
+
+/**
+ * Result for one exporter call. `exported` is the successfully delivered
+ * prefix of the supplied batch. A short success is a permanent partial
+ * result; a short retryable result retries only the unexported suffix.
+ */
+export interface ExportResult {
+  readonly status: 'success' | 'retryable' | 'failure'
+  readonly exported: number
+  readonly retryAfterMs?: number
+  readonly code?: string
+}
+
+export interface TraceExporter {
+  export(records: readonly TraceRecord[], signal: AbortSignal): Promise<ExportResult>
+  forceFlush?(signal: AbortSignal): Promise<ExportResult>
+  shutdown?(signal: AbortSignal): Promise<ExportResult>
+}
+
+export interface TraceSinkStats {
+  readonly accepted: number
+  readonly exported: number
+  readonly retried: number
+  readonly failed: number
+  readonly dropped: number
+  readonly queuedRecords: number
+  readonly queuedBytes: number
+  readonly lastError?: string
+  /** Backwards-friendly alias for queuedRecords. */
+  readonly queued: number
+  /** Backwards-friendly alias for lastError. */
+  readonly lastFailureCode?: string
+}
+
+export type TelemetryDiagnosticCode =
+  | 'sink_emit_failed'
+  | 'queue_full'
+  | 'record_too_large'
+  | 'export_failed'
+  | 'export_timeout'
+  | 'flush_timeout'
+  | 'shutdown_failed'
+  | 'emit_after_shutdown'
+
+export interface TelemetryDiagnostic {
+  readonly code: TelemetryDiagnosticCode
+  readonly severity: 'warning' | 'error'
+  readonly count: number
+  readonly sinkName?: string
+  /** Fixed, payload-free message. Never contains a TraceRecord or raw error. */
+  readonly message: string
+}
+
+export type DiagnosticMode = 'warn' | 'silent'
+
+export interface DiagnosticOptions {
+  readonly diagnostics?: DiagnosticMode
+  readonly onDiagnostic?: (diagnostic: TelemetryDiagnostic) => void
+  readonly diagnosticIntervalMs?: number
+  readonly sinkName?: string
+}
+
+export interface TraceSink {
+  /** Synchronous, non-blocking acceptance. Callers never await this method. */
+  emit(record: TraceRecord): void
+  forceFlush(options?: FlushOptions): Promise<FlushResult>
+  /** Idempotent. Emit after the shutdown cutoff is rejected and diagnosed. */
+  shutdown(options?: FlushOptions): Promise<FlushResult>
+  getStats?(): TraceSinkStats
+}
+
+export interface ObservabilityResource {
+  readonly serviceName?: string
+  readonly serviceVersion?: string
+  readonly deploymentEnvironment?: string
+  readonly release?: string
+}
+
+export interface TraceCapturePolicy {
+  readonly prompt?: 'none' | 'redacted'
+  readonly completion?: 'none' | 'redacted'
+  readonly toolInput?: 'none' | 'redacted'
+  readonly toolOutput?: 'none' | 'redacted'
+  readonly errorMessage?: 'code-only' | 'redacted'
+  readonly stack?: boolean
+  readonly streamEvents?: 'none' | 'first' | 'all'
+  readonly maxContentChars?: number
+}
+
+export interface ObservabilityConfig {
+  readonly sinks: readonly TraceSink[]
+  readonly resource?: ObservabilityResource
+  readonly capture?: TraceCapturePolicy
+  readonly onDiagnostic?: (diagnostic: TelemetryDiagnostic) => void
+}
+
+const EMPTY_STATS: TraceSinkStats = {
+  accepted: 0,
+  exported: 0,
+  retried: 0,
+  failed: 0,
+  dropped: 0,
+  queuedRecords: 0,
+  queuedBytes: 0,
+  queued: 0,
+}
+
+export function emptyTraceSinkStats(): TraceSinkStats {
+  return { ...EMPTY_STATS }
+}
+
+/** Payload-free, rate-limited diagnostics that cannot recurse through tracing. */
+export class DiagnosticReporter {
+  private readonly counts = new Map<TelemetryDiagnosticCode, number>()
+  private readonly lastEmitted = new Map<TelemetryDiagnosticCode, number>()
+
+  constructor(private readonly options: DiagnosticOptions = {}) {}
+
+  report(
+    code: TelemetryDiagnosticCode,
+    message: string,
+    severity: TelemetryDiagnostic['severity'] = 'warning',
+  ): void {
+    const count = (this.counts.get(code) ?? 0) + 1
+    this.counts.set(code, count)
+    const now = Date.now()
+    const interval = this.options.diagnosticIntervalMs ?? 60_000
+    if (now - (this.lastEmitted.get(code) ?? -Infinity) < interval) return
+    this.lastEmitted.set(code, now)
+
+    const diagnostic: TelemetryDiagnostic = {
+      code,
+      severity,
+      count,
+      ...(this.options.sinkName ? { sinkName: this.options.sinkName } : {}),
+      message,
+    }
+    try {
+      if (this.options.onDiagnostic) {
+        this.options.onDiagnostic(diagnostic)
+      } else if (this.options.diagnostics !== 'silent') {
+        console.warn(`[open-multi-agent observability] ${code}: ${message}`)
+      }
+    } catch {
+      // A diagnostic handler is itself telemetry. Never recurse or throw.
+    }
+  }
+}
+
+export function statsFlushResult(
+  stats: TraceSinkStats,
+  status: FlushResult['status'],
+): FlushResult {
+  return {
+    status,
+    accepted: stats.accepted,
+    exported: stats.exported,
+    dropped: stats.dropped,
+    failed: stats.failed,
+  }
+}

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -103,6 +103,9 @@ import {
   type TraceRuntime,
   type TraceSpan,
 } from '../observability/runtime.js'
+import { CompositeSink } from '../observability/composite.js'
+import type { TraceSink } from '../observability/sink.js'
+import { SensitiveDataProcessor } from '../observability/processors.js'
 import { extractKeywords, keywordScore } from '../utils/keywords.js'
 
 // ---------------------------------------------------------------------------
@@ -1980,13 +1983,14 @@ async function runTaskVerify(
  */
 export class OpenMultiAgent {
   private readonly config: Required<
-    Omit<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
-  > & Pick<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
+    Omit<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'observability' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
+  > & Pick<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'observability' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
 
   private readonly teams: Map<string, Team> = new Map()
   private readonly fallbackCheckpointStore = new InMemoryStore()
   private completedTaskCount = 0
   private readonly traceRecordObserver?: TraceRecordObserver
+  private readonly traceSink?: TraceSink
 
   /**
    * @param config - Optional top-level configuration.
@@ -2003,6 +2007,13 @@ export class OpenMultiAgent {
     }
 
     this.traceRecordObserver = traceRecordObserverFrom(config)
+    this.traceSink = config.observability && config.observability.sinks.length > 0
+      ? new CompositeSink(config.observability.sinks.map((sink) =>
+          new SensitiveDataProcessor(sink, { capture: config.observability?.capture })), {
+          onDiagnostic: config.observability.onDiagnostic,
+          sinkName: 'OpenMultiAgent',
+        })
+      : undefined
     this.config = {
       maxConcurrency: config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
       maxDelegationDepth: config.maxDelegationDepth ?? DEFAULT_MAX_DELEGATION_DEPTH,
@@ -2023,12 +2034,13 @@ export class OpenMultiAgent {
       onPlanReady: config.onPlanReady,
       onAgentStream: config.onAgentStream,
       onProgress: config.onProgress,
+      observability: config.observability,
       onTrace: config.onTrace,
     }
   }
 
   private startTrace(identity: RunIdentity): TraceRuntime | undefined {
-    return createTraceRuntime(identity, this.config.onTrace, this.traceRecordObserver)
+    return createTraceRuntime(identity, this.config.onTrace, this.traceRecordObserver, this.traceSink)
   }
 
   // -------------------------------------------------------------------------

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1342,6 +1342,8 @@ export interface OrchestratorConfig {
    */
   readonly defaultCwd?: string | null
   readonly onProgress?: (event: OrchestratorEvent) => void
+  /** Observability v2 sinks. User code owns forceFlush/shutdown lifecycle. */
+  readonly observability?: import('./observability/sink.js').ObservabilityConfig
   readonly onTrace?: (event: TraceEvent) => void | Promise<void>
   /**
    * Optional approval gate called between task execution rounds.

--- a/packages/core/tests/observability-v2-sink.test.ts
+++ b/packages/core/tests/observability-v2-sink.test.ts
@@ -1,0 +1,459 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createRunIdentity } from '../src/observability/identity.js'
+import type { TraceRecord, SpanEndRecord, SpanEventRecord, SpanStartRecord } from '../src/observability/records.js'
+import { TraceRuntime } from '../src/observability/runtime.js'
+import { BatchingTraceSink, DEFAULT_BATCHING_OPTIONS } from '../src/observability/batching.js'
+import { CompositeSink } from '../src/observability/composite.js'
+import { LegacyCallbackTraceSink } from '../src/observability/legacy-callback.js'
+import { FilteringSink, SensitiveDataProcessor } from '../src/observability/processors.js'
+import type {
+  ExportResult,
+  FlushResult,
+  TraceExporter,
+  TraceSink,
+  TraceSinkStats,
+} from '../src/observability/sink.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import type { LLMAdapter, TraceEvent } from '../src/types.js'
+
+let sequence = 0
+
+function base(recordType: TraceRecord['recordType']) {
+  return {
+    schemaVersion: 2 as const,
+    recordId: `record-${++sequence}`,
+    sequence,
+    timestampUnixMs: Date.now(),
+    runId: 'sink-test',
+    attempt: 1,
+    traceId: '1'.repeat(32),
+    spanId: sequence.toString(16).padStart(16, '0'),
+    recordType,
+  }
+}
+
+function start(attributes: Record<string, string | number | boolean> = {}): SpanStartRecord {
+  return {
+    ...base('span_start'),
+    kind: 'agent',
+    name: 'invoke_agent',
+    startUnixMs: Date.now(),
+    attributes,
+  }
+}
+
+function event(name: SpanEventRecord['name'] = 'retry_scheduled'): SpanEventRecord {
+  return { ...base('span_event'), name, attributes: {} }
+}
+
+function end(attributes: Record<string, string | number | boolean> = {}): SpanEndRecord {
+  const now = Date.now()
+  return {
+    ...base('span_end'),
+    kind: 'agent',
+    name: 'invoke_agent',
+    startUnixMs: now,
+    endUnixMs: now,
+    durationMs: 0,
+    status: { code: 'ok' },
+    attributes,
+  }
+}
+
+function exporter(
+  implementation: (records: readonly TraceRecord[], signal: AbortSignal) => Promise<ExportResult>,
+): TraceExporter {
+  return { export: implementation }
+}
+
+function sinkOptions(extra: Record<string, unknown> = {}) {
+  return {
+    scheduledDelayMs: 60_000,
+    exportTimeoutMs: 50,
+    retryDelayMs: 0,
+    retryJitter: false,
+    diagnostics: 'silent' as const,
+    ...extra,
+  }
+}
+
+function emptyStats(): TraceSinkStats {
+  return {
+    accepted: 0,
+    exported: 0,
+    retried: 0,
+    failed: 0,
+    dropped: 0,
+    queuedRecords: 0,
+    queuedBytes: 0,
+    queued: 0,
+  }
+}
+
+function okResult(): FlushResult {
+  return { status: 'ok', accepted: 0, exported: 0, dropped: 0, failed: 0 }
+}
+
+describe('BatchingTraceSink delivery lifecycle', () => {
+  it('locks the RFC-backed queue, record, batch, interval, timeout, and retry defaults', () => {
+    expect(DEFAULT_BATCHING_OPTIONS).toEqual({
+      maxQueueRecords: 2_048,
+      maxQueueBytes: 16 * 1024 * 1024,
+      maxRecordBytes: 256 * 1024,
+      maxBatchRecords: 512,
+      scheduledDelayMs: 5_000,
+      exportTimeoutMs: 30_000,
+      maxRetries: 3,
+      retryDelayMs: 1_000,
+      retryBackoff: 2,
+      maxRetryDelayMs: 30_000,
+    })
+  })
+
+  it('accepts synchronously and exports a batch asynchronously', async () => {
+    const batches: TraceRecord[][] = []
+    const sink = new BatchingTraceSink(exporter(async (records) => {
+      batches.push([...records])
+      return { status: 'success', exported: records.length }
+    }), sinkOptions())
+
+    sink.emit(start())
+    expect(batches).toHaveLength(0)
+    const flushed = await sink.forceFlush({ timeoutMs: 200 })
+
+    expect(batches).toHaveLength(1)
+    expect(flushed).toMatchObject({ status: 'ok', accepted: 1, exported: 1, failed: 0 })
+    expect(sink.getStats()).toMatchObject({ queuedRecords: 0, queuedBytes: 0 })
+  })
+
+  it('converts exporter rejection and permanent failure into stats, never a throw', async () => {
+    const rejecting = new BatchingTraceSink(exporter(async () => { throw new Error('secret payload') }), sinkOptions({ maxRetries: 0 }))
+    rejecting.emit(end())
+    await expect(rejecting.forceFlush({ timeoutMs: 200 })).resolves.toMatchObject({ status: 'error', failed: 1 })
+    expect(rejecting.getStats().lastError).toBe('EXPORT_REJECTED')
+
+    const permanent = new BatchingTraceSink(exporter(async () => ({ status: 'failure', exported: 0, code: 'BAD_REQUEST' })), sinkOptions())
+    permanent.emit(end())
+    await expect(permanent.forceFlush({ timeoutMs: 200 })).resolves.toMatchObject({ status: 'error', failed: 1 })
+    expect(permanent.getStats().lastError).toBe('BAD_REQUEST')
+
+    const malformed = new BatchingTraceSink(
+      exporter(async () => undefined as unknown as ExportResult),
+      sinkOptions({ maxRetries: 0 }),
+    )
+    malformed.emit(end())
+    await expect(malformed.forceFlush({ timeoutMs: 200 })).resolves.toMatchObject({ status: 'error', failed: 1 })
+    expect(malformed.getStats().lastError).toBe('INVALID_EXPORT_RESULT')
+  })
+
+  it('bounds a hung exporter with export timeout and aborts its signal', async () => {
+    let signal: AbortSignal | undefined
+    const sink = new BatchingTraceSink(exporter(async (_records, current) => {
+      signal = current
+      return await new Promise<ExportResult>(() => {})
+    }), sinkOptions({ exportTimeoutMs: 10, maxRetries: 0 }))
+    sink.emit(end())
+
+    const result = await sink.forceFlush({ timeoutMs: 100 })
+    expect(result).toMatchObject({ status: 'error', failed: 1 })
+    expect(signal?.aborted).toBe(true)
+  })
+
+  it('handles permanent partial success and retries only retryable remainders', async () => {
+    const partial = new BatchingTraceSink(exporter(async () => ({ status: 'success', exported: 1 })), sinkOptions())
+    partial.emit(start())
+    partial.emit(end())
+    await expect(partial.forceFlush({ timeoutMs: 200 })).resolves.toMatchObject({ status: 'partial', exported: 1, failed: 1 })
+
+    let calls = 0
+    const retried = new BatchingTraceSink(exporter(async (records) => {
+      calls++
+      return calls === 1
+        ? { status: 'retryable', exported: 1, code: 'RATE_LIMIT' }
+        : { status: 'success', exported: records.length }
+    }), sinkOptions({ maxRetries: 1 }))
+    retried.emit(start())
+    retried.emit(end())
+    const result = await retried.forceFlush({ timeoutMs: 200 })
+    expect(result).toMatchObject({ status: 'ok', exported: 2, failed: 0 })
+    expect(retried.getStats().retried).toBe(1)
+  })
+
+  it('enforces record-count and byte bounds with consistent stats', async () => {
+    const delivered: TraceRecord[] = []
+    const byCount = new BatchingTraceSink(exporter(async (records) => {
+      delivered.push(...records)
+      return { status: 'success', exported: records.length }
+    }), sinkOptions({ maxQueueRecords: 1 }))
+    byCount.emit(start())
+    byCount.emit(end())
+    expect(byCount.getStats()).toMatchObject({ accepted: 2, dropped: 1, queuedRecords: 1 })
+    await byCount.forceFlush({ timeoutMs: 200 })
+    expect(delivered[0]?.recordType).toBe('span_end')
+
+    const first = start({ payload: 'a'.repeat(100) })
+    const bytes = Buffer.byteLength(JSON.stringify(first), 'utf8')
+    const byBytes = new BatchingTraceSink(exporter(async (records) => ({ status: 'success', exported: records.length })), sinkOptions({
+      maxQueueBytes: bytes + 8,
+      maxRecordBytes: bytes * 2,
+    }))
+    byBytes.emit(first)
+    byBytes.emit(start({ payload: 'b'.repeat(100) }))
+    expect(byBytes.getStats()).toMatchObject({ accepted: 2, dropped: 1, queuedRecords: 1 })
+    expect(byBytes.getStats().queuedBytes).toBeLessThanOrEqual(bytes + 8)
+    await byBytes.shutdown({ timeoutMs: 200 })
+  })
+
+  it('drops oversize records before acceptance', () => {
+    const diagnostics = vi.fn()
+    const sink = new BatchingTraceSink(exporter(async (records) => ({ status: 'success', exported: records.length })), sinkOptions({
+      maxRecordBytes: 32,
+      onDiagnostic: diagnostics,
+    }))
+    sink.emit(start({ payload: 'x'.repeat(100) }))
+    sink.emit(start({ payload: 'y'.repeat(100) }))
+    expect(sink.getStats()).toMatchObject({ accepted: 0, dropped: 2, queuedRecords: 0 })
+    expect(diagnostics).toHaveBeenCalledOnce()
+    expect(diagnostics.mock.calls[0]?.[0]).toMatchObject({ code: 'record_too_large', count: 1 })
+  })
+
+  it('rate-limits default warnings and requires explicit silent mode to suppress them', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const noisy = new BatchingTraceSink(
+      exporter(async (records) => ({ status: 'success', exported: records.length })),
+      { ...sinkOptions(), diagnostics: 'warn', maxRecordBytes: 32 },
+    )
+    noisy.emit(start({ payload: 'x'.repeat(100) }))
+    noisy.emit(start({ payload: 'y'.repeat(100) }))
+    expect(warn).toHaveBeenCalledOnce()
+
+    const silent = new BatchingTraceSink(
+      exporter(async (records) => ({ status: 'success', exported: records.length })),
+      sinkOptions({ maxRecordBytes: 32 }),
+    )
+    silent.emit(start({ payload: 'z'.repeat(100) }))
+    expect(warn).toHaveBeenCalledOnce()
+    warn.mockRestore()
+  })
+
+  it('uses stream event, event, start, end as the priority drop order', async () => {
+    const delivered: TraceRecord[] = []
+    const sink = new BatchingTraceSink(exporter(async (records) => {
+      delivered.push(...records)
+      return { status: 'success', exported: records.length }
+    }), sinkOptions({ maxQueueRecords: 1 }))
+    sink.emit(event('stream_chunk'))
+    sink.emit(event('retry_scheduled'))
+    sink.emit(start())
+    sink.emit(end())
+    expect(sink.getStats()).toMatchObject({ accepted: 4, dropped: 3, queuedRecords: 1 })
+    await sink.forceFlush({ timeoutMs: 200 })
+    expect(delivered.map((record) => record.recordType)).toEqual(['span_end'])
+  })
+
+  it('forceFlush observes an acceptance watermark and supports concurrent callers', async () => {
+    let releaseFirst!: () => void
+    const firstGate = new Promise<void>((resolve) => { releaseFirst = resolve })
+    let call = 0
+    const sink = new BatchingTraceSink(exporter(async (records) => {
+      call++
+      if (call === 1) await firstGate
+      return { status: 'success', exported: records.length }
+    }), sinkOptions({ maxBatchRecords: 1 }))
+
+    sink.emit(start())
+    const flushOne = sink.forceFlush({ timeoutMs: 200 })
+    const flushTwo = sink.forceFlush({ timeoutMs: 200 })
+    sink.emit(end())
+    releaseFirst()
+
+    await expect(Promise.all([flushOne, flushTwo])).resolves.toEqual([
+      expect.objectContaining({ status: 'ok' }),
+      expect.objectContaining({ status: 'ok' }),
+    ])
+    expect(call).toBeGreaterThanOrEqual(1)
+    await sink.shutdown({ timeoutMs: 200 })
+  })
+
+  it('returns flush timeout promptly without changing later delivery', async () => {
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const sink = new BatchingTraceSink(exporter(async (records) => {
+      await gate
+      return { status: 'success', exported: records.length }
+    }), sinkOptions({ exportTimeoutMs: 500 }))
+    sink.emit(end())
+    await expect(sink.forceFlush({ timeoutMs: 5 })).resolves.toMatchObject({ status: 'timeout' })
+    release()
+    await expect(sink.forceFlush({ timeoutMs: 200 })).resolves.toMatchObject({ status: 'ok', exported: 1 })
+  })
+
+  it('makes concurrent/repeated shutdown deterministic and rejects later emits', async () => {
+    const exporterFlush = vi.fn(async () => ({ status: 'success' as const, exported: 0 }))
+    const shutdown = vi.fn(async () => ({ status: 'success' as const, exported: 0 }))
+    const sink = new BatchingTraceSink({
+      export: async (records) => ({ status: 'success', exported: records.length }),
+      forceFlush: exporterFlush,
+      shutdown,
+    }, sinkOptions())
+    sink.emit(end())
+    const first = sink.shutdown({ timeoutMs: 200 })
+    const second = sink.shutdown({ timeoutMs: 1 })
+    expect(first).toBe(second)
+    await expect(first).resolves.toMatchObject({ status: 'ok', exported: 1 })
+    expect(exporterFlush).toHaveBeenCalledOnce()
+    expect(shutdown).toHaveBeenCalledOnce()
+    sink.emit(end())
+    expect(sink.getStats()).toMatchObject({ accepted: 1, dropped: 1 })
+  })
+
+  it('bounds a hung exporter shutdown with the lifecycle deadline', async () => {
+    const sink = new BatchingTraceSink({
+      export: async (records) => ({ status: 'success', exported: records.length }),
+      shutdown: async () => await new Promise<ExportResult>(() => {}),
+    }, sinkOptions())
+    await expect(sink.shutdown({ timeoutMs: 5 })).resolves.toMatchObject({ status: 'timeout' })
+    await expect(sink.shutdown({ timeoutMs: 100 })).resolves.toMatchObject({ status: 'timeout' })
+  })
+
+  it('unrefs its scheduled timer', () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+    const sink = new BatchingTraceSink(exporter(async (records) => ({ status: 'success', exported: records.length })), sinkOptions())
+    sink.emit(start())
+    const handle = setTimeoutSpy.mock.results.at(-1)?.value as ReturnType<typeof setTimeout>
+    expect(handle.hasRef?.()).toBe(false)
+    setTimeoutSpy.mockRestore()
+    void sink.shutdown({ timeoutMs: 200 })
+  })
+})
+
+describe('OBS-2 composition, privacy, diagnostics, and compatibility', () => {
+  it('isolates a throwing Composite child and diagnostic handler', async () => {
+    const received: TraceRecord[] = []
+    const broken: TraceSink = {
+      emit: () => { throw new Error('secret') },
+      forceFlush: async () => { throw new Error('broken') },
+      shutdown: async () => { throw new Error('broken') },
+    }
+    const healthy: TraceSink = {
+      emit: (record) => { received.push(record) },
+      forceFlush: async () => okResult(),
+      shutdown: async () => okResult(),
+      getStats: emptyStats,
+    }
+    const composite = new CompositeSink([broken, healthy], {
+      onDiagnostic: () => { throw new Error('diagnostic failed') },
+      diagnosticIntervalMs: 0,
+    })
+    expect(() => composite.emit(end())).not.toThrow()
+    expect(received).toHaveLength(1)
+    await expect(composite.forceFlush()).resolves.toMatchObject({ status: 'partial' })
+  })
+
+  it('bounds a Composite child that ignores lifecycle timeouts', async () => {
+    const hanging: TraceSink = {
+      emit() {},
+      forceFlush: async () => await new Promise<FlushResult>(() => {}),
+      shutdown: async () => await new Promise<FlushResult>(() => {}),
+    }
+    const composite = new CompositeSink([hanging], { diagnostics: 'silent' })
+    await expect(composite.forceFlush({ timeoutMs: 5 })).resolves.toMatchObject({ status: 'timeout' })
+    await expect(composite.shutdown({ timeoutMs: 5 })).resolves.toMatchObject({ status: 'timeout' })
+  })
+
+  it('filters records and structurally removes sensitive/content/reasoning fields', async () => {
+    const received: TraceRecord[] = []
+    const target: TraceSink = {
+      emit: (record) => { received.push(record) },
+      forceFlush: async () => okResult(),
+      shutdown: async () => okResult(),
+    }
+    const processor = new FilteringSink(
+      new SensitiveDataProcessor(target),
+      (record) => record.recordType === 'span_start',
+    )
+    processor.emit(start({
+      'oma.agent.name': 'safe',
+      'request.authorization': 'Bearer secret',
+      'oma.prompt': 'private prompt',
+      'oma.reasoning.content': 'hidden thought',
+      'oma.reasoning.output_tokens': 7,
+    }))
+    processor.emit(end())
+    expect(received).toHaveLength(1)
+    expect(received[0]?.attributes).toEqual({
+      'oma.agent.name': 'safe',
+      'oma.reasoning.output_tokens': 7,
+    })
+  })
+
+  it('contains legacy callback sync throws and async rejections without unhandled rejection', async () => {
+    const sync = new LegacyCallbackTraceSink(() => { throw new Error('sync') }, { diagnostics: 'silent' })
+    const runtime = new TraceRuntime(createRunIdentity(), undefined, undefined, sync)
+    const span = runtime.startSpan({ kind: 'agent', name: 'invoke_agent', parent: runtime.root })
+    const legacy: TraceEvent = {
+      type: 'agent', runId: 'legacy', spanId: crypto.randomUUID(), agent: 'worker', turns: 1,
+      tokens: { input_tokens: 1, output_tokens: 1 }, toolCalls: 0,
+      startMs: 1, endMs: 2, durationMs: 1,
+    }
+    expect(() => span.end({ status: { code: 'ok' }, legacyEvent: legacy })).not.toThrow()
+    await expect(sync.forceFlush()).resolves.toMatchObject({ status: 'error', failed: 1 })
+
+    const rejected = new LegacyCallbackTraceSink(async () => { throw new Error('async') }, { diagnostics: 'silent' })
+    const asyncRuntime = new TraceRuntime(createRunIdentity(), undefined, undefined, rejected)
+    const asyncSpan = asyncRuntime.startSpan({ kind: 'agent', name: 'invoke_agent', parent: asyncRuntime.root })
+    asyncSpan.end({ status: { code: 'ok' }, legacyEvent: legacy })
+    await expect(rejected.forceFlush({ timeoutMs: 100 })).resolves.toMatchObject({ status: 'error', failed: 1 })
+  })
+
+  it('delivers all seven legacy event shapes unchanged through the bridge', async () => {
+    const received: TraceEvent[] = []
+    const bridge = new LegacyCallbackTraceSink((legacy) => { received.push(legacy) }, { diagnostics: 'silent' })
+    const runtime = new TraceRuntime(createRunIdentity(), undefined, undefined, bridge)
+    const baseEvent = {
+      runId: 'legacy-run', spanId: crypto.randomUUID(), agent: 'worker', startMs: 1, endMs: 2, durationMs: 1,
+    }
+    const events: TraceEvent[] = [
+      { ...baseEvent, type: 'llm_call', model: 'm', turn: 1, tokens: { input_tokens: 1, output_tokens: 1 } },
+      { ...baseEvent, type: 'tool_call', tool: 't', isError: false, input: {}, output: 'ok' },
+      { ...baseEvent, type: 'task', taskId: 't', taskTitle: 'T', success: true, retries: 0 },
+      { ...baseEvent, type: 'agent', turns: 1, tokens: { input_tokens: 1, output_tokens: 1 }, toolCalls: 0 },
+      { ...baseEvent, type: 'plan_ready', taskCount: 1, approved: true },
+      { ...baseEvent, type: 'agent_stream', streamType: 'text' },
+      { ...baseEvent, type: 'consensus', round: 1, accepted: true },
+    ]
+    for (const legacy of events) {
+      if (legacy.type === 'agent_stream') runtime.root.event('stream_chunk', {}, legacy)
+      else {
+        const span = runtime.startSpan({ kind: 'agent', name: 'invoke_agent', parent: runtime.root })
+        span.end({ status: { code: 'ok' }, legacyEvent: legacy })
+      }
+    }
+    await bridge.forceFlush()
+    expect(received).toEqual(events)
+  })
+
+  it('keeps sink failures isolated from Agent results through Orchestrator observability', async () => {
+    const broken: TraceSink = {
+      emit: () => { throw new Error('telemetry failed') },
+      forceFlush: async () => { throw new Error('telemetry failed') },
+      shutdown: async () => { throw new Error('telemetry failed') },
+    }
+    const adapter: LLMAdapter = {
+      name: 'sink-failure-test',
+      async chat() {
+        return {
+          id: 'ok', content: [{ type: 'text', text: 'business result' }], model: 'test',
+          stop_reason: 'end_turn', usage: { input_tokens: 1, output_tokens: 1 },
+        }
+      },
+      async *stream() {},
+    }
+    const oma = new OpenMultiAgent({
+      defaultModel: 'test',
+      observability: { sinks: [broken], onDiagnostic: () => {} },
+    })
+    const result = await oma.runAgent({ name: 'worker', model: 'test', adapter }, 'private prompt')
+    expect(result).toMatchObject({ success: true, output: 'business result', status: { code: 'ok' } })
+  })
+})

--- a/packages/core/tests/observability-v2-sink.test.ts
+++ b/packages/core/tests/observability-v2-sink.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
 import { createRunIdentity } from '../src/observability/identity.js'
 import type { TraceRecord, SpanEndRecord, SpanEventRecord, SpanStartRecord } from '../src/observability/records.js'
 import { TraceRuntime } from '../src/observability/runtime.js'
@@ -392,7 +393,7 @@ describe('OBS-2 composition, privacy, diagnostics, and compatibility', () => {
     const runtime = new TraceRuntime(createRunIdentity(), undefined, undefined, sync)
     const span = runtime.startSpan({ kind: 'agent', name: 'invoke_agent', parent: runtime.root })
     const legacy: TraceEvent = {
-      type: 'agent', runId: 'legacy', spanId: crypto.randomUUID(), agent: 'worker', turns: 1,
+      type: 'agent', runId: 'legacy', spanId: randomUUID(), agent: 'worker', turns: 1,
       tokens: { input_tokens: 1, output_tokens: 1 }, toolCalls: 0,
       startMs: 1, endMs: 2, durationMs: 1,
     }
@@ -411,7 +412,7 @@ describe('OBS-2 composition, privacy, diagnostics, and compatibility', () => {
     const bridge = new LegacyCallbackTraceSink((legacy) => { received.push(legacy) }, { diagnostics: 'silent' })
     const runtime = new TraceRuntime(createRunIdentity(), undefined, undefined, bridge)
     const baseEvent = {
-      runId: 'legacy-run', spanId: crypto.randomUUID(), agent: 'worker', startMs: 1, endMs: 2, durationMs: 1,
+      runId: 'legacy-run', spanId: randomUUID(), agent: 'worker', startMs: 1, endMs: 2, durationMs: 1,
     }
     const events: TraceEvent[] = [
       { ...baseEvent, type: 'llm_call', model: 'm', turn: 1, tokens: { input_tokens: 1, output_tokens: 1 } },


### PR DESCRIPTION
## Summary

- add the public `TraceSink` / `TraceExporter` lifecycle contract and `@open-multi-agent/core/observability` subpath
- add bounded `BatchingTraceSink`, `CompositeSink`, `FilteringSink`, `SensitiveDataProcessor`, and `LegacyCallbackTraceSink`
- wire one or more v2 sinks into `OpenMultiAgent` while preserving the OBS-1B no-sink fast path and legacy `onTrace` behavior
- document queue, retry, drop, diagnostics, privacy, and CLI/server/serverless lifecycle ownership

## Transport semantics

- synchronous, non-awaiting `emit(record): void`
- records + bytes bounded queue: 2,048 records / 16 MiB, 256 KiB per record
- 512-record batches, 5s scheduled delay, 30s export timeout
- three bounded retries with 1s exponential backoff, equal jitter, and a 30s cap
- priority drop order: `stream_chunk`, other events, `span_start`, then self-contained `span_end`
- watermark-based `forceFlush()` and idempotent cutoff-based `shutdown()` returning `ok` / `partial` / `timeout` / `error`
- rate-limited payload-free diagnostics and cumulative delivery/queue statistics

## Compatibility and privacy

- keeps all seven legacy `TraceEvent` shapes, UUID IDs, parent relationships, and completion/event timing unchanged
- contains synchronous callback throws and async callback rejections without changing run results or creating unhandled rejections
- leaves `onTrace` supported and not deprecated in this release
- keeps prompt, completion, tool input/output capture off by default and never captures reasoning/chain-of-thought content
- automatically applies structured secret removal/redaction to configured v2 sinks
- does not register process signal handlers or add runtime dependencies

## Validation

- `npm run lint`
- `npm test` — core: 79 files / 1,215 tests; create-oma-app: 4 files / 26 tests
- `npm run build`
- `git diff --check`
- root, package self-reference, and observability subpath import smoke tests
- `npm pack --dry-run -w @open-multi-agent/core` using an isolated npm cache
- 10,000 iterations x 15 rounds benchmark:
  - no-sink regression vs OBS-1B baseline: +0.363%
  - batch `emit` p95: 1.375 microseconds
  - representative 100-agent metadata envelope: 202,500 bytes (1.21% of the default byte queue)

## Scope

This PR intentionally does not add OTel/OTLP exporters, trace stores, databases, dashboards, Live Studio, or automatic process signal handling.
