### PR TITLE
feat(observability): add FileTraceStore reference implementation

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -259,10 +259,13 @@ implement the storage-medium-neutral `TraceStore` contract in a separate
 database adapter/package and migrate by replaying the committed TraceRecord
 stream. No database driver belongs in the core or this subpath.
 
-Use `npm run build -w @open-multi-agent/core` followed by
-`npm run bench:file-trace-store -w @open-multi-agent/core` for the repeatable
-1k/10k local boundary benchmark (append, fsync, reopen, query, compaction,
-heap estimate, file size, and batch-size comparison).
+From the repository root, run `npm run build -w @open-multi-agent/core`
+followed by
+`node --expose-gc packages/core/benchmarks/file-trace-store.mjs` for the
+repeatable 1k/10k local boundary benchmark (append, fsync, reopen, query,
+compaction, heap estimate, file size, and batch-size comparison). The benchmark
+is a repository development tool and is intentionally excluded from the npm
+tarball.
 
 ### Append, schema, and materialization
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -137,6 +137,133 @@ intended for unit tests, local inspection, and short-lived processes. It has no
 filesystem or database dependency, and it returns copies rather than mutable
 references to its internal records.
 
+### FileTraceStore: persistent single-process reference
+
+`FileTraceStore` is the Node-only reference implementation for local
+development, tests, CLIs, and modest single-process services. It ships in the
+core package—there is no extra dependency to install—but it must be imported
+from the explicit Node-only subpath:
+
+```typescript
+import { FileTraceStore } from '@open-multi-agent/core/observability/file'
+import {
+  BatchingTraceSink,
+  TraceStoreExporter,
+} from '@open-multi-agent/core/observability'
+
+const store = await FileTraceStore.open('./.oma/traces.ndjson')
+const sink = new BatchingTraceSink(new TraceStoreExporter(store))
+
+try {
+  const orchestrator = new OpenMultiAgent({ observability: { sinks: [sink] } })
+  await orchestrator.runAgent(agent, prompt)
+  await sink.forceFlush({ timeoutMs: 5_000 }) // exporter → FileTraceStore
+  await store.flush()                         // fsync the trace file
+} finally {
+  await sink.shutdown({ timeoutMs: 5_000 })
+  await store.close()
+}
+```
+
+Neither `@open-multi-agent/core` nor
+`@open-multi-agent/core/observability` exports or imports this implementation.
+Only `@open-multi-agent/core/observability/file` loads its Node filesystem
+code. Importing any of these modules performs no file I/O; `FileTraceStore.open`
+is the explicit creation/recovery boundary.
+
+`FileTraceStore` and `InMemoryTraceStore` run the same TraceStore contract.
+The in-memory store has no lifecycle or persistence and its state disappears
+with the process. The file store scans its log on open, rebuilds the same
+in-memory indexes, serializes every read/mutation on one instance, and exposes
+`flush`, `close`, and `compact`. Query cursors remain store-instance-specific:
+a cursor from a closed instance is intentionally invalid after reopen; start a
+fresh pagination walk.
+
+#### Disk envelope and recovery
+
+The append-only file is UTF-8 NDJSON with this versioned envelope:
+
+```text
+file_header(format="oma.file_trace_store", formatVersion=1, traceSchemaMajor=2)
+batch_start(batchId, operation, itemCount, payloadSha256)
+batch_item(batchId, index, payload)  # one TraceRecord or delete tombstone
+...
+batch_commit(batchId, itemCount, payloadSha256)
+```
+
+The format version belongs to the file envelope; each trace payload still has
+its own `schemaVersion: 2`. Recovery does not infer either version from memory.
+Unknown additive fields inside supported TraceRecord v2 payloads round-trip
+unchanged.
+
+An append/delete batch becomes visible only when its commit marker is a
+complete NDJSON line and its id, contiguous item count, and SHA-256 checksum
+match the start marker and payloads. On open, the store scans in file order and
+replays only committed batches. A final truncated line or trailing uncommitted
+batch produces a structured, payload-free diagnostic and is truncated back to
+the last committed byte boundary. Thus one API batch is entirely visible or
+entirely absent after restart. A malformed complete line, corruption before
+the tail, invalid committed payload, unsupported file format, or unsupported
+trace schema fails open loudly; it is never skipped.
+
+Delete and retention operations append committed tombstone batches containing
+the exact logical run IDs removed. Reopen therefore cannot resurrect deleted
+records, and it does not re-evaluate retention against a different clock.
+
+#### Write, flush, close, and failure semantics
+
+- A successful `append` means the complete committed envelope was accepted by
+  the operating system's file write and the descriptor was closed. It does
+  **not** mean `fsync` completed.
+- `flush()` waits behind all operations accepted before it and `fsync`s the
+  target file. Repeat calls are safe. It is the explicit boundary for surviving
+  an OS crash/power loss to the extent promised by the local filesystem.
+- `close()` stops accepting new operations, waits for already accepted work,
+  performs the same file `fsync`, and is idempotent. Calls other than repeated
+  `close()` reject afterward with a structured `CLOSED` error.
+- Graceful CLI/server shutdown should flush the batching sink first, then close
+  the store. On an abrupt process exit, fully written but not fsynced batches
+  may be lost by an OS/power failure; a process crash alone normally leaves
+  writes already accepted by the kernel recoverable.
+- Write, permission, disk-full, fsync, and rename failures reject with
+  `FileTraceStoreError`. They are never reported as successful. Error and
+  diagnostic messages contain no TraceRecord or telemetry payload.
+
+New files request mode `0600`. Platforms without POSIX mode enforcement emit a
+diagnostic and rely on their native access controls. The store registers no
+signal handlers and never calls `process.exit()`.
+
+#### Crash-safe compaction
+
+`await store.compact()` writes only the current effective records, in stable
+query/record order, to `<path>.compact.tmp` in the same directory. It sets mode
+`0600`, flushes/fsyncs the temp file, atomically renames it over the target, and
+fsyncs the parent directory when the platform/filesystem supports directory
+fsync. A rename failure leaves the original target authoritative and usable.
+An interrupted temp beside an existing target is diagnosed as stale and is
+ignored until the next compaction overwrites it. A temp without its target is
+treated as ambiguous possible data and open fails rather than creating an
+empty store. Repeated compaction of unchanged state is byte-deterministic.
+
+Compaction does not change query results. Deleted/retention-cleaned records and
+their tombstones disappear from the compacted file.
+
+#### Scope and migration boundary
+
+This is a reference store, not a database. It deliberately provides no
+cross-process lock, multi-process writer coordination, network-filesystem
+consistency, high-concurrency tuning, full-text search, advanced analytics,
+tenant authentication, or RBAC. Do not let two instances write one path, and
+do not use it as a shared NFS/SMB trace backend. For those requirements,
+implement the storage-medium-neutral `TraceStore` contract in a separate
+database adapter/package and migrate by replaying the committed TraceRecord
+stream. No database driver belongs in the core or this subpath.
+
+Use `npm run build -w @open-multi-agent/core` followed by
+`npm run bench:file-trace-store -w @open-multi-agent/core` for the repeatable
+1k/10k local boundary benchmark (append, fsync, reopen, query, compaction,
+heap estimate, file size, and batch-size comparison).
+
 ### Append, schema, and materialization
 
 `append(records)` accepts a batch atomically: validation failure leaves the

