### PR TITLE
feat(agent): add generic process backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Smoke-test that the built entry points import and the CLI runs
         working-directory: packages/core
         run: |
-          node -e "Promise.all([import('./dist/index.js'), import('./dist/mcp.js'), import('./dist/ai-sdk.js')]).then(() => console.log('entry points import OK')).catch((e) => { console.error(e); process.exit(1); })"
+          node -e "Promise.all([import('./dist/index.js'), import('./dist/acp.js'), import('./dist/process.js'), import('./dist/mcp.js'), import('./dist/ai-sdk.js')]).then(() => console.log('entry points import OK')).catch((e) => { console.error(e); process.exit(1); })"
           node dist/cli/oma.js help > /dev/null
           echo "CLI help runs OK"
       - name: Assert the create-oma-app template pins the current core version
@@ -99,7 +99,7 @@ jobs:
             exit 1
           fi
           missing=""
-          for f in dist/index.js dist/index.d.ts dist/cli/oma.js dist/mcp.js dist/mcp.d.ts dist/ai-sdk.js dist/ai-sdk.d.ts; do
+          for f in dist/index.js dist/index.d.ts dist/cli/oma.js dist/acp.js dist/acp.d.ts dist/process.js dist/process.d.ts dist/mcp.js dist/mcp.d.ts dist/ai-sdk.js dist/ai-sdk.d.ts; do
             echo "$paths" | grep -qxF "$f" || missing="$missing $f"
           done
           if [ -n "$missing" ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ The framework's key feature. The coordinator receives goal + roster → emits a 
 |-------|-------|----------------|
 | Orchestrator | `orchestrator/orchestrator.ts`, `scheduler.ts` | Top-level API, task decomposition, retry/backoff, coordinator |
 | Team | `team/team.ts`, `messaging.ts` | Agent roster, MessageBus (point-to-point + broadcast), SharedMemory binding |
-| Agent | `agent/agent.ts`, `runner.ts`, `pool.ts`, `structured-output.ts`, `loop-detector.ts`, `acp-backend.ts` | Lifecycle (idle→running→completed/error), conversation loop, concurrency pool + per-agent mutex, structured-output validation, loop detection; `AgentBackend` seam so an `Agent` runs on either an LLM `AgentRunner` or an external ACP subprocess |
+| Agent | `agent/agent.ts`, `runner.ts`, `pool.ts`, `structured-output.ts`, `loop-detector.ts`, `acp-backend.ts`, `process-backend.ts` | Lifecycle (idle→running→completed/error), conversation loop, concurrency pool + per-agent mutex, structured-output validation, loop detection; `AgentBackend` seam so an `Agent` runs on either an LLM `AgentRunner` or an external backend |
 | Task | `task/queue.ts`, `task.ts` | Dependency-aware queue, auto-unblock on completion, cascade failure to dependents |
 | Tool | `tool/framework.ts`, `executor.ts`, `mcp.ts`, `text-tool-extractor.ts`, `built-in/` | `defineTool()` + Zod, ToolRegistry, parallel batch exec, MCP bridge, local-model text tool-call fallback, filesystem sandbox |
 | LLM | `llm/adapter.ts` + 12 per-provider files + `openai-common.ts` + `reasoning-fallback.ts` | `LLMAdapter` (`chat` + `stream`); lazy `createAdapter()` factory; `baseURL` for OpenAI-compatible servers; cross-provider reasoning round-tripping |
@@ -55,7 +55,7 @@ The framework's key feature. The coordinator receives goal + roster → emits a 
 | CLI | `cli/oma.ts` | Shell/CI entry; built to `dist/cli/oma.js`, exposed as the `oma` npm bin |
 | Utils | `utils/*.ts` | Semaphore, token accounting, keyword helpers, trace plumbing, secret/PII redaction |
 | Types / Errors | `types.ts`, `errors.ts` | All interfaces in one file (avoids circular deps); shared error types |
-| Exports | `index.ts`, `mcp.ts`, `ai-sdk.ts`, `acp.ts` | Root + `/mcp` + `/ai-sdk` + `/acp` subpaths so optional peers don't break the main import |
+| Exports | `index.ts`, `mcp.ts`, `ai-sdk.ts`, `acp.ts`, `process.ts` | Root + `/mcp` + `/ai-sdk` + `/acp` + `/process` subpaths so optional peers and backend-specific helpers don't break the main import |
 
 ### Non-obvious invariants
 
@@ -67,7 +67,7 @@ Behavior that isn't visible from any single file and will cause bugs if missed:
 - **Filesystem tools are sandboxed, `bash` is not** — `file_read/file_write/file_edit/grep/glob` resolve every path (symlinks included) within `AgentConfig.cwd` / `OrchestratorConfig.defaultCwd`, defaulting to `<cwd>/.agent-workspace`. `null` disables the sandbox; `process.cwd()` widens it. → [docs/tool-configuration.md](docs/tool-configuration.md)
 - **Reasoning is dropped unless opted in** — provider-native `ReasoningBlock`s the target adapter can't echo are silently dropped unless `AgentConfig.preserveReasoningAsText` is on (then converted to inline `<thinking>` text). `<thinking>` text is never parsed back into a signed block. → [docs/context-management.md](docs/context-management.md)
 - **Local-model tool-call fallback** — `text-tool-extractor.ts` only runs when the server emits no native `tool_calls` (Ollama/vLLM/LM Studio); native calls always win.
-- **External (ACP) agents run their own loop** — `AgentConfig.backend = { kind: 'acp', … }` swaps the LLM `AgentRunner` for an `AcpBackend` (spawns a coding CLI over ACP). The runner's tool loop / sandbox / context strategy don't apply; OMA is the ACP *client*, the subprocess does its own file IO in `cwd` (no `fs/*` proxying yet), permission prompts default to auto-approve, `systemPrompt` is prepended to the session's first turn (ACP has no system-prompt field), and ACP's cumulative context-token figure is recorded as a per-turn delta into `tokenUsage.input_tokens` (no `usage_update` ⇒ not budget-gated). Everything downstream (`pool`/`scheduler`/`queue`/memory/budget) is backend-agnostic. → [docs/external-agents.md](docs/external-agents.md)
+- **External agent backends swap the LLM runner** — `AgentConfig.backend` can use `kind: 'process'` for a fresh local subprocess per run, or `kind: 'acp'` for a long-lived coding CLI over ACP. The runner's tool loop / sandbox / context strategy don't apply; the subprocess does its own work in `cwd`, while everything downstream (`pool`/`scheduler`/`queue`/memory/budget) is backend-agnostic. ACP-specific details: OMA is the ACP *client*, permission prompts default to auto-approve, `systemPrompt` is prepended to the session's first turn, and ACP's cumulative context-token figure is recorded as a per-turn delta into `tokenUsage.input_tokens` (no `usage_update` ⇒ not budget-gated). → [docs/external-agents.md](docs/external-agents.md)
 - **Secrets are auto-redacted** from traces, bash output, and dashboard payloads (`utils/redaction.ts`).
 
 ### Subsystem docs
@@ -83,7 +83,7 @@ Detailed behavior is documented in `docs/` — the single source of truth, so up
 | Checkpoint/resume over `MemoryStore` | `memory/checkpoint.ts`, `orchestrator/orchestrator.ts` | [checkpoint.md](docs/checkpoint.md) |
 | Tracing, progress events, dashboard | `utils/trace.ts`, `dashboard/` | [observability.md](docs/observability.md) |
 | CLI usage + JSON schemas | `cli/oma.ts` | [cli.md](docs/cli.md) |
-| External coding agents over ACP | `agent/acp-backend.ts` | [external-agents.md](docs/external-agents.md) |
+| External agent backends | `agent/acp-backend.ts`, `agent/process-backend.ts` | [external-agents.md](docs/external-agents.md) |
 
 ### Adding an LLM Adapter
 

--- a/docs/external-agents.md
+++ b/docs/external-agents.md
@@ -82,7 +82,7 @@ default and needs only one key (`ANTHROPIC_API_KEY`) for the whole team.
 
 ## Configuration
 
-`AgentConfig.backend` takes an `AgentBackendConfig` discriminated union:
+`AgentConfig.backend` takes an `ExternalAgentBackendConfig` discriminated union:
 
 | Field | Type | Default | Meaning |
 |-------|------|---------|---------|
@@ -128,9 +128,11 @@ backend: {
 The callback receives a minimal, SDK-agnostic `{ title, kind, optionKinds }` and returns
 `true` to approve / `false` to reject.
 
-> **Security.** Unlike OMA's filesystem-tool sandbox, an ACP agent accesses `cwd`
-> directly — it is a local subprocess with your permissions. Scope `cwd` to a project
-> you trust the agent with, and use `permission` to gate destructive actions.
+> **Security.** Unlike OMA's filesystem-tool sandbox, external backends access
+> `cwd` directly — they are local subprocesses with your permissions. Scope `cwd`
+> to a project you trust the backend with. ACP backends can use `permission` to
+> gate protocol permission prompts; process backends do not have protocol-level
+> permission prompts, so constrain the configured command, args, env, and cwd.
 
 ## How it works
 

--- a/docs/external-agents.md
+++ b/docs/external-agents.md
@@ -1,15 +1,20 @@
-# External Agents (ACP)
+# External Agents
 
 OMA can orchestrate **external agents that run as local processes** alongside its
-LLM-backed agents. The first supported kind is a coding agent driven over the
-[Agent Client Protocol (ACP)](https://agentclientprotocol.com) — a JSON-RPC-over-stdio
-standard implemented by Gemini CLI, Claude Code, Codex, and others.
+LLM-backed agents. Two backend kinds are built in:
 
-An ACP agent is a first-class team member: it sits in the same task DAG, writes to
-the same shared memory, cascades failure to its dependents, and counts against the
-same token budget as any LLM agent. The motivating shape is a **hybrid team** — an
-LLM planner decomposes the goal, an external coding agent writes the code, an LLM
-reviewer audits the diff — all in one `runTeam` / `runTasks` call.
+- `process` starts a generic local command for each agent run, sends the prompt by
+  stdin or argument, and maps stdout/stderr/exit status into a normal agent result.
+- `acp` drives a coding agent over the
+  [Agent Client Protocol (ACP)](https://agentclientprotocol.com) — a
+  JSON-RPC-over-stdio standard implemented by Gemini CLI, Claude Code, Codex, and
+  others.
+
+An external agent is a first-class team member: it sits in the same task DAG,
+writes to the same shared memory, cascades failure to its dependents, and returns
+the same result shape as any LLM agent. The motivating shape is a **hybrid team**
+— an LLM planner decomposes the goal, an external coding agent writes the code,
+an LLM reviewer audits the diff — all in one `runTeam` / `runTasks` call.
 
 ## Quick start
 
@@ -29,9 +34,9 @@ const team = oma.createTeam('hybrid-dev', {
       name: 'coder',
       systemPrompt: 'Writes and edits code by running an external coding CLI.',
       backend: {
-        kind: 'acp',
-        command: 'npx',
-        args: ['-y', '@agentclientprotocol/claude-agent-acp'], // Claude Code over ACP
+        kind: 'process',
+        command: 'node',
+        args: ['scripts/code-agent.js'],
         cwd: process.cwd(),
       },
     },
@@ -44,15 +49,18 @@ const result = await oma.runTeam(team, 'Add a slugify() utility with tests, then
 ```
 
 The coordinator routes the coding work to `coder` based on its roster description; the
-ACP subprocess does the file edits; `reviewer` then reads the result from shared memory.
+subprocess does the file edits; `reviewer` then reads the result from shared memory.
 
-A runnable version is at
+A runnable ACP version is at
 [`examples/integrations/external-agent-acp.ts`](../packages/core/examples/integrations/external-agent-acp.ts).
 
 ## Installation
 
+The `process` backend has no extra dependencies. It uses Node's built-in child
+process APIs and starts whatever local command you configure.
+
 ACP support requires the optional peer dependency, loaded lazily so it never affects
-consumers that don't use it:
+consumers that don't use ACP:
 
 ```bash
 npm install @agentclientprotocol/sdk
@@ -67,22 +75,22 @@ it — any ACP agent works. Common choices:
 | Gemini CLI | `gemini --acp` | Native ACP. Note: Google is reportedly retiring the free-tier Gemini CLI (and its `--experimental-acp` flag) — verify availability before relying on it. |
 | Codex | `codex-acp` (or `codex --experimental-acp`) | Experimental ACP support. |
 
-The example below uses Claude Code, which fits OMA's Anthropic-centric default and
-needs only one key (`ANTHROPIC_API_KEY`) for the whole team.
+The ACP examples in this guide use Claude Code, which fits OMA's Anthropic-centric
+default and needs only one key (`ANTHROPIC_API_KEY`) for the whole team.
 
 ## Configuration
 
-`AgentConfig.backend` takes an `AgentBackendConfig` (a discriminated union; only
-`kind: 'acp'` exists today):
+`AgentConfig.backend` takes an `AgentBackendConfig` discriminated union:
 
 | Field | Type | Default | Meaning |
 |-------|------|---------|---------|
-| `kind` | `'acp'` | — | Backend discriminant. |
+| `kind` | `'process' \| 'acp'` | — | Backend discriminant. |
 | `command` | `string` | — | Executable to spawn (`'npx'`, `'gemini'`, …). |
 | `args` | `string[]` | `[]` | Arguments passed to `command`. |
 | `env` | `Record<string,string>` | — | Extra env vars, merged over `process.env`. |
-| `cwd` | `string` | `process.cwd()` | Directory the agent reads and edits. |
-| `permission` | `'auto-approve' \| 'reject' \| fn` | `'auto-approve'` | How to answer permission prompts (below). |
+| `cwd` | `string` | `process.cwd()` | Working directory for the subprocess. |
+| `input` | `'stdin' \| 'argument' \| 'none'` | `'stdin'` | `process` only: how to pass the prompt to the command. |
+| `permission` | `'auto-approve' \| 'reject' \| fn` | `'auto-approve'` | `acp` only: how to answer permission prompts (below). |
 
 When `backend` is set, the LLM-specific fields (`model`, `provider`, `adapter`,
 sampling, `tools`, context strategy) do not apply — the external agent runs its own
@@ -91,7 +99,12 @@ still shapes the external agent because OMA — lacking any ACP system-prompt fi
 prepends it to the agent's first prompt (once per session), on top of seeding the
 coordinator's routing as it does for every agent.
 
-### Permissions
+For `process`, OMA starts a fresh subprocess per run. Use `input: 'stdin'` for
+commands that read a prompt from stdin, `input: 'argument'` when the command
+expects the prompt as the final argument, and `input: 'none'` for fixed adapters
+that derive their work from files or environment.
+
+### ACP permissions
 
 ACP agents ask the client to approve sensitive tool calls (editing a file, running a
 command). Because OMA runs agents autonomously inside a DAG, the default is
@@ -119,6 +132,30 @@ The callback receives a minimal, SDK-agnostic `{ title, kind, optionKinds }` and
 
 ## How it works
 
+Both built-in backends implement the same `AgentBackend` interface (`run` +
+`stream`) that `AgentRunner` already implements. The pool, scheduler, task queue,
+shared memory, and budget aggregation can therefore treat an external agent like
+an LLM agent, with no special cases.
+
+### Process backend
+
+The `process` backend starts a fresh subprocess for each run. It joins the
+configured `systemPrompt` and user prompt, passes the result to the command, and
+maps process outcomes as follows:
+
+| Process outcome | Maps to |
+|-----------------|---------|
+| stdout + exit `0` | success; stdout becomes `result.output` |
+| stderr + exit `0` | success; stderr is ignored unless the process writes it into stdout |
+| exit code / signal | task failure; stderr is redacted and included in the error output |
+| caller abort | cancellation; the child process is killed |
+| no token signal | `tokenUsage` is `{0, 0}` |
+
+Use this backend for simple local CLIs, scripts, or adapters that do not need a
+long-lived agent protocol.
+
+### ACP backend
+
 OMA takes the ACP **client** role. On the first run for an agent it spawns the
 subprocess, frames its stdio as newline-delimited JSON-RPC, `initialize`s, and opens a
 `session/new` in `cwd`. Each `agent.run(prompt)` then sends one `session/prompt` turn
@@ -134,11 +171,7 @@ and drains `session/update` notifications into a normal agent result:
 | stop `refusal` | task failure (cascades to dependents) |
 | stop `cancelled` | returns partial output (from an abort) |
 
-The seam is the `AgentBackend` interface (`run` + `stream`) that `AgentRunner` already
-implements — so the pool, scheduler, task queue, shared memory, and budget accounting
-treat an ACP agent exactly like an LLM agent, with no special cases.
-
-### Token accounting caveat
+### ACP token accounting caveat
 
 ACP reports a single **context-token** figure (`usage_update.used` — "tokens
 currently in context"), not an input/output split, and it is *cumulative* across a
@@ -153,10 +186,14 @@ budget on LLM agents, or bound the ACP agent with its own `--max-*` flags.
 ## Programmatic API
 
 Most users only touch `backend`. To construct a backend directly, import from the
-`@open-multi-agent/core/acp` subpath (this is where the optional peer is loaded):
+matching subpath:
 
 ```typescript
 import { createAcpBackend } from '@open-multi-agent/core/acp'
+import { createProcessBackend } from '@open-multi-agent/core/process'
+
+const processBackend = createProcessBackend({ command: 'node', args: ['agent.js'] })
+const processResult = await processBackend.run([{ role: 'user', content: [{ type: 'text', text: 'summarize' }] }])
 
 const backend = createAcpBackend({ command: 'npx', args: ['-y', '@agentclientprotocol/claude-agent-acp'] })
 const result = await backend.run([{ role: 'user', content: [{ type: 'text', text: 'refactor foo.ts' }] }])
@@ -173,9 +210,10 @@ of these forward):
 - **No `fs/*` proxying.** The agent does its own filesystem access within `cwd`; OMA
   does not yet proxy ACP file operations through its sandbox. Agents that require the
   client to serve files are not supported.
-- **ACP only.** Bespoke per-CLI adapters and non-coding business-system CLIs are out of
-  scope. ACP already covers the major coding agents.
+- **Process backend is stateless.** It starts one subprocess per run and maps stdout
+  to output. Use ACP or a custom backend when you need sessions, structured tool
+  events, or protocol-level permission prompts.
 - **No cost-based budgets.** Budgeting is token-based; `usage_update.cost` is ignored.
-- **Subprocess lifetime.** An orchestrated ACP agent's subprocess lives until the
+- **ACP subprocess lifetime.** An orchestrated ACP agent's subprocess lives until the
   process exits (there is no per-agent disposal hook in `runTeam` / `runTasks`).
   Use the programmatic API + `dispose()` when you need explicit teardown.

--- a/docs/external-agents.md
+++ b/docs/external-agents.md
@@ -51,6 +51,8 @@ const result = await oma.runTeam(team, 'Add a slugify() utility with tests, then
 The coordinator routes the coding work to `coder` based on its roster description; the
 subprocess does the file edits; `reviewer` then reads the result from shared memory.
 
+A runnable `process` version is at
+[`examples/integrations/external-agent-process.ts`](../packages/core/examples/integrations/external-agent-process.ts).
 A runnable ACP version is at
 [`examples/integrations/external-agent-acp.ts`](../packages/core/examples/integrations/external-agent-acp.ts).
 

--- a/packages/core/examples/integrations/README.md
+++ b/packages/core/examples/integrations/README.md
@@ -16,6 +16,8 @@ contributed them. Current:
   to a terminal status by deterministic code.
 - `external-agent-acp.ts`: external coding agents (Gemini CLI / Claude Code) as
   team members via the `acp` backend. See [docs/external-agents.md](../../../../docs/external-agents.md).
+- `external-agent-process.ts`: deterministic local subprocesses as team members
+  via the `process` backend.
 - `trace-observability.ts`: the `onTrace` API.
 - `with-vercel-ai-sdk/`: Next.js + AI SDK + `runTeam()`.
 - `express-customer-support/`: Express REST API + `runTasks()`. Contributed

--- a/packages/core/examples/integrations/external-agent-process.ts
+++ b/packages/core/examples/integrations/external-agent-process.ts
@@ -1,0 +1,61 @@
+/**
+ * Generic local processes as external agents.
+ *
+ * This example uses the `process` backend to run deterministic local Node.js
+ * snippets as OMA team members. It needs no model API key and no optional peer
+ * dependency: each agent is a subprocess, receives its prompt on stdin, writes
+ * its answer to stdout, and participates in the same task DAG/shared memory as
+ * any other agent.
+ *
+ * Run:
+ *   npx tsx packages/core/examples/integrations/external-agent-process.ts
+ */
+
+import { OpenMultiAgent, type AgentConfig } from '../../src/index.js'
+
+function processAgent(name: string, script: string): AgentConfig {
+  return {
+    name,
+    systemPrompt: `${name} runs as a deterministic local process.`,
+    backend: {
+      kind: 'process',
+      command: process.execPath,
+      args: ['-e', script],
+    },
+  }
+}
+
+const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+
+const team = oma.createTeam('local-process-team', {
+  name: 'local-process-team',
+  sharedMemory: true,
+  agents: [
+    processAgent('extractor', `
+      process.stdin.resume()
+      process.stdout.write('release notes: process backend, shared memory handoff')
+    `),
+    processAgent('summarizer', `
+      process.stdin.setEncoding('utf8')
+      let input = ''
+      process.stdin.on('data', chunk => { input += chunk })
+      process.stdin.on('end', () => {
+        const sawHandoff = input.includes('shared memory handoff')
+        process.stdout.write(sawHandoff ? 'summary: external process joined the DAG' : 'summary: missing handoff')
+      })
+    `),
+  ],
+})
+
+const result = await oma.runTasks(team, [
+  { title: 'Extract notes', description: 'Extract release-note facts.', assignee: 'extractor' },
+  {
+    title: 'Summarize notes',
+    description: 'Summarize the extracted facts.',
+    assignee: 'summarizer',
+    dependsOn: ['Extract notes'],
+  },
+])
+
+console.log(result.agentResults.get('extractor')?.output)
+console.log(result.agentResults.get('summarizer')?.output)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,6 +29,10 @@
       "types": "./dist/acp.d.ts",
       "import": "./dist/acp.js"
     },
+    "./process": {
+      "types": "./dist/process.d.ts",
+      "import": "./dist/process.js"
+    },
     "./mcp": {
       "types": "./dist/mcp.d.ts",
       "import": "./dist/mcp.js"

--- a/packages/core/src/acp.ts
+++ b/packages/core/src/acp.ts
@@ -19,6 +19,7 @@ export type { AcpBackendOptions, AcpConnection } from './agent/acp-backend.js'
 export type { AgentBackend } from './agent/runner.js'
 export type {
   AgentBackendConfig,
+  AcpAgentBackendConfig,
   AcpPermissionPolicy,
   AcpPermissionRequest,
 } from './types.js'

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -37,7 +37,7 @@
  */
 
 import type {
-  AgentBackendConfig,
+  ExternalAgentBackendConfig,
   AgentConfig,
   AgentState,
   AgentRunResult,
@@ -220,7 +220,7 @@ export class Agent {
    * The backend module is loaded via dynamic `import()` so its optional peer SDK
    * (e.g. `@agentclientprotocol/sdk`) is only resolved when a backend is used.
    */
-  private async createExternalBackend(backend: AgentBackendConfig): Promise<AgentBackend> {
+  private async createExternalBackend(backend: ExternalAgentBackendConfig): Promise<AgentBackend> {
     switch (backend.kind) {
       case 'acp': {
         const { createAcpBackend } = await import('./acp-backend.js')

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -238,6 +238,18 @@ export class Agent {
           callTimeoutMs: this.config.callTimeoutMs,
         })
       }
+      case 'process': {
+        const { createProcessBackend } = await import('./process-backend.js')
+        return createProcessBackend({
+          command: backend.command,
+          args: backend.args,
+          env: backend.env,
+          cwd: backend.cwd,
+          input: backend.input,
+          systemPrompt: this.config.systemPrompt,
+          agentName: this.name,
+        })
+      }
       default:
         throw new Error(
           `Agent "${this.name}": unknown backend kind "${(backend as { kind: string }).kind}".`,

--- a/packages/core/src/agent/process-backend-io.ts
+++ b/packages/core/src/agent/process-backend-io.ts
@@ -1,0 +1,101 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { resolve as resolvePath } from 'node:path'
+
+import type {
+  ContentBlock,
+  LLMMessage,
+  ProcessBackendInputMode,
+  TokenUsage,
+} from '../types.js'
+import { redactSensitiveText } from '../utils/redaction.js'
+import type { RunResult } from './runner.js'
+
+export const ZERO_PROCESS_USAGE: TokenUsage = { input_tokens: 0, output_tokens: 0 }
+
+export interface ProcessBackendOptions {
+  readonly command: string
+  readonly args?: readonly string[]
+  readonly env?: Readonly<Record<string, string>>
+  readonly cwd?: string
+  readonly input?: ProcessBackendInputMode
+  readonly systemPrompt?: string
+  readonly agentName?: string
+}
+
+export function spawnProcess(
+  options: ProcessBackendOptions,
+  inputMode: ProcessBackendInputMode,
+  prompt: string,
+): ChildProcessWithoutNullStreams {
+  const args = [...(options.args ?? [])]
+  if (inputMode === 'argument') args.push(prompt)
+
+  const child = spawn(options.command, args, {
+    cwd: resolvePath(options.cwd ?? process.cwd()),
+    env: { ...process.env, ...options.env },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  })
+  child.stdin.on('error', () => {})
+  if (inputMode === 'stdin') {
+    child.stdin.end(prompt)
+  } else {
+    child.stdin.end()
+  }
+  return child
+}
+
+export function waitForExit(
+  child: ChildProcessWithoutNullStreams,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    child.once('error', reject)
+    child.once('close', (code, signal) => resolve({ code, signal }))
+  })
+}
+
+export function buildPrompt(messages: LLMMessage[], systemPrompt?: string): string {
+  const userText = lastUserText(messages)
+  const role = systemPrompt?.trim()
+  return [role, userText].filter(Boolean).join('\n\n')
+}
+
+export function cancelledResult(label: string, stdout = ''): RunResult {
+  const output = stdout || `Process backend "${label}" cancelled.`
+  return {
+    messages: [],
+    output,
+    toolCalls: [],
+    tokenUsage: ZERO_PROCESS_USAGE,
+    turns: 0,
+    aborted: true,
+  }
+}
+
+export function processExitError(
+  label: string,
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  stderr: string,
+): Error {
+  const detail = code === null ? `signal ${signal ?? 'unknown'}` : `code ${code}`
+  const redactedStderr = redactSensitiveText(stderr.trim())
+  const suffix = redactedStderr ? `: ${redactedStderr}` : ''
+  return new Error(`Process backend "${label}" exited with ${detail}${suffix}`)
+}
+
+export function toError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err))
+}
+
+function lastUserText(messages: LLMMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i]
+    if (message.role !== 'user') continue
+    return message.content
+      .filter((b): b is Extract<ContentBlock, { type: 'text' }> => b.type === 'text')
+      .map((b) => b.text)
+      .join('\n')
+      .trim()
+  }
+  return ''
+}

--- a/packages/core/src/agent/process-backend-io.ts
+++ b/packages/core/src/agent/process-backend-io.ts
@@ -32,6 +32,7 @@ export function spawnProcess(
 
   const child = spawn(options.command, args, {
     cwd: resolvePath(options.cwd ?? process.cwd()),
+    detached: process.platform !== 'win32',
     env: { ...process.env, ...options.env },
     stdio: ['pipe', 'pipe', 'pipe'],
   })

--- a/packages/core/src/agent/process-backend.ts
+++ b/packages/core/src/agent/process-backend.ts
@@ -1,0 +1,153 @@
+/**
+ * @fileoverview {@link AgentBackend} that runs a generic local process.
+ *
+ * This backend is intentionally protocol-neutral: it sends one prompt to a
+ * subprocess and maps stdout/stderr/exit into the same AgentBackend result shape
+ * used by LLM and ACP-backed agents. Protocol-specific adapters can build on
+ * their own backends; this covers simple CLIs and testable process lifecycle
+ * semantics without introducing a new runtime dependency.
+ */
+
+import type { LLMMessage, StreamEvent } from '../types.js'
+import type { AgentBackend, RunOptions, RunResult } from './runner.js'
+import {
+  ZERO_PROCESS_USAGE,
+  buildPrompt,
+  cancelledResult,
+  processExitError,
+  spawnProcess,
+  toError,
+  waitForExit,
+  type ProcessBackendOptions,
+} from './process-backend-io.js'
+
+export type { ProcessBackendOptions } from './process-backend-io.js'
+
+export function createProcessBackend(options: ProcessBackendOptions): AgentBackend {
+  return new ProcessBackend(options)
+}
+
+export class ProcessBackend implements AgentBackend {
+  constructor(private readonly options: ProcessBackendOptions) {}
+
+  async run(messages: LLMMessage[], options: RunOptions = {}): Promise<RunResult> {
+    let result: RunResult = {
+      messages: [],
+      output: '',
+      toolCalls: [],
+      tokenUsage: ZERO_PROCESS_USAGE,
+      turns: 0,
+    }
+    for await (const event of this.stream(messages, options)) {
+      if (event.type === 'done') {
+        result = event.data as RunResult
+      } else if (event.type === 'error') {
+        throw event.data
+      }
+    }
+    return result
+  }
+
+  async *stream(messages: LLMMessage[], options: RunOptions = {}): AsyncGenerator<StreamEvent> {
+    const label = this.options.agentName ?? 'process'
+    const inputMode = this.options.input ?? 'stdin'
+    const prompt = buildPrompt(messages, this.options.systemPrompt)
+
+    if (inputMode !== 'none' && prompt.length === 0) {
+      yield { type: 'error', data: new Error(`Process backend "${label}" received an empty prompt.`) }
+      return
+    }
+    if (options.abortSignal?.aborted) {
+      yield { type: 'done', data: cancelledResult(label) }
+      return
+    }
+
+    let child: ChildProcessWithoutNullStreams
+    try {
+      child = spawnProcess(this.options, inputMode, prompt)
+    } catch (err) {
+      yield { type: 'error', data: toError(err) }
+      return
+    }
+
+    const abort = options.abortSignal
+    const onAbort = () => {
+      if (!child.killed) child.kill()
+    }
+    abort?.addEventListener('abort', onAbort, { once: true })
+
+    let stdout = ''
+    let stderr = ''
+    const chunks: string[] = []
+    let wake: (() => void) | undefined
+    const wakeReader = () => {
+      wake?.()
+      wake = undefined
+    }
+
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk
+      chunks.push(chunk)
+      wakeReader()
+    })
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk
+    })
+
+    const exit = waitForExit(child)
+
+    try {
+      while (true) {
+        while (chunks.length > 0) {
+          yield { type: 'text', data: chunks.shift()! }
+        }
+
+        const outcome = await Promise.race([
+          exit.then(result => ({ kind: 'exit' as const, result })),
+          new Promise<{ kind: 'chunk' }>(resolve => { wake = () => resolve({ kind: 'chunk' }) }),
+        ])
+
+        if (outcome.kind === 'chunk') continue
+
+        while (chunks.length > 0) {
+          yield { type: 'text', data: chunks.shift()! }
+        }
+
+        if (abort?.aborted) {
+          yield { type: 'done', data: cancelledResult(label, stdout) }
+          return
+        }
+
+        if (outcome.result.code !== 0) {
+          yield { type: 'error', data: processExitError(label, outcome.result.code, outcome.result.signal, stderr) }
+          return
+        }
+
+        const output = stdout
+        const assistantMsg = output
+          ? ({ role: 'assistant', content: [{ type: 'text', text: output }] } satisfies LLMMessage)
+          : undefined
+        if (assistantMsg) options.onMessage?.(assistantMsg)
+        yield {
+          type: 'done',
+          data: {
+            messages: assistantMsg ? [assistantMsg] : [],
+            output,
+            toolCalls: [],
+            tokenUsage: ZERO_PROCESS_USAGE,
+            turns: 1,
+          } satisfies RunResult,
+        }
+        return
+      }
+    } catch (err) {
+      yield { type: 'error', data: toError(err) }
+    } finally {
+      abort?.removeEventListener('abort', onAbort)
+      wakeReader()
+    }
+  }
+}
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'

--- a/packages/core/src/agent/process-backend.ts
+++ b/packages/core/src/agent/process-backend.ts
@@ -8,7 +8,9 @@
  * semantics without introducing a new runtime dependency.
  */
 
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import type { LLMMessage, StreamEvent } from '../types.js'
+import { killProcessTree, killProcessTreeAndWait } from '../utils/process-tree.js'
 import type { AgentBackend, RunOptions, RunResult } from './runner.js'
 import {
   ZERO_PROCESS_USAGE,
@@ -71,9 +73,7 @@ export class ProcessBackend implements AgentBackend {
     }
 
     const abort = options.abortSignal
-    const onAbort = () => {
-      if (!child.killed) child.kill()
-    }
+    const onAbort = () => killProcessTree(child)
     abort?.addEventListener('abort', onAbort, { once: true })
 
     let stdout = ''
@@ -97,6 +97,11 @@ export class ProcessBackend implements AgentBackend {
     })
 
     const exit = waitForExit(child)
+    let exited = false
+    void exit.then(
+      () => { exited = true },
+      () => { exited = true },
+    )
 
     try {
       while (true) {
@@ -147,7 +152,9 @@ export class ProcessBackend implements AgentBackend {
     } finally {
       abort?.removeEventListener('abort', onAbort)
       wakeReader()
+      if (!exited) {
+        await killProcessTreeAndWait(child, exit)
+      }
     }
   }
 }
-import type { ChildProcessWithoutNullStreams } from 'node:child_process'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -244,6 +244,8 @@ export type {
   StructuredTraceError,
   TraceErrorKind,
   AgentBackendConfig,
+  ExternalAgentBackendConfig,
+  AcpAgentBackendConfig,
   AcpPermissionPolicy,
   AcpPermissionRequest,
   BeforeRunHookContext,

--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -1,0 +1,22 @@
+/**
+ * @fileoverview `@open-multi-agent/core/process` — run generic local processes
+ * as OMA agent backends.
+ *
+ * Most users never import this module: set {@link AgentBackendConfig} on an
+ * agent's `backend` field and OMA loads the backend for you. Import from here
+ * only to construct a backend directly (advanced / programmatic use):
+ *
+ * ```ts
+ * import { createProcessBackend } from '@open-multi-agent/core/process'
+ * const backend = createProcessBackend({ command: 'node', args: ['agent.js'] })
+ * ```
+ */
+
+export { ProcessBackend, createProcessBackend } from './agent/process-backend.js'
+export type { ProcessBackendOptions } from './agent/process-backend.js'
+export type { AgentBackend } from './agent/runner.js'
+export type {
+  AgentBackendConfig,
+  ProcessAgentBackendConfig,
+  ProcessBackendInputMode,
+} from './types.js'

--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -2,7 +2,7 @@
  * @fileoverview `@open-multi-agent/core/process` — run generic local processes
  * as OMA agent backends.
  *
- * Most users never import this module: set {@link AgentBackendConfig} on an
+ * Most users never import this module: set {@link ExternalAgentBackendConfig} on an
  * agent's `backend` field and OMA loads the backend for you. Import from here
  * only to construct a backend directly (advanced / programmatic use):
  *
@@ -16,7 +16,7 @@ export { ProcessBackend, createProcessBackend } from './agent/process-backend.js
 export type { ProcessBackendOptions } from './agent/process-backend.js'
 export type { AgentBackend } from './agent/runner.js'
 export type {
-  AgentBackendConfig,
+  ExternalAgentBackendConfig,
   ProcessAgentBackendConfig,
   ProcessBackendInputMode,
 } from './types.js'

--- a/packages/core/src/tool/built-in/bash.ts
+++ b/packages/core/src/tool/built-in/bash.ts
@@ -5,10 +5,11 @@
  * optional timeout and a custom working directory.
  */
 
-import { spawn, type ChildProcess } from 'child_process'
+import { spawn } from 'child_process'
 import { z } from 'zod'
 import { defineTool } from '../framework.js'
 import { isSensitiveName, redactSensitiveText } from '../../utils/redaction.js'
+import { killProcessTree } from '../../utils/process-tree.js'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -191,43 +192,6 @@ function runCommand(
       }
     })
   })
