### PR TITLE
Add per-call tool gate hook

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -191,6 +191,7 @@ export class Agent {
       toolPreset: this.config.toolPreset,
       allowedTools: this.config.tools,
       disallowedTools: this.config.disallowedTools,
+      ...(this.config.onToolCall !== undefined ? { onToolCall: this.config.onToolCall } : {}),
       cwd: this.config.cwd,
       agentName: this.name,
       agentRole: this.config.systemPrompt?.slice(0, 50) ?? 'assistant',

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -34,6 +34,7 @@ import type {
   ContextStrategy,
   ThinkingConfig,
   RunIdentity,
+  ToolCallGate,
 } from '../types.js'
 import { LLMCallTimeoutError, TokenBudgetExceededError } from '../errors.js'
 import { LoopDetector } from './loop-detector.js'
@@ -134,6 +135,8 @@ export interface RunnerOptions {
   readonly toolPreset?: 'readonly' | 'readwrite' | 'full'
   readonly allowedTools?: readonly string[]
   readonly disallowedTools?: readonly string[]
+  /** Optional per-call tool gate inherited from agent or orchestrator config. */
+  readonly onToolCall?: ToolCallGate
   /**
    * Root directory passed to built-in filesystem tools via `ToolUseContext.cwd`.
    * `null` disables the sandbox; `undefined` falls back to
@@ -1174,6 +1177,7 @@ export class AgentRunner implements AgentBackend {
                 block.name,
                 block.input,
                 executionContext,
+                { onToolCall: this.options.onToolCall },
               )
             } catch (err) {
               // Tool executor errors become error results — the loop continues.
@@ -1194,6 +1198,15 @@ export class AgentRunner implements AgentBackend {
               agent: options.traceAgent ?? this.options.agentName ?? 'unknown',
               tool: block.name,
               isError: result.isError ?? false,
+              ...(result.metadata?.toolCallGate
+                ? {
+                    gated: true,
+                    gateAction: result.metadata.toolCallGate.action,
+                    ...(result.metadata.toolCallGate.reason
+                      ? { gateReason: result.metadata.toolCallGate.reason }
+                      : {}),
+                  }
+                : {}),
               input: redactSensitiveObject(block.input),
               output: redactSensitiveText(result.data),
               startMs: startTime,
@@ -1571,6 +1584,8 @@ export class AgentRunner implements AgentBackend {
       },
       abortSignal: options.abortSignal ?? this.options.abortSignal,
       cwd: this.options.cwd === undefined ? defaultWorkspaceDir() : this.options.cwd,
+      ...(options.runId !== undefined ? { runId: options.runId } : {}),
+      ...(options.taskId !== undefined ? { taskId: options.taskId } : {}),
       ...(options.team !== undefined ? { team: options.team } : {}),
       ...(this.options.credentials !== undefined ? { credentials: this.options.credentials } : {}),
     }

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -1203,7 +1203,7 @@ export class AgentRunner implements AgentBackend {
                     gated: true,
                     gateAction: result.metadata.toolCallGate.action,
                     ...(result.metadata.toolCallGate.reason
-                      ? { gateReason: result.metadata.toolCallGate.reason }
+                      ? { gateReason: redactSensitiveText(result.metadata.toolCallGate.reason) }
                       : {}),
                   }
                 : {}),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,7 +95,7 @@ export type { TaskQueueEvent } from './task/queue.js'
 
 export { defineTool, ToolRegistry, zodToJsonSchema } from './tool/framework.js'
 export { ToolExecutor, truncateToolOutput } from './tool/executor.js'
-export type { ToolExecutorOptions, BatchToolCall } from './tool/executor.js'
+export type { ToolExecutorExecutionOptions, ToolExecutorOptions, BatchToolCall } from './tool/executor.js'
 export {
   registerBuiltInTools,
   BUILT_IN_TOOLS,
@@ -224,6 +224,10 @@ export type {
   ToolDefinition,
   ToolResult,
   ToolUseContext,
+  ToolCallContext,
+  ToolCallDecision,
+  ToolCallGate,
+  ToolCallGateMetadata,
   AgentInfo,
   TeamInfo,
   DelegationPoolView,

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -963,6 +963,7 @@ function buildTaskAgentTeamInfo(
       baseURL: targetConfig.baseURL ?? ctx.config.defaultBaseURL,
       apiKey: targetConfig.apiKey ?? ctx.config.defaultApiKey,
       cwd: targetConfig.cwd === undefined ? ctx.config.defaultCwd : targetConfig.cwd,
+      onToolCall: targetConfig.onToolCall ?? ctx.config.onToolCall,
     }, ctx.config.defaultToolPreset), route)
     const tempAgent = buildAgent(effective, { includeDelegateTool: true })
 
@@ -1264,6 +1265,7 @@ async function executeQueue(
           baseURL: agentConfig.baseURL ?? config.defaultBaseURL,
           apiKey: agentConfig.apiKey ?? config.defaultApiKey,
           cwd: agentConfig.cwd === undefined ? config.defaultCwd : agentConfig.cwd,
+          onToolCall: agentConfig.onToolCall ?? config.onToolCall,
         }, config.defaultToolPreset), workerRoute)
         const routedAgent = workerRoute
           ? buildAgent(workerEffectiveConfig, { includeDelegateTool: true })
@@ -1586,6 +1588,7 @@ interface ConsensusAgentDefaults {
   readonly defaultBaseURL: OrchestratorConfig['defaultBaseURL']
   readonly defaultApiKey: OrchestratorConfig['defaultApiKey']
   readonly defaultCwd: OrchestratorConfig['defaultCwd']
+  readonly onToolCall: OrchestratorConfig['onToolCall']
   readonly maxConcurrency: number
 }
 
@@ -1620,6 +1623,7 @@ function applyConsensusDefaults(config: AgentConfig, defaults: ConsensusAgentDef
     baseURL: config.baseURL ?? defaults.defaultBaseURL,
     apiKey: config.apiKey ?? defaults.defaultApiKey,
     cwd: config.cwd === undefined ? defaults.defaultCwd : config.cwd,
+    onToolCall: config.onToolCall ?? defaults.onToolCall,
   }
 }
 
@@ -1914,6 +1918,7 @@ async function runTaskVerify(
       defaultBaseURL: config.defaultBaseURL,
       defaultApiKey: config.defaultApiKey,
       defaultCwd: config.defaultCwd,
+      onToolCall: config.onToolCall,
       maxConcurrency: config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
     },
     onTrace: config.onTrace,
@@ -1983,8 +1988,8 @@ async function runTaskVerify(
  */
 export class OpenMultiAgent {
   private readonly config: Required<
-    Omit<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'observability' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
-  > & Pick<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'observability' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
+    Omit<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
+  > & Pick<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
 
   private readonly teams: Map<string, Team> = new Map()
   private readonly fallbackCheckpointStore = new InMemoryStore()
@@ -2036,6 +2041,7 @@ export class OpenMultiAgent {
       onProgress: config.onProgress,
       observability: config.observability,
       onTrace: config.onTrace,
+      onToolCall: config.onToolCall,
     }
   }
 
@@ -2099,6 +2105,7 @@ export class OpenMultiAgent {
       apiKey: config.apiKey ?? this.config.defaultApiKey,
       cwd: config.cwd === undefined ? this.config.defaultCwd : config.cwd,
       maxTokenBudget: effectiveBudget,
+      onToolCall: config.onToolCall ?? this.config.onToolCall,
     }, this.config.defaultToolPreset)
     const agent = buildAgent(effective)
     this.config.onProgress?.({
@@ -2261,6 +2268,7 @@ export class OpenMultiAgent {
         apiKey: bestAgent.apiKey ?? this.config.defaultApiKey,
         cwd: bestAgent.cwd === undefined ? this.config.defaultCwd : bestAgent.cwd,
         maxTokenBudget: effectiveBudget,
+        onToolCall: bestAgent.onToolCall ?? this.config.onToolCall,
       }, this.config.defaultToolPreset), routeMatches(options?.modelRouting, { phase: 'short-circuit', agent: bestAgent.name }))
       const agent = buildAgent(effective)
 
@@ -2973,6 +2981,7 @@ export class OpenMultiAgent {
       defaultBaseURL: this.config.defaultBaseURL,
       defaultApiKey: this.config.defaultApiKey,
       defaultCwd: this.config.defaultCwd,
+      onToolCall: this.config.onToolCall,
       maxConcurrency: this.config.maxConcurrency,
     }
 
@@ -3281,6 +3290,7 @@ export class OpenMultiAgent {
       toolPreset: coordinatorOverrides?.toolPreset,
       tools: coordinatorOverrides?.tools,
       disallowedTools: coordinatorOverrides?.disallowedTools,
+      onToolCall: coordinatorOverrides?.onToolCall ?? this.config.onToolCall,
       cwd: coordinatorOverrides?.cwd === undefined
         ? this.config.defaultCwd
         : coordinatorOverrides.cwd,
@@ -3766,6 +3776,7 @@ export class OpenMultiAgent {
         baseURL: config.baseURL ?? this.config.defaultBaseURL,
         apiKey: config.apiKey ?? this.config.defaultApiKey,
         cwd: config.cwd === undefined ? this.config.defaultCwd : config.cwd,
+        onToolCall: config.onToolCall ?? this.config.onToolCall,
       }, this.config.defaultToolPreset)
       pool.add(buildAgent(effective, { includeDelegateTool: true }))
     }