--- a/packages/core/benchmarks/file-trace-store.mjs
+++ b/packages/core/benchmarks/file-trace-store.mjs
@@ -1,0 +1,123 @@
+import { mkdtemp, rm, stat } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { performance } from 'node:perf_hooks'
+
+const [candidatePath] = process.argv.slice(2)
+const moduleUrl = candidatePath
+  ? pathToFileURL(candidatePath).href
+  : new URL('../dist/observability/file.js', import.meta.url).href
+const { FileTraceStore } = await import(`${moduleUrl}?file-trace-store-benchmark`)
+
+function records(count, prefix) {
+  return Array.from({ length: count }, (_, index) => {
+    const runIndex = Math.floor(index / 2)
+    const isEnd = index % 2 === 1
+    const start = 1_700_000_000_000 + runIndex
+    return {
+      schemaVersion: 2,
+      recordId: `${prefix}-record-${index}`,
+      sequence: isEnd ? 2 : 1,
+      timestampUnixMs: start + (isEnd ? 1 : 0),
+      runId: `${prefix}-run-${String(runIndex).padStart(6, '0')}`,
+      attempt: 1,
+      traceId: `${prefix}-trace-${runIndex}`,
+      spanId: `${prefix}-span-${runIndex}`,
+      recordType: isEnd ? 'span_end' : 'span_start',
+      kind: 'run',
+      name: 'oma.run',
+      startUnixMs: start,
+      ...(isEnd ? {
+        endUnixMs: start + 1,
+        durationMs: 1,
+        status: { code: 'ok' },
+      } : {}),
+      attributes: {},
+    }
+  })
+}
+
+async function queryAll(store) {
+  let cursor
+  let count = 0
+  do {
+    const page = await store.queryRuns({ limit: 500, order: 'started_asc', ...(cursor ? { cursor } : {}) })
+    count += page.items.length
+    cursor = page.nextCursor
+  } while (cursor)
+  return count
+}
+
+async function measureScale(root, count) {
+  global.gc?.()
+  const heapBefore = process.memoryUsage().heapUsed
+  const path = join(root, `scale-${count}.ndjson`)
+  const payload = records(count, `scale-${count}`)
+  const store = await FileTraceStore.open(path)
+  const appendStarted = performance.now()
+  await store.append(payload)
+  const appendMs = performance.now() - appendStarted
+  const flushStarted = performance.now()
+  await store.flush()
+  const flushMs = performance.now() - flushStarted
+  global.gc?.()
+  const heapAfterIndex = process.memoryUsage().heapUsed
+  await store.close()
+
+  const reopenStarted = performance.now()
+  const reopened = await FileTraceStore.open(path)
+  const reopenMs = performance.now() - reopenStarted
+  const queryStarted = performance.now()
+  const runs = await queryAll(reopened)
+  const queryMs = performance.now() - queryStarted
+  const beforeCompactionBytes = (await stat(path)).size
+  const compactionStarted = performance.now()
+  const compaction = await reopened.compact()
+  const compactionMs = performance.now() - compactionStarted
+  await reopened.close()
+
+  return {
+    records: count,
+    runs,
+    appendMs,
+    flushMs,
+    reopenMs,
+    queryMs,
+    compactionMs,
+    estimatedIndexHeapBytes: Math.max(0, heapAfterIndex - heapBefore),
+    bytesBeforeCompaction: beforeCompactionBytes,
+    bytesAfterCompaction: compaction.fileSizeBytes,
+  }
+}
+
+async function measureBatchSize(root, batchSize, count = 1_000) {
+  const path = join(root, `batch-${batchSize}.ndjson`)
+  const payload = records(count, `batch-${batchSize}`)
+  const store = await FileTraceStore.open(path)
+  const started = performance.now()
+  for (let index = 0; index < payload.length; index += batchSize) {
+    await store.append(payload.slice(index, index + batchSize))
+  }
+  const appendMs = performance.now() - started
+  await store.flush()
+  await store.close()
+  return { batchSize, appendMs, fileSizeBytes: (await stat(path)).size }
+}
+
+const root = await mkdtemp(join(tmpdir(), 'oma-file-trace-benchmark-'))
+try {
+  const scales = []
+  for (const count of [1_000, 10_000]) scales.push(await measureScale(root, count))
+  const batchSizes = []
+  for (const size of [1, 10, 100, 1_000]) batchSizes.push(await measureBatchSize(root, size))
+  console.log(JSON.stringify({
+    node: process.version,
+    platform: `${process.platform}-${process.arch}`,
+    durability: 'append=write-complete; flush/close=fsync',
+    scales,
+    batchSizes,
+  }, null, 2))
+} finally {
+  await rm(root, { recursive: true, force: true })
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "description": "TypeScript multi-agent framework: one runTeam() call from goal to result. Auto task decomposition and parallel execution for multi-step LLM jobs. Deploys anywhere Node.js runs.",
   "files": [
     "dist",
+    "benchmarks/file-trace-store.mjs",
     "README.md",
     "LICENSE"
   ],
@@ -24,6 +25,10 @@
     "./observability": {
       "types": "./dist/observability/index.d.ts",
       "import": "./dist/observability/index.js"
+    },
+    "./observability/file": {
+      "types": "./dist/observability/file.d.ts",
+      "import": "./dist/observability/file.js"
     },
     "./acp": {
       "types": "./dist/acp.d.ts",
@@ -51,6 +56,7 @@
     "test:coverage": "vitest run --coverage",
     "lint": "tsc --noEmit",
     "test:e2e": "RUN_E2E=1 vitest run tests/e2e/",
+    "bench:file-trace-store": "node --expose-gc benchmarks/file-trace-store.mjs",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,6 @@
   "description": "TypeScript multi-agent framework: one runTeam() call from goal to result. Auto task decomposition and parallel execution for multi-step LLM jobs. Deploys anywhere Node.js runs.",
   "files": [
     "dist",
-    "benchmarks/file-trace-store.mjs",
     "README.md",
     "LICENSE"
   ],
@@ -56,7 +55,6 @@
     "test:coverage": "vitest run --coverage",
     "lint": "tsc --noEmit",
     "test:e2e": "RUN_E2E=1 vitest run tests/e2e/",
-    "bench:file-trace-store": "node --expose-gc benchmarks/file-trace-store.mjs",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/packages/core/src/observability/file-store.ts
+++ b/packages/core/src/observability/file-store.ts
@@ -1,0 +1,834 @@
+/**
+ * Node-only, single-process reference TraceStore backed by append-only NDJSON.
+ * Import from `@open-multi-agent/core/observability/file`.
+ *
+ * The file contains a versioned header followed by committed mutation batches.
+ * A batch is visible only after its `batch_commit` marker, item count, and
+ * SHA-256 payload checksum all validate. Recovery truncates an incomplete tail
+ * back to the last committed byte boundary, so a crashed append is replayed in
+ * full or not at all.
+ */
+
+import { createHash, randomUUID } from 'node:crypto'
+import {
+  mkdir,
+  open,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  type FileHandle,
+} from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { TraceRecord } from './records.js'
+import { InMemoryTraceStore } from './in-memory-store.js'
+import {
+  TRACE_STORE_SCHEMA_MAJOR,
+  TraceStoreError,
+  type AppendResult,
+  type DeleteResult,
+  type GetRunOptions,
+  type Page,
+  type RetentionPolicy,
+  type RunSummary,
+  type StoredRun,
+  type TraceDeleteQuery,
+  type TraceQuery,
+  type TraceStore,
+  type TraceStoreDiagnostic,
+} from './store.js'
+
+export const FILE_TRACE_STORE_FORMAT = 'oma.file_trace_store' as const
+export const FILE_TRACE_STORE_FORMAT_VERSION = 1 as const
+
+export type FileTraceStoreErrorCode =
+  | 'INVALID_PATH'
+  | 'OPEN_FAILED'
+  | 'READ_FAILED'
+  | 'WRITE_FAILED'
+  | 'SYNC_FAILED'
+  | 'CLOSE_FAILED'
+  | 'CORRUPT_FILE'
+  | 'UNSUPPORTED_FILE_FORMAT'
+  | 'UNSUPPORTED_TRACE_SCHEMA'
+  | 'RECOVERY_FAILED'
+  | 'STALE_COMPACTION_FILE'
+  | 'RENAME_FAILED'
+  | 'COMPACTION_FAILED'
+  | 'CLOSED'
+  | 'RECOVERY_REQUIRED'
+
+/** Payload-free, structured FileTraceStore lifecycle or filesystem failure. */
+export class FileTraceStoreError extends Error {
+  readonly name = 'FileTraceStoreError'
+
+  constructor(
+    readonly code: FileTraceStoreErrorCode,
+    message: string,
+    readonly operation?: string,
+    readonly path?: string,
+    readonly lineNumber?: number,
+    readonly causeCode?: string,
+  ) {
+    super(message)
+  }
+}
+
+export type FileTraceStoreDiagnosticCode =
+  | 'trailing_partial_line'
+  | 'incomplete_batch'
+  | 'stale_compaction_file'
+  | 'directory_sync_unsupported'
+  | 'minimal_permissions_not_enforced'
+
+export interface FileTraceStoreDiagnostic {
+  readonly code: FileTraceStoreDiagnosticCode
+  readonly severity: 'warning'
+  readonly message: string
+  readonly lineNumber?: number
+}
+
+export interface FileTraceStoreOptions {
+  /** Injectable wall clock used only by retention. */
+  readonly now?: () => number
+  readonly onDiagnostic?: (
+    diagnostic: FileTraceStoreDiagnostic | TraceStoreDiagnostic,
+  ) => void
+}
+
+export interface FileTraceStoreCompactionResult {
+  readonly recordsWritten: number
+  readonly fileSizeBytes: number
+}
+
+interface FileHeader {
+  readonly type: 'file_header'
+  readonly format: typeof FILE_TRACE_STORE_FORMAT
+  readonly formatVersion: typeof FILE_TRACE_STORE_FORMAT_VERSION
+  readonly traceSchemaMajor: typeof TRACE_STORE_SCHEMA_MAJOR
+}
+
+type MutationOperation = 'append' | 'delete'
+
+interface BatchStart {
+  readonly type: 'batch_start'
+  readonly formatVersion: typeof FILE_TRACE_STORE_FORMAT_VERSION
+  readonly batchId: string
+  readonly operation: MutationOperation
+  readonly itemCount: number
+  readonly payloadSha256: string
+}
+
+interface BatchItem {
+  readonly type: 'batch_item'
+  readonly batchId: string
+  readonly index: number
+  readonly payload: unknown
+}
+
+interface BatchCommit {
+  readonly type: 'batch_commit'
+  readonly batchId: string
+  readonly itemCount: number
+  readonly payloadSha256: string
+}
+
+interface PendingBatch {
+  readonly start: BatchStart
+  readonly payloads: unknown[]
+  readonly startLine: number
+}
+
+interface ParsedFile {
+  readonly memory: InMemoryTraceStore
+  readonly header: FileHeader
+  readonly repairOffset?: number
+}
+
+const HEADER: FileHeader = {
+  type: 'file_header',
+  format: FILE_TRACE_STORE_FORMAT,
+  formatVersion: FILE_TRACE_STORE_FORMAT_VERSION,
+  traceSchemaMajor: TRACE_STORE_SCHEMA_MAJOR,
+}
+
+const DIRECTORY_SYNC_UNSUPPORTED = new Set(['EINVAL', 'ENOTSUP', 'EOPNOTSUPP', 'EISDIR', 'EPERM'])
+
+/** @internal Mutable indirection used only for deterministic filesystem failure tests. */
+export const FILE_TRACE_STORE_IO = {
+  mkdir,
+  open,
+  readFile,
+  rename,
+  stat,
+  unlink,
+  writeFile: (handle: FileHandle, data: string) => handle.writeFile(data, 'utf8'),
+  sync: (handle: FileHandle) => handle.sync(),
+  close: (handle: FileHandle) => handle.close(),
+  truncate: (handle: FileHandle, length: number) => handle.truncate(length),
+  chmod: (handle: FileHandle, mode: number) => handle.chmod(mode),
+}
+
+function errno(error: unknown): string | undefined {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code
+  return typeof code === 'string' ? code : undefined
+}
+
+function emitSafely(
+  callback: FileTraceStoreOptions['onDiagnostic'],
+  diagnostic: FileTraceStoreDiagnostic | TraceStoreDiagnostic,
+): void {
+  try { callback?.(diagnostic) } catch { /* diagnostics never affect storage */ }
+}
+
+function fileError(
+  code: FileTraceStoreErrorCode,
+  message: string,
+  operation: string,
+  path: string,
+  cause?: unknown,
+  lineNumber?: number,
+): FileTraceStoreError {
+  return new FileTraceStoreError(code, message, operation, path, lineNumber, errno(cause))
+}
+
+function parseObject(line: string, path: string, lineNumber: number): Record<string, unknown> {
+  try {
+    const value = JSON.parse(line) as unknown
+    if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('not-object')
+    return value as Record<string, unknown>
+  } catch {
+    throw fileError(
+      'CORRUPT_FILE',
+      'FileTraceStore encountered an invalid complete NDJSON line.',
+      'recover', path, undefined, lineNumber,
+    )
+  }
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function payloadChecksum(payloads: readonly unknown[]): string {
+  const hash = createHash('sha256')
+  for (const payload of payloads) {
+    hash.update(JSON.stringify(payload))
+    hash.update('\n')
+  }
+  return hash.digest('hex')
+}
+
+function serializeBatch(
+  operation: MutationOperation,
+  payloads: readonly unknown[],
+  batchId: string = randomUUID(),
+): string {
+  const checksum = payloadChecksum(payloads)
+  const start: BatchStart = {
+    type: 'batch_start',
+    formatVersion: FILE_TRACE_STORE_FORMAT_VERSION,
+    batchId,
+    operation,
+    itemCount: payloads.length,
+    payloadSha256: checksum,
+  }
+  const lines = [JSON.stringify(start)]
+  for (let index = 0; index < payloads.length; index++) {
+    lines.push(JSON.stringify({
+      type: 'batch_item', batchId, index, payload: payloads[index],
+    } satisfies BatchItem))
+  }
+  lines.push(JSON.stringify({
+    type: 'batch_commit', batchId, itemCount: payloads.length, payloadSha256: checksum,
+  } satisfies BatchCommit))
+  return `${lines.join('\n')}\n`
+}
+
+function cloneJson<T>(value: T, field: string): T {
+  try {
+    return JSON.parse(JSON.stringify(value)) as T
+  } catch {
+    throw new TraceStoreError('INVALID_ARGUMENT', `${field} must be JSON-serializable.`, field)
+  }
+}
+
+/**
+ * Persistent local TraceStore reference. One instance serializes all reads and
+ * writes; two instances/processes must not write the same file concurrently.
+ */
+export class FileTraceStore implements TraceStore {
+  readonly filePath: string
+  readonly compactionTempPath: string
+
+  private memory: InMemoryTraceStore
+  private header: FileHeader
+  private operationChain: Promise<void> = Promise.resolve()
+  private state: 'open' | 'closing' | 'closed' | 'failed' = 'open'
+  private closePromise: Promise<void> | null = null
+  private readonly diagnostics: FileTraceStoreDiagnostic[] = []
+
+  private constructor(
+    filePath: string,
+    memory: InMemoryTraceStore,
+    header: FileHeader,
+    private readonly options: FileTraceStoreOptions,
+  ) {
+    this.filePath = filePath
+    this.compactionTempPath = `${filePath}.compact.tmp`
+    this.memory = memory
+    this.header = header
+  }
+
+  /** Open or create a store, scan the full log, repair only an incomplete tail, and rebuild indexes. */
+  static async open(filePath: string, options: FileTraceStoreOptions = {}): Promise<FileTraceStore> {
+    if (typeof filePath !== 'string' || filePath.length === 0 || filePath.includes('\0')) {
+      throw new FileTraceStoreError('INVALID_PATH', 'FileTraceStore path must be a non-empty filesystem path.', 'open')
+    }
+    const absolute = resolve(filePath)
+    const tempPath = `${absolute}.compact.tmp`
+    const tempExists = await FileTraceStore.pathExists(tempPath, 'open')
+    const targetExists = await FileTraceStore.pathExists(absolute, 'open')
+    if (!targetExists && tempExists) {
+      throw fileError(
+        'STALE_COMPACTION_FILE',
+        'A compaction temp file exists without the target file; refusing to create an empty store.',
+        'open', absolute,
+      )
+    }
+    if (!targetExists) await FileTraceStore.createFile(absolute, options)
+
+    const provisional = new FileTraceStore(
+      absolute,
+      new InMemoryTraceStore({ now: options.now }),
+      HEADER,
+      options,
+    )
+    if (tempExists) provisional.emitFileDiagnostic({
+      code: 'stale_compaction_file', severity: 'warning',
+      message: 'A stale compaction temp file was found; the committed target file remains authoritative.',
+    })
+    const parsed = await provisional.parseFile(true)
+    provisional.memory = parsed.memory
+    provisional.header = parsed.header
+    if (process.platform === 'win32') provisional.emitFileDiagnostic({
+      code: 'minimal_permissions_not_enforced', severity: 'warning',
+      message: 'This platform does not enforce POSIX mode 0600; protect the file with platform access controls.',
+    })
+    return provisional
+  }
+
+  get isClosed(): boolean {
+    return this.state === 'closed'
+  }
+
+  getDiagnostics(): readonly FileTraceStoreDiagnostic[] {
+    return cloneJson(this.diagnostics, 'diagnostics')
+  }
+
+  async append(records: readonly TraceRecord[]): Promise<AppendResult> {
+    const snapshot = cloneJson(records, 'records')
+    return this.enqueue(async () => {
+      const result = await this.memory.append(snapshot)
+      if (snapshot.length > 0) {
+        try {
+          await this.appendMutation('append', snapshot)
+        } catch (error) {
+          await this.rollbackAfterMutationFailure(error)
+          throw error
+        }
+      }
+      for (const diagnostic of result.diagnostics) emitSafely(this.options.onDiagnostic, diagnostic)
+      return result
+    })
+  }
+
+  async getRun(runId: string, options: GetRunOptions = {}): Promise<StoredRun | null> {
+    const optionsSnapshot = cloneJson(options, 'options')
+    return this.enqueue(() => this.memory.getRun(runId, optionsSnapshot))
+  }
+
+  async queryRuns(query: TraceQuery = {}): Promise<Page<RunSummary>> {
+    const snapshot = cloneJson(query, 'query')
+    return this.enqueue(() => this.memory.queryRuns(snapshot))
+  }
+
+  async deleteRun(runId: string): Promise<DeleteResult> {
+    return this.enqueue(async () => {
+      const result = await this.memory.deleteRun(runId)
+      return this.persistDeleteResult(result)
+    })
+  }
+
+  async delete(query: TraceDeleteQuery): Promise<DeleteResult> {
+    const snapshot = cloneJson(query, 'query')
+    return this.enqueue(async () => {
+      const result = await this.memory.delete(snapshot)
+      return this.persistDeleteResult(result)
+    })
+  }
+
+  async applyRetention(policy: RetentionPolicy): Promise<DeleteResult> {
+    const snapshot = cloneJson(policy, 'policy')
+    return this.enqueue(async () => {
+      const result = await this.memory.applyRetention(snapshot)
+      return this.persistDeleteResult(result)
+    })
+  }
+
+  /** fsync all writes that completed before this call. The store remains open. */
+  async flush(): Promise<void> {
+    return this.enqueue(() => this.syncTarget('flush'))
+  }
+
+  /**
+   * Rewrite only current effective records through same-directory temp → fsync
+   * → atomic rename → directory fsync. Query results and in-memory cursors are unchanged.
+   */
+  async compact(): Promise<FileTraceStoreCompactionResult> {
+    return this.enqueue(async () => {
+      const records = await this.currentRecords()
+      const checksum = payloadChecksum(records)
+      const body = records.length > 0
+        ? `${JSON.stringify(this.header)}\n${serializeBatch('append', records, `compact-${checksum.slice(0, 24)}`)}`
+        : `${JSON.stringify(this.header)}\n`
+      let handle: FileHandle | undefined
+      let renamed = false
+      try {
+        handle = await FILE_TRACE_STORE_IO.open(this.compactionTempPath, 'w', 0o600)
+        await FILE_TRACE_STORE_IO.chmod(handle, 0o600)
+        await FILE_TRACE_STORE_IO.writeFile(handle, body)
+        await FILE_TRACE_STORE_IO.sync(handle)
+        await FILE_TRACE_STORE_IO.close(handle)
+        handle = undefined
+        try {
+          await FILE_TRACE_STORE_IO.rename(this.compactionTempPath, this.filePath)
+          renamed = true
+        } catch (error) {
+          throw fileError(
+            'RENAME_FAILED',
+            'FileTraceStore compaction could not atomically replace the target; the original remains authoritative.',
+            'compact.rename', this.filePath, error,
+          )
+        }
+        await this.syncDirectory('compact')
+        const info = await FILE_TRACE_STORE_IO.stat(this.filePath)
+        return { recordsWritten: records.length, fileSizeBytes: info.size }
+      } catch (error) {
+        if (handle) await FILE_TRACE_STORE_IO.close(handle).catch(() => undefined)
+        if (error instanceof FileTraceStoreError) throw error
+        throw fileError(
+          renamed ? 'COMPACTION_FAILED' : 'COMPACTION_FAILED',
+          renamed
+            ? 'FileTraceStore replaced the compacted file but could not confirm the final durability step.'
+            : 'FileTraceStore compaction failed before replacing the committed target file.',
+          'compact', this.filePath, error,
+        )
+      }
+    })
+  }
+
+  /** Idempotently fsync prior writes and reject all later operations. */
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise
+    if (this.state === 'closed') return Promise.resolve()
+    if (this.state === 'failed') {
+      this.state = 'closed'
+      this.closePromise = Promise.reject(fileError(
+        'RECOVERY_REQUIRED',
+        'FileTraceStore cannot close cleanly after an unrecoverable write failure.',
+        'close', this.filePath,
+      ))
+      return this.closePromise
+    }
+    this.state = 'closing'
+    const closing = this.operationChain.then(async () => {
+      if (this.state === 'failed') {
+        throw fileError(
+          'RECOVERY_REQUIRED',
+          'FileTraceStore cannot close cleanly after an unrecoverable write failure.',
+          'close', this.filePath,
+        )
+      }
+      try {
+        await this.syncTarget('close')
+      } catch (error) {
+        if (error instanceof FileTraceStoreError) throw error
+        throw fileError('CLOSE_FAILED', 'FileTraceStore close failed.', 'close', this.filePath, error)
+      }
+    })
+    this.closePromise = closing.then(
+      () => { this.state = 'closed' },
+      (error) => { this.state = 'closed'; throw error },
+    )
+    this.operationChain = this.closePromise.then(() => undefined, () => undefined)
+    return this.closePromise
+  }
+
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.state === 'failed') {
+      return Promise.reject(fileError(
+        'RECOVERY_REQUIRED',
+        'FileTraceStore requires reopen/recovery before further operations.',
+        'operation', this.filePath,
+      ))
+    }
+    if (this.state !== 'open') {
+      return Promise.reject(fileError(
+        'CLOSED',
+        'FileTraceStore is closing or closed.',
+        'operation', this.filePath,
+      ))
+    }
+    const run = this.operationChain.then(operation)
+    this.operationChain = run.then(() => undefined, () => undefined)
+    return run
+  }
+
+  private async persistDeleteResult(result: DeleteResult): Promise<DeleteResult> {
+    if (result.runIds.length === 0) return result
+    try {
+      await this.appendMutation('delete', result.runIds.map((runId) => ({ runId })))
+      return result
+    } catch (error) {
+      await this.rollbackAfterMutationFailure(error)
+      throw error
+    }
+  }
+
+  private async appendMutation(operation: MutationOperation, payloads: readonly unknown[]): Promise<void> {
+    let startSize: number
+    try {
+      startSize = (await FILE_TRACE_STORE_IO.stat(this.filePath)).size
+    } catch (error) {
+      throw fileError('WRITE_FAILED', 'FileTraceStore could not inspect its data file before writing.', 'append.stat', this.filePath, error)
+    }
+    let handle: FileHandle | undefined
+    try {
+      handle = await FILE_TRACE_STORE_IO.open(this.filePath, 'a')
+      await FILE_TRACE_STORE_IO.writeFile(handle, serializeBatch(operation, payloads))
+      await FILE_TRACE_STORE_IO.close(handle)
+    } catch (error) {
+      if (handle) await FILE_TRACE_STORE_IO.close(handle).catch(() => undefined)
+      const writeError = fileError(
+        'WRITE_FAILED',
+        'FileTraceStore append did not complete; the mutation was not acknowledged.',
+        'append.write', this.filePath, error,
+      )
+      try {
+        await this.truncateAndSync(startSize)
+      } catch (rollbackError) {
+        this.state = 'failed'
+        throw fileError(
+          'RECOVERY_REQUIRED',
+          'FileTraceStore could not roll back a failed append; reopen is required.',
+          'append.rollback', this.filePath, rollbackError,
+        )
+      }
+      throw writeError
+    }
+  }
+
+  private async rollbackAfterMutationFailure(original: unknown): Promise<void> {
+    if (this.state === 'failed') return
+    try {
+      const parsed = await this.parseFile(false)
+      this.memory = parsed.memory
+      this.header = parsed.header
+    } catch (recoveryError) {
+      this.state = 'failed'
+      throw fileError(
+        'RECOVERY_REQUIRED',
+        'FileTraceStore could not rebuild state after a failed mutation.',
+        'rollback', this.filePath, recoveryError,
+      )
+    }
+    if (original instanceof Error) return
+  }
+
+  private async truncateAndSync(length: number): Promise<void> {
+    let handle: FileHandle | undefined
+    try {
+      handle = await FILE_TRACE_STORE_IO.open(this.filePath, 'r+')
+      await FILE_TRACE_STORE_IO.truncate(handle, length)
+      await FILE_TRACE_STORE_IO.sync(handle)
+      await FILE_TRACE_STORE_IO.close(handle)
+    } finally {
+      if (handle) await FILE_TRACE_STORE_IO.close(handle).catch(() => undefined)
+    }
+  }
+
+  private async syncTarget(operation: string): Promise<void> {
+    let handle: FileHandle | undefined
+    try {
+      handle = await FILE_TRACE_STORE_IO.open(this.filePath, 'r')
+      await FILE_TRACE_STORE_IO.sync(handle)
+      await FILE_TRACE_STORE_IO.close(handle)
+    } catch (error) {
+      if (handle) await FILE_TRACE_STORE_IO.close(handle).catch(() => undefined)
+      throw fileError(
+        'SYNC_FAILED',
+        'FileTraceStore could not fsync its data file.',
+        operation, this.filePath, error,
+      )
+    }
+  }
+
+  private async currentRecords(): Promise<TraceRecord[]> {
+    const records: TraceRecord[] = []
+    let cursor: string | undefined
+    do {
+      const page = await this.memory.queryRuns({ limit: 500, order: 'started_asc', ...(cursor ? { cursor } : {}) })
+      for (const summary of page.items) {
+        const run = await this.memory.getRun(summary.runId, { includeRecords: true })
+        if (run?.records) records.push(...run.records)
+      }
+      cursor = page.nextCursor
+    } while (cursor)
+    return records
+  }
+
+  private async parseFile(repairTail: boolean): Promise<ParsedFile> {
+    let raw: Buffer
+    try {
+      raw = await FILE_TRACE_STORE_IO.readFile(this.filePath)
+    } catch (error) {
+      throw fileError('READ_FAILED', 'FileTraceStore could not read its data file.', 'recover.read', this.filePath, error)
+    }
+    const memory = new InMemoryTraceStore({ now: this.options.now })
+    let offset = 0
+    let lineNumber = 0
+    let lastCommittedOffset = 0
+    let header: FileHeader | undefined
+    let pending: PendingBatch | undefined
+    while (offset < raw.length) {
+      const newline = raw.indexOf(0x0a, offset)
+      if (newline === -1) {
+        this.emitFileDiagnostic({
+          code: 'trailing_partial_line', severity: 'warning', lineNumber: lineNumber + 1,
+          message: 'A trailing partial NDJSON line was ignored and will be truncated.',
+        })
+        break
+      }
+      lineNumber++
+      const line = raw.subarray(offset, newline).toString('utf8')
+      const nextOffset = newline + 1
+      if (line.length === 0) {
+        throw fileError(
+          'CORRUPT_FILE',
+          'FileTraceStore encountered an empty complete NDJSON line.',
+          'recover', this.filePath, undefined, lineNumber,
+        )
+      }
+      const value = parseObject(line, this.filePath, lineNumber)
+      if (!header) {
+        header = this.parseHeader(value, lineNumber)
+        lastCommittedOffset = nextOffset
+        offset = nextOffset
+        continue
+      }
+      const type = value['type']
+      if (type === 'batch_start') {
+        if (pending) throw this.corruption('A new batch began before the prior batch committed.', lineNumber)
+        pending = { start: this.parseBatchStart(value, lineNumber), payloads: [], startLine: lineNumber }
+      } else if (type === 'batch_item') {
+        if (!pending) throw this.corruption('A batch item appeared without a batch start.', lineNumber)
+        const item = this.parseBatchItem(value, lineNumber)
+        if (item.batchId !== pending.start.batchId || item.index !== pending.payloads.length) {
+          throw this.corruption('A batch item has a mismatched id or non-contiguous index.', lineNumber)
+        }
+        if (pending.payloads.length >= pending.start.itemCount) {
+          throw this.corruption('A batch contains more items than declared.', lineNumber)
+        }
+        pending.payloads.push(item.payload)
+      } else if (type === 'batch_commit') {
+        if (!pending) throw this.corruption('A batch commit appeared without a batch start.', lineNumber)
+        const commit = this.parseBatchCommit(value, lineNumber)
+        const checksum = payloadChecksum(pending.payloads)
+        if (commit.batchId !== pending.start.batchId
+          || commit.itemCount !== pending.start.itemCount
+          || pending.payloads.length !== pending.start.itemCount
+          || commit.payloadSha256 !== pending.start.payloadSha256
+          || checksum !== pending.start.payloadSha256) {
+          throw this.corruption('A committed batch failed its id, count, or checksum validation.', lineNumber)
+        }
+        await this.applyRecoveredBatch(memory, pending, lineNumber)
+        pending = undefined
+        lastCommittedOffset = nextOffset
+      } else {
+        throw this.corruption('FileTraceStore encountered an unknown envelope line type.', lineNumber)
+      }
+      offset = nextOffset
+    }
+    if (!header) {
+      throw fileError(
+        'CORRUPT_FILE',
+        'FileTraceStore has no complete version header.',
+        'recover', this.filePath,
+      )
+    }
+    const hasPartialLine = offset < raw.length
+    if (pending) this.emitFileDiagnostic({
+      code: 'incomplete_batch', severity: 'warning', lineNumber: pending.startLine,
+      message: 'An uncommitted trailing batch was ignored and will be truncated.',
+    })
+    const needsRepair = hasPartialLine || pending !== undefined
+    if (needsRepair && repairTail) {
+      try {
+        await this.truncateAndSync(lastCommittedOffset)
+      } catch (error) {
+        throw fileError(
+          'RECOVERY_FAILED',
+          'FileTraceStore could not truncate an incomplete tail during recovery.',
+          'recover.truncate', this.filePath, error,
+        )
+      }
+    }
+    return { memory, header, ...(needsRepair ? { repairOffset: lastCommittedOffset } : {}) }
+  }
+
+  private parseHeader(value: Record<string, unknown>, lineNumber: number): FileHeader {
+    if (value['type'] !== 'file_header' || value['format'] !== FILE_TRACE_STORE_FORMAT) {
+      throw this.corruption('FileTraceStore header format is invalid.', lineNumber)
+    }
+    if (value['formatVersion'] !== FILE_TRACE_STORE_FORMAT_VERSION) {
+      throw fileError(
+        'UNSUPPORTED_FILE_FORMAT',
+        'FileTraceStore file format version is unsupported.',
+        'recover.header', this.filePath, undefined, lineNumber,
+      )
+    }
+    if (value['traceSchemaMajor'] !== TRACE_STORE_SCHEMA_MAJOR) {
+      throw fileError(
+        'UNSUPPORTED_TRACE_SCHEMA',
+        'FileTraceStore trace schema major is unsupported.',
+        'recover.header', this.filePath, undefined, lineNumber,
+      )
+    }
+    return HEADER
+  }
+
+  private parseBatchStart(value: Record<string, unknown>, lineNumber: number): BatchStart {
+    if (value['formatVersion'] !== FILE_TRACE_STORE_FORMAT_VERSION
+      || !nonEmpty(value['batchId'])
+      || (value['operation'] !== 'append' && value['operation'] !== 'delete')
+      || !Number.isInteger(value['itemCount']) || (value['itemCount'] as number) < 0
+      || !nonEmpty(value['payloadSha256'])) {
+      throw this.corruption('A batch_start envelope is malformed.', lineNumber)
+    }
+    return value as unknown as BatchStart
+  }
+
+  private parseBatchItem(value: Record<string, unknown>, lineNumber: number): BatchItem {
+    if (!nonEmpty(value['batchId']) || !Number.isInteger(value['index']) || (value['index'] as number) < 0
+      || !Object.prototype.hasOwnProperty.call(value, 'payload')) {
+      throw this.corruption('A batch_item envelope is malformed.', lineNumber)
+    }
+    return value as unknown as BatchItem
+  }
+
+  private parseBatchCommit(value: Record<string, unknown>, lineNumber: number): BatchCommit {
+    if (!nonEmpty(value['batchId']) || !Number.isInteger(value['itemCount']) || (value['itemCount'] as number) < 0
+      || !nonEmpty(value['payloadSha256'])) {
+      throw this.corruption('A batch_commit envelope is malformed.', lineNumber)
+    }
+    return value as unknown as BatchCommit
+  }
+
+  private async applyRecoveredBatch(
+    memory: InMemoryTraceStore,
+    pending: PendingBatch,
+    lineNumber: number,
+  ): Promise<void> {
+    try {
+      if (pending.start.operation === 'append') {
+        await memory.append(pending.payloads as TraceRecord[])
+      } else {
+        for (const payload of pending.payloads) {
+          if (!payload || typeof payload !== 'object' || Array.isArray(payload)
+            || !nonEmpty((payload as Record<string, unknown>)['runId'])) {
+            throw new Error('invalid-delete-payload')
+          }
+          await memory.deleteRun((payload as { runId: string }).runId)
+        }
+      }
+    } catch (error) {
+      if (error instanceof TraceStoreError && error.code === 'UNSUPPORTED_SCHEMA_VERSION') {
+        throw fileError(
+          'UNSUPPORTED_TRACE_SCHEMA',
+          'A committed batch contains an unsupported trace schema major.',
+          'recover.batch', this.filePath, error, lineNumber,
+        )
+      }
+      throw fileError(
+        'CORRUPT_FILE',
+        'A committed batch contains invalid data.',
+        'recover.batch', this.filePath, error, lineNumber,
+      )
+    }
+  }
+
+  private corruption(message: string, lineNumber: number): FileTraceStoreError {
+    return fileError('CORRUPT_FILE', message, 'recover', this.filePath, undefined, lineNumber)
+  }
+
+  private emitFileDiagnostic(diagnostic: FileTraceStoreDiagnostic): void {
+    this.diagnostics.push(diagnostic)
+    emitSafely(this.options.onDiagnostic, diagnostic)
+  }
+
+  private async syncDirectory(operation: string): Promise<void> {
+    let handle: FileHandle | undefined
+    try {
+      handle = await FILE_TRACE_STORE_IO.open(dirname(this.filePath), 'r')
+      await FILE_TRACE_STORE_IO.sync(handle)
+      await FILE_TRACE_STORE_IO.close(handle)
+    } catch (error) {
+      if (handle) await FILE_TRACE_STORE_IO.close(handle).catch(() => undefined)
+      const code = errno(error)
+      if (code && DIRECTORY_SYNC_UNSUPPORTED.has(code)) {
+        this.emitFileDiagnostic({
+          code: 'directory_sync_unsupported', severity: 'warning',
+          message: 'The platform/filesystem does not support directory fsync; rename durability is best-effort.',
+        })
+        return
+      }
+      throw fileError(
+        'SYNC_FAILED',
+        'FileTraceStore could not fsync the parent directory after an atomic rename.',
+        operation, this.filePath, error,
+      )
+    }
+  }
+
+  private static async pathExists(path: string, operation: string): Promise<boolean> {
+    try {
+      await FILE_TRACE_STORE_IO.stat(path)
+      return true
+    } catch (error) {
+      if (errno(error) === 'ENOENT') return false
+      throw fileError('OPEN_FAILED', 'FileTraceStore could not inspect its filesystem path.', operation, path, error)
+    }
+  }
+
+  private static async createFile(path: string, options: FileTraceStoreOptions): Promise<void> {
+    let handle: FileHandle | undefined
+    try {
+      await FILE_TRACE_STORE_IO.mkdir(dirname(path), { recursive: true })
+      handle = await FILE_TRACE_STORE_IO.open(path, 'wx', 0o600)
+      await FILE_TRACE_STORE_IO.chmod(handle, 0o600)
+      await FILE_TRACE_STORE_IO.writeFile(handle, `${JSON.stringify(HEADER)}\n`)
+      await FILE_TRACE_STORE_IO.sync(handle)
+      await FILE_TRACE_STORE_IO.close(handle)
+      handle = undefined
+      const provisional = new FileTraceStore(
+        path, new InMemoryTraceStore({ now: options.now }), HEADER, options,
+      )
+      await provisional.syncDirectory('open.create')
+    } catch (error) {
+      if (handle) await FILE_TRACE_STORE_IO.close(handle).catch(() => undefined)
+      if (errno(error) === 'EEXIST') return
+      throw fileError('OPEN_FAILED', 'FileTraceStore could not create its data file.', 'open.create', path, error)
+    }
+  }
+}