-}
-
-/**
- * Kill the child and any descendants spawned through `&` / job-control.
- *
- * POSIX: we rely on `detached: true` at spawn time, which puts the bash
- * shell in its own process group; sending SIGKILL to the negated PID
- * delivers to every member of that group.
- *
- * Windows: there are no POSIX process groups, and `child.kill()` terminates
- * only the direct child — orphaned descendants would both survive and hold
- * the stdio pipes open, delaying the `close` event until they exit. Use
- * `taskkill /T /F` (always present in System32) to terminate the whole tree.
- */
-function killProcessTree(child: ChildProcess): void {
-  if (child.pid === undefined) {
-    child.kill('SIGKILL')
-    return
-  }
-  if (process.platform === 'win32') {
-    const killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
-      stdio: 'ignore',
-    })
-    // taskkill fails when the tree already exited; direct kill is then a no-op.
-    killer.on('error', () => child.kill('SIGKILL'))
-    killer.on('exit', (code) => {
-      if (code !== 0) child.kill('SIGKILL')
-    })
-    return
-  }
-  try {
-    process.kill(-child.pid, 'SIGKILL')
-  } catch {
-    // The child may already have exited; fall through to a direct kill,
-    // which is a no-op in that case.
-    child.kill('SIGKILL')
-  }
 }
 
 function buildSafeShellEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -541,11 +541,10 @@ export type AcpPermissionPolicy =
  * own agentic loop, while OMA drives it, collects its output and token usage, and
  * schedules it in the task DAG alongside LLM agents.
  *