--- a/packages/core/src/tool/executor.ts
+++ b/packages/core/src/tool/executor.ts
@@ -10,7 +10,7 @@
  * the framework.
  */
 
-import type { ToolResult, ToolUseContext } from '../types.js'
+import type { ToolCallGate, ToolCallGateMetadata, ToolResult, ToolResultMetadata, ToolUseContext } from '../types.js'
 import type { ToolDefinition } from '../types.js'
 import { ToolRegistry } from './framework.js'
 import { Semaphore } from '../utils/semaphore.js'
@@ -31,6 +31,17 @@ export interface ToolExecutorOptions {
    * Per-tool `maxOutputChars` takes priority over this value.
    */
   maxToolOutputChars?: number
+  /**
+   * Optional per-call gate. Runs after input validation and before execution.
+   * Returning `{ action: 'deny' }` produces an error ToolResult instead of
+   * invoking the tool implementation.
+   */
+  onToolCall?: ToolCallGate
+}
+
+export interface ToolExecutorExecutionOptions {
+  /** Per-execution gate override. Takes priority over the constructor option. */
+  readonly onToolCall?: ToolCallGate
 }
 
 /** Describes one call in a batch. */
@@ -55,11 +66,13 @@ export class ToolExecutor {
   private readonly registry: ToolRegistry
   private readonly semaphore: Semaphore
   private readonly maxToolOutputChars?: number
+  private readonly onToolCall?: ToolCallGate
 
   constructor(registry: ToolRegistry, options: ToolExecutorOptions = {}) {
     this.registry = registry
     this.semaphore = new Semaphore(options.maxConcurrency ?? 4)
     this.maxToolOutputChars = options.maxToolOutputChars
+    this.onToolCall = options.onToolCall
   }
 
   // -------------------------------------------------------------------------
@@ -80,6 +93,7 @@ export class ToolExecutor {
     toolName: string,
     input: Record<string, unknown>,
     context: ToolUseContext,
+    options: ToolExecutorExecutionOptions = {},
   ): Promise<ToolResult> {
     const tool = this.registry.get(toolName)
     if (tool === undefined) {
@@ -95,7 +109,7 @@ export class ToolExecutor {
       )
     }
 
-    return this.runTool(tool, input, context)
+    return this.runTool(tool, input, context, options)
   }
 
   // -------------------------------------------------------------------------
@@ -149,6 +163,7 @@ export class ToolExecutor {
     tool: ToolDefinition<any>,
     rawInput: Record<string, unknown>,
     context: ToolUseContext,
+    options: ToolExecutorExecutionOptions,
   ): Promise<ToolResult> {
     // --- Zod validation ---
     const inputParseResult = this.runZodSchema(tool.inputSchema, rawInput)
@@ -165,6 +180,33 @@ export class ToolExecutor {
       )
     }
 
+    const gate = options.onToolCall ?? this.onToolCall
+    let gateMetadata: ToolCallGateMetadata | undefined
+    if (gate) {
+      let decision: Awaited<ReturnType<ToolCallGate>>
+      try {
+        decision = await gate({
+          toolName: tool.name,
+          input: inputParseResult.data as Record<string, unknown>,
+          agentName: context.agent.name,
+          ...(context.runId !== undefined ? { runId: context.runId } : {}),
+          ...(context.taskId !== undefined ? { taskId: context.taskId } : {}),
+        })
+      } catch (err) {
+        return this.errorResult(`Tool "${tool.name}" onToolCall hook threw an error: ${this.errorMessage(err)}`)
+      }
+      gateMetadata = {
+        action: decision.action,
+        ...(decision.action === 'deny' && decision.reason !== undefined ? { reason: decision.reason } : {}),
+      }
+      if (gateMetadata.action === 'deny') {
+        const suffix = gateMetadata.reason ? `: ${gateMetadata.reason}` : '.'
+        return this.errorResult(`Tool "${tool.name}" denied by onToolCall${suffix}`, {
+          toolCallGate: gateMetadata,
+        })
+      }
+    }
+
     // --- Execute ---
     try {
       const result = await tool.execute(inputParseResult.data, context)
@@ -176,15 +218,14 @@ export class ToolExecutor {
           )
         }
       }