--- a/packages/core/src/observability/file.ts
+++ b/packages/core/src/observability/file.ts
@@ -1,0 +1,15 @@
+/** Node-only FileTraceStore entrypoint: `@open-multi-agent/core/observability/file`. */
+
+export {
+  FILE_TRACE_STORE_FORMAT,
+  FILE_TRACE_STORE_FORMAT_VERSION,
+  FileTraceStore,
+  FileTraceStoreError,
+} from './file-store.js'
+export type {
+  FileTraceStoreCompactionResult,
+  FileTraceStoreDiagnostic,
+  FileTraceStoreDiagnosticCode,
+  FileTraceStoreErrorCode,
+  FileTraceStoreOptions,
+} from './file-store.js'

--- a/packages/core/tests/file-trace-store.test.ts
+++ b/packages/core/tests/file-trace-store.test.ts
@@ -1,0 +1,414 @@
+import {
+  appendFile,
+  chmod,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  FILE_TRACE_STORE_FORMAT,
+  FILE_TRACE_STORE_IO,
+  FileTraceStore,
+  FileTraceStoreError,
+  type FileTraceStoreDiagnostic,
+} from '../src/observability/file-store.js'
+import type { TraceRecord } from '../src/observability/records.js'
+import type {
+  AppendResult,
+  DeleteResult,
+  GetRunOptions,
+  Page,
+  RetentionPolicy,
+  RunSummary,
+  StoredRun,
+  TraceDeleteQuery,
+  TraceQuery,
+  TraceStore,
+} from '../src/observability/store.js'
+import { TraceStoreError } from '../src/observability/store.js'
+import {
+  attemptRecords,
+  runTraceStoreContractSuite,
+  type TraceStoreContractFactoryOptions,
+} from './helpers/trace-store-contract.js'
+
+const temporaryRoots: string[] = []
+
+async function temporaryPath(name = 'traces.ndjson'): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'oma-file-trace-store-'))
+  temporaryRoots.push(root)
+  return join(root, name)
+}
+
+class DeferredTraceStore implements TraceStore {
+  constructor(private readonly pending: Promise<FileTraceStore>) {}
+  append(records: readonly TraceRecord[]): Promise<AppendResult> {
+    return this.pending.then((store) => store.append(records))
+  }
+  getRun(runId: string, options?: GetRunOptions): Promise<StoredRun | null> {
+    return this.pending.then((store) => store.getRun(runId, options))
+  }
+  queryRuns(query?: TraceQuery): Promise<Page<RunSummary>> {
+    return this.pending.then((store) => store.queryRuns(query))
+  }
+  deleteRun(runId: string): Promise<DeleteResult> {
+    return this.pending.then((store) => store.deleteRun(runId))
+  }
+  delete(query: TraceDeleteQuery): Promise<DeleteResult> {
+    return this.pending.then((store) => store.delete(query))
+  }
+  applyRetention(policy: RetentionPolicy): Promise<DeleteResult> {
+    return this.pending.then((store) => store.applyRetention(policy))
+  }
+}
+
+function contractStore(options: TraceStoreContractFactoryOptions = {}): TraceStore {
+  const path = join(tmpdir(), `oma-file-trace-contract-${randomUUID()}.ndjson`)
+  temporaryRoots.push(path)
+  const pending = FileTraceStore.open(path, {
+    now: options.now,
+    onDiagnostic: (diagnostic) => {
+      if ('runId' in diagnostic) options.onDiagnostic?.(diagnostic)
+    },
+  })
+  return new DeferredTraceStore(pending)
+}
+
+runTraceStoreContractSuite('FileTraceStore', contractStore)
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await Promise.all(temporaryRoots.splice(0).map((path) => rm(path, { recursive: true, force: true })))
+})
+
+describe('FileTraceStore file format and recovery', () => {
+  it('creates a versioned 0600 file and reopens with identical query results', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    await store.append(attemptRecords({ runId: 'reopen', status: 'error' }))
+    const before = await store.queryRuns({ status: ['error'] })
+    await store.flush()
+    await store.close()
+
+    const firstLine = (await readFile(path, 'utf8')).split('\n')[0]
+    expect(JSON.parse(firstLine!)).toEqual({
+      type: 'file_header', format: FILE_TRACE_STORE_FORMAT,
+      formatVersion: 1, traceSchemaMajor: 2,
+    })
+    if (process.platform !== 'win32') expect((await stat(path)).mode & 0o777).toBe(0o600)
+
+    const reopened = await FileTraceStore.open(path)
+    expect(await reopened.queryRuns({ status: ['error'] })).toEqual(before)
+    await reopened.close()
+  })
+
+  it('serializes concurrent same-instance appends in invocation order', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    await Promise.all(['a', 'b', 'c', 'd'].map((runId, index) =>
+      store.append(attemptRecords({ runId, start: 1_000 + index }))))
+    expect((await store.queryRuns({ order: 'started_asc' })).items.map((run) => run.runId))
+      .toEqual(['a', 'b', 'c', 'd'])
+    const loggedRunIds = (await readFile(path, 'utf8')).split('\n')
+      .filter((line) => line.includes('"type":"batch_item"'))
+      .map((line) => (JSON.parse(line) as { payload: { runId: string } }).payload.runId)
+      .filter((runId, index, all) => index === 0 || runId !== all[index - 1])
+    expect(loggedRunIds).toEqual(['a', 'b', 'c', 'd'])
+    await store.close()
+  })
+
+  it('hides an entire batch when the file ends midway through that batch', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    await store.append(attemptRecords({ runId: 'half-batch' }))
+    await store.close()
+    const lines = (await readFile(path, 'utf8')).split('\n')
+    await writeFile(path, `${lines.slice(0, 3).join('\n')}\n`, 'utf8')
+
+    const diagnostics: FileTraceStoreDiagnostic[] = []
+    const reopened = await FileTraceStore.open(path, {
+      onDiagnostic: (diagnostic) => { if (!('runId' in diagnostic)) diagnostics.push(diagnostic) },
+    })
+    expect(await reopened.getRun('half-batch')).toBeNull()
+    expect(diagnostics).toEqual([expect.objectContaining({ code: 'incomplete_batch' })])
+    expect((await readFile(path, 'utf8')).split('\n')).toHaveLength(2)
+    await reopened.close()
+  })
+
+  it('recovers a trailing partial line, diagnoses it, and preserves prior commits', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    await store.append(attemptRecords({ runId: 'committed' }))
+    await store.close()
+    const committedRaw = await readFile(path, 'utf8')
+    await appendFile(path, '{"type":"batch_start"', 'utf8')
+
+    const diagnostics: FileTraceStoreDiagnostic[] = []
+    const reopened = await FileTraceStore.open(path, {
+      onDiagnostic: (diagnostic) => { if (!('runId' in diagnostic)) diagnostics.push(diagnostic) },
+    })
+    expect((await reopened.getRun('committed'))?.status).toBe('ok')
+    expect(diagnostics).toEqual([expect.objectContaining({ code: 'trailing_partial_line' })])
+    expect(await readFile(path, 'utf8')).toBe(committedRaw)
+    await reopened.close()
+  })
+
+  it('fails loudly on a complete corrupt line even when valid data follows it', async () => {
+    const firstPath = await temporaryPath('first.ndjson')
+    const secondPath = await temporaryPath('second.ndjson')
+    const first = await FileTraceStore.open(firstPath)
+    const second = await FileTraceStore.open(secondPath)
+    await first.append(attemptRecords({ runId: 'first' }))
+    await second.append(attemptRecords({ runId: 'second' }))
+    await Promise.all([first.close(), second.close()])
+    const firstRaw = await readFile(firstPath, 'utf8')
+    const secondLines = (await readFile(secondPath, 'utf8')).split('\n')
+    await writeFile(firstPath, `${firstRaw}{invalid-json}\n${secondLines.slice(1).join('\n')}`, 'utf8')
+
+    await expect(FileTraceStore.open(firstPath)).rejects.toMatchObject({
+      code: 'CORRUPT_FILE', operation: 'recover',
+    })
+  })
+
+  it('rejects unsupported on-disk format and trace schema versions', async () => {
+    const formatPath = await temporaryPath('format.ndjson')
+    await writeFile(formatPath, `${JSON.stringify({
+      type: 'file_header', format: FILE_TRACE_STORE_FORMAT,
+      formatVersion: 99, traceSchemaMajor: 2,
+    })}\n`)
+    await expect(FileTraceStore.open(formatPath)).rejects.toMatchObject({ code: 'UNSUPPORTED_FILE_FORMAT' })
+
+    const schemaPath = await temporaryPath('schema.ndjson')
+    await writeFile(schemaPath, `${JSON.stringify({
+      type: 'file_header', format: FILE_TRACE_STORE_FORMAT,
+      formatVersion: 1, traceSchemaMajor: 99,
+    })}\n`)
+    await expect(FileTraceStore.open(schemaPath)).rejects.toMatchObject({ code: 'UNSUPPORTED_TRACE_SCHEMA' })
+  })
+
+  it('preserves recordId and first span_end idempotency across reopen', async () => {
+    const path = await temporaryPath()
+    const records = attemptRecords({ runId: 'dedupe-reopen', status: 'ok' })
+    const store = await FileTraceStore.open(path)
+    await store.append(records)
+    await store.close()
+
+    const reopened = await FileTraceStore.open(path)
+    await expect(reopened.append(records)).resolves.toMatchObject({ written: 0, deduplicated: 2 })
+    const duplicateEnd = {
+      ...records[1]!, recordId: 'different-end-record', sequence: 4,
+      status: { code: 'error' as const },
+    } as TraceRecord
+    await expect(reopened.append([duplicateEnd])).resolves.toMatchObject({
+      written: 0, deduplicated: 1,
+      diagnostics: [expect.objectContaining({ code: 'duplicate_span_end' })],
+    })
+    expect((await reopened.getRun('dedupe-reopen'))?.status).toBe('ok')
+    await reopened.close()
+  })
+
+  it('does not resurrect delete or retention results after reopen', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path, { now: () => 10_000 })
+    await store.append(attemptRecords({ runId: 'delete', start: 1_000 }))
+    await store.append(attemptRecords({ runId: 'retained-away', start: 2_000, status: 'error' }))
+    await store.append(attemptRecords({ runId: 'keep', start: 9_000 }))
+    await store.deleteRun('delete')
+    await store.applyRetention({ maxAgeMs: 5_000, statuses: ['error'] })
+    await store.close()
+
+    const reopened = await FileTraceStore.open(path, { now: () => 10_000 })
+    expect((await reopened.queryRuns({ order: 'started_asc' })).items.map((run) => run.runId)).toEqual(['keep'])
+    await reopened.close()
+  })
+
+  it('declares cursors instance-bound by rejecting them after reopen', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    await store.append(attemptRecords({ runId: 'cursor-a' }))
+    await store.append(attemptRecords({ runId: 'cursor-b', start: 2_000 }))
+    const cursor = (await store.queryRuns({ limit: 1 })).nextCursor!
+    await store.close()
+    const reopened = await FileTraceStore.open(path)
+    await expect(reopened.queryRuns({ limit: 1, cursor })).rejects.toMatchObject({ code: 'INVALID_CURSOR' })
+    await reopened.close()
+  })
+})
+
+describe('FileTraceStore lifecycle and filesystem failures', () => {
+  it('defines append as write-complete and flush as the fsync boundary', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    const sync = vi.spyOn(FILE_TRACE_STORE_IO, 'sync')
+    await store.append(attemptRecords({ runId: 'durability-boundary' }))
+    expect(sync).not.toHaveBeenCalled()
+    await store.flush()
+    expect(sync).toHaveBeenCalledTimes(1)
+    await store.close()
+  })
+
+  it('makes flush repeatable, close idempotent, and post-close operations structured errors', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    await store.append(attemptRecords({ runId: 'lifecycle' }))
+    await expect(store.flush()).resolves.toBeUndefined()
+    await expect(store.flush()).resolves.toBeUndefined()
+    const first = store.close()
+    const second = store.close()
+    expect(second).toBe(first)
+    await expect(first).resolves.toBeUndefined()
+    await expect(store.close()).resolves.toBeUndefined()
+    await expect(store.getRun('lifecycle')).rejects.toMatchObject({ code: 'CLOSED' })
+    await expect(store.flush()).rejects.toMatchObject({ code: 'CLOSED' })
+  })
+
+  it('rolls back memory and disk state when a write fails', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    vi.spyOn(FILE_TRACE_STORE_IO, 'writeFile').mockRejectedValueOnce(Object.assign(new Error('disk full'), { code: 'ENOSPC' }))
+    await expect(store.append(attemptRecords({ runId: 'write-failed' }))).rejects.toMatchObject({
+      code: 'WRITE_FAILED', causeCode: 'ENOSPC',
+    })
+    expect(await store.getRun('write-failed')).toBeNull()
+    vi.restoreAllMocks()
+    await store.append(attemptRecords({ runId: 'after-failure' }))
+    await store.close()
+    const reopened = await FileTraceStore.open(path)
+    expect(await reopened.getRun('write-failed')).toBeNull()
+    expect((await reopened.getRun('after-failure'))?.status).toBe('ok')
+    await reopened.close()
+  })
+
+  it('reports fsync failure instead of claiming flush success', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    await store.append(attemptRecords({ runId: 'sync-failed' }))
+    vi.spyOn(FILE_TRACE_STORE_IO, 'sync').mockRejectedValueOnce(Object.assign(new Error('sync failed'), { code: 'EIO' }))
+    await expect(store.flush()).rejects.toMatchObject({ code: 'SYNC_FAILED', causeCode: 'EIO' })
+    vi.restoreAllMocks()
+    await store.close()
+  })
+
+  it.skipIf(process.platform === 'win32')('returns a structured permission failure when the parent is not writable', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oma-file-trace-permission-'))
+    temporaryRoots.push(root)
+    await chmod(root, 0o500)
+    try {
+      await expect(FileTraceStore.open(join(root, 'denied.ndjson'))).rejects.toMatchObject({
+        code: 'OPEN_FAILED', causeCode: expect.stringMatching(/EACCES|EPERM/),
+      })
+    } finally {
+      await chmod(root, 0o700)
+    }
+  })
+
+  it('keeps the original usable when compaction rename fails', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    await store.append(attemptRecords({ runId: 'rename-safe' }))
+    const before = await readFile(path, 'utf8')
+    vi.spyOn(FILE_TRACE_STORE_IO, 'rename').mockRejectedValueOnce(Object.assign(new Error('rename denied'), { code: 'EACCES' }))
+    await expect(store.compact()).rejects.toMatchObject({ code: 'RENAME_FAILED', causeCode: 'EACCES' })
+    expect(await readFile(path, 'utf8')).toBe(before)
+    expect((await store.getRun('rename-safe'))?.status).toBe('ok')
+    vi.restoreAllMocks()
+    await store.close()
+  })
+
+  it('keeps the original usable when compaction temp fsync fails before rename', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    await store.append(attemptRecords({ runId: 'compact-sync-safe' }))
+    const before = await readFile(path, 'utf8')
+    vi.spyOn(FILE_TRACE_STORE_IO, 'sync').mockRejectedValueOnce(Object.assign(new Error('sync denied'), { code: 'EIO' }))
+    await expect(store.compact()).rejects.toMatchObject({ code: 'COMPACTION_FAILED', causeCode: 'EIO' })
+    expect(await readFile(path, 'utf8')).toBe(before)
+    expect((await store.getRun('compact-sync-safe'))?.status).toBe('ok')
+    vi.restoreAllMocks()
+    await store.close()
+  })
+})
+
+describe('FileTraceStore compaction', () => {
+  it('preserves query results, removes deleted data, and is byte-deterministic when repeated', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    await store.append(attemptRecords({ runId: 'deleted', start: 1_000 }))
+    await store.append(attemptRecords({ runId: 'kept', start: 2_000, status: 'error' }))
+    await store.deleteRun('deleted')
+    const before = await store.queryRuns({ order: 'started_asc' })
+    const first = await store.compact()
+    const compactedOnce = await readFile(path, 'utf8')
+    expect(compactedOnce).not.toContain('"runId":"deleted"')
+    expect(await store.queryRuns({ order: 'started_asc' })).toEqual(before)
+    const second = await store.compact()
+    const compactedTwice = await readFile(path, 'utf8')
+    expect(compactedTwice).toBe(compactedOnce)
+    expect(second).toEqual(first)
+    await store.close()
+
+    const reopened = await FileTraceStore.open(path)
+    expect(await reopened.queryRuns({ order: 'started_asc' })).toEqual(before)
+    await reopened.close()
+  })
+
+  it('diagnoses a stale temp while keeping the target authoritative', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    await store.append(attemptRecords({ runId: 'target-wins' }))
+    await store.close()
+    await writeFile(`${path}.compact.tmp`, 'interrupted compaction', 'utf8')
+
+    const diagnostics: FileTraceStoreDiagnostic[] = []
+    const reopened = await FileTraceStore.open(path, {
+      onDiagnostic: (diagnostic) => { if (!('runId' in diagnostic)) diagnostics.push(diagnostic) },
+    })
+    expect((await reopened.getRun('target-wins'))?.status).toBe('ok')
+    expect(diagnostics).toEqual([expect.objectContaining({ code: 'stale_compaction_file' })])
+    await reopened.close()
+  })
+
+  it('fails loudly when only a stale compaction temp exists', async () => {
+    const path = await temporaryPath()
+    await writeFile(`${path}.compact.tmp`, 'possible committed data', 'utf8')
+    await expect(FileTraceStore.open(path)).rejects.toMatchObject({ code: 'STALE_COMPACTION_FILE' })
+  })
+})
+
+describe('FileTraceStore import boundary', () => {
+  it('is exported only from the Node-only file subpath module', async () => {
+    const root = await import('../src/index.js')
+    const observability = await import('../src/observability/index.js')
+    const file = await import('../src/observability/file.js')
+    expect(root).not.toHaveProperty('FileTraceStore')
+    expect(observability).not.toHaveProperty('FileTraceStore')
+    expect(file.FileTraceStore).toBe(FileTraceStore)
+  })
+
+  it('uses payload-free structured corruption errors', async () => {
+    const path = await temporaryPath()
+    const secret = 'secret-telemetry-payload'
+    await writeFile(path, `${JSON.stringify({
+      type: 'file_header', format: FILE_TRACE_STORE_FORMAT,
+      formatVersion: 1, traceSchemaMajor: 2,
+    })}\n{${secret}}\n`)
+    const error = await FileTraceStore.open(path).catch((caught) => caught as FileTraceStoreError)
+    expect(error).toBeInstanceOf(FileTraceStoreError)
+    expect(error.code).toBe('CORRUPT_FILE')
+    expect(error.message).not.toContain(secret)
+  })
+
+  it('keeps TraceStore validation errors unchanged', async () => {
+    const path = await temporaryPath()
+    const store = await FileTraceStore.open(path)
+    await expect(store.append([{ schemaVersion: 99 } as unknown as TraceRecord]))
+      .rejects.toBeInstanceOf(TraceStoreError)
+    await store.close()
+  })
+})


