### PR TITLE
feat(otel): add optional OpenTelemetry adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,31 @@ jobs:
             exit 1
           fi
 
+      - name: Smoke-test that the otel entry point imports
+        working-directory: packages/otel
+        run: node -e "import('./dist/index.js').then(() => console.log('otel entry point imports OK')).catch((e) => { console.error(e); process.exit(1); })"
+
+      - name: Assert the otel tarball ships exactly the expected files
+        working-directory: packages/otel
+        run: |
+          paths=$(npm pack --dry-run --json | jq -r '.[0].files[].path')
+          unexpected=$(echo "$paths" | grep -vE '^(dist/|README\.md$|LICENSE$|package\.json$)' || true)
+          if [ -n "$unexpected" ]; then
+            echo "Unexpected files staged for the @open-multi-agent/otel tarball:"
+            echo "$unexpected"
+            echo "Only dist/, README.md, LICENSE, package.json may ship."
+            exit 1
+          fi
+          missing=""
+          for f in dist/index.js dist/index.d.ts; do
+            echo "$paths" | grep -qxF "$f" || missing="$missing $f"
+          done
+          if [ -n "$missing" ]; then
+            echo "Required entry points missing from the @open-multi-agent/otel tarball:$missing"
+            echo "Either the build did not run or an entry was dropped from package.json \"files\"."
+            exit 1
+          fi
+
   scaffold-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,12 +23,12 @@ Tests live in `tests/` (vitest), E2E under `tests/e2e/`. Standalone `examples/` 
 
 - **ESM imports need `.js` extensions**: `import { X } from './foo.js'` even though the source is `foo.ts`. TypeScript strict; no eslint/prettier, so match existing patterns.
 - **After a change**, run `npm run lint` (typecheck) + the relevant tests. `tests/` need no API keys; `examples/` and `tests/e2e/` do.
-- **Keep runtime deps at three** (`@anthropic-ai/sdk`, `openai`, `zod`); new SDKs enter as lazy optional peers.
+- **Keep dependency ownership explicit** — there is no fixed runtime-dependency count. OpenTelemetry-specific APIs, SDKs, semantic-convention packages, and exporters belong in `@open-multi-agent/otel`; `@open-multi-agent/core` must remain importable and runnable without them. New optional provider SDKs should continue to load lazily.
 - **PRs** must pass `npm run lint && npm test` (CI on Node 18/20/22). Conventional commits, reference PR/issue #. Full flow: [.github/CONTRIBUTING.md](.github/CONTRIBUTING.md).
 
 ## Architecture
 
-ES module TypeScript framework for multi-agent orchestration. **Three runtime dependencies only**: `@anthropic-ai/sdk`, `openai`, `zod`. Optional peers (`@aws-sdk/client-bedrock-runtime`, `@google/genai`, `@modelcontextprotocol/sdk`, `ai`) load lazily via dynamic `import()` so unused SDKs never resolve; the three-dependency promise covers `dependencies` only.
+ES module TypeScript framework for multi-agent orchestration. Core owns the dependencies required by its native provider contracts; optional peers (`@aws-sdk/client-bedrock-runtime`, `@google/genai`, `@modelcontextprotocol/sdk`, `ai`) load lazily via dynamic `import()` so unused SDKs never resolve. OpenTelemetry APIs, SDKs, semantic conventions, and exporters are owned by the separately installable `@open-multi-agent/otel` package, never by the core root import.
 
 **`OpenMultiAgent`** (`src/orchestrator/orchestrator.ts`) is the top-level public API with three execution modes:
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 open-multi-agent contributors
+Copyright (c) open-multi-agent contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 
 Graph-first frameworks make you wire every node and edge up front. OMA runs a **dynamic workflow**: a coordinator turns the goal into a task DAG at runtime, parallelizes independent tasks, and synthesizes the result. That plan is emitted as data for a deterministic scheduler to run, so it stays inspectable and replayable. It is the same bet Anthropic made with Claude Code's [dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code); OMA offers it as an open library that runs on any provider, in your own backend.
 
-Lightweight core: the engine plus Anthropic, OpenAI, and any OpenAI-compatible endpoint work out of the box; Gemini, Bedrock, MCP, and the Vercel AI SDK bridge are opt-in peer dependencies.
+Lightweight core: the engine plus Anthropic, OpenAI, and any OpenAI-compatible endpoint work out of the box; Gemini, Bedrock, MCP, and the Vercel AI SDK bridge are opt-in peer dependencies. OpenTelemetry is a separately installable integration (`@open-multi-agent/otel`): OTel APIs, SDKs, semantic-convention mappings, and exporter integrations stay outside the core import, and applications explicitly supply their own provider.
 
 ## Get started
 
@@ -128,7 +128,7 @@ npm test               # run the test suite
 
 - [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) — env vars, model examples, local tool-calling, timeouts, troubleshooting.
 - [Tool configuration](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) — tool presets, custom tools, the filesystem sandbox, and MCP.