-      return this.maybeTruncate(tool, result)
+      return this.withGateMetadata(this.maybeTruncate(tool, result), gateMetadata)
     } catch (err) {
-      const message =
-        err instanceof Error
-          ? err.message
-          : typeof err === 'string'
-            ? err
-            : JSON.stringify(err)
-      return this.maybeTruncate(tool, this.errorResult(`Tool "${tool.name}" threw an error: ${message}`))
+      return this.maybeTruncate(
+        tool,
+        this.errorResult(`Tool "${tool.name}" threw an error: ${this.errorMessage(err)}`, gateMetadata
+          ? { toolCallGate: gateMetadata }
+          : undefined),
+      )
     }
   }
 
@@ -219,11 +260,31 @@ export class ToolExecutor {
     return { ...result, data: truncateToolOutput(result.data, maxChars) }
   }
 
+  private withGateMetadata(result: ToolResult, gateMetadata: ToolCallGateMetadata | undefined): ToolResult {
+    if (!gateMetadata) return result
+    return {
+      ...result,
+      metadata: {
+        ...result.metadata,
+        toolCallGate: gateMetadata,
+      },
+    }
+  }
+
+  private errorMessage(err: unknown): string {
+    return err instanceof Error
+      ? err.message
+      : typeof err === 'string'
+        ? err
+        : JSON.stringify(err)
+  }
+
   /** Construct an error ToolResult. */