- * A discriminated union keyed by {@link kind}; only `'acp'` exists today.
  * Requires the optional peer `@agentclientprotocol/sdk`.
  */
-export interface AgentBackendConfig {
-  /** Backend discriminant. Only `'acp'` is supported today. */
+export interface AcpAgentBackendConfig {
+  /** Backend discriminant. */
   readonly kind: 'acp'
   /** Executable to spawn (e.g. `'npx'`, `'gemini'`, `'codex-acp'`). */
   readonly command: string
@@ -562,6 +561,39 @@ export interface AgentBackendConfig {
   /** How to answer the agent's permission prompts. Defaults to `'auto-approve'`. */
   readonly permission?: AcpPermissionPolicy
 }
+
+/** How a generic process backend receives a prompt. */
+export type ProcessBackendInputMode = 'stdin' | 'argument' | 'none'
+
+/**
+ * Configuration for running a generic local process as an OMA team member.
+ *
+ * Unlike ACP, this backend does not speak an agent protocol. It starts a fresh
+ * process per run, sends the prompt by stdin or final argument, maps stdout to
+ * the agent output, and treats non-zero exits as task failures.
+ */
+export interface ProcessAgentBackendConfig {
+  /** Backend discriminant. */
+  readonly kind: 'process'
+  /** Executable to spawn (e.g. `'node'`, `'python'`, `'my-cli'`). */
+  readonly command: string
+  /** Arguments passed to `command` before the prompt argument, if any. */
+  readonly args?: readonly string[]
+  /** Extra environment variables for the subprocess, merged over `process.env`. */
+  readonly env?: Readonly<Record<string, string>>
+  /** Working directory for the subprocess. Defaults to `process.cwd()`. */
+  readonly cwd?: string
+  /**
+   * Prompt delivery mode. Defaults to `'stdin'`.
+   * - `'stdin'`: write the prompt to stdin and close it.
+   * - `'argument'`: append the prompt as the final command argument.
+   * - `'none'`: do not send the prompt; useful for fixed command adapters.
+   */
+  readonly input?: ProcessBackendInputMode
+}
+
+/** External backend configuration keyed by `kind`. */
+export type AgentBackendConfig = AcpAgentBackendConfig | ProcessAgentBackendConfig
 
 /** Static configuration for a single agent. */
 export interface AgentConfig {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -509,7 +509,7 @@ export interface BeforeRunHookContext {
 
 /**
  * A minimal, SDK-agnostic view of an ACP `session/request_permission` prompt,
- * passed to a {@link AgentBackendConfig.permission} callback so callers can decide
+ * passed to a {@link AcpAgentBackendConfig.permission} callback so callers can decide
  * without importing `@agentclientprotocol/sdk`.
  */
 export interface AcpPermissionRequest {
@@ -543,7 +543,7 @@ export type AcpPermissionPolicy =
  *
  * Requires the optional peer `@agentclientprotocol/sdk`.
  */
-export interface AcpAgentBackendConfig {
+export interface AgentBackendConfig {
   /** Backend discriminant. */
   readonly kind: 'acp'
   /** Executable to spawn (e.g. `'npx'`, `'gemini'`, `'codex-acp'`). */
@@ -561,6 +561,9 @@ export interface AcpAgentBackendConfig {
   /** How to answer the agent's permission prompts. Defaults to `'auto-approve'`. */
   readonly permission?: AcpPermissionPolicy
 }
+
+/** Alias for the ACP backend config; `AgentBackendConfig` is kept for v1.10 compatibility. */
+export interface AcpAgentBackendConfig extends AgentBackendConfig {}
 
 /** How a generic process backend receives a prompt. */
 export type ProcessBackendInputMode = 'stdin' | 'argument' | 'none'
@@ -593,7 +596,7 @@ export interface ProcessAgentBackendConfig {
 }
 
 /** External backend configuration keyed by `kind`. */
-export type AgentBackendConfig = AcpAgentBackendConfig | ProcessAgentBackendConfig
+export type ExternalAgentBackendConfig = AgentBackendConfig | ProcessAgentBackendConfig
 
 /** Static configuration for a single agent. */
 export interface AgentConfig {
@@ -615,15 +618,16 @@ export interface AgentConfig {
    */
   readonly adapter?: LLMAdapter
   /**
-   * Run this agent on an external {@link AgentBackendConfig} (e.g. a coding CLI
-   * over the Agent Client Protocol) instead of an LLM adapter. When set, the
+   * Run this agent on an external {@link ExternalAgentBackendConfig} instead of
+   * an LLM adapter. When set, the
    * LLM-specific fields (`model`, `provider`, `adapter`, sampling, tools, context
    * strategy) do not apply — the external agent runs its own loop — but the agent
    * still participates in the task DAG, shared memory, cascade-on-failure, and
-   * token budget like any other team member. Requires the optional peer
-   * `@agentclientprotocol/sdk`; import the backend from `@open-multi-agent/core/acp`.
+   * token budget like any other team member. ACP backends require the optional
+   * peer `@agentclientprotocol/sdk`; generic process backends use Node child
+   * processes and do not require an optional peer.
    */
-  readonly backend?: AgentBackendConfig
+  readonly backend?: ExternalAgentBackendConfig
   readonly provider?: SupportedProvider
   /**
    * Custom base URL for OpenAI-compatible APIs (Ollama, vLLM, LM Studio, etc.).

--- a/packages/core/src/utils/process-tree.ts
+++ b/packages/core/src/utils/process-tree.ts
@@ -1,0 +1,46 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+
+const DEFAULT_KILL_WAIT_MS = 1_000
+
+/**
+ * Kill a child process and its descendants.
+ *
+ * POSIX: callers must spawn the child with `detached: true`, which creates a
+ * process group. Sending SIGKILL to `-pid` terminates every process in it.
+ *
+ * Windows: `taskkill /T /F` terminates the process tree.
+ */
+export function killProcessTree(child: ChildProcess): void {
+  if (child.pid === undefined) {
+    child.kill('SIGKILL')
+    return
+  }
+  if (process.platform === 'win32') {
+    const killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
+      stdio: 'ignore',
+    })
+    killer.on('error', () => child.kill('SIGKILL'))
+    killer.on('exit', (code) => {
+      if (code !== 0) child.kill('SIGKILL')
+    })
+    return
+  }
+  try {
+    process.kill(-child.pid, 'SIGKILL')
+  } catch {
+    child.kill('SIGKILL')
+  }
+}
+
+export async function killProcessTreeAndWait(
+  child: ChildProcess,
+  exit: Promise<unknown>,
+  waitMs = DEFAULT_KILL_WAIT_MS,
+): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  killProcessTree(child)
+  await Promise.race([
+    exit.catch(() => undefined),
+    new Promise(resolve => setTimeout(resolve, waitMs)),
+  ])
+}

--- a/packages/core/tests/agent-backend-config-types.test.ts
+++ b/packages/core/tests/agent-backend-config-types.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import type {
+  AgentBackendConfig,
+  AgentConfig,
+  ExternalAgentBackendConfig,
+} from '../src/types.js'
+
+interface CustomAcpBackendConfig extends AgentBackendConfig {
+  readonly label: 'custom-acp'
+}
+
+describe('agent backend config types', () => {
+  it('keeps AgentBackendConfig as the ACP interface while AgentConfig accepts all external backends', () => {
+    const acp: CustomAcpBackendConfig = {
+      label: 'custom-acp',
+      kind: 'acp',
+      command: 'npx',
+      permission: 'reject',
+    }
+    const processBackend: ExternalAgentBackendConfig = {
+      kind: 'process',
+      command: process.execPath,
+    }
+    const agent: AgentConfig = {
+      name: 'process-agent',
+      backend: processBackend,
+    }
+
+    expect(acp.permission).toBe('reject')
+    expect(agent.backend?.kind).toBe('process')
+  })
+})

--- a/packages/core/tests/process-backend-lifecycle.test.ts
+++ b/packages/core/tests/process-backend-lifecycle.test.ts
@@ -1,0 +1,100 @@
+import { existsSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { describe, it, expect } from 'vitest'
+import { Agent } from '../src/agent/agent.js'
+import { ToolExecutor } from '../src/tool/executor.js'
+import { ToolRegistry } from '../src/tool/framework.js'
+
+function makeAgent(script: string): Agent {
+  const registry = new ToolRegistry()
+  return new Agent(
+    {
+      name: 'cli-worker',
+      systemPrompt: 'You are a local process worker.',
+      backend: {
+        kind: 'process',
+        command: process.execPath,
+        args: ['-e', script],
+      },
+    },
+    registry,
+    new ToolExecutor(registry),
+  )
+}
+
+async function waitForFile(path: string, timeoutMs = 1_000): Promise<void> {
+  const start = Date.now()
+  while (!existsSync(path)) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Timed out waiting for ${path}`)
+    }
+    await delay(10)
+  }
+}
+
+function descendantMarkerScript(
+  markerPath: string,
+  options: { readyPath?: string; writeReady?: boolean } = {},
+): string {
+  const childScript = `
+    const fs = require('node:fs')
+    process.on('SIGHUP', () => {})
+    process.on('SIGTERM', () => {})
+    setTimeout(() => fs.writeFileSync(${JSON.stringify(markerPath)}, 'alive'), 350)
+    setTimeout(() => {}, 10_000)
+  `
+  return `
+    const { spawn } = require('node:child_process')
+    const fs = require('node:fs')
+    const child = spawn(process.execPath, [
+      '-e',
+      ${JSON.stringify(childScript)}
+    ], { stdio: 'ignore' })
+    child.unref()
+    ${options.readyPath ? `fs.writeFileSync(${JSON.stringify(options.readyPath)}, 'ready')` : ''}
+    ${options.writeReady ? "process.stdout.write('ready\\n')" : ''}
+    setTimeout(() => {}, 10_000)
+  `
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, ms))
+}
+
+describe('process backend lifecycle cleanup', () => {
+  it('kills descendant processes when a run is aborted', async () => {
+    const marker = join(tmpdir(), `oma-process-abort-${process.pid}-${Date.now()}`)
+    const ready = join(tmpdir(), `oma-process-abort-ready-${process.pid}-${Date.now()}`)
+    await rm(marker, { force: true })
+    await rm(ready, { force: true })
+    const agent = makeAgent(descendantMarkerScript(marker, { readyPath: ready }))
+    const controller = new AbortController()
+
+    const pending = agent.run('wait', { abortSignal: controller.signal })
+    await waitForFile(ready)
+    controller.abort()
+    const result = await pending
+    await delay(700)
+
+    expect(result.success).toBe(false)
+    expect(result.status.code).toBe('cancelled')
+    expect(existsSync(marker)).toBe(false)
+    await rm(ready, { force: true })
+  })
+
+  it('kills descendant processes when stream consumption stops early', async () => {
+    const marker = join(tmpdir(), `oma-process-stream-${process.pid}-${Date.now()}`)
+    await rm(marker, { force: true })
+    const agent = makeAgent(descendantMarkerScript(marker, { writeReady: true }))
+
+    for await (const event of agent.stream('wait')) {
+      if (event.type === 'text') break
+    }
+    await delay(700)
+
+    expect(existsSync(marker)).toBe(false)
+  })
+
+})

--- a/packages/core/tests/process-backend.test.ts
+++ b/packages/core/tests/process-backend.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { Agent } from '../src/agent/agent.js'
 import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
 import { ToolExecutor } from '../src/tool/executor.js'
 import { ToolRegistry } from '../src/tool/framework.js'
 import type { AgentConfig } from '../src/types.js'
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)))
 
 function makeAgent(script: string): Agent {
   const registry = new ToolRegistry()
@@ -147,5 +152,23 @@ describe('process backend', () => {
     expect(result.tasks?.find(task => task.title === 'Review')?.status).toBe('failed')
     expect(result.agentResults.get('coder')?.output).toContain('exited with code 3')
     expect(result.agentResults.has('reviewer')).toBe(false)
+  })
+
+  it('exposes a public process backend subpath', async () => {
+    const processExports = await import('../src/process.js')
+
+    expect(processExports.ProcessBackend).toBeDefined()
+    expect(processExports.createProcessBackend).toBeDefined()
+  })
+
+  it('declares the process backend subpath in the package exports', async () => {
+    const packageJson = JSON.parse(
+      await readFile(join(packageRoot, 'package.json'), 'utf8'),
+    ) as { exports: Record<string, unknown> }
+
+    expect(packageJson.exports['./process']).toEqual({
+      types: './dist/process.d.ts',
+      import: './dist/process.js',
+    })
   })
 })

--- a/packages/core/tests/process-backend.test.ts
+++ b/packages/core/tests/process-backend.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { Agent } from '../src/agent/agent.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
 import { ToolExecutor } from '../src/tool/executor.js'
 import { ToolRegistry } from '../src/tool/framework.js'
+import type { AgentConfig } from '../src/types.js'
 
 function makeAgent(script: string): Agent {
   const registry = new ToolRegistry()
@@ -18,6 +20,18 @@ function makeAgent(script: string): Agent {
     registry,
     new ToolExecutor(registry),
   )
+}
+
+function processAgent(name: string, script: string): AgentConfig {
+  return {
+    name,
+    systemPrompt: `${name} runs as a local process.`,
+    backend: {
+      kind: 'process',
+      command: process.execPath,
+      args: ['-e', script],
+    },
+  }
 }
 
 describe('process backend', () => {
@@ -74,5 +88,64 @@ describe('process backend', () => {
     expect(result.output).toContain('exited with code 7')
     expect(result.output).toContain('api_key=[redacted]')
     expect(result.output).not.toContain('super-secret-value')
+  })
+
+  it('participates in runTasks dependency handoff through shared memory', async () => {
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('process-team', {
+      name: 'process-team',
+      sharedMemory: true,
+      agents: [
+        processAgent('researcher', `
+          process.stdin.resume()
+          process.stdout.write('research-output')
+        `),
+        processAgent('reviewer', `
+          process.stdin.setEncoding('utf8')
+          let input = ''
+          process.stdin.on('data', chunk => { input += chunk })
+          process.stdin.on('end', () => {
+            process.stdout.write(input.includes('research-output') ? 'review saw research' : 'missing context')
+          })
+        `),
+      ],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Research', description: 'Gather context', assignee: 'researcher' },
+      { title: 'Review', description: 'Review prior output', assignee: 'reviewer', dependsOn: ['Research'] },
+    ])
+
+    expect(result.success).toBe(true)
+    expect(result.agentResults.get('researcher')?.output).toBe('research-output')
+    expect(result.agentResults.get('reviewer')?.output).toBe('review saw research')
+    const researchTask = result.tasks?.find(task => task.title === 'Research')
+    expect(researchTask?.status).toBe('completed')
+    await expect(
+      team.getSharedMemoryInstance()?.read(`researcher/task:${researchTask?.id}:result`),
+    ).resolves.toMatchObject({ value: 'research-output' })
+  })
+
+  it('isolates process failures by preventing dependent tasks from running', async () => {
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('process-failure-team', {
+      name: 'process-failure-team',
+      sharedMemory: true,
+      agents: [
+        processAgent('coder', `process.stderr.write('boom'); process.exit(3)`),
+        processAgent('reviewer', `process.stdout.write('should not run')`),
+      ],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Code', description: 'Write code', assignee: 'coder' },
+      { title: 'Review', description: 'Review code', assignee: 'reviewer', dependsOn: ['Code'] },
+    ])
+
+    expect(result.success).toBe(false)
+    expect(result.tasks?.find(task => task.title === 'Code')?.status).toBe('failed')
+    expect(result.tasks?.find(task => task.title === 'Review')?.status).toBe('failed')
+    expect(result.agentResults.get('coder')?.output).toContain('exited with code 3')
+    expect(result.agentResults.has('reviewer')).toBe(false)
   })
 })

--- a/packages/core/tests/process-backend.test.ts
+++ b/packages/core/tests/process-backend.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { Agent } from '../src/agent/agent.js'
+import { ToolExecutor } from '../src/tool/executor.js'
+import { ToolRegistry } from '../src/tool/framework.js'
+
+function makeAgent(script: string): Agent {
+  const registry = new ToolRegistry()
+  return new Agent(
+    {
+      name: 'cli-worker',
+      systemPrompt: 'You are a local process worker.',
+      backend: {
+        kind: 'process',
+        command: process.execPath,
+        args: ['-e', script],
+      },
+    },
+    registry,
+    new ToolExecutor(registry),
+  )
+}
+
+describe('process backend', () => {
+  it('runs a local process as an agent backend and sends the prompt on stdin', async () => {
+    const agent = makeAgent(`
+      process.stdin.setEncoding('utf8')
+      let input = ''
+      process.stdin.on('data', chunk => { input += chunk })
+      process.stdin.on('end', () => {
+        process.stdout.write('processed:' + input.trim())
+      })
+    `)
+
+    const result = await agent.run('summarize checkout')
+
+    expect(result.success).toBe(true)
+    expect(result.output).toBe(
+      'processed:You are a local process worker.\n\nsummarize checkout',
+    )
+    expect(result.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: result.output }],
+      },
+    ])
+    expect(result.tokenUsage).toEqual({ input_tokens: 0, output_tokens: 0 })
+  })
+
+  it('kills a pending process when the caller aborts the run', async () => {
+    const agent = makeAgent(`
+      process.stdin.resume()
+      setTimeout(() => process.stdout.write('too late'), 10_000)
+    `)
+    const controller = new AbortController()
+
+    const pending = agent.run('wait', { abortSignal: controller.signal })
+    setTimeout(() => controller.abort(), 20)
+    const result = await pending
+
+    expect(result.success).toBe(false)
+    expect(result.status.code).toBe('cancelled')
+    expect(result.output).toContain('cancelled')
+  })
+
+  it('reports non-zero process exits without leaking secret stderr values', async () => {
+    const agent = makeAgent(`
+      process.stderr.write('api_key=super-secret-value\\n')
+      process.exit(7)
+    `)
+
+    const result = await agent.run('fail')
+
+    expect(result.success).toBe(false)
+    expect(result.output).toContain('exited with code 7')
+    expect(result.output).toContain('api_key=[redacted]')
+    expect(result.output).not.toContain('super-secret-value')
+  })
+})


### PR DESCRIPTION
## What

Extends the external-agent v1 by adding a protocol-neutral `process` backend alongside the existing ACP backend. The ACP backend remains the richer protocol-specific path; the new backend runs a configured local command as an agent, supports stdin/argument/no prompt delivery, handles cancellation, redacts stderr on failures, and exposes a public `@open-multi-agent/core/process` subpath.

This also updates the external-agent docs, package entrypoint smoke checks, and adds a no-key runnable process-backend example.

## Why

Refs #204.

The existing ACP implementation is a strong v1 foundation for external agents that speak an agent protocol. This PR is intended as a follow-on extension to that work, not a replacement: it keeps ACP as the protocol-aware backend and adds a smaller generic backend for local CLIs, scripts, and adapters that only need prompt-in/stdout-out process semantics.

That lets simpler external process agents participate in the same `AgentBackend` flow as ACP agents, including `runTasks`, shared memory handoff, dependency ordering, cancellation, and cascade-on-failure behavior.

## Validation

- `npm run lint && npm test`
- `npm run build`
- `npm run test:scaffold`
- `npx tsx packages/core/examples/integrations/external-agent-process.ts`
- package entrypoint smoke for `dist/index.js`, `dist/acp.js`, `dist/process.js`, `dist/mcp.js`, and `dist/ai-sdk.js`

## Checklist

- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] Added/updated tests for changed behavior
- [x] No new runtime dependencies (or justified in the PR description)

Disclosure: I used AI-assisted coding tools while preparing this PR. I reviewed the changes myself, tested them, and take responsibility for the implementation and any follow-up revisions needed.