-- [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — stable run identity and outcome semantics on every top-level result, plus `onProgress`, `onTrace`, and the post-run dashboard.
+- [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — stable run identity and outcome semantics on every top-level result, plus `onProgress`, `onTrace`, and the post-run dashboard. [`@open-multi-agent/otel`](packages/otel/README.md) is the optional adapter for applications with an explicitly configured OpenTelemetry provider.
 - [Shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — the default store and custom `MemoryStore` backends.
 - [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — opt-in snapshots over any `MemoryStore`; restore preserves `runId`, increments `attempt`, and starts a fresh trace.
 - [Context management](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — sliding window, summarization, compaction, and custom compressors.

--- a/README_zh.md
+++ b/README_zh.md
@@ -52,7 +52,7 @@
 
 图优先的框架要求你预先列出每个节点与每条边。OMA 是**动态工作流**（dynamic workflow）：协调者在运行时把目标拆成任务 DAG，并行执行独立任务并合成结果；这份计划以数据形式交给确定性调度器执行，因此始终可审查、可回放。这与 Anthropic 在 2026 年 5 月为 Claude Code 推出的 [dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code) 是同一押注；OMA 以开源库的形式把它带到任意 provider、你自己的后端。
 
-轻量内核：编排引擎加上 Anthropic、OpenAI 及任意 OpenAI 兼容端点开箱即用；Gemini、Bedrock、MCP、Vercel AI SDK bridge 为可选 peer 依赖，按需安装。
+轻量内核：编排引擎加上 Anthropic、OpenAI 及任意 OpenAI 兼容端点开箱即用；Gemini、Bedrock、MCP、Vercel AI SDK bridge 为可选 peer 依赖，按需安装。OpenTelemetry 通过独立可选包 `@open-multi-agent/otel` 集成：OTel API、SDK、semantic convention 映射和 exporter 集成均不进入 core root import，应用显式提供自己的 provider。
 
 ## 快速开始
 
@@ -136,7 +136,7 @@ npm test               # 运行测试套件
 
 - [Provider](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) — 环境变量、模型示例、本地模型工具调用、超时、常见问题。
 - [工具配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) — 工具预设、自定义工具、文件系统沙箱、MCP。
-- [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — 每个顶层结果都包含稳定的运行标识（identity）与结果（outcome）语义，并提供 `onProgress`、`onTrace` 和运行后 dashboard。
+- [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — 每个顶层结果都包含稳定的运行标识（identity）与结果（outcome）语义，并提供 `onProgress`、`onTrace` 和运行后 dashboard。[`@open-multi-agent/otel`](packages/otel/README.md) 是面向已显式配置 OpenTelemetry provider 的应用的可选适配器。
 - [共享记忆](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — 默认存储与自定义 `MemoryStore` 后端。
 - [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — 在任意 `MemoryStore` 上保存可选快照；`restore()` 保留 `runId`、递增 `attempt`，并启动新的 trace。
 - [上下文管理](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — 滑动窗口、摘要、压缩、自定义压缩器。

--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -44,7 +44,7 @@ const orchestrator = new OpenMultiAgent({ checkpoint: true }) // default for all
 
 ## Durable persistence: `FileStore`
 
-`InMemoryStore` is a plain `Map` — it dies with the process, so a checkpoint held there does not survive a restart. For durability out of the box, use the bundled **`FileStore`**: a zero-dependency, filesystem-backed `MemoryStore` (Node built-ins only, so the three-dependency promise holds). Each write lands atomically — temp file → `fsync` → `rename` — so a reader never sees a half-written file, even across a power loss, not just a process crash.
+`InMemoryStore` is a plain `Map` — it dies with the process, so a checkpoint held there does not survive a restart. For durability out of the box, use the bundled **`FileStore`**: a zero-dependency, filesystem-backed `MemoryStore` that uses only Node built-ins and adds no runtime dependency to core. Each write lands atomically — temp file → `fsync` → `rename` — so a reader never sees a half-written file, even across a power loss, not just a process crash.
 
 ```typescript
 import { OpenMultiAgent, Team, InMemoryStore, FileStore } from '@open-multi-agent/core'

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -207,6 +207,59 @@ semantics; TraceStore deliberately provides none of those. CheckpointStore
 persists execution state used to restore work. Losing telemetry must not roll
 back a durable run, and deleting traces must not imply deleting checkpoints or
 shared memory.
+## Optional OpenTelemetry package
+
+`@open-multi-agent/otel` is an independent workspace/package that adapts OBS-2
+`TraceRecord` batches to OpenTelemetry spans. It is not imported by core, so a
+core-only installation has no OpenTelemetry runtime dependency or import path.
+
+```typescript
+import { OpenMultiAgent } from '@open-multi-agent/core'
+import { createOtelTraceSink } from '@open-multi-agent/otel'
+
+// The application has already constructed and configured this OTel provider.
+const sink = createOtelTraceSink({
+  tracerProvider: provider,
+  metadata: { environment: 'production', release: '2026.07.15' },
+})
+const orchestrator = new OpenMultiAgent({ observability: { sinks: [sink] } })
+```
+
+Pass exactly one application-owned `tracer` or `tracerProvider`; supplying
+neither is a configuration error. The adapter never reads, initializes, or
+replaces the global provider. `forceFlush()` delegates to a supplied provider
+when it supports that operation. Provider shutdown is skipped by default, even
+when available: set `shutdownOnShutdown: true` only when the adapter owns that
+provider's lifecycle. Rejection/timeout maps to the OBS-2 exporter result and
+diagnostics, never to an Agent/Task/Run failure.
+
+OMA run/agent/task/LLM/tool/consensus/checkpoint records become spans;
+retry, verdict, first-chunk, and stream records become `oma.*` events. DAG,
+delegation, consumed-synthesis, and restore-continuation relations become OTel
+links. The adapter keeps `schemaVersion: 2`, run/attempt, OMA trace/span IDs,
+record ID, and sequence as stable `oma.*` attributes. It maps `error`,
+`timeout`, and `budget_exhausted` to OTel `Error`; all remaining OMA statuses
+remain OTel `Unset` and are preserved in `oma.status`.
+
+For LLM/tool spans it also emits a bounded compatibility subset of the current
+development-status GenAI conventions (provider/model, token/cache/reasoning
+counts, tool name, and TTFT). Every span records
+`oma.otel.mapping.version` and `oma.otel.gen_ai_semconv.version`; the stable
+contract is `oma.*`, not the evolving GenAI field names. It emits no metrics,
+so no high-cardinality run/task/tenant/request fields become metric labels.
+
+The adapter exports no prompt, completion, tool arguments/results, raw payload,
+credential, chain-of-thought, or reasoning content. Numeric token counts remain
+eligible. It forwards only an explicit low-sensitivity `oma.*` allowlist rather
+than arbitrary record attributes. `contentCapture` is a reserved disabled-only extension point; there
+is no content-capture switch in this release.
+
+The first release intentionally provides no OTLP convenience subpath. The
+application selects its own OTel SDK and OTLP/exporter implementation, avoiding
+eager OTLP imports, implicit global-provider configuration, and a second
+SDK/exporter compatibility matrix. See
+[`packages/otel/README.md`](../packages/otel/README.md) for the full API and
+mapping table.
 
 ## Flush and shutdown
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -241,6 +241,20 @@ record ID, and sequence as stable `oma.*` attributes. It maps `error`,
 `timeout`, and `budget_exhausted` to OTel `Error`; all remaining OMA statuses
 remain OTel `Unset` and are preserved in `oma.status`.
 
+Links whose targets were observed by the same adapter use the target span's
+actual SDK-generated OTel context. Each link records `oma.link.resolved` plus
+the stable OMA target trace/span IDs. A same-process restore resolves through a
+bounded cache of the 256 most recent root contexts. After a process restart the
+previous SDK context is unavailable, so `continued_from` falls back to a remote
+unsampled context built from the OMA IDs and marks itself unresolved; the OMA
+target attributes remain available for correlation.
+
+Completed OTel `Span` objects are released immediately. Lightweight contexts
+live only until their root span closes, at which point the trace-local registry
+is cleared. Root close and adapter shutdown end any remaining open spans as
+incomplete before clearing state, so telemetry loss cannot produce an unbounded
+live-span registry.
+
 For LLM/tool spans it also emits a bounded compatibility subset of the current
 development-status GenAI conventions (provider/model, token/cache/reasoning
 counts, tool name, and TTFT). Every span records

--- a/package-lock.json
+++ b/package-lock.json
@@ -1597,6 +1597,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8.0.0"
@@ -6628,13 +6629,13 @@
     },
     "packages/otel": {
       "name": "@open-multi-agent/otel",
-      "version": "1.10.0",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@open-multi-agent/core": "^1.10.0",
-        "@opentelemetry/api": "^1.9.0"
+        "@open-multi-agent/core": "^1.10.0"
       },
       "devDependencies": {
+        "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/sdk-trace-base": "^2.9.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0",
@@ -6642,6 +6643,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1589,6 +1589,99 @@
       "resolved": "packages/core",
       "link": true
     },
+    "node_modules/@open-multi-agent/otel": {
+      "resolved": "packages/otel",
+      "link": true
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -6525,6 +6618,24 @@
         "create-oma-app": "dist/index.js"
       },
       "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.6.0",
+        "vitest": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "packages/otel": {
+      "name": "@open-multi-agent/otel",
+      "version": "1.10.0",
+      "license": "MIT",
+      "dependencies": {
+        "@open-multi-agent/core": "^1.10.0",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "devDependencies": {
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 open-multi-agent contributors
+Copyright (c) open-multi-agent contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -52,7 +52,7 @@
 
 Graph-first frameworks make you wire every node and edge up front. OMA runs a **dynamic workflow**: a coordinator turns the goal into a task DAG at runtime, parallelizes independent tasks, and synthesizes the result. That plan is emitted as data for a deterministic scheduler to run, so it stays inspectable and replayable. It is the same bet Anthropic made with Claude Code's [dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code); OMA offers it as an open library that runs on any provider, in your own backend.
 
-Lightweight core: the engine plus Anthropic, OpenAI, and any OpenAI-compatible endpoint work out of the box; Gemini, Bedrock, MCP, and the Vercel AI SDK bridge are opt-in peer dependencies.
+Lightweight core: the engine plus Anthropic, OpenAI, and any OpenAI-compatible endpoint work out of the box; Gemini, Bedrock, MCP, and the Vercel AI SDK bridge are opt-in peer dependencies. OpenTelemetry is a separately installable integration (`@open-multi-agent/otel`): OTel APIs, SDKs, semantic-convention mappings, and exporter integrations stay outside the core import, and applications explicitly supply their own provider.
 
 ## Contents
 
@@ -443,7 +443,7 @@ Before going live, wire up the controls that protect token spend, recover from f
 
 - [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) — env vars, model examples, local tool-calling, timeouts, troubleshooting.
 - [Tool configuration](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) — tool presets, custom tools, the filesystem sandbox, and MCP.
-- [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — stable run identity and outcome semantics on every top-level result, plus `onProgress`, `onTrace`, and the post-run dashboard.
+- [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — stable run identity and outcome semantics on every top-level result, plus `onProgress`, `onTrace`, and the post-run dashboard. [`@open-multi-agent/otel`](https://github.com/open-multi-agent/open-multi-agent/blob/main/packages/otel/README.md) is the optional adapter for applications with an explicitly configured OpenTelemetry provider.
 - [Shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — the default store and custom `MemoryStore` backends.
 - [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — checkpoint v2 identity rules, v1 compatibility, and restore over any `MemoryStore`.
 - [Context management](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — sliding window, summarization, compaction, and custom compressors.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -384,9 +384,9 @@ See [docs/providers.md](https://github.com/open-multi-agent/open-multi-agent/blo
 
 ### Dependencies
 
-Installing `@open-multi-agent/core` pulls in three runtime dependencies: `@anthropic-ai/sdk`, `openai`, and `zod`. That is the entire core: Anthropic, OpenAI, and every OpenAI-compatible endpoint run on these three alone.
+At present, `@open-multi-agent/core` directly installs `@anthropic-ai/sdk`, `openai`, and `zod`; this is an implementation detail, not a fixed dependency-count policy. Anthropic, OpenAI, and every OpenAI-compatible endpoint use those packages today.
 
-Everything else is an opt-in peer dependency you install only when you reach for it. Each loads lazily, so a project that never uses one never installs it.
+Other provider integrations are opt-in peer dependencies that load lazily, so a project that never uses one never installs it. OpenTelemetry integration is a separately installable package: OTel APIs, SDKs, semantic-convention mappings, and exporter integrations live in `@open-multi-agent/otel`, so importing or running core does not require OpenTelemetry.
 
 | Capability | Install | Trigger |
 |------------|---------|---------|
@@ -394,6 +394,7 @@ Everything else is an opt-in peer dependency you install only when you reach for
 | Bedrock provider | `npm i @aws-sdk/client-bedrock-runtime` | `provider: 'bedrock'` |
 | MCP tools | `npm i @modelcontextprotocol/sdk` | `connectMCPTools()` |
 | Vercel AI SDK bridge | `npm i ai @ai-sdk/<provider>` | `new AISdkAdapter(...)` |
+| OpenTelemetry traces | `npm i @open-multi-agent/otel` plus your application-selected OTel SDK/exporter | `createOtelTraceSink(...)` |
 
 ### Vercel AI SDK (optional)
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -52,7 +52,7 @@
 
 图优先的框架要求你预先列出每个节点与每条边。OMA 是**动态工作流**（dynamic workflow）：协调者在运行时把目标拆成任务 DAG，并行执行独立任务并合成结果；这份计划以数据形式交给确定性调度器执行，因此始终可审查、可回放。这与 Anthropic 在 2026 年 5 月为 Claude Code 推出的 [dynamic workflows](https://claude.com/blog/introducing-dynamic-workflows-in-claude-code) 是同一押注；OMA 以开源库的形式把它带到任意 provider、你自己的后端。
 
-轻量内核：编排引擎加上 Anthropic、OpenAI 及任意 OpenAI 兼容端点开箱即用；Gemini、Bedrock、MCP、Vercel AI SDK bridge 为可选 peer 依赖，按需安装。
+轻量内核：编排引擎加上 Anthropic、OpenAI 及任意 OpenAI 兼容端点开箱即用；Gemini、Bedrock、MCP、Vercel AI SDK bridge 为可选 peer 依赖，按需安装。OpenTelemetry 通过独立可选包 `@open-multi-agent/otel` 集成：OTel API、SDK、semantic convention 映射和 exporter 集成均不进入 core root import，应用显式提供自己的 provider。
 
 ## 目录
 
@@ -384,9 +384,9 @@ const agent: AgentConfig = {
 
 ### 依赖
 
-安装 `@open-multi-agent/core` 会引入三个运行时依赖：`@anthropic-ai/sdk`、`openai`、`zod`。内核仅此而已：Anthropic、OpenAI 及所有 OpenAI 兼容端点仅凭这三个依赖即可运行。
+目前安装 `@open-multi-agent/core` 会直接引入 `@anthropic-ai/sdk`、`openai`、`zod`；这是实现细节，而非固定依赖数量的承诺。Anthropic、OpenAI 及所有 OpenAI 兼容端点目前即由这些包支撑。
 
-其余均为可选 peer 依赖，按需安装；每个都是懒加载，未用到的项目不会引入。
+其余 provider 集成均为可选 peer 依赖，按需安装；每个都是懒加载，未用到的项目不会引入。OpenTelemetry 集成是独立安装的包：OTel API、SDK、semantic convention 映射和 exporter 集成都在 `@open-multi-agent/otel` 中，导入或运行 core 不需要 OpenTelemetry。
 
 | 能力 | 安装 | 触发 |
 |------|------|------|
@@ -394,6 +394,7 @@ const agent: AgentConfig = {
 | Bedrock provider | `npm i @aws-sdk/client-bedrock-runtime` | `provider: 'bedrock'` |
 | MCP 工具 | `npm i @modelcontextprotocol/sdk` | `connectMCPTools()` |
 | Vercel AI SDK bridge | `npm i ai @ai-sdk/<provider>` | `new AISdkAdapter(...)` |
+| OpenTelemetry trace | `npm i @open-multi-agent/otel`，另装应用自选的 OTel SDK/exporter | `createOtelTraceSink(...)` |
 
 ### Vercel AI SDK（可选）
 
@@ -442,7 +443,7 @@ await oma.runAgent(
 
 - [Provider](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) — 环境变量、模型示例、本地模型工具调用、超时、常见问题。
 - [工具配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) — 工具预设、自定义工具、文件系统沙箱、MCP。
-- [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — 每个顶层结果都包含稳定的运行标识（identity）与结果（outcome）语义，并提供 `onProgress`、`onTrace` 和运行后 dashboard。
+- [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — 每个顶层结果都包含稳定的运行标识（identity）与结果（outcome）语义，并提供 `onProgress`、`onTrace` 和运行后 dashboard。[`@open-multi-agent/otel`](https://github.com/open-multi-agent/open-multi-agent/blob/main/packages/otel/README.md) 是面向已显式配置 OpenTelemetry provider 的应用的可选适配器。
 - [共享记忆](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — 默认存储与自定义 `MemoryStore` 后端。
 - [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — checkpoint v2 identity 规则、v1 兼容，以及基于任意 `MemoryStore` 的恢复流程。
 - [上下文管理](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — 滑动窗口、摘要、压缩、自定义压缩器。

--- a/packages/core/src/memory/file-store.ts
+++ b/packages/core/src/memory/file-store.ts
@@ -5,8 +5,7 @@
  *
  * {@link InMemoryStore} lives in a `Map` and dies with the process, so the
  * checkpoint it holds does not outlive a crash. `FileStore` closes that gap
- * using only Node built-ins (no new runtime dependency), keeping the
- * three-dependency promise intact.
+ * using only Node built-ins, so it adds no runtime dependency to core.
  *
  * **Design.** One JSON file holds the whole store. An in-memory `Map` mirrors
  * it, so reads (`get`/`list`) are served from memory and match

--- a/packages/core/tests/otel-package-boundary.test.ts
+++ b/packages/core/tests/otel-package-boundary.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 
@@ -11,5 +12,19 @@ describe('optional OTel package boundary', () => {
     const core = await import('../src/index.js')
     expect(core.OpenMultiAgent).toBeTypeOf('function')
     expect(core.BatchingTraceSink).toBeTypeOf('function')
+  })
+
+  // The workspace hoists @opentelemetry/*, so a stray core import would still
+  // resolve here; scan the source instead of relying on module resolution.
+  it('keeps OpenTelemetry references out of core source files', () => {
+    const walk = (dir: string): string[] =>
+      readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+        const path = join(dir, entry.name)
+        if (entry.isDirectory()) return walk(path)
+        return entry.name.endsWith('.ts') ? [path] : []
+      })
+    const srcDir = fileURLToPath(new URL('../src', import.meta.url))
+    const offenders = walk(srcDir).filter((file) => readFileSync(file, 'utf8').includes('@opentelemetry'))
+    expect(offenders).toEqual([])
   })
 })

--- a/packages/core/tests/otel-package-boundary.test.ts
+++ b/packages/core/tests/otel-package-boundary.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+describe('optional OTel package boundary', () => {
+  it('keeps the core import and runtime dependency set independent from OpenTelemetry', async () => {
+    const packagePath = fileURLToPath(new URL('../package.json', import.meta.url))
+    const manifest = JSON.parse(readFileSync(packagePath, 'utf8')) as { dependencies?: Record<string, string> }
+    expect(Object.keys(manifest.dependencies ?? {}).filter((name) => name.startsWith('@opentelemetry/'))).toEqual([])
+
+    const core = await import('../src/index.js')
+    expect(core.OpenMultiAgent).toBeTypeOf('function')
+    expect(core.BatchingTraceSink).toBeTypeOf('function')
+  })
+})

--- a/packages/otel/LICENSE
+++ b/packages/otel/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) open-multi-agent
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/otel/LICENSE
+++ b/packages/otel/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) open-multi-agent
+Copyright (c) open-multi-agent contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -1,0 +1,104 @@
+# `@open-multi-agent/otel`
+
+Optional OpenTelemetry adapter for `@open-multi-agent/core` TraceRecord v2.
+It converts OBS-2 `TraceExporter` batches into spans on a tracer you explicitly
+provide. The package never reads, registers, or replaces the global
+`TracerProvider`.
+
+```bash
+npm install @open-multi-agent/core @open-multi-agent/otel
+# Install and configure the OpenTelemetry SDK/exporter chosen by your application.
+```
+
+## Use an application-owned provider
+
+```ts
+import { OpenMultiAgent } from '@open-multi-agent/core'
+import { createOtelTraceSink } from '@open-multi-agent/otel'
+
+// `provider` is configured by the application with its SDK and exporter.
+const sink = createOtelTraceSink({
+  tracerProvider: provider,
+  metadata: {
+    environment: 'production',
+    release: '2026.07.15',
+    tenantId: 'opaque-tenant-id',
+  },
+})
+
+const oma = new OpenMultiAgent({ observability: { sinks: [sink] } })
+```
+
+Pass exactly one of `tracer` or `tracerProvider`. Passing neither is a clear
+configuration error: this package does not fall back to `trace.getTracer()` or
+any global provider.
+
+## Lifecycle and ownership
+
+The caller owns the tracer/provider in every mode.
+
+- `sink.forceFlush()` first flushes the OMA batching queue, then delegates to
+  `provider.forceFlush()` when a provider was supplied and implements it.
+- With a direct `tracer`, there is no provider lifecycle to delegate to, so the
+  adapter phase is a successful no-op.
+- `sink.shutdown()` does **not** shut down a caller-owned provider by default.
+  Set `shutdownOnShutdown: true` only when this adapter is the component that
+  owns the provider lifecycle.
+- Provider rejection or timeout becomes the OBS-2 exporter result and sink
+  diagnostics/stats; it never changes an Agent, Task, or Run result.
+
+Use a `BatchingTraceSink` directly via `createOtelTraceExporter()` when the
+application owns batching configuration itself.
+
+## Mapping
+
+The adapter creates one OTel span for each OMA `span_start`/`span_end` pair.
+An end record that arrives without a start creates a marked incomplete span so
+the self-contained OBS-2 end snapshot remains observable. Duplicates and
+orphan events are ignored with payload-free diagnostics.
+
+| OMA operation | OTel representation |
+|---|---|
+| root run | `oma.run` span (`INTERNAL`) |
+| coordinator decomposition/synthesis | OMA plan/agent/callback span, original name retained |
+| task, agent attempt, consensus, checkpoint | `INTERNAL` span, original name retained |
+| LLM | `CLIENT` span with compatible `gen_ai.*` attributes |
+| tool / delegation | `INTERNAL` span; delegated task relation is an OTel link |
+| retry / consensus verdict / stream chunks | `oma.*` events |
+| DAG / restore / synthesis consumption | OTel links with `oma.link.relation` |
+
+Stable correlation attributes include `oma.schema.version = 2`,
+`oma.run.id`, `oma.run.attempt`, `oma.trace.id`, `oma.span.id`,
+`oma.record.id`, `oma.record.sequence`, and `oma.otel.mapping.version`.
+`oma.otel.gen_ai_semconv.version` records the current compatible GenAI mapping:
+`1.43.0-development`. `oma.*` remains the stable OMA contract; the GenAI
+attributes are a compatibility surface and can evolve with OpenTelemetry.
+
+`ok`, `cancelled`, `rejected`, and `skipped` map to OTel `Unset`; `error`,
+`timeout`, and `budget_exhausted` map to `Error`. The source OMA status is
+always retained as `oma.status`.
+
+The adapter maps model/provider, input/output/cache/reasoning token counts,
+tool name/error facts, cost metadata, retry fields, and TTFT. It emits no
+metrics, so no OMA high-cardinality values become metric labels.
+
+## Privacy
+
+Prompt, completion, tool arguments/results, raw payloads, credentials, and
+reasoning/chain-of-thought content are filtered by default. The adapter uses an
+explicit low-sensitivity `oma.*` allowlist rather than forwarding arbitrary
+record attributes. This includes `<thinking>` and provider reasoning content.
+Token counts remain eligible for
+export. `contentCapture` is a reserved type-level extension point whose only
+accepted value is `mode: 'disabled'`; there is intentionally no content-capture
+switch in this release. Applications that need such a feature must add an
+explicit, separately reviewed capture policy upstream of the adapter.
+
+## OTLP convenience decision
+
+This initial release deliberately has no `/otlp-http` convenience subpath.
+The application chooses and configures its own OpenTelemetry SDK and OTLP (or
+other) exporter, keeping this package's runtime surface to the OTel API and
+avoiding eager OTLP imports, global-provider configuration, and a second
+SDK/exporter version matrix. An explicit convenience subpath can be added later
+without changing the root import.

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -44,6 +44,11 @@ The caller owns the tracer/provider in every mode.
 - `sink.shutdown()` does **not** shut down a caller-owned provider by default.
   Set `shutdownOnShutdown: true` only when this adapter is the component that
   owns the provider lifecycle.
+- Completed OTel `Span` objects are released immediately. Lightweight contexts
+  remain only until their OMA root closes; the 256 most recent root contexts
+  are retained so a same-process checkpoint restore can resolve its continuation
+  link. Shutdown ends any still-open span as incomplete and clears all adapter
+  state.
 - Provider rejection or timeout becomes the OBS-2 exporter result and sink
   diagnostics/stats; it never changes an Agent, Task, or Run result.
 
@@ -65,7 +70,21 @@ orphan events are ignored with payload-free diagnostics.
 | LLM | `CLIENT` span with compatible `gen_ai.*` attributes |
 | tool / delegation | `INTERNAL` span; delegated task relation is an OTel link |
 | retry / consensus verdict / stream chunks | `oma.*` events |
-| DAG / restore / synthesis consumption | OTel links with `oma.link.relation` |
+| DAG / restore / synthesis consumption | OTel links with `oma.link.relation` and explicit resolution metadata |
+
+When the referenced span was observed by the same adapter, the OTel link uses
+that span's actual SDK-generated `SpanContext`, so backends can resolve it to the
+exported span. This covers DAG dependencies, delegation, synthesis consumption,
+and same-process checkpoint restore. Every link also records
+`oma.link.resolved`, `oma.link.target.trace_id`, and
+`oma.link.target.span_id`; the target IDs are the stable OMA identifiers.
+
+After a process restart, the adapter has no access to the previous provider's
+SDK-generated context because checkpoints intentionally contain only OMA IDs.
+Such a `continued_from` link remains a valid remote OTel link using the OMA IDs,
+`TraceFlags.NONE`, and `oma.link.resolved = false`. Use its target attributes
+for correlation; a backend cannot be expected to navigate it to the previously
+exported OTel span.
 
 Stable correlation attributes include `oma.schema.version = 2`,
 `oma.run.id`, `oma.run.attempt`, `oma.trace.id`, `oma.span.id`,

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@open-multi-agent/otel",
+  "version": "1.10.0",
+  "description": "Optional OpenTelemetry adapter for @open-multi-agent/core TraceRecord v2.",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit -p tsconfig.lint.json",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": [
+    "open-telemetry",
+    "opentelemetry",
+    "observability",
+    "multi-agent",
+    "llm"
+  ],
+  "author": {
+    "name": "open-multi-agent",
+    "url": "https://github.com/open-multi-agent"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/open-multi-agent/open-multi-agent.git",
+    "directory": "packages/otel"
+  },
+  "homepage": "https://github.com/open-multi-agent/open-multi-agent#readme",
+  "bugs": {
+    "url": "https://github.com/open-multi-agent/open-multi-agent/issues"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "dependencies": {
+    "@open-multi-agent/core": "^1.10.0",
+    "@opentelemetry/api": "^1.9.0"
+  },
+  "devDependencies": {
+    "@opentelemetry/sdk-trace-base": "^2.9.0",
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  }
+}

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/otel",
-  "version": "1.10.0",
+  "version": "0.1.0",
   "description": "Optional OpenTelemetry adapter for @open-multi-agent/core TraceRecord v2.",
   "files": [
     "dist",
@@ -52,10 +52,13 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@open-multi-agent/core": "^1.10.0",
+    "@open-multi-agent/core": "^1.10.0"
+  },
+  "peerDependencies": {
     "@opentelemetry/api": "^1.9.0"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-trace-base": "^2.9.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.6.0",

--- a/packages/otel/src/exporter.ts
+++ b/packages/otel/src/exporter.ts
@@ -1,4 +1,4 @@
-import { context, SpanStatusCode, trace } from '@opentelemetry/api'
+import { ROOT_CONTEXT, SpanStatusCode, trace } from '@opentelemetry/api'
 import type {
   Attributes,
   Span,
@@ -284,7 +284,9 @@ export class OTelTraceExporter implements TraceExporter {
     const parent = record.parentSpanId
       ? this.spanContexts.get(spanKey(record.traceId, record.parentSpanId))
       : undefined
-    const parentContext = parent ? trace.setSpanContext(context.active(), parent) : undefined
+    // Root spans must not parent under whatever application span happens to be
+    // active at export time; batching makes that ambient context arbitrary.
+    const parentContext = parent ? trace.setSpanContext(ROOT_CONTEXT, parent) : ROOT_CONTEXT
     const attributes: Attributes = {
       ...spanAttributes(record),
       ...this.metadata,

--- a/packages/otel/src/exporter.ts
+++ b/packages/otel/src/exporter.ts
@@ -1,0 +1,348 @@
+import { context, trace } from '@opentelemetry/api'
+import type {
+  Attributes,
+  Span,
+  Tracer,
+  TracerProvider,
+} from '@opentelemetry/api'
+import {
+  BatchingTraceSink,
+  type BatchingTraceSinkOptions,
+  type ExportResult,
+  type SpanEndRecord,
+  type SpanEventRecord,
+  type SpanStartRecord,
+  type TraceLink,
+  type TraceExporter,
+  type TraceRecord,
+  type TraceSink,
+} from '@open-multi-agent/core'
+import {
+  baseAttributes,
+  mapLink,
+  mapOmaAttributes,
+  mapSpanKind,
+  mapStatus,
+  spanAttributes,
+} from './mapping.js'
+
+export type OTelDiagnosticCode =
+  | 'span_start_failed'
+  | 'duplicate_span_start'
+  | 'orphan_event'
+  | 'duplicate_span_end'
+  | 'incomplete_span'
+  | 'span_end_failed'
+  | 'force_flush_failed'
+  | 'force_flush_timeout'
+  | 'shutdown_skipped'
+  | 'shutdown_failed'
+  | 'shutdown_timeout'
+
+export interface OTelDiagnostic {
+  readonly code: OTelDiagnosticCode
+  readonly message: string
+}
+
+export interface OTelTracerProvider extends TracerProvider {
+  forceFlush?(): Promise<void>
+  shutdown?(): Promise<void>
+}
+
+export interface OTelTraceExporterOptions {
+  /** Use an application-owned tracer directly. It is never globally registered or shut down. */
+  readonly tracer?: Tracer
+  /**
+   * Use an application-owned provider to create the adapter tracer. Its
+   * forceFlush is delegated when available; shutdown remains opt-in.
+   */
+  readonly tracerProvider?: OTelTracerProvider
+  readonly instrumentationName?: string
+  readonly instrumentationVersion?: string
+  /** Optional low-sensitivity metadata, added only when callers provide it. */
+  readonly metadata?: OTelMetadata
+  /**
+   * Reserved for a separately reviewed future capture policy. This release only
+   * accepts the disabled value and never exports content-bearing fields.
+   */
+  readonly contentCapture?: OTelContentCaptureExtension
+  /** Opt in to calling shutdown on the supplied provider. Defaults to false. */
+  readonly shutdownOnShutdown?: boolean
+  /** Receives payload-free adapter diagnostics. */
+  readonly onDiagnostic?: (diagnostic: OTelDiagnostic) => void
+}
+
+export interface OTelMetadata {
+  readonly environment?: string
+  readonly release?: string
+  readonly tenantId?: string
+  readonly requestId?: string
+}
+
+export interface OTelContentCaptureExtension {
+  readonly mode?: 'disabled'
+}
+
+export interface OTelTraceSinkOptions extends OTelTraceExporterOptions {
+  readonly batching?: BatchingTraceSinkOptions
+}
+
+interface SpanEntry {
+  readonly span: Span
+  readonly startUnixMs: number
+  readonly linkKeys: Set<string>
+  ended: boolean
+}
+
+function spanKey(traceId: string, spanId: string): string {
+  return `${traceId}/${spanId}`
+}
+
+function linkKey(link: TraceLink): string {
+  return `${link.traceId}/${link.spanId}/${link.relation}`
+}
+
+function lifecycleResult(status: 'success' | 'failure', code?: string): ExportResult {
+  return { status, exported: 0, ...(code ? { code } : {}) }
+}
+
+/**
+ * Adapts OMA TraceRecord v2 to an application-owned OpenTelemetry tracer.
+ * It deliberately does not configure or replace OpenTelemetry's global provider.
+ */
+export class OTelTraceExporter implements TraceExporter {
+  private readonly tracer: Tracer
+  private readonly provider?: OTelTracerProvider
+  private readonly spans = new Map<string, SpanEntry>()
+  private readonly shutdownOnShutdown: boolean
+  private readonly metadata: Attributes
+
+  constructor(private readonly options: OTelTraceExporterOptions) {
+    if ((options.tracer === undefined) === (options.tracerProvider === undefined)) {
+      throw new TypeError('Provide exactly one of tracer or tracerProvider; global OpenTelemetry state is never used.')
+    }
+    if (options.contentCapture?.mode !== undefined && options.contentCapture.mode !== 'disabled') {
+      throw new TypeError('Content capture is not implemented by @open-multi-agent/otel.')
+    }
+    this.provider = options.tracerProvider
+    this.tracer = options.tracer ?? options.tracerProvider!.getTracer(
+      options.instrumentationName ?? '@open-multi-agent/otel',
+      options.instrumentationVersion ?? '1.10.0',
+    )
+    this.shutdownOnShutdown = options.shutdownOnShutdown ?? false
+    this.metadata = {
+      ...(options.metadata?.environment ? {
+        'oma.environment': options.metadata.environment,
+        'deployment.environment.name': options.metadata.environment,
+      } : {}),
+      ...(options.metadata?.release ? {
+        'oma.release': options.metadata.release,
+        'service.version': options.metadata.release,
+      } : {}),
+      ...(options.metadata?.tenantId ? { 'oma.tenant.id': options.metadata.tenantId } : {}),
+      ...(options.metadata?.requestId ? { 'oma.request.id': options.metadata.requestId } : {}),
+    }
+  }
+
+  export(records: readonly TraceRecord[], _signal: AbortSignal): Promise<ExportResult> {
+    let exported = 0
+    for (const record of records) {
+      try {
+        this.accept(record)
+        exported++
+      } catch {
+        this.diagnostic('span_start_failed', 'The OpenTelemetry tracer rejected an OMA trace record.')
+        return Promise.resolve({ status: 'failure', exported, code: 'OTEL_RECORD_REJECTED' })
+      }
+    }
+    return Promise.resolve({ status: 'success', exported })
+  }
+
+  async forceFlush(signal: AbortSignal): Promise<ExportResult> {
+    if (!this.provider?.forceFlush) return lifecycleResult('success')
+    return this.delegateLifecycle(this.provider.forceFlush.bind(this.provider), signal, 'force_flush')
+  }
+
+  async shutdown(signal: AbortSignal): Promise<ExportResult> {
+    if (!this.shutdownOnShutdown || !this.provider?.shutdown) {
+      this.diagnostic('shutdown_skipped', 'Provider shutdown was skipped because the adapter does not own the provider.')
+      return lifecycleResult('success')
+    }
+    return this.delegateLifecycle(this.provider.shutdown.bind(this.provider), signal, 'shutdown')
+  }
+
+  private accept(record: TraceRecord): void {
+    if (record.recordType === 'span_start') {
+      this.start(record)
+      return
+    }
+    if (record.recordType === 'span_event') {
+      this.event(record)
+      return
+    }
+    this.end(record)
+  }
+
+  private start(record: SpanStartRecord): void {
+    const key = spanKey(record.traceId, record.spanId)
+    if (this.spans.has(key)) {
+      this.diagnostic('duplicate_span_start', 'Duplicate OMA span_start record ignored.')
+      return
+    }
+    this.spans.set(key, {
+      span: this.createSpan(record),
+      startUnixMs: record.startUnixMs,
+      linkKeys: new Set(record.links?.map(linkKey)),
+      ended: false,
+    })
+  }
+
+  private event(record: SpanEventRecord): void {
+    const entry = this.spans.get(spanKey(record.traceId, record.spanId))
+    if (!entry || entry.ended) {
+      this.diagnostic('orphan_event', 'OMA span_event arrived without an open OTel span and was ignored.')
+      return
+    }
+    const attributes: Attributes = {
+      ...baseAttributes(record),
+      ...this.metadata,
+      ...this.safeEventAttributes(record),
+      'oma.event.name': record.name,
+    }
+    entry.span.addEvent(`oma.${record.name}`, attributes, record.timestampUnixMs)
+    if (record.name === 'first_chunk') {
+      const ttftSeconds = Math.max(0, record.timestampUnixMs - entry.startUnixMs) / 1_000
+      entry.span.setAttribute('gen_ai.response.time_to_first_chunk', ttftSeconds)
+      entry.span.setAttribute('oma.ttft.ms', ttftSeconds * 1_000)
+    }
+  }
+
+  private end(record: SpanEndRecord): void {
+    const key = spanKey(record.traceId, record.spanId)
+    let entry = this.spans.get(key)
+    if (entry?.ended) {
+      this.diagnostic('duplicate_span_end', 'Duplicate OMA span_end record ignored.')
+      return
+    }
+    if (!entry) {
+      this.diagnostic('incomplete_span', 'OMA span_end arrived without span_start; a synthetic OTel span was created.')
+      const span = this.createSpan(record, true)
+      entry = {
+        span,
+        startUnixMs: record.startUnixMs,
+        linkKeys: new Set(record.links?.map(linkKey)),
+        ended: false,
+      }
+      this.spans.set(key, entry)
+    }
+    try {
+      entry.span.setAttributes({
+        ...spanAttributes(record),
+        ...this.metadata,
+        'oma.status': record.status.code,
+      })
+      this.addEndLinks(entry, record.links)
+      entry.span.setStatus(mapStatus(record.status))
+      if (record.error) {
+        const errorAttributes: Attributes = {
+          'error.type': record.error.code ?? record.error.kind,
+          'oma.error.kind': record.error.kind,
+          ...(record.error.code ? { 'oma.error.code': record.error.code } : {}),
+          ...(record.error.name ? { 'oma.error.name': record.error.name } : {}),
+          ...(record.error.retryable !== undefined ? { 'oma.error.retryable': record.error.retryable } : {}),
+          ...(record.error.httpStatus !== undefined ? { 'oma.error.http_status': record.error.httpStatus } : {}),
+          ...(record.error.provider ? { 'oma.error.provider': record.error.provider } : {}),
+          ...(record.error.attempt !== undefined ? { 'oma.error.attempt': record.error.attempt } : {}),
+        }
+        entry.span.setAttributes(errorAttributes)
+        entry.span.addEvent('exception', errorAttributes, record.endUnixMs)
+      }
+      entry.span.end(record.endUnixMs)
+      entry.ended = true
+    } catch {
+      this.diagnostic('span_end_failed', 'The OpenTelemetry tracer rejected an OMA span_end record.')
+      throw new Error('OTEL_SPAN_END_FAILED')
+    }
+  }
+
+  private createSpan(record: SpanStartRecord | SpanEndRecord, incomplete = false): Span {
+    const parent = record.parentSpanId
+      ? this.spans.get(spanKey(record.traceId, record.parentSpanId))
+      : undefined
+    const parentContext = parent ? trace.setSpan(context.active(), parent.span) : undefined
+    const attributes: Attributes = {
+      ...spanAttributes(record),
+      ...this.metadata,
+      ...(incomplete ? { 'oma.record.incomplete': true } : {}),
+    }
+    const span = this.tracer.startSpan(record.name, {
+      kind: mapSpanKind(record.kind),
+      attributes,
+      links: record.links?.map(mapLink),
+      startTime: record.startUnixMs,
+    }, parentContext)
+    return span
+  }
+
+  private safeEventAttributes(record: SpanEventRecord): Attributes {
+    return mapOmaAttributes(record.attributes)
+  }
+
+  private addEndLinks(entry: SpanEntry, links: readonly TraceLink[] | undefined): void {
+    for (const link of links ?? []) {
+      const key = linkKey(link)
+      if (entry.linkKeys.has(key)) continue
+      entry.span.addLink(mapLink(link))
+      entry.linkKeys.add(key)
+    }
+  }
+
+  private async delegateLifecycle(
+    action: () => Promise<void>,
+    signal: AbortSignal,
+    operation: 'force_flush' | 'shutdown',
+  ): Promise<ExportResult> {
+    if (signal.aborted) {
+      this.diagnostic(`${operation}_timeout` as OTelDiagnosticCode, `OpenTelemetry ${operation} timed out.`)
+      return lifecycleResult('failure', `OTEL_${operation.toUpperCase()}_TIMEOUT`)
+    }
+    const actionResult = Promise.resolve().then(action).then(
+      () => ({ kind: 'success' as const }),
+      () => ({ kind: 'failure' as const }),
+    )
+    let removeAbortListener: (() => void) | undefined
+    const timeout = new Promise<{ kind: 'timeout' }>((resolve) => {
+      const onAbort = () => resolve({ kind: 'timeout' })
+      signal.addEventListener('abort', onAbort, { once: true })
+      removeAbortListener = () => signal.removeEventListener('abort', onAbort)
+    })
+    const outcome = await Promise.race([actionResult, timeout])
+    removeAbortListener?.()
+    if (outcome.kind === 'success') return lifecycleResult('success')
+    if (outcome.kind === 'timeout') {
+      this.diagnostic(`${operation}_timeout` as OTelDiagnosticCode, `OpenTelemetry ${operation} timed out.`)
+      return lifecycleResult('failure', `OTEL_${operation.toUpperCase()}_TIMEOUT`)
+    }
+    this.diagnostic(`${operation}_failed` as OTelDiagnosticCode, `OpenTelemetry ${operation} failed.`)
+    return lifecycleResult('failure', `OTEL_${operation.toUpperCase()}_FAILED`)
+  }
+
+  private diagnostic(code: OTelDiagnosticCode, message: string): void {
+    try {
+      this.options.onDiagnostic?.({ code, message })
+    } catch {
+      // Diagnostics are best effort and must never alter OMA execution.
+    }
+  }
+}
+
+/** Build an OBS-2 TraceSink around the OTel adapter without adding OTel to core. */
+export function createOtelTraceSink(options: OTelTraceSinkOptions): TraceSink {
+  const { batching, ...exporterOptions } = options
+  return new BatchingTraceSink(new OTelTraceExporter(exporterOptions), batching)
+}
+
+/** Convenience factory for callers that want to provide the adapter to their own BatchingTraceSink. */
+export function createOtelTraceExporter(options: OTelTraceExporterOptions): OTelTraceExporter {
+  return new OTelTraceExporter(options)
+}

--- a/packages/otel/src/exporter.ts
+++ b/packages/otel/src/exporter.ts
@@ -26,11 +26,13 @@ import {
   mapStatus,
   spanAttributes,
 } from './mapping.js'
+import { PACKAGE_VERSION } from './version.js'
 
 export type OTelDiagnosticCode =
   | 'span_start_failed'
   | 'duplicate_span_start'
   | 'orphan_event'
+  | 'span_event_failed'
   | 'duplicate_span_end'
   | 'incomplete_span'
   | 'span_end_failed'
@@ -108,6 +110,28 @@ function lifecycleResult(status: 'success' | 'failure', code?: string): ExportRe
   return { status, exported: 0, ...(code ? { code } : {}) }
 }
 
+const ACCEPT_FAILURES: Record<TraceRecord['recordType'], {
+  readonly diagnostic: OTelDiagnosticCode
+  readonly message: string
+  readonly code: string
+}> = {
+  span_start: {
+    diagnostic: 'span_start_failed',
+    message: 'The OpenTelemetry tracer rejected an OMA span_start record.',
+    code: 'OTEL_SPAN_START_FAILED',
+  },
+  span_event: {
+    diagnostic: 'span_event_failed',
+    message: 'The OpenTelemetry tracer rejected an OMA span_event record.',
+    code: 'OTEL_SPAN_EVENT_FAILED',
+  },
+  span_end: {
+    diagnostic: 'span_end_failed',
+    message: 'The OpenTelemetry tracer rejected an OMA span_end record.',
+    code: 'OTEL_SPAN_END_FAILED',
+  },
+}
+
 /**
  * Adapts OMA TraceRecord v2 to an application-owned OpenTelemetry tracer.
  * It deliberately does not configure or replace OpenTelemetry's global provider.
@@ -132,7 +156,7 @@ export class OTelTraceExporter implements TraceExporter {
     this.provider = options.tracerProvider
     this.tracer = options.tracer ?? options.tracerProvider!.getTracer(
       options.instrumentationName ?? '@open-multi-agent/otel',
-      options.instrumentationVersion ?? '1.10.0',
+      options.instrumentationVersion ?? PACKAGE_VERSION,
     )
     this.shutdownOnShutdown = options.shutdownOnShutdown ?? false
     this.metadata = {
@@ -156,8 +180,9 @@ export class OTelTraceExporter implements TraceExporter {
         this.accept(record)
         exported++
       } catch {
-        this.diagnostic('span_start_failed', 'The OpenTelemetry tracer rejected an OMA trace record.')
-        return Promise.resolve({ status: 'failure', exported, code: 'OTEL_RECORD_REJECTED' })
+        const failure = ACCEPT_FAILURES[record.recordType]
+        this.diagnostic(failure.diagnostic, failure.message)
+        return Promise.resolve({ status: 'failure', exported, code: failure.code })
       }
     }
     return Promise.resolve({ status: 'success', exported })
@@ -245,38 +270,33 @@ export class OTelTraceExporter implements TraceExporter {
       }
       this.openSpans.set(key, entry)
     }
-    try {
-      entry.span.setAttributes({
-        ...spanAttributes(record),
-        ...this.metadata,
-        'oma.status': record.status.code,
-      })
-      this.addEndLinks(entry, record.links)
-      entry.span.setStatus(mapStatus(record.status))
-      if (record.error) {
-        const errorAttributes: Attributes = {
-          'error.type': record.error.code ?? record.error.kind,
-          'oma.error.kind': record.error.kind,
-          ...(record.error.code ? { 'oma.error.code': record.error.code } : {}),
-          ...(record.error.name ? { 'oma.error.name': record.error.name } : {}),
-          ...(record.error.retryable !== undefined ? { 'oma.error.retryable': record.error.retryable } : {}),
-          ...(record.error.httpStatus !== undefined ? { 'oma.error.http_status': record.error.httpStatus } : {}),
-          ...(record.error.provider ? { 'oma.error.provider': record.error.provider } : {}),
-          ...(record.error.attempt !== undefined ? { 'oma.error.attempt': record.error.attempt } : {}),
-        }
-        entry.span.setAttributes(errorAttributes)
-        entry.span.addEvent('exception', errorAttributes, record.endUnixMs)
+    entry.span.setAttributes({
+      ...spanAttributes(record),
+      ...this.metadata,
+      'oma.status': record.status.code,
+    })
+    this.addEndLinks(entry, record.links)
+    entry.span.setStatus(mapStatus(record.status))
+    if (record.error) {
+      const errorAttributes: Attributes = {
+        'error.type': record.error.code ?? record.error.kind,
+        'oma.error.kind': record.error.kind,
+        ...(record.error.code ? { 'oma.error.code': record.error.code } : {}),
+        ...(record.error.name ? { 'oma.error.name': record.error.name } : {}),
+        ...(record.error.retryable !== undefined ? { 'oma.error.retryable': record.error.retryable } : {}),
+        ...(record.error.httpStatus !== undefined ? { 'oma.error.http_status': record.error.httpStatus } : {}),
+        ...(record.error.provider ? { 'oma.error.provider': record.error.provider } : {}),
+        ...(record.error.attempt !== undefined ? { 'oma.error.attempt': record.error.attempt } : {}),
       }
-      entry.span.end(record.endUnixMs)
-      this.openSpans.delete(key)
-      if (record.kind === 'run') {
-        const rootContext = this.spanContexts.get(key)
-        if (rootContext) this.rememberRootContext(key, rootContext)
-        this.finalizeTrace(record.traceId, record.endUnixMs)
-      }
-    } catch {
-      this.diagnostic('span_end_failed', 'The OpenTelemetry tracer rejected an OMA span_end record.')
-      throw new Error('OTEL_SPAN_END_FAILED')
+      entry.span.setAttributes(errorAttributes)
+      entry.span.addEvent('exception', errorAttributes, record.endUnixMs)
+    }
+    entry.span.end(record.endUnixMs)
+    this.openSpans.delete(key)
+    if (record.kind === 'run') {
+      const rootContext = this.spanContexts.get(key)
+      if (rootContext) this.rememberRootContext(key, rootContext)
+      this.finalizeTrace(record.traceId, record.endUnixMs)
     }
   }
 

--- a/packages/otel/src/exporter.ts
+++ b/packages/otel/src/exporter.ts
@@ -1,7 +1,8 @@
-import { context, trace } from '@opentelemetry/api'
+import { context, SpanStatusCode, trace } from '@opentelemetry/api'
 import type {
   Attributes,
   Span,
+  SpanContext,
   Tracer,
   TracerProvider,
 } from '@opentelemetry/api'
@@ -91,8 +92,9 @@ interface SpanEntry {
   readonly span: Span
   readonly startUnixMs: number
   readonly linkKeys: Set<string>
-  ended: boolean
 }
+
+const MAX_RECENT_ROOT_CONTEXTS = 256
 
 function spanKey(traceId: string, spanId: string): string {
   return `${traceId}/${spanId}`
@@ -113,7 +115,10 @@ function lifecycleResult(status: 'success' | 'failure', code?: string): ExportRe
 export class OTelTraceExporter implements TraceExporter {
   private readonly tracer: Tracer
   private readonly provider?: OTelTracerProvider
-  private readonly spans = new Map<string, SpanEntry>()
+  private readonly openSpans = new Map<string, SpanEntry>()
+  private readonly spanContexts = new Map<string, SpanContext>()
+  private readonly traceSpanKeys = new Map<string, Set<string>>()
+  private readonly recentRootContexts = new Map<string, SpanContext>()
   private readonly shutdownOnShutdown: boolean
   private readonly metadata: Attributes
 
@@ -164,6 +169,10 @@ export class OTelTraceExporter implements TraceExporter {
   }
 
   async shutdown(signal: AbortSignal): Promise<ExportResult> {
+    this.finalizeAllOpenSpans(Date.now())
+    this.spanContexts.clear()
+    this.traceSpanKeys.clear()
+    this.recentRootContexts.clear()
     if (!this.shutdownOnShutdown || !this.provider?.shutdown) {
       this.diagnostic('shutdown_skipped', 'Provider shutdown was skipped because the adapter does not own the provider.')
       return lifecycleResult('success')
@@ -185,21 +194,22 @@ export class OTelTraceExporter implements TraceExporter {
 
   private start(record: SpanStartRecord): void {
     const key = spanKey(record.traceId, record.spanId)
-    if (this.spans.has(key)) {
+    if (this.openSpans.has(key) || this.spanContexts.has(key) || this.recentRootContexts.has(key)) {
       this.diagnostic('duplicate_span_start', 'Duplicate OMA span_start record ignored.')
       return
     }
-    this.spans.set(key, {
-      span: this.createSpan(record),
+    const span = this.createSpan(record)
+    this.registerSpanContext(record.traceId, key, span.spanContext())
+    this.openSpans.set(key, {
+      span,
       startUnixMs: record.startUnixMs,
       linkKeys: new Set(record.links?.map(linkKey)),
-      ended: false,
     })
   }
 
   private event(record: SpanEventRecord): void {
-    const entry = this.spans.get(spanKey(record.traceId, record.spanId))
-    if (!entry || entry.ended) {
+    const entry = this.openSpans.get(spanKey(record.traceId, record.spanId))
+    if (!entry) {
       this.diagnostic('orphan_event', 'OMA span_event arrived without an open OTel span and was ignored.')
       return
     }
@@ -219,21 +229,21 @@ export class OTelTraceExporter implements TraceExporter {
 
   private end(record: SpanEndRecord): void {
     const key = spanKey(record.traceId, record.spanId)
-    let entry = this.spans.get(key)
-    if (entry?.ended) {
+    let entry = this.openSpans.get(key)
+    if (!entry && (this.spanContexts.has(key) || this.recentRootContexts.has(key))) {
       this.diagnostic('duplicate_span_end', 'Duplicate OMA span_end record ignored.')
       return
     }
     if (!entry) {
       this.diagnostic('incomplete_span', 'OMA span_end arrived without span_start; a synthetic OTel span was created.')
       const span = this.createSpan(record, true)
+      this.registerSpanContext(record.traceId, key, span.spanContext())
       entry = {
         span,
         startUnixMs: record.startUnixMs,
         linkKeys: new Set(record.links?.map(linkKey)),
-        ended: false,
       }
-      this.spans.set(key, entry)
+      this.openSpans.set(key, entry)
     }
     try {
       entry.span.setAttributes({
@@ -258,7 +268,12 @@ export class OTelTraceExporter implements TraceExporter {
         entry.span.addEvent('exception', errorAttributes, record.endUnixMs)
       }
       entry.span.end(record.endUnixMs)
-      entry.ended = true
+      this.openSpans.delete(key)
+      if (record.kind === 'run') {
+        const rootContext = this.spanContexts.get(key)
+        if (rootContext) this.rememberRootContext(key, rootContext)
+        this.finalizeTrace(record.traceId, record.endUnixMs)
+      }
     } catch {
       this.diagnostic('span_end_failed', 'The OpenTelemetry tracer rejected an OMA span_end record.')
       throw new Error('OTEL_SPAN_END_FAILED')
@@ -267,9 +282,9 @@ export class OTelTraceExporter implements TraceExporter {
 
   private createSpan(record: SpanStartRecord | SpanEndRecord, incomplete = false): Span {
     const parent = record.parentSpanId
-      ? this.spans.get(spanKey(record.traceId, record.parentSpanId))
+      ? this.spanContexts.get(spanKey(record.traceId, record.parentSpanId))
       : undefined
-    const parentContext = parent ? trace.setSpan(context.active(), parent.span) : undefined
+    const parentContext = parent ? trace.setSpanContext(context.active(), parent) : undefined
     const attributes: Attributes = {
       ...spanAttributes(record),
       ...this.metadata,
@@ -278,7 +293,7 @@ export class OTelTraceExporter implements TraceExporter {
     const span = this.tracer.startSpan(record.name, {
       kind: mapSpanKind(record.kind),
       attributes,
-      links: record.links?.map(mapLink),
+      links: record.links?.map((link) => this.mapLink(link)),
       startTime: record.startUnixMs,
     }, parentContext)
     return span
@@ -292,8 +307,64 @@ export class OTelTraceExporter implements TraceExporter {
     for (const link of links ?? []) {
       const key = linkKey(link)
       if (entry.linkKeys.has(key)) continue
-      entry.span.addLink(mapLink(link))
+      entry.span.addLink(this.mapLink(link))
       entry.linkKeys.add(key)
+    }
+  }
+
+  private mapLink(link: TraceLink) {
+    const key = spanKey(link.traceId, link.spanId)
+    return mapLink(link, this.spanContexts.get(key) ?? this.recentRootContexts.get(key))
+  }
+
+  private registerSpanContext(traceId: string, key: string, spanContext: SpanContext): void {
+    this.spanContexts.set(key, spanContext)
+    let keys = this.traceSpanKeys.get(traceId)
+    if (!keys) {
+      keys = new Set()
+      this.traceSpanKeys.set(traceId, keys)
+    }
+    keys.add(key)
+  }
+
+  private rememberRootContext(key: string, spanContext: SpanContext): void {
+    this.recentRootContexts.delete(key)
+    this.recentRootContexts.set(key, spanContext)
+    while (this.recentRootContexts.size > MAX_RECENT_ROOT_CONTEXTS) {
+      const oldest = this.recentRootContexts.keys().next().value as string | undefined
+      if (oldest === undefined) break
+      this.recentRootContexts.delete(oldest)
+    }
+  }
+
+  private finalizeTrace(traceId: string, endUnixMs: number): void {
+    const keys = this.traceSpanKeys.get(traceId)
+    if (!keys) return
+    for (const key of keys) {
+      const entry = this.openSpans.get(key)
+      if (entry) this.finalizeIncompleteSpan(key, entry, endUnixMs)
+      this.spanContexts.delete(key)
+    }
+    this.traceSpanKeys.delete(traceId)
+  }
+
+  private finalizeAllOpenSpans(endUnixMs: number): void {
+    for (const [key, entry] of this.openSpans) {
+      this.finalizeIncompleteSpan(key, entry, endUnixMs)
+    }
+    this.openSpans.clear()
+  }
+
+  private finalizeIncompleteSpan(key: string, entry: SpanEntry, endUnixMs: number): void {
+    this.diagnostic('incomplete_span', 'OMA trace closed without span_end; the open OTel span was ended as incomplete.')
+    try {
+      entry.span.setAttribute('oma.record.incomplete', true)
+      entry.span.setStatus({ code: SpanStatusCode.UNSET })
+      entry.span.end(endUnixMs)
+    } catch {
+      this.diagnostic('span_end_failed', 'The OpenTelemetry tracer rejected cleanup of an incomplete OMA span.')
+    } finally {
+      this.openSpans.delete(key)
     }
   }
 

--- a/packages/otel/src/index.ts
+++ b/packages/otel/src/index.ts
@@ -1,0 +1,25 @@
+export {
+  OMA_OTEL_MAPPING_VERSION,
+  OMA_SCHEMA_VERSION,
+  OTEL_GENAI_SEMCONV_VERSION,
+  addGenAiAttributes,
+  isSafeOmaAttribute,
+  mapLink,
+  mapOmaAttributes,
+  mapSpanKind,
+  mapStatus,
+} from './mapping.js'
+export {
+  createOtelTraceExporter,
+  createOtelTraceSink,
+  OTelTraceExporter,
+} from './exporter.js'
+export type {
+  OTelDiagnostic,
+  OTelDiagnosticCode,
+  OTelContentCaptureExtension,
+  OTelMetadata,
+  OTelTraceExporterOptions,
+  OTelTraceSinkOptions,
+  OTelTracerProvider,
+} from './exporter.js'

--- a/packages/otel/src/mapping.ts
+++ b/packages/otel/src/mapping.ts
@@ -1,0 +1,217 @@
+import {
+  SpanKind as OTelSpanKind,
+  SpanStatusCode,
+  TraceFlags,
+} from '@opentelemetry/api'
+import type {
+  AttributeValue,
+  Attributes,
+  Link,
+  SpanContext,
+  SpanStatus,
+} from '@opentelemetry/api'
+import type {
+  RunStatus,
+  SpanEndRecord,
+  SpanKind,
+  SpanStartRecord,
+  TraceAttributeValue,
+  TraceLink,
+  TraceRecordBase,
+} from '@open-multi-agent/core'
+
+/** Version of OMA's stable TraceRecord-to-OTel mapping. */
+export const OMA_OTEL_MAPPING_VERSION = '1.0.0'
+
+/**
+ * The GenAI conventions are development-status and deliberately remain a
+ * compatibility mapping rather than part of OMA's stable public schema.
+ */
+export const OTEL_GENAI_SEMCONV_VERSION = '1.43.0-development'
+
+export const OMA_SCHEMA_VERSION = 2
+
+const CONTENT_ATTRIBUTE = /(^|[._-])(prompt|completion|content|message|messages|argument|arguments|result|results|reasoning|thinking|payload)($|[._-])/i
+const SECRET_ATTRIBUTE = /(^|[._-])(authorization|cookie|set_cookie|api[_-]?key|password|passwd|secret|access[_-]?token|refresh[_-]?token|private[_-]?key)($|[._-])/i
+const SAFE_OMA_ATTRIBUTES = new Set([
+  'oma.agent.attempt',
+  'oma.agent.name',
+  'oma.agent.tool_calls',
+  'oma.agent.turns',
+  'oma.approval.approved',
+  'oma.callback.name',
+  'oma.checkpoint.mode',
+  'oma.consensus.accepted',
+  'oma.consensus.round',
+  'oma.consensus.rounds',
+  'oma.consensus.scope',
+  'oma.consensus.verdict',
+  'oma.cost.amount',
+  'oma.cost.currency',
+  'oma.cost.price_version',
+  'oma.cost.source',
+  'oma.environment',
+  'oma.llm.model',
+  'oma.llm.provider',
+  'oma.llm.response_model',
+  'oma.llm.turn',
+  'oma.model',
+  'oma.phase',
+  'oma.plan.approved',
+  'oma.plan.task_count',
+  'oma.provider',
+  'oma.release',
+  'oma.request.id',
+  'oma.retry.attempt',
+  'oma.retry.delay_ms',
+  'oma.retry.max_attempts',
+  'oma.status',
+  'oma.stream.type',
+  'oma.task.id',
+  'oma.task.retries',
+  'oma.tenant.id',
+  'oma.tool.is_error',
+  'oma.tool.name',
+  'oma.ttft.ms',
+])
+
+function toAttributeValue(value: TraceAttributeValue): AttributeValue {
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value
+  return [...value] as AttributeValue
+}
+
+function isTokenUsageAttribute(key: string): boolean {
+  return key.startsWith('oma.usage.') && (key.endsWith('_tokens') || key.endsWith('.tokens'))
+}
+
+/** OMA content is never exported by this package; only an explicit safe metadata allowlist crosses the boundary. */
+export function isSafeOmaAttribute(key: string): boolean {
+  if (!key.startsWith('oma.')) return false
+  if (isTokenUsageAttribute(key)) return true
+  if (CONTENT_ATTRIBUTE.test(key) || SECRET_ATTRIBUTE.test(key)) return false
+  return SAFE_OMA_ATTRIBUTES.has(key)
+}
+
+export function mapOmaAttributes(
+  attributes: Readonly<Record<string, TraceAttributeValue>>,
+): Attributes {
+  const mapped: Attributes = {}
+  for (const [key, value] of Object.entries(attributes)) {
+    if (isSafeOmaAttribute(key)) mapped[key] = toAttributeValue(value)
+  }
+  return mapped
+}
+
+function readNumber(attributes: Attributes, ...keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = attributes[key]
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+  }
+  return undefined
+}
+
+function readString(attributes: Attributes, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = attributes[key]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return undefined
+}
+
+/** Add a bounded compatibility subset of the current GenAI semantic conventions. */
+export function addGenAiAttributes(kind: SpanKind, attributes: Attributes): void {
+  if (kind === 'llm') attributes['gen_ai.operation.name'] = 'chat'
+  if (kind === 'agent') attributes['gen_ai.operation.name'] = 'invoke_agent'
+  if (kind === 'tool') attributes['gen_ai.operation.name'] = 'execute_tool'
+
+  const provider = readString(attributes, 'oma.llm.provider', 'oma.provider', 'oma.error.provider')
+  if (provider !== undefined) attributes['gen_ai.provider.name'] = provider
+
+  const model = readString(attributes, 'oma.llm.model', 'oma.model')
+  if (model !== undefined) attributes['gen_ai.request.model'] = model
+
+  const responseModel = readString(attributes, 'oma.llm.response_model', 'oma.response.model')
+  if (responseModel !== undefined) attributes['gen_ai.response.model'] = responseModel
+
+  const inputTokens = readNumber(attributes, 'oma.usage.input_tokens')
+  if (inputTokens !== undefined) attributes['gen_ai.usage.input_tokens'] = inputTokens
+  const outputTokens = readNumber(attributes, 'oma.usage.output_tokens')
+  if (outputTokens !== undefined) attributes['gen_ai.usage.output_tokens'] = outputTokens
+  const cacheRead = readNumber(attributes, 'oma.usage.cache_read_input_tokens', 'oma.usage.cache_read.input_tokens')
+  if (cacheRead !== undefined) attributes['gen_ai.usage.cache_read.input_tokens'] = cacheRead
+  const cacheCreation = readNumber(attributes, 'oma.usage.cache_creation_input_tokens', 'oma.usage.cache_creation.input_tokens')
+  if (cacheCreation !== undefined) attributes['gen_ai.usage.cache_creation.input_tokens'] = cacheCreation
+  const reasoningTokens = readNumber(attributes, 'oma.usage.reasoning_output_tokens', 'oma.usage.reasoning.output_tokens')
+  if (reasoningTokens !== undefined) attributes['gen_ai.usage.reasoning.output_tokens'] = reasoningTokens
+
+  const toolName = readString(attributes, 'oma.tool.name')
+  if (toolName !== undefined && kind === 'tool') attributes['gen_ai.tool.name'] = toolName
+
+  const ttftMs = readNumber(attributes, 'oma.ttft.ms')
+  if (ttftMs !== undefined) attributes['gen_ai.response.time_to_first_chunk'] = ttftMs / 1_000
+}
+
+export function mapSpanKind(kind: SpanKind): OTelSpanKind {
+  return kind === 'llm' ? OTelSpanKind.CLIENT : OTelSpanKind.INTERNAL
+}
+
+/** Keep successful OMA instrumentation spans Unset, per the OTel Trace API guidance. */
+export function mapStatus(status: RunStatus): SpanStatus {
+  switch (status.code) {
+    case 'error':
+    case 'timeout':
+    case 'budget_exhausted':
+      return {
+        code: SpanStatusCode.ERROR,
+        ...(status.message ? { message: 'oma.' + status.code } : {}),
+      }
+    case 'ok':
+    case 'cancelled':
+    case 'rejected':
+    case 'skipped':
+      return { code: SpanStatusCode.UNSET }
+  }
+  return { code: SpanStatusCode.UNSET }
+}
+
+export function mapLink(link: TraceLink): Link {
+  const context: SpanContext = {
+    traceId: link.traceId,
+    spanId: link.spanId,
+    traceFlags: TraceFlags.SAMPLED,
+    isRemote: false,
+  }
+  return {
+    context,
+    attributes: {
+      'oma.link.relation': link.relation,
+      ...mapOmaAttributes(link.attributes ?? {}),
+    },
+  }
+}
+
+export function baseAttributes(record: TraceRecordBase & { readonly recordType: string }): Attributes {
+  return {
+    'oma.schema.version': OMA_SCHEMA_VERSION,
+    'oma.otel.mapping.version': OMA_OTEL_MAPPING_VERSION,
+    'oma.otel.gen_ai_semconv.version': OTEL_GENAI_SEMCONV_VERSION,
+    'oma.record.id': record.recordId,
+    'oma.record.sequence': record.sequence,
+    'oma.record.type': record.recordType,
+    'oma.run.id': record.runId,
+    'oma.run.attempt': record.attempt,
+    'oma.trace.id': record.traceId,
+    'oma.span.id': record.spanId,
+    ...(record.parentSpanId ? { 'oma.parent_span.id': record.parentSpanId } : {}),
+  }
+}
+
+export function spanAttributes(record: SpanStartRecord | SpanEndRecord): Attributes {
+  const attributes: Attributes = {
+    ...baseAttributes(record),
+    'oma.span.kind': record.kind,
+    ...mapOmaAttributes(record.attributes),
+  }
+  addGenAiAttributes(record.kind, attributes)
+  return attributes
+}

--- a/packages/otel/src/mapping.ts
+++ b/packages/otel/src/mapping.ts
@@ -174,17 +174,21 @@ export function mapStatus(status: RunStatus): SpanStatus {
   return { code: SpanStatusCode.UNSET }
 }
 
-export function mapLink(link: TraceLink): Link {
-  const context: SpanContext = {
+export function mapLink(link: TraceLink, resolvedContext?: SpanContext): Link {
+  const resolved = resolvedContext !== undefined
+  const context: SpanContext = resolvedContext ?? {
     traceId: link.traceId,
     spanId: link.spanId,
-    traceFlags: TraceFlags.SAMPLED,
-    isRemote: false,
+    traceFlags: TraceFlags.NONE,
+    isRemote: true,
   }
   return {
     context,
     attributes: {
       'oma.link.relation': link.relation,
+      'oma.link.resolved': resolved,
+      'oma.link.target.trace_id': link.traceId,
+      'oma.link.target.span_id': link.spanId,
       ...mapOmaAttributes(link.attributes ?? {}),
     },
   }

--- a/packages/otel/src/version.ts
+++ b/packages/otel/src/version.ts
@@ -3,4 +3,4 @@
  * instrumentationVersion. A guard test asserts it matches package.json, so
  * bumping the package without bumping this constant fails CI.
  */
-export const PACKAGE_VERSION = '1.10.0'
+export const PACKAGE_VERSION = '0.1.0'

--- a/packages/otel/src/version.ts
+++ b/packages/otel/src/version.ts
@@ -1,0 +1,6 @@
+/**
+ * The published package version, used as the default tracer
+ * instrumentationVersion. A guard test asserts it matches package.json, so
+ * bumping the package without bumping this constant fails CI.
+ */
+export const PACKAGE_VERSION = '1.10.0'

--- a/packages/otel/tests/otel-exporter.test.ts
+++ b/packages/otel/tests/otel-exporter.test.ts
@@ -1,11 +1,11 @@
-import { SpanStatusCode, TraceFlags } from '@opentelemetry/api'
+import { context, ROOT_CONTEXT, SpanStatusCode, TraceFlags, trace } from '@opentelemetry/api'
 import {
   BasicTracerProvider,
   InMemorySpanExporter,
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base'
 import { describe, expect, it } from 'vitest'
-import type { Tracer } from '@opentelemetry/api'
+import type { Context, ContextManager, Tracer } from '@opentelemetry/api'
 import type {
   SpanEndRecord,
   SpanEventRecord,
@@ -140,6 +140,32 @@ describe('@open-multi-agent/otel', () => {
     expect(() => createOtelTraceExporter({})).toThrow(/exactly one of tracer or tracerProvider/)
     const { provider } = inMemory()
     expect(() => createOtelTraceExporter({ tracer: provider.getTracer('test'), tracerProvider: provider })).toThrow(/exactly one/)
+  })
+
+  it('starts OMA root spans from ROOT_CONTEXT instead of the ambient application span', async () => {
+    const { exporter, provider } = inMemory()
+    const appSpan = provider.getTracer('app').startSpan('app.request')
+    const ambient = trace.setSpan(ROOT_CONTEXT, appSpan)
+    const manager: ContextManager = {
+      active: () => ambient,
+      with: (_context, fn, thisArg, ...args) => fn.call(thisArg, ...args),
+      bind: <T>(_context: Context, target: T) => target,
+      enable: () => manager,
+      disable: () => manager,
+    }
+    expect(context.setGlobalContextManager(manager)).toBe(true)
+    try {
+      const adapter = createOtelTraceExporter({ tracerProvider: provider })
+      await exportRecords(adapter, [
+        start(ROOT_SPAN_ID, 'oma.run', 'run'),
+        end(ROOT_SPAN_ID, 'oma.run', 'run'),
+      ])
+    } finally {
+      context.disable()
+      appSpan.end()
+    }
+    const root = exporter.getFinishedSpans().find((span) => span.name === 'oma.run')!
+    expect(root.parentSpanContext).toBeUndefined()
   })
 
   it('maps the full OMA hierarchy, links, event records, and OMA correlation attributes with the official in-memory exporter', async () => {

--- a/packages/otel/tests/otel-exporter.test.ts
+++ b/packages/otel/tests/otel-exporter.test.ts
@@ -1,0 +1,403 @@
+import { SpanStatusCode } from '@opentelemetry/api'
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base'
+import { describe, expect, it } from 'vitest'
+import type { Tracer } from '@opentelemetry/api'
+import type {
+  SpanEndRecord,
+  SpanEventRecord,
+  SpanStartRecord,
+  TraceAttributeValue,
+  TraceLink,
+} from '@open-multi-agent/core'
+import {
+  createOtelTraceExporter,
+  OTelTraceExporter,
+  type OTelTracerProvider,
+} from '../src/index.js'
+
+const TRACE_ID = 'a'.repeat(32)
+const ROOT_SPAN_ID = '1'.repeat(16)
+
+let nextRecord = 0
+
+function start(
+  spanId: string,
+  name: string,
+  kind: SpanStartRecord['kind'],
+  options: {
+    parentSpanId?: string
+    attributes?: Readonly<Record<string, TraceAttributeValue>>
+    links?: readonly TraceLink[]
+    startUnixMs?: number
+  } = {},
+): SpanStartRecord {
+  const startUnixMs = options.startUnixMs ?? 1_000
+  return {
+    schemaVersion: 2,
+    recordId: `start-${++nextRecord}`,
+    sequence: nextRecord,
+    timestampUnixMs: startUnixMs,
+    runId: 'run-42',
+    attempt: 2,
+    traceId: TRACE_ID,
+    spanId,
+    ...(options.parentSpanId ? { parentSpanId: options.parentSpanId } : {}),
+    recordType: 'span_start',
+    kind,
+    name,
+    startUnixMs,
+    ...(options.links ? { links: options.links } : {}),
+    attributes: options.attributes ?? {},
+  }
+}
+
+function event(
+  spanId: string,
+  name: SpanEventRecord['name'],
+  attributes: Readonly<Record<string, TraceAttributeValue>> = {},
+  timestampUnixMs = 1_500,
+): SpanEventRecord {
+  return {
+    schemaVersion: 2,
+    recordId: `event-${++nextRecord}`,
+    sequence: nextRecord,
+    timestampUnixMs,
+    runId: 'run-42',
+    attempt: 2,
+    traceId: TRACE_ID,
+    spanId,
+    recordType: 'span_event',
+    name,
+    attributes,
+  }
+}
+
+function end(
+  spanId: string,
+  name: string,
+  kind: SpanEndRecord['kind'],
+  options: {
+    parentSpanId?: string
+    attributes?: Readonly<Record<string, TraceAttributeValue>>
+    links?: readonly TraceLink[]
+    status?: SpanEndRecord['status']
+    error?: SpanEndRecord['error']
+    startUnixMs?: number
+    endUnixMs?: number
+  } = {},
+): SpanEndRecord {
+  const startUnixMs = options.startUnixMs ?? 1_000
+  const endUnixMs = options.endUnixMs ?? 2_000
+  return {
+    schemaVersion: 2,
+    recordId: `end-${++nextRecord}`,
+    sequence: nextRecord,
+    timestampUnixMs: endUnixMs,
+    runId: 'run-42',
+    attempt: 2,
+    traceId: TRACE_ID,
+    spanId,
+    ...(options.parentSpanId ? { parentSpanId: options.parentSpanId } : {}),
+    recordType: 'span_end',
+    kind,
+    name,
+    startUnixMs,
+    endUnixMs,
+    durationMs: endUnixMs - startUnixMs,
+    status: options.status ?? { code: 'ok' },
+    ...(options.error ? { error: options.error } : {}),
+    ...(options.links ? { links: options.links } : {}),
+    attributes: options.attributes ?? {},
+  }
+}
+
+function inMemory() {
+  const exporter = new InMemorySpanExporter()
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  })
+  return { exporter, provider }
+}
+
+async function exportRecords(adapter: OTelTraceExporter, records: readonly (SpanStartRecord | SpanEventRecord | SpanEndRecord)[]) {
+  const result = await adapter.export(records, new AbortController().signal)
+  await adapter.forceFlush(new AbortController().signal)
+  return result
+}
+
+describe('@open-multi-agent/otel', () => {
+  it('requires an explicitly owned tracer or tracerProvider and never falls back to globals', () => {
+    expect(() => createOtelTraceExporter({})).toThrow(/exactly one of tracer or tracerProvider/)
+    const { provider } = inMemory()
+    expect(() => createOtelTraceExporter({ tracer: provider.getTracer('test'), tracerProvider: provider })).toThrow(/exactly one/)
+  })
+
+  it('maps the full OMA hierarchy, links, event records, and OMA correlation attributes with the official in-memory exporter', async () => {
+    const { exporter, provider } = inMemory()
+    const adapter = createOtelTraceExporter({
+      tracerProvider: provider,
+      metadata: { environment: 'test', release: '2026.07', tenantId: 'tenant-opaque', requestId: 'request-opaque' },
+    })
+    const agentId = '2'.repeat(16)
+    const llmId = '3'.repeat(16)
+    const toolId = '4'.repeat(16)
+    const taskId = '5'.repeat(16)
+    const planId = '6'.repeat(16)
+    const consensusId = '7'.repeat(16)
+    const checkpointId = '8'.repeat(16)
+    const callbackId = '9'.repeat(16)
+    const links: readonly TraceLink[] = [
+      { traceId: 'b'.repeat(32), spanId: 'b'.repeat(16), relation: 'depends_on' },
+      { traceId: 'c'.repeat(32), spanId: 'c'.repeat(16), relation: 'delegated_from' },
+      { traceId: 'd'.repeat(32), spanId: 'd'.repeat(16), relation: 'consumed' },
+      { traceId: 'e'.repeat(32), spanId: 'e'.repeat(16), relation: 'continued_from' },
+    ]
+
+    const result = await exportRecords(adapter, [
+      start(ROOT_SPAN_ID, 'oma.run', 'run'),
+      start(planId, 'coordinator.decomposition', 'plan', { parentSpanId: ROOT_SPAN_ID }),
+      start(taskId, 'oma.task', 'task', { parentSpanId: ROOT_SPAN_ID }),
+      event(taskId, 'retry_scheduled', { 'oma.retry.attempt': 2, 'oma.retry.delay_ms': 25 }),
+      event(taskId, 'stream_chunk', { 'oma.stream.type': 'text' }, 1_550),
+      start(agentId, 'oma.agent', 'agent', { parentSpanId: taskId }),
+      start(llmId, 'chat', 'llm', {
+        parentSpanId: agentId,
+        attributes: {
+          'oma.llm.model': 'gpt-test',
+          'oma.llm.provider': 'openai',
+          'oma.usage.input_tokens': 21,
+          'oma.usage.output_tokens': 34,
+          'oma.usage.cache_read_input_tokens': 5,
+          'oma.usage.cache_creation_input_tokens': 3,
+          'oma.usage.reasoning_output_tokens': 8,
+          'oma.cost.amount': 0.12,
+          'oma.cost.currency': 'USD',
+        },
+      }),
+      event(llmId, 'first_chunk', {}, 1_600),
+      start(toolId, 'delegate_to_agent', 'tool', {
+        parentSpanId: agentId,
+        attributes: { 'oma.tool.name': 'delegate_to_agent', 'oma.tool.is_error': false },
+      }),
+      start(consensusId, 'consensus.judge', 'consensus', { parentSpanId: ROOT_SPAN_ID }),
+      start(checkpointId, 'checkpoint.restore', 'checkpoint', { parentSpanId: ROOT_SPAN_ID }),
+      start(callbackId, 'coordinator.synthesis', 'callback', { parentSpanId: ROOT_SPAN_ID }),
+      end(toolId, 'delegate_to_agent', 'tool', { parentSpanId: agentId, attributes: { 'oma.tool.name': 'delegate_to_agent' } }),
+      end(llmId, 'chat', 'llm', { parentSpanId: agentId, attributes: {
+        'oma.llm.model': 'gpt-test',
+        'oma.llm.provider': 'openai',
+        'oma.usage.input_tokens': 21,
+        'oma.usage.output_tokens': 34,
+        'oma.usage.cache_read_input_tokens': 5,
+        'oma.usage.cache_creation_input_tokens': 3,
+        'oma.usage.reasoning_output_tokens': 8,
+        'oma.cost.amount': 0.12,
+        'oma.cost.currency': 'USD',
+      } }),
+      end(agentId, 'oma.agent', 'agent', { parentSpanId: taskId }),
+      end(taskId, 'oma.task', 'task', { parentSpanId: ROOT_SPAN_ID, links }),
+      end(planId, 'coordinator.decomposition', 'plan', { parentSpanId: ROOT_SPAN_ID }),
+      end(consensusId, 'consensus.judge', 'consensus', { parentSpanId: ROOT_SPAN_ID }),
+      end(checkpointId, 'checkpoint.restore', 'checkpoint', { parentSpanId: ROOT_SPAN_ID }),
+      end(callbackId, 'coordinator.synthesis', 'callback', { parentSpanId: ROOT_SPAN_ID }),
+      end(ROOT_SPAN_ID, 'oma.run', 'run'),
+    ])
+
+    expect(result).toEqual({ status: 'success', exported: 21 })
+    const spans = exporter.getFinishedSpans()
+    expect(spans).toHaveLength(9)
+    const root = spans.find((span) => span.name === 'oma.run')!
+    const agent = spans.find((span) => span.name === 'oma.agent')!
+    const llm = spans.find((span) => span.name === 'chat')!
+    const task = spans.find((span) => span.name === 'oma.task')!
+    expect(agent.parentSpanContext?.spanId).toBe(task.spanContext().spanId)
+    expect(llm.parentSpanContext?.spanId).toBe(agent.spanContext().spanId)
+    expect(root.attributes).toMatchObject({
+      'oma.schema.version': 2,
+      'oma.run.id': 'run-42',
+      'oma.run.attempt': 2,
+      'oma.trace.id': TRACE_ID,
+      'oma.span.id': ROOT_SPAN_ID,
+      'oma.otel.mapping.version': '1.0.0',
+      'oma.otel.gen_ai_semconv.version': '1.43.0-development',
+      'deployment.environment.name': 'test',
+      'service.version': '2026.07',
+      'oma.tenant.id': 'tenant-opaque',
+      'oma.request.id': 'request-opaque',
+    })
+    expect(task.links).toHaveLength(4)
+    expect(task.links.map((link) => link.attributes['oma.link.relation']))
+      .toEqual(['depends_on', 'delegated_from', 'consumed', 'continued_from'])
+    expect(task.events.some((item) => item.name === 'oma.retry_scheduled')).toBe(true)
+    expect(task.events.some((item) => item.name === 'oma.stream_chunk')).toBe(true)
+    expect(llm.attributes).toMatchObject({
+      'gen_ai.operation.name': 'chat',
+      'gen_ai.provider.name': 'openai',
+      'gen_ai.request.model': 'gpt-test',
+      'gen_ai.usage.input_tokens': 21,
+      'gen_ai.usage.output_tokens': 34,
+      'gen_ai.usage.cache_read.input_tokens': 5,
+      'gen_ai.usage.cache_creation.input_tokens': 3,
+      'gen_ai.usage.reasoning.output_tokens': 8,
+      'oma.cost.amount': 0.12,
+      'oma.cost.currency': 'USD',
+      'gen_ai.response.time_to_first_chunk': 0.6,
+    })
+    expect(llm.events.some((item) => item.name === 'oma.first_chunk')).toBe(true)
+  })
+
+  it('maps OMA error statuses without leaking error messages and keeps non-errors Unset', async () => {
+    const { exporter, provider } = inMemory()
+    const adapter = createOtelTraceExporter({ tracerProvider: provider })
+    const errorId = 'f'.repeat(16)
+    const skippedId = '0'.repeat(15) + '1'
+    await exportRecords(adapter, [
+      start(errorId, 'chat', 'llm'),
+      end(errorId, 'chat', 'llm', {
+        status: { code: 'timeout', message: 'provider said: secret prompt text' },
+        error: { kind: 'timeout', code: 'LLM_TIMEOUT', message: 'secret prompt text', provider: 'openai' },
+      }),
+      start(skippedId, 'oma.task', 'task'),
+      end(skippedId, 'oma.task', 'task', { status: { code: 'skipped' } }),
+    ])
+    const timeout = exporter.getFinishedSpans().find((span) => span.name === 'chat')!
+    const skipped = exporter.getFinishedSpans().find((span) => span.name === 'oma.task')!
+    expect(timeout.status.code).toBe(SpanStatusCode.ERROR)
+    expect(timeout.attributes).toMatchObject({
+      'oma.status': 'timeout',
+      'error.type': 'LLM_TIMEOUT',
+      'oma.error.provider': 'openai',
+    })
+    expect(JSON.stringify({ attributes: timeout.attributes, events: timeout.events })).not.toContain('secret prompt text')
+    expect(skipped.status.code).toBe(SpanStatusCode.UNSET)
+  })
+
+  it('drops prompt, completion, tool payload, and reasoning content while preserving counted usage', async () => {
+    const { exporter, provider } = inMemory()
+    const adapter = createOtelTraceExporter({ tracerProvider: provider })
+    const id = '2'.repeat(15) + 'a'
+    await exportRecords(adapter, [
+      start(id, 'chat', 'llm', { attributes: {
+        'oma.prompt': 'private prompt',
+        'oma.completion': 'private completion',
+        'oma.tool.arguments': '{"credential":"do-not-export"}',
+        'oma.tool.result': 'private result',
+        'oma.reasoning.content': 'chain of thought',
+        'oma.request.body': 'raw request body',
+        'oma.raw': 'unclassified raw payload',
+        'oma.usage.input_tokens': 9,
+        'oma.usage.reasoning_output_tokens': 4,
+      } }),
+      end(id, 'chat', 'llm', { attributes: {
+        'oma.prompt': 'private prompt',
+        'oma.completion': 'private completion',
+        'oma.tool.arguments': '{"credential":"do-not-export"}',
+        'oma.tool.result': 'private result',
+        'oma.reasoning.content': 'chain of thought',
+        'oma.request.body': 'raw request body',
+        'oma.raw': 'unclassified raw payload',
+        'oma.usage.input_tokens': 9,
+        'oma.usage.reasoning_output_tokens': 4,
+      } }),
+    ])
+    const span = exporter.getFinishedSpans()[0]!
+    expect(span.attributes).toMatchObject({
+      'oma.usage.input_tokens': 9,
+      'gen_ai.usage.input_tokens': 9,
+      'gen_ai.usage.reasoning.output_tokens': 4,
+    })
+    expect(JSON.stringify(span.attributes)).not.toMatch(/private|credential|chain of thought|raw request|unclassified/)
+  })
+
+  it('reports duplicate, out-of-order, and incomplete records without throwing or exporting content', async () => {
+    const { exporter, provider } = inMemory()
+    const diagnostics: string[] = []
+    const adapter = createOtelTraceExporter({ tracerProvider: provider, onDiagnostic: (item) => diagnostics.push(item.code) })
+    const id = '3'.repeat(15) + 'b'
+    const orphanId = '4'.repeat(15) + 'c'
+    const ended = end(id, 'oma.task', 'task')
+    const result = await exportRecords(adapter, [
+      event(orphanId, 'stream_chunk', { 'oma.stream.type': 'text', 'oma.completion': 'not exported' }),
+      ended,
+      start(id, 'oma.task', 'task'),
+      start(id, 'oma.task', 'task'),
+      ended,
+    ])
+    expect(result).toEqual({ status: 'success', exported: 5 })
+    expect(diagnostics).toEqual(expect.arrayContaining(['orphan_event', 'incomplete_span', 'duplicate_span_start', 'duplicate_span_end']))
+    const span = exporter.getFinishedSpans().find((item) => item.name === 'oma.task')!
+    expect(span.attributes['oma.record.incomplete']).toBe(true)
+    expect(JSON.stringify({ attributes: span.attributes, events: span.events })).not.toContain('not exported')
+  })
+
+  it('maps local span rejection and provider flush/shutdown failures to OBS-2 ExportResult without taking provider ownership by default', async () => {
+    const { provider } = inMemory()
+    const diagnostics: string[] = []
+    const throwingTracer = {
+      ...provider.getTracer('test'),
+      startSpan: () => { throw new Error('local OTel failure') },
+    } as unknown as Tracer
+    const rejected = createOtelTraceExporter({ tracer: throwingTracer })
+    await expect(rejected.export([start('5'.repeat(16), 'oma.run', 'run')], new AbortController().signal))
+      .resolves.toEqual({ status: 'failure', exported: 0, code: 'OTEL_RECORD_REJECTED' })
+
+    let starts = 0
+    const partiallyRejectingTracer = {
+      ...provider.getTracer('test'),
+      startSpan: (...args: Parameters<Tracer['startSpan']>) => {
+        starts++
+        if (starts === 2) throw new Error('second record rejected')
+        return provider.getTracer('test').startSpan(...args)
+      },
+    } as unknown as Tracer
+    const partial = createOtelTraceExporter({ tracer: partiallyRejectingTracer })
+    await expect(partial.export([
+      start('6'.repeat(16), 'oma.run', 'run'),
+      start('7'.repeat(16), 'oma.task', 'task'),
+    ], new AbortController().signal)).resolves.toEqual({
+      status: 'failure', exported: 1, code: 'OTEL_RECORD_REJECTED',
+    })
+
+    let flushed = 0
+    let shutdown = 0
+    const lifecycleProvider: OTelTracerProvider = {
+      getTracer: provider.getTracer.bind(provider),
+      forceFlush: async () => { flushed++ },
+      shutdown: async () => { shutdown++ },
+    }
+    const userOwned = createOtelTraceExporter({ tracerProvider: lifecycleProvider, onDiagnostic: (item) => diagnostics.push(item.code) })
+    await expect(userOwned.forceFlush(new AbortController().signal)).resolves.toEqual({ status: 'success', exported: 0 })
+    await expect(userOwned.shutdown(new AbortController().signal)).resolves.toEqual({ status: 'success', exported: 0 })
+    expect(flushed).toBe(1)
+    expect(shutdown).toBe(0)
+    expect(diagnostics).toContain('shutdown_skipped')
+
+    const owned = createOtelTraceExporter({ tracerProvider: lifecycleProvider, shutdownOnShutdown: true })
+    await owned.shutdown(new AbortController().signal)
+    expect(shutdown).toBe(1)
+
+    const rejectingProvider: OTelTracerProvider = {
+      getTracer: provider.getTracer.bind(provider),
+      forceFlush: async () => { throw new Error('collector unreachable') },
+    }
+    const rejecting = createOtelTraceExporter({ tracerProvider: rejectingProvider })
+    await expect(rejecting.forceFlush(new AbortController().signal)).resolves.toEqual({
+      status: 'failure', exported: 0, code: 'OTEL_FORCE_FLUSH_FAILED',
+    })
+
+    const hangingProvider: OTelTracerProvider = {
+      getTracer: provider.getTracer.bind(provider),
+      forceFlush: async () => new Promise<void>(() => {}),
+    }
+    const hanging = createOtelTraceExporter({ tracerProvider: hangingProvider })
+    const controller = new AbortController()
+    controller.abort()
+    await expect(hanging.forceFlush(controller.signal)).resolves.toEqual({
+      status: 'failure', exported: 0, code: 'OTEL_FORCE_FLUSH_TIMEOUT',
+    })
+  })
+})

--- a/packages/otel/tests/otel-exporter.test.ts
+++ b/packages/otel/tests/otel-exporter.test.ts
@@ -526,6 +526,50 @@ describe('@open-multi-agent/otel', () => {
     expect(JSON.stringify({ attributes: span.attributes, events: span.events })).not.toContain('not exported')
   })
 
+  it('reports span_event and span_end failures with their own single diagnostic code', async () => {
+    const { provider } = inMemory()
+    const failOn = (method: 'addEvent' | 'end'): Tracer => {
+      const tracer = provider.getTracer('test')
+      return {
+        startSpan: (...args: Parameters<Tracer['startSpan']>) => new Proxy(tracer.startSpan(...args), {
+          get(target, prop) {
+            if (prop === method) return () => { throw new Error(`${method} rejected`) }
+            const value = Reflect.get(target, prop) as unknown
+            return typeof value === 'function' ? (value as (...fnArgs: unknown[]) => unknown).bind(target) : value
+          },
+        }),
+      } as unknown as Tracer
+    }
+
+    const eventDiagnostics: string[] = []
+    const eventCase = createOtelTraceExporter({
+      tracer: failOn('addEvent'),
+      onDiagnostic: (item) => eventDiagnostics.push(item.code),
+    })
+    const eventId = '6'.repeat(15) + 'e'
+    await expect(eventCase.export([
+      start(eventId, 'oma.task', 'task'),
+      event(eventId, 'retry_scheduled'),
+    ], new AbortController().signal)).resolves.toEqual({
+      status: 'failure', exported: 1, code: 'OTEL_SPAN_EVENT_FAILED',
+    })
+    expect(eventDiagnostics).toEqual(['span_event_failed'])
+
+    const endDiagnostics: string[] = []
+    const endCase = createOtelTraceExporter({
+      tracer: failOn('end'),
+      onDiagnostic: (item) => endDiagnostics.push(item.code),
+    })
+    const endId = '7'.repeat(15) + 'f'
+    await expect(endCase.export([
+      start(endId, 'oma.task', 'task'),
+      end(endId, 'oma.task', 'task'),
+    ], new AbortController().signal)).resolves.toEqual({
+      status: 'failure', exported: 1, code: 'OTEL_SPAN_END_FAILED',
+    })
+    expect(endDiagnostics).toEqual(['span_end_failed'])
+  })
+
   it('maps local span rejection and provider flush/shutdown failures to OBS-2 ExportResult without taking provider ownership by default', async () => {
     const { provider } = inMemory()
     const diagnostics: string[] = []
@@ -535,7 +579,7 @@ describe('@open-multi-agent/otel', () => {
     } as unknown as Tracer
     const rejected = createOtelTraceExporter({ tracer: throwingTracer })
     await expect(rejected.export([start('5'.repeat(16), 'oma.run', 'run')], new AbortController().signal))
-      .resolves.toEqual({ status: 'failure', exported: 0, code: 'OTEL_RECORD_REJECTED' })
+      .resolves.toEqual({ status: 'failure', exported: 0, code: 'OTEL_SPAN_START_FAILED' })
 
     let starts = 0
     const partiallyRejectingTracer = {
@@ -551,7 +595,7 @@ describe('@open-multi-agent/otel', () => {
       start('6'.repeat(16), 'oma.run', 'run'),
       start('7'.repeat(16), 'oma.task', 'task'),
     ], new AbortController().signal)).resolves.toEqual({
-      status: 'failure', exported: 1, code: 'OTEL_RECORD_REJECTED',
+      status: 'failure', exported: 1, code: 'OTEL_SPAN_START_FAILED',
     })
 
     let flushed = 0

--- a/packages/otel/tests/otel-exporter.test.ts
+++ b/packages/otel/tests/otel-exporter.test.ts
@@ -1,4 +1,4 @@
-import { SpanStatusCode } from '@opentelemetry/api'
+import { SpanStatusCode, TraceFlags } from '@opentelemetry/api'
 import {
   BasicTracerProvider,
   InMemorySpanExporter,
@@ -33,6 +33,9 @@ function start(
     attributes?: Readonly<Record<string, TraceAttributeValue>>
     links?: readonly TraceLink[]
     startUnixMs?: number
+    traceId?: string
+    runId?: string
+    attempt?: number
   } = {},
 ): SpanStartRecord {
   const startUnixMs = options.startUnixMs ?? 1_000
@@ -41,9 +44,9 @@ function start(
     recordId: `start-${++nextRecord}`,
     sequence: nextRecord,
     timestampUnixMs: startUnixMs,
-    runId: 'run-42',
-    attempt: 2,
-    traceId: TRACE_ID,
+    runId: options.runId ?? 'run-42',
+    attempt: options.attempt ?? 2,
+    traceId: options.traceId ?? TRACE_ID,
     spanId,
     ...(options.parentSpanId ? { parentSpanId: options.parentSpanId } : {}),
     recordType: 'span_start',
@@ -88,6 +91,9 @@ function end(
     error?: SpanEndRecord['error']
     startUnixMs?: number
     endUnixMs?: number
+    traceId?: string
+    runId?: string
+    attempt?: number
   } = {},
 ): SpanEndRecord {
   const startUnixMs = options.startUnixMs ?? 1_000
@@ -97,9 +103,9 @@ function end(
     recordId: `end-${++nextRecord}`,
     sequence: nextRecord,
     timestampUnixMs: endUnixMs,
-    runId: 'run-42',
-    attempt: 2,
-    traceId: TRACE_ID,
+    runId: options.runId ?? 'run-42',
+    attempt: options.attempt ?? 2,
+    traceId: options.traceId ?? TRACE_ID,
     spanId,
     ...(options.parentSpanId ? { parentSpanId: options.parentSpanId } : {}),
     recordType: 'span_end',
@@ -151,10 +157,10 @@ describe('@open-multi-agent/otel', () => {
     const checkpointId = '8'.repeat(16)
     const callbackId = '9'.repeat(16)
     const links: readonly TraceLink[] = [
-      { traceId: 'b'.repeat(32), spanId: 'b'.repeat(16), relation: 'depends_on' },
-      { traceId: 'c'.repeat(32), spanId: 'c'.repeat(16), relation: 'delegated_from' },
-      { traceId: 'd'.repeat(32), spanId: 'd'.repeat(16), relation: 'consumed' },
-      { traceId: 'e'.repeat(32), spanId: 'e'.repeat(16), relation: 'continued_from' },
+      { traceId: TRACE_ID, spanId: planId, relation: 'depends_on' },
+      { traceId: TRACE_ID, spanId: consensusId, relation: 'delegated_from' },
+      { traceId: TRACE_ID, spanId: checkpointId, relation: 'consumed' },
+      { traceId: TRACE_ID, spanId: callbackId, relation: 'continued_from' },
     ]
 
     const result = await exportRecords(adapter, [
@@ -232,6 +238,22 @@ describe('@open-multi-agent/otel', () => {
     expect(task.links).toHaveLength(4)
     expect(task.links.map((link) => link.attributes['oma.link.relation']))
       .toEqual(['depends_on', 'delegated_from', 'consumed', 'continued_from'])
+    const expectedLinkTargets = new Map([
+      ['depends_on', spans.find((span) => span.name === 'coordinator.decomposition')!],
+      ['delegated_from', spans.find((span) => span.name === 'consensus.judge')!],
+      ['consumed', spans.find((span) => span.name === 'checkpoint.restore')!],
+      ['continued_from', spans.find((span) => span.name === 'coordinator.synthesis')!],
+    ])
+    for (const link of task.links) {
+      const relation = link.attributes['oma.link.relation'] as string
+      const target = expectedLinkTargets.get(relation)!
+      expect(link.context).toEqual(target.spanContext())
+      expect(link.attributes).toMatchObject({
+        'oma.link.resolved': true,
+        'oma.link.target.trace_id': TRACE_ID,
+        'oma.link.target.span_id': target.attributes['oma.span.id'],
+      })
+    }
     expect(task.events.some((item) => item.name === 'oma.retry_scheduled')).toBe(true)
     expect(task.events.some((item) => item.name === 'oma.stream_chunk')).toBe(true)
     expect(llm.attributes).toMatchObject({
@@ -248,6 +270,150 @@ describe('@open-multi-agent/otel', () => {
       'gen_ai.response.time_to_first_chunk': 0.6,
     })
     expect(llm.events.some((item) => item.name === 'oma.first_chunk')).toBe(true)
+  })
+
+  it('resolves recent-root continuation links and marks unknown cross-process links as remote', async () => {
+    const { exporter, provider } = inMemory()
+    const adapter = createOtelTraceExporter({ tracerProvider: provider })
+    const previousTraceId = 'b'.repeat(32)
+    const previousRootId = 'b'.repeat(16)
+    await exportRecords(adapter, [
+      start(previousRootId, 'previous.run', 'run', { traceId: previousTraceId, runId: 'continued-run', attempt: 1 }),
+      end(previousRootId, 'previous.run', 'run', { traceId: previousTraceId, runId: 'continued-run', attempt: 1 }),
+    ])
+    const previous = exporter.getFinishedSpans().find((span) => span.name === 'previous.run')!
+
+    const restoredTraceId = 'c'.repeat(32)
+    const restoredRootId = 'c'.repeat(16)
+    const continuedFrom: TraceLink = {
+      traceId: previousTraceId,
+      spanId: previousRootId,
+      relation: 'continued_from',
+    }
+    await exportRecords(adapter, [
+      start(restoredRootId, 'restored.run', 'run', {
+        traceId: restoredTraceId,
+        runId: 'continued-run',
+        attempt: 2,
+        links: [continuedFrom],
+      }),
+      end(restoredRootId, 'restored.run', 'run', {
+        traceId: restoredTraceId,
+        runId: 'continued-run',
+        attempt: 2,
+        links: [continuedFrom],
+      }),
+    ])
+    const restored = exporter.getFinishedSpans().find((span) => span.name === 'restored.run')!
+    expect(restored.links[0]!.context).toEqual(previous.spanContext())
+    expect(restored.links[0]!.attributes['oma.link.resolved']).toBe(true)
+
+    const fresh = inMemory()
+    const freshAdapter = createOtelTraceExporter({ tracerProvider: fresh.provider })
+    const unknownTraceId = 'd'.repeat(32)
+    const unknownSpanId = 'd'.repeat(16)
+    const unknownLink: TraceLink = {
+      traceId: unknownTraceId,
+      spanId: unknownSpanId,
+      relation: 'continued_from',
+    }
+    const freshRootId = 'e'.repeat(16)
+    await exportRecords(freshAdapter, [
+      start(freshRootId, 'fresh.run', 'run', { links: [unknownLink] }),
+      end(freshRootId, 'fresh.run', 'run', { links: [unknownLink] }),
+    ])
+    const unresolved = fresh.exporter.getFinishedSpans().find((span) => span.name === 'fresh.run')!.links[0]!
+    expect(unresolved.context).toEqual({
+      traceId: unknownTraceId,
+      spanId: unknownSpanId,
+      traceFlags: TraceFlags.NONE,
+      isRemote: true,
+    })
+    expect(unresolved.attributes).toMatchObject({
+      'oma.link.resolved': false,
+      'oma.link.target.trace_id': unknownTraceId,
+      'oma.link.target.span_id': unknownSpanId,
+    })
+  })
+
+  it('parents children from retained contexts after the parent Span object is released', async () => {
+    const { exporter, provider } = inMemory()
+    const adapter = createOtelTraceExporter({ tracerProvider: provider })
+    const parentId = '2'.repeat(16)
+    const childId = '3'.repeat(16)
+    await exportRecords(adapter, [
+      start(ROOT_SPAN_ID, 'oma.run', 'run'),
+      start(parentId, 'completed.parent', 'task', { parentSpanId: ROOT_SPAN_ID }),
+      end(parentId, 'completed.parent', 'task', { parentSpanId: ROOT_SPAN_ID }),
+      start(childId, 'late.child', 'agent', { parentSpanId: parentId }),
+      end(childId, 'late.child', 'agent', { parentSpanId: parentId }),
+      end(ROOT_SPAN_ID, 'oma.run', 'run'),
+    ])
+    const parent = exporter.getFinishedSpans().find((span) => span.name === 'completed.parent')!
+    const child = exporter.getFinishedSpans().find((span) => span.name === 'late.child')!
+    expect(child.parentSpanContext).toEqual(parent.spanContext())
+  })
+
+  it('releases completed traces and bounds recent root contexts', async () => {
+    const { provider } = inMemory()
+    const adapter = createOtelTraceExporter({ tracerProvider: provider })
+    const state = adapter as unknown as {
+      openSpans: Map<string, unknown>
+      spanContexts: Map<string, unknown>
+      traceSpanKeys: Map<string, unknown>
+      recentRootContexts: Map<string, unknown>
+    }
+
+    for (let index = 1; index <= 300; index++) {
+      const traceId = index.toString(16).padStart(32, '0')
+      const rootId = index.toString(16).padStart(16, '0')
+      await adapter.export([
+        start(rootId, `run.${index}`, 'run', { traceId, runId: `run-${index}`, attempt: 1 }),
+        end(rootId, `run.${index}`, 'run', { traceId, runId: `run-${index}`, attempt: 1 }),
+      ], new AbortController().signal)
+    }
+
+    expect(state.openSpans.size).toBe(0)
+    expect(state.spanContexts.size).toBe(0)
+    expect(state.traceSpanKeys.size).toBe(0)
+    expect(state.recentRootContexts.size).toBe(256)
+  })
+
+  it('ends and clears incomplete spans when a root closes or the exporter shuts down', async () => {
+    const rootCase = inMemory()
+    const diagnostics: string[] = []
+    const rootAdapter = createOtelTraceExporter({
+      tracerProvider: rootCase.provider,
+      onDiagnostic: (item) => diagnostics.push(item.code),
+    })
+    const childId = '4'.repeat(16)
+    await exportRecords(rootAdapter, [
+      start(ROOT_SPAN_ID, 'oma.run', 'run'),
+      start(childId, 'missing.end', 'task', { parentSpanId: ROOT_SPAN_ID }),
+      end(ROOT_SPAN_ID, 'oma.run', 'run'),
+    ])
+    const incompleteChild = rootCase.exporter.getFinishedSpans().find((span) => span.name === 'missing.end')!
+    expect(incompleteChild.attributes['oma.record.incomplete']).toBe(true)
+    expect(incompleteChild.status.code).toBe(SpanStatusCode.UNSET)
+    expect(diagnostics).toContain('incomplete_span')
+
+    const shutdownCase = inMemory()
+    const shutdownAdapter = createOtelTraceExporter({ tracerProvider: shutdownCase.provider })
+    const openId = '5'.repeat(16)
+    await shutdownAdapter.export([start(openId, 'shutdown.incomplete', 'task')], new AbortController().signal)
+    await shutdownAdapter.shutdown(new AbortController().signal)
+    const shutdownSpan = shutdownCase.exporter.getFinishedSpans().find((span) => span.name === 'shutdown.incomplete')!
+    expect(shutdownSpan.attributes['oma.record.incomplete']).toBe(true)
+    const shutdownState = shutdownAdapter as unknown as {
+      openSpans: Map<string, unknown>
+      spanContexts: Map<string, unknown>
+      traceSpanKeys: Map<string, unknown>
+      recentRootContexts: Map<string, unknown>
+    }
+    expect(shutdownState.openSpans.size).toBe(0)
+    expect(shutdownState.spanContexts.size).toBe(0)
+    expect(shutdownState.traceSpanKeys.size).toBe(0)
+    expect(shutdownState.recentRootContexts.size).toBe(0)
   })
 
   it('maps OMA error statuses without leaking error messages and keeps non-errors Unset', async () => {

--- a/packages/otel/tests/otel-sink-integration.test.ts
+++ b/packages/otel/tests/otel-sink-integration.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import type { Tracer } from '@opentelemetry/api'
+import {
+  OpenMultiAgent,
+  type AgentConfig,
+  type LLMAdapter,
+  type LLMChatOptions,
+  type LLMMessage,
+  type LLMResponse,
+} from '@open-multi-agent/core'
+import { createOtelTraceSink } from '../src/index.js'
+
+function adapter(): LLMAdapter {
+  return {
+    name: 'otel-failure-test',
+    async chat(_messages: LLMMessage[], _options: LLMChatOptions): Promise<LLMResponse> {
+      return {
+        id: 'response',
+        content: [{ type: 'text', text: 'completed despite telemetry failure' }],
+        model: 'test-model',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }
+    },
+    async *stream() { /* unused */ },
+  }
+}
+
+describe('OTel sink failure isolation', () => {
+  it('does not change an Agent result when a user tracer rejects OTel records', async () => {
+    const rejectingTracer = {
+      startSpan: () => { throw new Error('otel unavailable') },
+    } as unknown as Tracer
+    const sink = createOtelTraceSink({
+      tracer: rejectingTracer,
+      batching: { scheduledDelayMs: 1, maxRetries: 0, diagnostics: 'silent', retryJitter: false },
+    })
+    const agent: AgentConfig = { name: 'worker', model: 'test-model', adapter: adapter() }
+    const result = await new OpenMultiAgent({ observability: { sinks: [sink] } }).runAgent(agent, 'hello')
+
+    expect(result.success).toBe(true)
+    expect(result.status?.code).toBe('ok')
+    const delivery = await sink.forceFlush({ timeoutMs: 100 })
+    expect(delivery.status).toBe('error')
+    expect(delivery.failed).toBeGreaterThan(0)
+  })
+})

--- a/packages/otel/tests/version-sync.test.ts
+++ b/packages/otel/tests/version-sync.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { PACKAGE_VERSION } from '../src/version.js'
+
+describe('package version constant', () => {
+  it('matches package.json so the default instrumentationVersion cannot drift on release', () => {
+    const manifestPath = fileURLToPath(new URL('../package.json', import.meta.url))
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { version: string }
+    expect(PACKAGE_VERSION).toBe(manifest.version)
+  })
+})

--- a/packages/otel/tsconfig.json
+++ b/packages/otel/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/otel/tsconfig.lint.json
+++ b/packages/otel/tsconfig.lint.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "..",
+    "paths": {
+      "@open-multi-agent/core": ["../core/src/index.ts"]
+    }
+  }
+}

--- a/packages/otel/vitest.config.ts
+++ b/packages/otel/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@open-multi-agent/core': fileURLToPath(new URL('../core/src/index.ts', import.meta.url)),
+    },
+  },
+  test: {
+    include: ['tests/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
## Summary

- add the independently installable `@open-multi-agent/otel` workspace package for OBS-2 TraceRecord v2
- map OMA spans, events, links, statuses, GenAI compatibility fields, and privacy-safe attributes to an application-owned OpenTelemetry tracer/provider
- keep OTel APIs, SDKs, semantic-convention mappings, and exporter integrations outside core imports; document the explicit ownership boundary in English and Chinese READMEs
- do not initialize or replace the global TracerProvider; provider shutdown remains opt-in

## Validation

- `npm run lint`
- `npm test` (core 1233, create-oma-app 26, otel 7)
- `npm run build`
- Node 18, 20, and 22 OTel tests
- core and OTel import smoke tests
- `npm pack --dry-run -w @open-multi-agent/core`
- `npm pack --dry-run -w @open-multi-agent/otel`
- `git diff --check`