### PR DESCRIPTION
## Summary

- add a Node-only `FileTraceStore` reference implementation at `@open-multi-agent/core/observability/file`
- persist TraceStore mutations in a versioned append-only NDJSON envelope with committed-batch recovery
- add explicit flush, close, diagnostics, and crash-safe compaction lifecycle
- reuse the unchanged OBS-4A TraceStore contract suite and add filesystem/recovery failure-injection coverage
- document the storage, privacy, durability, and single-process boundaries
- include a repeatable 1k/10k local benchmark

## Disk and recovery semantics

The file begins with an explicit format/schema header. Each append or delete mutation is written as:

`batch_start -> batch_item... -> batch_commit`

A batch becomes visible only after its commit marker, item count, contiguous indexes, and SHA-256 payload checksum validate. Reopen scans sequentially and rebuilds the in-memory indexes. A trailing partial line or uncommitted final batch is diagnosed and truncated to the last committed boundary; complete malformed lines or unsupported schemas fail loudly.

Delete and retention operations persist exact run tombstones so reopen cannot resurrect removed data.

## Durability and lifecycle

- `append()` resolves after the complete envelope is written and the descriptor is closed; it does not imply fsync
- `flush()` waits for prior operations and fsyncs the target
- `close()` rejects new operations, flushes prior writes, and is idempotent
- compaction writes a mode-0600 same-directory temp file, fsyncs it, atomically renames it, and fsyncs the directory where supported
- write, permission, fsync, disk-full, corruption, and rename failures are structured and payload-free
- no process signal handlers are registered

## Validation

- unchanged TraceStore contract suite against InMemoryTraceStore and FileTraceStore
- FileTraceStore targeted tests: 35 passed
- OBS-1A/1B, OBS-2, legacy trace, exporter, and store compatibility: 118 passed
- Node 18.20.8, 20.19.4, and 22.22.3 targeted matrix: 52 passed per version
- full workspace `npm test`: 1327 passed
- `npm run lint`
- `npm run build`
- `git diff --check`
- root, observability, and observability/file import smokes
- `npm pack --dry-run -w @open-multi-agent/core`

## Reference-store boundary

This implementation intentionally does not provide cross-process locking, multi-process writers, network-filesystem consistency, database indexing, full-text search, advanced analytics, tenant authentication, RBAC, or RunStore CAS/lease semantics. It is intended for local development, tests, CLIs, and modest single-process services.