-  private errorResult(message: string): ToolResult {
+  private errorResult(message: string, metadata?: ToolResultMetadata): ToolResult {
     return {
       data: message,
       isError: true,
+      ...(metadata ? { metadata } : {}),
     }
   }
 }

--- a/packages/core/src/tool/executor.ts
+++ b/packages/core/src/tool/executor.ts
@@ -174,7 +174,7 @@ export class ToolExecutor {
     }
 
     // --- Abort check after parse (parse can be expensive for large inputs) ---
-    if (context.abortSignal?.aborted === true) {
+    if (this.isAbortSignalAborted(context.abortSignal)) {
       return this.errorResult(
         `Tool "${tool.name}" was aborted before execution began.`,
       )
@@ -183,7 +183,7 @@ export class ToolExecutor {
     const gate = options.onToolCall ?? this.onToolCall
     let gateMetadata: ToolCallGateMetadata | undefined
     if (gate) {
-      let decision: Awaited<ReturnType<ToolCallGate>>
+      let decision: unknown
       try {
         decision = await gate({
           toolName: tool.name,
@@ -195,9 +195,17 @@ export class ToolExecutor {
       } catch (err) {
         return this.errorResult(`Tool "${tool.name}" onToolCall hook threw an error: ${this.errorMessage(err)}`)
       }
-      gateMetadata = {
-        action: decision.action,
-        ...(decision.action === 'deny' && decision.reason !== undefined ? { reason: decision.reason } : {}),
+      gateMetadata = this.gateMetadataFromDecision(decision)
+      if (!gateMetadata) {
+        return this.errorResult(
+          `Tool "${tool.name}" onToolCall hook returned an invalid onToolCall decision.`,
+        )
+      }
+      if (this.isAbortSignalAborted(context.abortSignal)) {
+        return this.errorResult(
+          `Tool "${tool.name}" was aborted before execution began.`,
+          { toolCallGate: gateMetadata },
+        )
       }
       if (gateMetadata.action === 'deny') {
         const suffix = gateMetadata.reason ? `: ${gateMetadata.reason}` : '.'
@@ -215,6 +223,7 @@ export class ToolExecutor {
         if (!outputParseResult.success) {
           return this.errorResult(
             `Invalid output for tool "${tool.name}":\n${outputParseResult.issuesMessage}`,
+            gateMetadata ? { toolCallGate: gateMetadata } : undefined,
           )
         }
       }
@@ -269,6 +278,22 @@ export class ToolExecutor {
         toolCallGate: gateMetadata,
       },
     }
+  }
+
+  private gateMetadataFromDecision(decision: unknown): ToolCallGateMetadata | undefined {
+    if (decision === null || typeof decision !== 'object') return undefined
+    const action = (decision as { readonly action?: unknown }).action
+    if (action !== 'allow' && action !== 'deny') return undefined
+    const reason = (decision as { readonly reason?: unknown }).reason
+    if (reason !== undefined && typeof reason !== 'string') return undefined
+    if (action === 'deny' && reason !== undefined) {
+      return { action, reason }
+    }
+    return { action }
+  }
+
+  private isAbortSignalAborted(signal: AbortSignal | undefined): boolean {
+    return signal?.aborted === true
   }
 
   private errorMessage(err: unknown): string {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -356,6 +356,10 @@ export interface ToolUseContext {
   readonly cwd?: string | null
   /** Arbitrary caller-supplied metadata (session ID, request ID, etc.). */
   readonly metadata?: Readonly<Record<string, unknown>>
+  /** Run ID associated with this tool call, when available. */
+  readonly runId?: string
+  /** Task ID associated with this tool call, when available. */
+  readonly taskId?: string
   /**
    * Per-agent scoped secrets for tool code to consume (API tokens, service
    * keys, etc.), sourced from {@link AgentConfig.credentials}. A tool reads
@@ -376,6 +380,29 @@ export interface AgentInfo {
   readonly name: string
   readonly role: string
   readonly model: string
+}
+
+/** Context passed to the optional per-call tool gate. */
+export interface ToolCallContext {
+  readonly toolName: string
+  readonly input: Record<string, unknown>
+  readonly agentName: string
+  readonly runId?: string
+  readonly taskId?: string
+}
+
+/** Decision returned by the optional per-call tool gate. */
+export type ToolCallDecision =
+  | { readonly action: 'allow' }
+  | { readonly action: 'deny'; readonly reason?: string }
+
+/** Optional middleware invoked after input validation and before tool execution. */
+export type ToolCallGate = (context: ToolCallContext) => ToolCallDecision | Promise<ToolCallDecision>
+
+/** Metadata attached to tool results when a per-call gate runs. */
+export interface ToolCallGateMetadata {
+  readonly action: ToolCallDecision['action']
+  readonly reason?: string
 }
 
 /**
@@ -424,6 +451,8 @@ export interface ToolResultMetadata {
    * total so budgets/cost tracking stay accurate across delegation.
    */
   readonly tokenUsage?: TokenUsage
+  /** Per-call gate decision, if an onToolCall hook evaluated this tool call. */
+  readonly toolCallGate?: ToolCallGateMetadata
 }
 
 /** Value returned by a tool's `execute` function. */
@@ -618,6 +647,12 @@ export interface AgentConfig {
   readonly tools?: readonly string[]
   /** Names of tools explicitly disallowed for this agent. */
   readonly disallowedTools?: readonly string[]
+  /**
+   * Optional per-call tool gate. Called after tool input validates and before
+   * execution. Return `{ action: 'deny' }` to surface an error ToolResult to the
+   * model without throwing or invoking the tool implementation.
+   */
+  readonly onToolCall?: ToolCallGate
   /** Predefined tool preset for common use cases. */
   readonly toolPreset?: 'readonly' | 'readwrite' | 'full'
   /**
@@ -1346,6 +1381,12 @@ export interface OrchestratorConfig {
   readonly observability?: import('./observability/sink.js').ObservabilityConfig
   readonly onTrace?: (event: TraceEvent) => void | Promise<void>
   /**
+   * Optional per-call tool gate inherited by agents that do not define their own
+   * {@link AgentConfig.onToolCall}. This is a coordination layer, not a sandbox
+   * or security boundary.
+   */
+  readonly onToolCall?: ToolCallGate
+  /**
    * Optional approval gate called between task execution rounds.
    *
    * After a batch of tasks completes, this callback receives all
@@ -1594,6 +1635,8 @@ export interface CoordinatorConfig {
   readonly tools?: readonly string[]
   /** Tool names explicitly denied to the coordinator. */
   readonly disallowedTools?: readonly string[]
+  /** See {@link AgentConfig.onToolCall}. */
+  readonly onToolCall?: ToolCallGate
   /**
    * Root directory used by the coordinator's filesystem tools.
    * Defaults to {@link OrchestratorConfig.defaultCwd}. Pass `null` to
@@ -1656,6 +1699,12 @@ export interface ToolCallTrace extends TraceEventBase {
   readonly type: 'tool_call'
   readonly tool: string
   readonly isError: boolean
+  /** True when an onToolCall gate evaluated this tool invocation. */
+  readonly gated?: boolean
+  /** Decision returned by the gate, when one evaluated this call. */
+  readonly gateAction?: ToolCallDecision['action']
+  /** Optional denial/debug reason supplied by the gate. */
+  readonly gateReason?: string
   /** The input arguments passed to the tool after best-effort sensitive-field redaction. */
   readonly input: Record<string, unknown>
   /** The serialised output returned by the tool after executor truncation and best-effort sensitive-value redaction. */

--- a/packages/core/tests/default-deny-tools.test.ts
+++ b/packages/core/tests/default-deny-tools.test.ts
@@ -12,7 +12,7 @@
  * plus the `defaultToolPreset` escape hatch that restores the prior convenience.
  */
 
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { z } from 'zod'
 import { Agent } from '../src/agent/agent.js'
 import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
@@ -249,6 +249,34 @@ describe('default-deny: runTeam short-circuit', () => {
     // Granted via the default preset → the executor ran the real command.
     expect(solo.toolCalls[0]!.output.toLowerCase()).not.toContain('not granted')
     expect(solo.toolCalls[0]!.output).toContain(sentinel)
+  })
+
+  it('onToolCall can deny a granted tool before it executes', async () => {
+    const sentinel = 'OMA_GATE_should_never_run'
+    const { adapter } = scriptedAdapter([
+      toolUse('bash', { command: `echo ${sentinel}` }),
+      text('finished'),
+    ])
+    const onToolCall = vi.fn(async () => ({ action: 'deny' as const, reason: 'blocked by policy' }))
+
+    const oma = new OpenMultiAgent({ defaultToolPreset: 'full', onToolCall })
+    const team = oma.createTeam('t', {
+      name: 't',
+      agents: [{ name: 'solo', model: 'mock-model', adapter }],
+    })
+
+    const result = await oma.runTeam(team, SIMPLE_GOAL)
+    const solo = result.agentResults.get('solo')!
+
+    expect(onToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      toolName: 'bash',
+      input: { command: `echo ${sentinel}` },
+      agentName: 'solo',
+    }))
+    expect(solo.toolCalls).toHaveLength(1)
+    expect(solo.toolCalls[0]!.toolName).toBe('bash')
+    expect(solo.toolCalls[0]!.output).toContain('blocked by policy')
+    expect(solo.toolCalls[0]!.output).not.toContain(sentinel)
   })
 
   it('per-agent toolPreset overrides defaultToolPreset', async () => {

--- a/packages/core/tests/tool-executor.test.ts
+++ b/packages/core/tests/tool-executor.test.ts
@@ -101,6 +101,36 @@ describe('ToolExecutor', () => {
     expect(result.data).toContain('Invalid input')
   })
 
+  it('runs onToolCall after validation and returns an error result on deny', async () => {
+    const execute = vi.fn(async () => ({ data: 'SHOULD_NOT_RUN', isError: false }))
+    const gate = vi.fn(async () => ({ action: 'deny' as const, reason: 'requires human approval' }))
+    const registry = new ToolRegistry()
+    registry.register(defineTool({
+      name: 'bash',
+      description: 'Runs a shell command.',
+      inputSchema: z.object({ command: z.string() }),
+      execute,
+    }))
+    const executor = new ToolExecutor(registry, { onToolCall: gate })
+
+    const result = await executor.execute(
+      'bash',
+      { command: 'rm -rf /tmp/demo' },
+      { ...dummyContext, runId: 'run-1', taskId: 'task-1' },
+    )
+
+    expect(gate).toHaveBeenCalledWith({
+      toolName: 'bash',
+      input: { command: 'rm -rf /tmp/demo' },
+      agentName: 'test-agent',
+      runId: 'run-1',
+      taskId: 'task-1',
+    })
+    expect(execute).not.toHaveBeenCalled()
+    expect(result.isError).toBe(true)
+    expect(result.data).toContain('requires human approval')
+  })
+
   it('catches tool execution errors and returns them as error results', async () => {
     const { executor } = makeExecutor(failTool())
     const result = await executor.execute('fail', {}, dummyContext)

--- a/packages/core/tests/tool-executor.test.ts
+++ b/packages/core/tests/tool-executor.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { z } from 'zod'
 import { ToolRegistry, defineTool } from '../src/tool/framework.js'
 import { ToolExecutor, truncateToolOutput } from '../src/tool/executor.js'
-import type { ToolUseContext } from '../src/types.js'
+import type { ToolCallDecision, ToolUseContext } from '../src/types.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -36,6 +36,12 @@ function makeExecutor(...tools: ReturnType<typeof defineTool>[]) {
   const registry = new ToolRegistry()
   for (const t of tools) registry.register(t)
   return { executor: new ToolExecutor(registry), registry }
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => { resolve = r })
+  return { promise, resolve }
 }
 
 function jsonPayloadStringSchema() {
@@ -129,6 +135,64 @@ describe('ToolExecutor', () => {
     expect(execute).not.toHaveBeenCalled()
     expect(result.isError).toBe(true)
     expect(result.data).toContain('requires human approval')
+  })
+
+  it('does not execute the tool when aborted while onToolCall is pending', async () => {
+    const execute = vi.fn(async () => ({ data: 'SHOULD_NOT_RUN', isError: false }))
+    const gateStarted = deferred<void>()
+    const gateDecision = deferred<{ action: 'allow' }>()
+    const registry = new ToolRegistry()
+    registry.register(defineTool({
+      name: 'slow_gate',
+      description: 'Runs after a delayed gate.',
+      inputSchema: z.object({}),
+      execute,
+    }))
+    const executor = new ToolExecutor(registry, {
+      onToolCall: vi.fn(() => {
+        gateStarted.resolve()
+        return gateDecision.promise
+      }),
+    })
+    const controller = new AbortController()
+
+    const resultPromise = executor.execute(
+      'slow_gate',
+      {},
+      { ...dummyContext, abortSignal: controller.signal },
+    )
+    await gateStarted.promise
+    controller.abort()
+    gateDecision.resolve({ action: 'allow' })
+
+    const result = await resultPromise
+
+    expect(execute).not.toHaveBeenCalled()
+    expect(result.isError).toBe(true)
+    expect(result.data).toContain('aborted')
+  })
+
+  it.each([
+    ['null', null],
+    ['unknown action', { action: 'maybe' }],
+  ])('returns an error result when onToolCall returns a malformed decision: %s', async (_name, decision) => {
+    const execute = vi.fn(async () => ({ data: 'SHOULD_NOT_RUN', isError: false }))
+    const registry = new ToolRegistry()
+    registry.register(defineTool({
+      name: 'malformed_gate',
+      description: 'Uses a malformed gate decision.',
+      inputSchema: z.object({}),
+      execute,
+    }))
+    const executor = new ToolExecutor(registry, {
+      onToolCall: vi.fn(async () => decision as unknown as ToolCallDecision),
+    })
+
+    const result = await executor.execute('malformed_gate', {}, dummyContext)
+
+    expect(execute).not.toHaveBeenCalled()
+    expect(result.isError).toBe(true)
+    expect(result.data).toContain('invalid onToolCall decision')
   })
 
   it('catches tool execution errors and returns them as error results', async () => {
@@ -513,6 +577,27 @@ describe('ToolExecutor outputSchema validation', () => {
     const result = await executor.execute('json-truncated', {}, dummyContext)
     expect(result.isError).toBe(true)
     expect(result.data).toContain('Invalid output for tool "json-truncated"')
+  })
+
+  it('preserves gate metadata when output schema validation fails', async () => {
+    const tool = defineTool({
+      name: 'json-gated-invalid',
+      description: 'Returns invalid JSON output after the gate allows it.',
+      inputSchema: z.object({}),
+      outputSchema: jsonPayloadStringSchema(),
+      execute: async () => ({ data: 'not-json' }),
+    })
+    const registry = new ToolRegistry()
+    registry.register(tool)
+    const executor = new ToolExecutor(registry, {
+      onToolCall: async () => ({ action: 'allow' }),
+    })
+
+    const result = await executor.execute('json-gated-invalid', {}, dummyContext)
+
+    expect(result.isError).toBe(true)
+    expect(result.data).toContain('Invalid output for tool "json-gated-invalid"')
+    expect(result.metadata?.toolCallGate).toEqual({ action: 'allow' })
   })
 
   it('missing outputSchema is a no-op', async () => {

--- a/packages/core/tests/trace.test.ts
+++ b/packages/core/tests/trace.test.ts
@@ -349,6 +349,46 @@ describe('AgentRunner trace events', () => {
     expect(toolTraces[0]!.input).toEqual({})
   })
 
+  it('tool_call trace includes gate fields when onToolCall denies execution', async () => {
+    const traces: TraceEvent[] = []
+    const execute = vi.fn(async () => ({ data: 'SHOULD_NOT_RUN' }))
+    const registry = new ToolRegistry()
+    registry.register(
+      defineTool({
+        name: 'bash',
+        description: 'runs shell',
+        inputSchema: z.object({ command: z.string() }),
+        execute,
+      }),
+    )
+    const executor = new ToolExecutor(registry, {
+      onToolCall: async () => ({ action: 'deny', reason: 'blocked by policy' }),
+    })
+    const adapter = mockAdapter([
+      toolUseResponse('bash', { command: 'rm -rf /tmp/demo' }),
+      textResponse('Handled'),
+    ])
+
+    const runner = new AgentRunner(adapter, registry, executor, {
+      model: 'test-model',
+      agentName: 'tooler',
+      allowedTools: ['bash'],
+    })
+
+    await runner.run(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+      { onTrace: (e) => { traces.push(e) }, runId: 'run-gated', traceAgent: 'tooler' },
+    )
+
+    expect(execute).not.toHaveBeenCalled()
+    const tool = traces.find((t): t is Extract<TraceEvent, { type: 'tool_call' }> => t.type === 'tool_call')!
+    expect(tool.isError).toBe(true)
+    expect(tool.output).toContain('blocked by policy')
+    expect(tool.gated).toBe(true)
+    expect(tool.gateAction).toBe('deny')
+    expect(tool.gateReason).toBe('blocked by policy')
+  })
+
   it('tool_call trace.output reflects executor truncation', async () => {
     // Pins the jsdoc contract on `ToolCallTrace.output`: whatever truncation
     // ToolExecutor applies (per-tool maxOutputChars or agent-level maxToolOutputChars)

--- a/packages/core/tests/trace.test.ts
+++ b/packages/core/tests/trace.test.ts
@@ -389,6 +389,45 @@ describe('AgentRunner trace events', () => {
     expect(tool.gateReason).toBe('blocked by policy')
   })
 
+  it('redacts sensitive gateReason values in tool_call traces', async () => {
+    const traces: TraceEvent[] = []
+    const execute = vi.fn(async () => ({ data: 'SHOULD_NOT_RUN' }))
+    const registry = new ToolRegistry()
+    registry.register(
+      defineTool({
+        name: 'bash',
+        description: 'runs shell',
+        inputSchema: z.object({ command: z.string() }),
+        execute,
+      }),
+    )
+    const executor = new ToolExecutor(registry, {
+      onToolCall: async () => ({ action: 'deny', reason: 'password=hunter2' }),
+    })
+    const adapter = mockAdapter([
+      toolUseResponse('bash', { command: 'echo ok' }),
+      textResponse('Handled'),
+    ])
+
+    const runner = new AgentRunner(adapter, registry, executor, {
+      model: 'test-model',
+      agentName: 'tooler',
+      allowedTools: ['bash'],
+    })
+
+    await runner.run(
+      [{ role: 'user', content: [{ type: 'text', text: 'test' }] }],
+      { onTrace: (e) => { traces.push(e) }, runId: 'run-redacted-gate', traceAgent: 'tooler' },
+    )
+
+    expect(execute).not.toHaveBeenCalled()
+    const tool = traces.find((t): t is Extract<TraceEvent, { type: 'tool_call' }> => t.type === 'tool_call')!
+    expect(tool.gated).toBe(true)
+    expect(tool.gateAction).toBe('deny')
+    expect(tool.gateReason).toBe('password=[redacted]')
+    expect(tool.gateReason).not.toContain('hunter2')
+  })
+
   it('tool_call trace.output reflects executor truncation', async () => {
     // Pins the jsdoc contract on `ToolCallTrace.output`: whatever truncation
     // ToolExecutor applies (per-tool maxOutputChars or agent-level maxToolOutputChars)


### PR DESCRIPTION
## What

Adds an optional per-call `onToolCall` gate for tool execution. The hook runs after tool input validation and before the tool implementation, and can return `allow` or `deny` for that specific call.

Denied calls return a normal error `ToolResult` without invoking the tool, and trace events include compact gate metadata when a gate evaluates a tool call.

## Why

Part of #96.

This gives applications a policy hook for risk decisions around built-in shell/filesystem tools without changing the existing default-deny, allowlist, denylist, or tool preset behavior.

## Validation

- `npm run lint`
- `npm test`
- `npm run build`
- `npm run test:coverage`
- `npm run test:scaffold`
- package smoke checks for built entry-point imports, CLI help, template typecheck, and tarball file lists

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Added/updated tests for changed behavior
- [x] No new runtime dependencies (or justified in the PR description)

Disclosure: I used AI-assisted coding tools while preparing this PR. I reviewed the changes myself, tested them, and take responsibility for the implementation and any follow-up revisions needed.
