### PR TITLE
chore(observability): complete OBS-5 release readiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Smoke-test that the built entry points import and the CLI runs
         working-directory: packages/core
         run: |
-          node -e "Promise.all([import('./dist/index.js'), import('./dist/acp.js'), import('./dist/process.js'), import('./dist/mcp.js'), import('./dist/ai-sdk.js')]).then(() => console.log('entry points import OK')).catch((e) => { console.error(e); process.exit(1); })"
+          node -e "Promise.all([import('./dist/index.js'), import('./dist/observability/index.js'), import('./dist/observability/file.js'), import('./dist/acp.js'), import('./dist/process.js'), import('./dist/mcp.js'), import('./dist/ai-sdk.js')]).then(() => console.log('entry points import OK')).catch((e) => { console.error(e); process.exit(1); })"
           node dist/cli/oma.js help > /dev/null
           echo "CLI help runs OK"
       - name: Assert the create-oma-app template pins the current core version
@@ -99,7 +99,7 @@ jobs:
             exit 1
           fi
           missing=""
-          for f in dist/index.js dist/index.d.ts dist/cli/oma.js dist/acp.js dist/acp.d.ts dist/process.js dist/process.d.ts dist/mcp.js dist/mcp.d.ts dist/ai-sdk.js dist/ai-sdk.d.ts; do
+          for f in dist/index.js dist/index.d.ts dist/observability/index.js dist/observability/index.d.ts dist/observability/file.js dist/observability/file.d.ts dist/cli/oma.js dist/acp.js dist/acp.d.ts dist/process.js dist/process.d.ts dist/mcp.js dist/mcp.d.ts dist/ai-sdk.js dist/ai-sdk.d.ts; do
             echo "$paths" | grep -qxF "$f" || missing="$missing $f"
           done
           if [ -n "$missing" ]; then
@@ -153,6 +153,15 @@ jobs:
             echo "Either the build did not run or an entry was dropped from package.json \"files\"."
             exit 1
           fi
+
+      - name: Run public observability examples without network or API keys
+        run: npm run test:observability-examples
+
+      - name: Run tolerant same-host observability regression gate
+        run: npm run bench:observability:ci
+
+      - name: Install real core and OTel tarballs in clean consumers
+        run: npm run test:observability-pack
 
   scaffold-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 20
       - name: Scaffold from the published npm package and reach the run gate
         env:
-          # The tag is the core version (e.g. v1.10.0); create-oma-app has its
+          # The tag is the core version (e.g. v1.11.0); create-oma-app has its
           # own version, so we resolve the scaffolder via @latest and verify it
           # pins THIS release's core below.
           RELEASE_TAG: ${{ github.event.release.tag_name }}
@@ -40,7 +40,7 @@ jobs:
           npm_config_prefer_online: 'true'
         run: |
           set -euo pipefail
-          want="${RELEASE_TAG#v}"   # v1.10.0 -> 1.10.0
+          want="${RELEASE_TAG#v}"   # v1.11.0 -> 1.11.0
 
           # npm's CDN takes a moment to serve a freshly published version, and
           # BOTH create-oma-app and the core it pins may have just gone out — so

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ Detailed behavior is documented in `docs/` — the single source of truth, so up
 | Providers, env vars, local servers, AI SDK bridge | `llm/` | [providers.md](docs/providers.md) |
 | Shared memory + custom backends | `memory/` | [shared-memory.md](docs/shared-memory.md) |
 | Checkpoint/resume over `MemoryStore` | `memory/checkpoint.ts`, `orchestrator/orchestrator.ts` | [checkpoint.md](docs/checkpoint.md) |
-| Tracing, progress events, dashboard | `utils/trace.ts`, `dashboard/` | [observability.md](docs/observability.md) |
+| Tracing, progress events, dashboard, migration, performance | `observability/`, `utils/trace.ts`, `dashboard/` | [observability.md](docs/observability.md), [observability-migration.md](docs/observability-migration.md), [observability-performance.md](docs/observability-performance.md) |
 | CLI usage + JSON schemas | `cli/oma.ts` | [cli.md](docs/cli.md) |
 | External agent backends | `agent/acp-backend.ts`, `agent/process-backend.ts` | [external-agents.md](docs/external-agents.md) |
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Graph-first frameworks make you wire every node and edge up front. OMA runs a **
 
 Lightweight core: the engine plus Anthropic, OpenAI, and any OpenAI-compatible endpoint work out of the box; Gemini, Bedrock, MCP, and the Vercel AI SDK bridge are opt-in peer dependencies. OpenTelemetry is a separately installable integration (`@open-multi-agent/otel`): OTel APIs, SDKs, semantic-convention mappings, and exporter integrations stay outside the core import, and applications explicitly supply their own provider.
 
+Dependencies are governed by demonstrated value and their security, size,
+maintenance, and compatibility cost—not by a permanent dependency-count cap.
+Optional or platform-specific SDKs remain isolated when that keeps unused code
+out of the root import.
+
 ## Get started
 
 One command scaffolds a production starter or the teaching DAG demo:
@@ -103,15 +108,13 @@ Full head-to-head on each on the package page: [How is this different?](packages
 
 ## Repository
 
-This is a monorepo. The published package is **`@open-multi-agent/core`**, and it lives in [`packages/core/`](packages/core/) — the source of truth for the library, its tests, examples, and the npm package page.
+This is a monorepo. The main package is **`@open-multi-agent/core`**; the optional OpenTelemetry adapter is published independently as **`@open-multi-agent/otel`**.
 
 ```
 open-multi-agent/
 ├── packages/
-│   └── core/          # @open-multi-agent/core — the published library
-│       ├── src/       # framework source
-│       ├── tests/     # vitest suite
-│       └── examples/  # runnable examples (npx tsx packages/core/examples/<path>.ts)
+│   ├── core/          # @open-multi-agent/core — framework, tests, examples
+│   └── otel/          # @open-multi-agent/otel — optional adapter
 └── docs/              # subsystem documentation
 ```
 
@@ -128,7 +131,7 @@ npm test               # run the test suite
 
 - [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) — env vars, model examples, local tool-calling, timeouts, troubleshooting.
 - [Tool configuration](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) — tool presets, custom tools, the filesystem sandbox, and MCP.
-- [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — stable run identity and outcome semantics on every top-level result, plus `onProgress`, `onTrace`, and the post-run dashboard. [`@open-multi-agent/otel`](packages/otel/README.md) is the optional adapter for applications with an explicitly configured OpenTelemetry provider.
+- [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — stable identity/status, TraceRecord v2, bounded sink/exporter lifecycle, InMemory/File TraceStore, and the post-run dashboard. Existing callbacks have a staged [`onTrace` migration guide](docs/observability-migration.md); [`@open-multi-agent/otel`](packages/otel/README.md) uses an application-owned provider.
 - [Shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — the default store and custom `MemoryStore` backends.
 - [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — opt-in snapshots over any `MemoryStore`; restore preserves `runId`, increments `attempt`, and starts a fresh trace.
 - [Context management](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — sliding window, summarization, compaction, and custom compressors.

--- a/README_zh.md
+++ b/README_zh.md
@@ -54,6 +54,8 @@
 
 轻量内核：编排引擎加上 Anthropic、OpenAI 及任意 OpenAI 兼容端点开箱即用；Gemini、Bedrock、MCP、Vercel AI SDK bridge 为可选 peer 依赖，按需安装。OpenTelemetry 通过独立可选包 `@open-multi-agent/otel` 集成：OTel API、SDK、semantic convention 映射和 exporter 集成均不进入 core root import，应用显式提供自己的 provider。
 
+依赖按明确价值以及安全、体积、维护和兼容成本治理，而不是永久限制依赖数量。可选或平台特定 SDK 在能避免主入口 eager import 未使用代码时继续隔离。
+
 ## 快速开始
 
 一条命令即可初始化生产模板或教学用 multi-agent DAG：
@@ -111,15 +113,13 @@ npm install @open-multi-agent/core
 
 ## 仓库结构
 
-这是一个 monorepo。发布的包为 **`@open-multi-agent/core`**，位于 [`packages/core/`](packages/core/)，即库本体、测试、示例与 npm 包页的单一事实源。
+这是一个 monorepo。主包为 **`@open-multi-agent/core`**；可选 OpenTelemetry 适配器以 **`@open-multi-agent/otel`** 独立发布。
 
 ```
 open-multi-agent/
 ├── packages/
-│   └── core/          # @open-multi-agent/core（发布的库）
-│       ├── src/       # 框架源码
-│       ├── tests/     # vitest 测试套件
-│       └── examples/  # 可直接运行的示例（npx tsx packages/core/examples/<path>.ts）
+│   ├── core/          # @open-multi-agent/core（框架、测试、示例）
+│   └── otel/          # @open-multi-agent/otel（可选适配器）
 └── docs/              # 子系统文档
 ```
 
@@ -136,7 +136,7 @@ npm test               # 运行测试套件
 
 - [Provider](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) — 环境变量、模型示例、本地模型工具调用、超时、常见问题。
 - [工具配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) — 工具预设、自定义工具、文件系统沙箱、MCP。
-- [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — 每个顶层结果都包含稳定的运行标识（identity）与结果（outcome）语义，并提供 `onProgress`、`onTrace` 和运行后 dashboard。[`@open-multi-agent/otel`](packages/otel/README.md) 是面向已显式配置 OpenTelemetry provider 的应用的可选适配器。
+- [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — 稳定 identity/status、TraceRecord v2、有界 sink/exporter 生命周期、InMemory/File TraceStore 与运行后 dashboard。旧 callback 可按 [`onTrace` 分阶段迁移指南](docs/observability-migration.md) 无停机迁移；[`@open-multi-agent/otel`](packages/otel/README.md) 使用应用自有 provider。
 - [共享记忆](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — 默认存储与自定义 `MemoryStore` 后端。
 - [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — 在任意 `MemoryStore` 上保存可选快照；`restore()` 保留 `runId`、递增 `attempt`，并启动新的 trace。
 - [上下文管理](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — 滑动窗口、摘要、压缩、自定义压缩器。

--- a/docs/observability-migration.md
+++ b/docs/observability-migration.md
@@ -1,0 +1,178 @@
+# Migrating from `onTrace` to Observability v2
+
+Observability v2 is an additive path. Existing `onTrace` integrations can keep
+running while transport, storage, and OpenTelemetry are migrated one layer at a
+time. There is no stop-the-world rewrite.
+
+The copyable snippets on this page are mirrored by the compile-only
+[`public-snippets.ts`](../packages/core/examples/integrations/observability-v2/public-snippets.ts)
+fixture and typechecked in the Node 18/20/22 test matrix.
+
+## Compatibility contract
+
+- `onTrace` remains supported throughout the current 1.x line and is **not**
+  marked deprecated in this release.
+- The seven-member `TraceEvent` union, completion/event timing, UUID `spanId`,
+  UUID `parentId` tree, and best-effort-redacted legacy tool payloads remain
+  unchanged.
+- A synchronous callback throw or asynchronous rejection never changes an
+  Agent, Task, or Run result and does not become an unhandled rejection.
+- New identity, status, start/event/end, links, diagnostics, stores, and OTel
+  mapping use `TraceRecord` schema v2. They do not mutate the legacy event
+  shapes.
+
+## Migration stages
+
+| Stage | Change | Rollback |
+|---|---|---|
+| 0 | Keep `onTrace` exactly as it is. | None needed. |
+| 1 | Put the callback behind `LegacyCallbackTraceSink`. | Move the same callback back to `onTrace`. |
+| 2 | Add `BatchingTraceSink` and a custom `TraceExporter`. | Keep the stage-1 bridge while disabling the new exporter. |
+| 3 | Replace the custom exporter with `TraceStoreExporter` or `@open-multi-agent/otel`. | Switch exporters; the OMA run contract is unchanged. |
+| 4 | Make the application own `forceFlush` / `shutdown` / store/provider close. | Keep explicit flush and lengthen timeouts; never make business success depend on telemetry. |
+
+### Stage 0: no immediate migration
+
+```ts
+import { OpenMultiAgent, type TraceEvent } from '@open-multi-agent/core'
+
+function existingCallback(event: TraceEvent): void {
+  legacyCollector.write(event)
+}
+
+const oma = new OpenMultiAgent({ onTrace: existingCallback })
+```
+
+This remains a valid 1.x configuration.
+
+### Stage 1: wrap the existing callback
+
+```ts
+import { OpenMultiAgent } from '@open-multi-agent/core'
+import { LegacyCallbackTraceSink } from '@open-multi-agent/core/observability'
+
+const legacySink = new LegacyCallbackTraceSink(existingCallback)
+const oma = new OpenMultiAgent({
+  observability: { sinks: [legacySink] },
+})
+
+try {
+  await oma.runAgent(agent, prompt)
+  await legacySink.forceFlush({ timeoutMs: 1_000 })
+} finally {
+  await legacySink.shutdown({ timeoutMs: 1_000 })
+}
+```
+
+Configure the bridge directly in `observability.sinks`. Do not also pass the
+same callback through `onTrace`, or the application has deliberately configured
+two deliveries. The bridge retains the legacy privacy surface; v2 sinks beside
+it still receive the narrower default-safe records.
+
+### Stage 2: batch a custom exporter
+
+```ts
+import {
+  BatchingTraceSink,
+  type TraceExporter,
+} from '@open-multi-agent/core/observability'
+
+const exporter: TraceExporter = {
+  async export(records, signal) {
+    const delivered = await sendBatch(records, { signal })
+    return { status: 'success', exported: delivered }
+  },
+}
+
+const sink = new BatchingTraceSink(exporter)
+const oma = new OpenMultiAgent({ observability: { sinks: [sink] } })
+```
+
+`emit()` only admits a record to a bounded local queue. Export results describe
+the delivered prefix: a short `success` is a permanent partial delivery; a
+short `retryable` retries only the remaining suffix. Rejection, timeout, queue
+overflow, and permanent failure are visible in `getStats()`, diagnostics, and
+flush results but never alter business results.
+
+Runnable version: [`batching-exporter.ts`](../packages/core/examples/integrations/observability-v2/batching-exporter.ts).
+
+### Stage 3A: choose a TraceStore
+
+```ts
+import {
+  BatchingTraceSink,
+  InMemoryTraceStore,
+  TraceStoreExporter,
+} from '@open-multi-agent/core/observability'
+
+const store = new InMemoryTraceStore()
+const sink = new BatchingTraceSink(new TraceStoreExporter(store))
+```
+
+Use `InMemoryTraceStore` for tests and local inspection. Use the Node-only
+`FileTraceStore` subpath for durable local files, CLIs, and modest
+single-process services. It is not a shared database and must not have two
+processes writing the same path.
+
+Runnable versions: [`in-memory-store.ts`](../packages/core/examples/integrations/observability-v2/in-memory-store.ts)
+and [`file-trace-store.ts`](../packages/core/examples/integrations/observability-v2/file-trace-store.ts).
+
+### Stage 3B: choose the OpenTelemetry adapter
+
+The first compatible install pair is:
+
+```bash
+npm install @open-multi-agent/core@^1.11.0 @open-multi-agent/otel@^0.1.0
+```
+
+```ts
+import { createOtelTraceSink } from '@open-multi-agent/otel'
+
+const sink = createOtelTraceSink({ tracerProvider: applicationProvider })
+const oma = new OpenMultiAgent({ observability: { sinks: [sink] } })
+```
+
+The application constructs the provider, processors, sampler, resource, and
+exporter. The adapter does not use the global provider. Provider shutdown is
+off by default; after draining the OMA sink, the application shuts down the
+provider it owns.
+
+Runnable in-memory-provider version: [`otel-provider.ts`](../packages/core/examples/integrations/observability-v2/otel-provider.ts).
+
+### Stage 4: own lifecycle explicitly
+
+| Runtime | End-of-work sequence |
+|---|---|
+| Serverless/FaaS warm singleton | `run → sink.forceFlush(short timeout)`; do not shut down the shared singleton per invocation. |
+| Short-lived CLI | `run → sink.forceFlush → store.flush (if file-backed) → sink.shutdown → store.close`. |
+| Long-lived server | stop accepting work and await in-flight requests, then `sink.forceFlush → sink.shutdown → store.close → provider.shutdown` for resources the application owns. |
+
+OMA does not install signal handlers, call `process.exit()`, close a supplied
+store, or shut down an application-owned provider. See the runnable
+[`CLI`](../packages/core/examples/integrations/observability-v2/cli-lifecycle.ts),
+[`SIGTERM server`](../packages/core/examples/integrations/observability-v2/server-lifecycle.ts),
+and [`FaaS`](../packages/core/examples/integrations/observability-v2/serverless-lifecycle.ts)
+examples.
+
+## Privacy difference to account for
+
+Legacy `onTrace` intentionally keeps its historical redacted tool input/output
+fields. V2 instrumentation does not collect prompt, completion, tool arguments,
+tool results, or reasoning content by default. Numeric usage facts, including
+reasoning-token counts, remain eligible. Trace privacy does not redact
+CheckpointStore or shared-memory data; use `RedactingStore` separately where
+persisted run state needs masking.
+
+## Cutover checklist
+
+1. Run legacy and v2 destinations side by side only when duplicate delivery is
+   intentional and separately keyed.
+2. Compare run counts by `runId`; do not equate legacy UUID span IDs with v2
+   W3C-compatible trace/span IDs.
+3. Alert on sink `dropped`, `failed`, and `lastError` rather than turning them
+   into Agent failures.
+4. Exercise exporter rejection, hang, and partial delivery before cutover.
+5. Add lifecycle handling for every process mode before removing the stage-1
+   bridge.
+6. Keep rollback as a configuration change until the new backend has met its
+   retention, privacy, and durability requirements.

--- a/docs/observability-performance.md
+++ b/docs/observability-performance.md
@@ -1,0 +1,140 @@
+# Observability v2 performance baseline
+
+This document records a reproducible engineering snapshot, not a permanent
+marketing promise. Absolute timings depend on Node, CPU, OS, filesystem, power
+state, and background load. Release decisions use same-host medians and the RFC
+budgets; CI uses deliberately wider gates to avoid hardware-dependent flakes.
+
+## Budgets
+
+| Path | Dedicated benchmark gate | CI guard |
+|---|---:|---:|
+| no sink wall time | `<1%` median regression versus the OBS-1A identity/status baseline | measured in dedicated release run, not a shallow CI checkout |
+| no sink retained memory | `<1 KiB` additional per retained top-level result versus OBS-1A | reported with `--expose-gc`; not an absolute shared-runner gate |
+| legacy synchronous callback dispatch | p95 `<10 µs` per completion event | p95 `<100 µs` |
+| batching enqueue | p95 `<20 µs` per record | p95 `<200 µs` |
+| OTel conversion + in-memory processor | p95 `<50 µs` per record | p95 `<500 µs` |
+| same-host whole-run sink overhead | report relative to no sink | `<1,000%` to catch order-of-magnitude regressions |
+
+The wide CI thresholds are 10x the dedicated microsecond budgets. They are a
+regression alarm, not the release acceptance result.
+
+## Matrix and method
+
+The existing benchmark scripts remain the shared harness:
+
+| Matrix row | Harness and statistic |
+|---|---|
+| no sink | `observability-no-sink.mjs`; alternating baseline/candidate rounds, median wall time |
+| no-sink memory | same harness under `--expose-gc`; retained result arrays, alternating median bytes/result |
+| legacy callback | `observability-sinks.mjs`; full-run medians plus direct legacy dispatch p95 |
+| `BatchingTraceSink` | full-run medians and synchronous enqueue p95 |
+| `InMemoryTraceStore` | 1k/10k append, first-page query, and estimated retained heap |
+| `FileTraceStore` | 1k/10k append, fsync, reopen, full query, compaction, file size, and batch-size comparison |
+| OTel adapter | official `InMemorySpanExporter` + `SimpleSpanProcessor`; per-record p95 and 1k/10k batches |
+| 1/10/100-agent equivalent envelopes | metadata-only start/end record sets; bytes and enqueue p95 |
+| streaming metadata | 10k payload-free `stream_chunk` events; bytes and enqueue p95 |
+| queue pressure/drop | record-count and byte-pressure snapshots from bounded queues |
+
+Commands from the repository root after building:
+
+```bash
+# Same-host historical comparison. The baseline must be a separately built
+# OBS-1A/core dist, while candidate is this checkout's core dist.
+node --expose-gc packages/core/benchmarks/observability-no-sink.mjs \
+  /tmp/oma-obs1a-baseline/packages/core/dist/index.js \
+  packages/core/dist/index.js
+
+# Sink/store/OTel matrix.
+node --expose-gc packages/core/benchmarks/observability-sinks.mjs \
+  packages/core/dist/index.js packages/otel/dist/index.js
+
+# File durability and query boundary.
+node --expose-gc packages/core/benchmarks/file-trace-store.mjs
+
+# Tolerant CI gate.
+npm run bench:observability:ci
+```
+
+Defaults are nine alternating rounds and 2,000 top-level runs for the historical
+comparison. Override with `OMA_BENCH_ITERATIONS`, `OMA_BENCH_ROUNDS`,
+`OMA_BENCH_MEMORY_ITERATIONS`, and `OMA_BENCH_MEMORY_ROUNDS`. Record all
+overrides with the result.
+
+## Current release snapshot
+
+Final OBS-5 dedicated run: Node `v22.22.3`, macOS/Darwin `25.5.0`
+`darwin-arm64`, Apple M1. Historical wall-time comparison used 2,000 runs × 9
+alternating rounds; retained-memory comparison used 2,000 retained results × 3
+alternating rounds. Microsecond p95 samples used 10,000 legacy/batching events
+and 1,000 post-warm-up OTel records.
+
+| Check | Result | Gate |
+|---|---:|---:|
+| no-sink median regression | `-0.530%` (18.743 ms baseline; 18.644 ms candidate) | `<1%` |
+| additional retained bytes/result | `-1.18 B` (1,154.16 B baseline; 1,152.98 B candidate) | `<1,024 B` |
+| legacy dispatch p95 | `0.125 µs` | `<10 µs` |
+| batching enqueue p95 | `1.250 µs` | `<20 µs` |
+| OTel conversion/processor p95 | `15.208 µs` | `<50 µs` |
+
+All five dedicated gates pass. The historical baseline is the built OBS-1A
+merge `58096804a04c241a4c02943050acc4c89c884a85`; key source blobs in the
+baseline snapshot were hash-matched to that commit before measurement.
+
+### Matrix snapshot
+
+| Path | 1k records | 10k records |
+|---|---:|---:|
+| InMemory append | 5.14 ms | 36.33 ms |
+| InMemory first-page query | 15.20 ms | 42.46 ms |
+| InMemory estimated retained heap | 414,384 B | 1,878,976 B |
+| OTel convert + in-memory process | 12.24 ms | 79.00 ms |
+| File append (write-complete) | 12.47 ms | 84.80 ms |
+| File fsync | 3.56 ms | 7.60 ms |
+| File reopen/index rebuild | 9.77 ms | 63.51 ms |
+| File full paginated query | 16.33 ms | 339.57 ms |
+| File compaction | 32.65 ms | 933.37 ms |
+
+The file rows represent 500/5,000 logical runs (two records each). File sizes
+were 431,818/4,393,820 bytes before compaction and 427,810/4,353,812 bytes
+after. For 1,000 records, append time by batch size was 158.99 ms (1), 26.62 ms
+(10), 9.04 ms (100), and 7.92 ms (1,000).
+
+Equivalent metadata envelopes produced enqueue p95 of 1.291 µs (1 agent),
+1.250 µs (10 agents), and 1.250 µs (100 agents), using at least 1,000 timing
+samples per row. The representative 100-agent envelope was 202,500 bytes for
+402 records, 1.21% of the default 16 MiB queue. Ten thousand payload-free
+stream metadata events occupied 4,196,674 bytes and enqueued at 1.084 µs p95.
+
+Pressure injection behaved as designed: a 100-record queue accepted 1,000
+events, retained 100, and reported 900 drops; a four-record-equivalent byte
+limit accepted 100, retained 4, and reported 96 drops. No unbounded growth or
+silent loss was observed.
+
+Whole deterministic-run medians were 9.001 µs/run (no sink), 15.185 µs/run
+(legacy callback), and 59.117 µs/run (batch sink). These end-to-end relative
+figures include creation and JSON byte accounting for six v2 records per run;
+the RFC release gates are the hot-path p95 and historical no-sink comparison,
+not a promise that enabled tracing has zero total work.
+
+## Content capture boundary
+
+There is no public content-on mode in this release. `TraceCapturePolicy` keeps
+the default metadata-only contract and `@open-multi-agent/otel` exposes only a
+disabled content-capture extension point. Therefore content-on benchmarking is
+explicitly a non-goal, not a missing benchmark row. No synthetic prompt or tool
+payload path is added merely to satisfy the matrix; metadata-only remains the
+product baseline.
+
+## Interpreting storage numbers
+
+- `InMemoryTraceStore` numbers include in-process indexes and are not a
+  durability claim.
+- `FileTraceStore.append()` is write-complete, while `flush()` and `close()` are
+  the fsync boundary. Report both separately.
+- Reopen time includes a full append-log scan and in-memory index rebuild.
+- Compaction is same-directory temp write, fsync, atomic rename, and best-effort
+  parent-directory fsync. It is not a database vacuum or multi-process test.
+- Queue-pressure output is expected to show drops. Passing means memory remains
+  bounded and the drops appear in stats/diagnostics, not that no record is ever
+  dropped.

--- a/docs/observability-release-readiness.md
+++ b/docs/observability-release-readiness.md
@@ -1,0 +1,275 @@
+# Observability v2 release-readiness record
+
+This is the auditable OBS-5 contract, failure-injection, packaging, and release
+note record. It does not publish packages, create a tag, or create a GitHub
+Release. Performance numbers live in
+[`observability-performance.md`](./observability-performance.md); adoption and
+cutover steps live in
+[`observability-migration.md`](./observability-migration.md).
+
+Baseline: `6339ee50515e149eb1fb5a073f44024d3ab821a3`, including PR #384.
+
+## Public contract source of truth
+
+| Contract | Public surface | Implementation source | Primary evidence |
+|---|---|---|---|
+| `RunIdentity` | core root types | `types.ts`, `observability/identity.ts` | `observability-v2-identity.test.ts`, checkpoint tests |
+| `RunStatus` / `errorInfo` / compatible `success` | core root types/results | `types.ts`, `observability/status.ts` | identity and span suites |
+| `TraceRecord` v2 | core root and `/observability` | `observability/records.ts`, `runtime.ts` | `observability-v2-spans.test.ts` |
+| `TraceSink` | core root and `/observability` | `observability/sink.ts` | sink lifecycle suite |
+| `TraceExporter` | core root and `/observability` | `observability/sink.ts` | sink lifecycle suite |
+| `BatchingTraceSink` | core root and `/observability` | `observability/batching.ts` | sink lifecycle suite and benchmark |
+| `CompositeSink` | core root and `/observability` | `observability/composite.ts` | composition failure tests |
+| `FilteringSink` | core root and `/observability` | `observability/processors.ts` | filter/privacy tests |
+| `SensitiveDataProcessor` | core root and `/observability` | `observability/processors.ts` | default privacy tests |
+| `LegacyCallbackTraceSink` | core root and `/observability` | `observability/legacy-callback.ts` | seven-shape fidelity and direct migration tests |
+| `InMemoryTraceStore` | core root and `/observability` | `observability/in-memory-store.ts` | reusable TraceStore contract suite |
+| `TraceStoreExporter` | core root and `/observability` | `observability/store-exporter.ts` | exporter retry/idempotency tests |
+| `FileTraceStore` | `/observability/file` only | `observability/file-store.ts` | reusable contract + file/recovery suite |
+| `@open-multi-agent/otel` | separate package root | `packages/otel/src` | official in-memory exporter suites |
+| `forceFlush` / `shutdown` | `TraceSink`; OTel sink | batching/composite/legacy/OTel implementations | concurrency, timeout, reentry suites |
+| diagnostics / stats | sink and file-store types | `sink.ts`, `file-store.ts` | payload-free diagnostic and counter tests |
+| checkpoint/restore identity | top-level run results and checkpoint v2 | `memory/checkpoint.ts`, `identity.ts`, orchestrator | v1 read, v2 continuation, runId-conflict tests |
+
+The public contract is the exported type plus the implementation and its tests.
+The private design RFC is historical rationale, not a substitute for current
+package exports. A contract redesign discovered here must be a separate
+follow-up; OBS-5 only permits narrow correctness and compatibility fixes.
+
+## Responsibility boundaries
+
+| Component | Owns | Does not own |
+|---|---|---|
+| Dashboard | static post-run task DAG artifact | live delivery, durable state, trace query |
+| TraceStore | best-effort TraceRecord append/query/delete/retention | authoritative run state, CAS, lease, resume |
+| CheckpointStore | task-grained execution snapshots used by `restore()` | telemetry retention or trace query |
+| Future RunStore | authoritative durable run state machine | implemented by this release |
+| OTel adapter | mapping OMA records to spans/events/links | global provider setup, SDK/exporter choice, collector, provider ownership |
+
+## Failure-injection matrix
+
+`Automated` means a committed test runs in the Node 18/20/22 `npm test` CI
+matrix. `Runnable` is a no-network example exercised by the package CI job.
+`Manual` is an external condition and is not represented as passed.
+
+| Failure | Status | Evidence / expected result |
+|---|---|---|
+| pre-abort | Automated | identity + span suites: `cancelled`, not success; spans close |
+| in-flight abort | Automated | identity + span suites: `cancelled`; no open lifecycle |
+| whole-run timeout | Automated | identity + span suites: `timeout`, distinct from caller abort |
+| budget exhaustion | Automated | identity + span suites: `budget_exhausted` |
+| provider error | Automated | provider 401/429/500 classification and span closure |
+| callback sync throw | Automated | legacy suites; callback failure isolated and counted |
+| callback async reject | Automated | legacy suites; no unhandled rejection; flush reports failure |
+| exporter reject | Automated | batching suite; bounded retry/failure stats |
+| exporter hang | Automated | export signal aborted at timeout; business work unaffected |
+| partial export | Automated | delivered prefix counted; permanent/retryable suffix semantics |
+| bounded retry | Automated | retry count and unexported suffix assertions |
+| queue record overflow | Automated | priority drop and cumulative stats |
+| queue byte overflow | Automated | byte bound and cumulative stats |
+| oversize record | Automated | rejected before acceptance; payload-free diagnostic |
+| concurrent `forceFlush` | Automated | independent watermarks complete without lost records |
+| shutdown timeout/reentry | Automated | shared idempotent result; later emit dropped and diagnosed |
+| diagnostic handler throw | Automated | swallowed without recursion or business failure |
+| OTel span start/event/end failure | Automated | record-specific result and diagnostic codes |
+| OTel incomplete/out-of-order records | Automated | marked incomplete; duplicate/orphan diagnostics; no throw |
+| File write failure | Automated | memory/disk rollback; structured payload-free error |
+| File fsync failure | Automated | `flush()` rejects; no durability success claim |
+| File rename failure | Automated | original target remains authoritative and usable |
+| trailing partial line | Automated | diagnosed and truncated to last committed boundary |
+| uncommitted batch | Automated | entire batch invisible after recovery |
+| middle-file corruption | Automated | open fails loudly; later valid data is not silently replayed |
+| compaction interruption | Automated | stale temp policy and original-target authority |
+| SIGTERM graceful shutdown | Runnable | explicit application handler; stop intake, flush, shutdown |
+| FaaS flush timeout | Runnable | invocation receives `timeout`; shared singleton is not shut down |
+| hard process/OS crash | Manual | start-only spans may remain incomplete; filesystem durability is limited by last fsync |
+
+Across automated cases, telemetry failure does not alter Agent/Task/Run business
+results, does not create unhandled rejections, and is visible through a result,
+stats, or payload-free diagnostic. Hard process termination is the explicit
+exception to guaranteed span closure.
+
+## Privacy and security evidence
+
+The default path is verified end to end, not only documented:
+
+- `observability-v2-privacy.test.ts` runs a deterministic agent and tool through
+  `BatchingTraceSink → TraceStoreExporter → InMemoryTraceStore`, then proves the
+  prompt, completion, tool arguments, tool result, `<thinking>`, and reasoning
+  content are absent while numeric usage remains.
+- `otel-exporter.test.ts` proves the OTel allowlist excludes prompt,
+  completion, tool payload, raw request/payload, credentials, and reasoning
+  content while preserving eligible token counts.
+- sink tests prove structured secret fields and reasoning content are removed
+  before delivery, and diagnostic handler failures are isolated.
+- file tests prove `0600` on POSIX, payload-free corruption errors, and
+  structured write/fsync/rename failures.
+- legacy trace tests preserve the historical, broader behavior: redacted tool
+  input/output remains available to `onTrace` and the legacy bridge.
+
+Trace privacy does not redact checkpoint or shared-memory payloads. That data
+plane requires a separately configured `RedactingStore` where appropriate.
+
+## Package and version compatibility decision
+
+The already-published `@open-multi-agent/core@1.10.0` predates the public
+Observability v2 sink/store APIs. It cannot satisfy the OTel adapter and must
+not be included in the adapter's compatible range.
+
+Decision:
+
+- first core release containing the complete Observability v2 public API:
+  `@open-multi-agent/core@1.11.0`;
+- first adapter release: `@open-multi-agent/otel@0.1.0`;
+- adapter core dependency: `^1.11.0`;
+- starter templates are prepared to pin core `1.11.0`;
+- no new versioning system is introduced.
+
+This is an additive feature set, so a core minor is appropriate. The OTel
+adapter remains on its independent `0.x` line. The package boundary is based on
+module ownership, optional installation, provider lifecycle, and compatibility—not
+on a permanent count of core dependencies. Any new dependency must justify
+security, install size, maintenance, and compatibility cost; unused optional or
+platform-specific SDKs should remain outside eager root imports when useful.
+
+## Tarball and consumer smoke contract
+
+`scripts/observability-tarball-smoke.mjs` builds real `npm pack` tarballs and
+installs them into clean temporary consumers:
+
+1. **core only** — imports core, `/observability`, and
+   `/observability/file`; runs in-memory and file stores without installing
+   OTel;
+2. **core + OTel** — installs the core and OTel tarballs plus official OTel API
+   and SDK dependencies; reconstructs parent hierarchy, link resolution, and
+   error status with `InMemorySpanExporter`; flushes and shuts down explicitly;
+3. **minimum declared core** — proves core `1.11.0` contains every symbol used
+   by OTel and that the manifest range is exactly `^1.11.0`.
+
+The same script always tests the current core tarball in scenario 2. Once the
+repository advances beyond `1.11.x`, CI can pass a separately obtained
+`OMA_OBSERVABILITY_MIN_CORE_TARBALL` for scenario 3 while scenario 2 continues
+to smoke the higher current version.
+
+Tarball checks allow only `dist/`, `README.md`, `LICENSE`, and `package.json`,
+verify every export target exists, and keep tests, source, examples, and
+benchmarks out. Core source/package tests also prevent OTel references from
+entering core and keep the FileTraceStore implementation behind
+`/observability/file`. The core root is already Node-oriented and reaches
+`node:fs` through pre-existing `FileStore` and built-in file-tool exports; OBS-5
+does not claim it is browser-safe or attempt an unrelated root-export redesign.
+
+## Draft release notes
+
+### Observability v2
+
+- Stable `runId` / attempt identity and normalized runtime status now appear on
+  every top-level runtime result. New result fields stay optional in 1.x TypeScript
+  declarations for source compatibility but are present at runtime.
+- Caller abort, whole-run timeout, provider failure, budget exhaustion, and
+  approval rejection now have distinct outcomes; legacy `success` remains and
+  derives from `status.code === 'ok'`.
+- Checkpoint schema v2 preserves logical identity across restore, increments the
+  attempt, starts a new trace, and links to the prior root. Schema v1 remains
+  readable.
+- TraceRecord schema v2 adds start/event/end records, W3C-compatible IDs,
+  structured errors, and DAG/delegation/synthesis/restore links.
+- `TraceSink`, `TraceExporter`, and `BatchingTraceSink` add bounded queueing,
+  partial delivery, retry, diagnostics, `forceFlush`, and idempotent shutdown.
+- `InMemoryTraceStore`, `TraceStoreExporter`, and the Node-only
+  `FileTraceStore` reference implementation add local query and persistence.
+- `@open-multi-agent/otel` is an independently installed adapter for an
+  application-owned OpenTelemetry provider.
+- `onTrace` remains supported, is not deprecated in this release, and preserves
+  all seven existing event shapes and UUID parent relationships.
+- V2 content capture is off by default: prompts, completions, tool payloads,
+  credentials, and reasoning content are not collected. Legacy `onTrace`
+  retains its historical redacted tool payload behavior.
+- `FileTraceStore` is a single-process reference store, not a shared database.
+  Durability past OS/power failure begins at explicit `flush()`/`close()` fsync.
+
+Release order:
+
+1. publish core `1.11.0`;
+2. run a registry-installed core smoke;
+3. publish OTel `0.1.0` with core range `^1.11.0`;
+4. run the joint registry-installed smoke.
+
+This task prepares and locally validates that sequence. npm publish, tags, and
+GitHub Releases remain Manual.
+
+## Final verdict
+
+结论：CONDITIONAL GO
+
+Blocker
+
+- None in the locally testable OBS-5 scope.
+
+Major
+
+- The literal requirement “core root import does not load `node:fs`” is not true
+  of the pre-OBS-v2 package: the existing root statically exports `FileStore`
+  and built-in file tools. OBS-5 verified the scoped compatibility invariant
+  that root and `/observability` do not reach the new FileTraceStore module,
+  `/observability` itself does not reach `node:fs`, and
+  `/observability/file` does. Accept this existing Node-oriented root boundary
+  for 1.11.0 or create a separate root-export/browser-compatibility redesign;
+  do not mix that redesign into OBS-5.
+
+Minor
+
+- Clean-consumer installs repeat npm's existing `node-domexception` deprecation
+  warning through the current dependency graph; it does not affect the smoke.
+
+Manual
+
+- Current OBS-5 branch GitHub Actions: not run because this task explicitly
+  forbids push/PR. Local commands matching the Node 18/20/22 test matrix pass.
+- npm permissions and registry publication.
+- Post-publish registry install smoke, in the documented core-first order.
+- Tag and GitHub Release creation.
+- optional real OTLP collector canary.
+
+已验证
+
+- Baseline ancestor check passed at PR #384 merge commit `6339ee5`.
+- Public contracts, package exports, private RFC rationale, and PR #371/#373/
+  #374/#375/#376/#384 implementation/validation records were audited.
+- Legacy bridge direct migration works without also configuring `onTrace`; all
+  seven historical shapes and UUID parent behavior remain covered.
+- Public migration snippets typecheck; seven no-key examples execute.
+- Failure-injection and privacy suites pass, including payload-free diagnostics,
+  FileTraceStore `0600`, and actual sink/store/OTel content exclusion.
+- Dedicated performance gates pass: no-sink `-0.530%`, additional retained
+  `-1.18 B/run`, legacy `0.125 µs`, batch enqueue `1.250 µs`, OTel
+  `15.208 µs` p95.
+- Core 1.11.0 / OTel 0.1.0 / `^1.11.0` compatibility is locked by manifests,
+  tests, starter pins, lockfile, and minimum-version consumer fixture.
+- Node 18.20.8, 20.19.4, and 22.22.3 local full matrices each pass: core 1,350,
+  create-oma-app 26, OTel 15 tests.
+- Root lint, build, dedicated benchmark matrix, tolerant benchmark gate,
+  `git diff --check`, both dry-run packs, and real tarball consumer scenarios
+  pass.
+
+未验证/风险
+
+- No current-branch remote CI result until a PR is allowed.
+- Registry permissions, actual publication, provenance, tag, and GitHub Release
+  remain external/manual.
+- A real OTLP collector/backend canary is optional; official
+  `InMemorySpanExporter` covers adapter semantics locally.
+- FileTraceStore remains single-process/reference only; no multi-process or
+  network-filesystem guarantee is implied.
+
+下一步
+
+- Accept the documented pre-existing root `node:fs` scope exception.
+- Open a PR when authorized and require the normal remote CI matrix to pass.
+- Merge OBS-5, publish core 1.11.0, run registry core smoke, then publish OTel
+  0.1.0 and run the joint registry smoke.
+- Do not publish, tag, or create a GitHub Release from this task.
+
+OBS-5 is locally merge-ready once the root `node:fs` scope exception is
+accepted. It is not yet externally release-complete because remote CI and the
+manual registry sequence have intentionally not run.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -2,6 +2,12 @@
 
 `open-multi-agent` exposes three telemetry layers: live progress events, structured trace spans, and a static post-run dashboard.
 
+For an existing callback integration, follow the staged
+[`onTrace` migration guide](./observability-migration.md). Release engineering
+and benchmark evidence are recorded in
+[`observability-performance.md`](./observability-performance.md) and
+[`observability-release-readiness.md`](./observability-release-readiness.md).
+
 ## Run identity and outcome
 
 Every top-level execution (`runAgent`, `runTeam`, `runTasks`, `runFromPlan`,
@@ -329,14 +335,18 @@ first with `runId` as the tie-breaker, and repeated application is safe.
 TraceStore retention only affects that store. It cannot delete copies already
 exported to OTel or another vendor.
 
-### TraceStore is not RunStore or CheckpointStore
+### Dashboard, TraceStore, CheckpointStore, and RunStore
 
-TraceStore is append/query telemetry and can be best-effort. A future RunStore
-is the authoritative durable state machine with CAS, lease, suspend, and resume
-semantics; TraceStore deliberately provides none of those. CheckpointStore
-persists execution state used to restore work. Losing telemetry must not roll
-back a durable run, and deleting traces must not imply deleting checkpoints or
-shared memory.
+| Data plane | Responsibility | Reliability boundary |
+|---|---|---|
+| Dashboard | static post-run task DAG, timing, token facts, and task details | derived artifact; no live delivery or authoritative state |
+| TraceStore | append/query telemetry, retention, and trace deletion | best-effort; no CAS, lease, suspend, or resume |
+| CheckpointStore | task-grained execution snapshot consumed by `restore()` | execution recovery state; not a trace query system |
+| future RunStore | authoritative durable run state machine | not implemented by Observability v2 |
+
+Losing telemetry must not roll back a durable run. Deleting traces must not
+delete checkpoints, shared memory, or remotely exported OTel data.
+
 ## Optional OpenTelemetry package
 
 `@open-multi-agent/otel` is an independent workspace/package that adapts OBS-2
@@ -432,15 +442,20 @@ return { result, telemetry: telemetry.status }
 // Short-lived CLI: finish delivery before natural process exit.
 try {
   await main()
-  await sink.forceFlush({ timeoutMs: 5_000 })
 } finally {
+  await sink.forceFlush({ timeoutMs: 5_000 })
+  await store?.flush()
   await sink.shutdown({ timeoutMs: 5_000 })
+  await store?.close()
 }
 
 // Long-lived server: application-owned graceful shutdown.
 async function stopServer() {
+  await stopAcceptingAndWaitForInflight(server)
+  await sink.forceFlush({ timeoutMs: 10_000 })
   await sink.shutdown({ timeoutMs: 10_000 })
-  await server.close()
+  await store?.close()
+  await provider?.shutdown()
 }
 // Register stopServer with your server/process framework if desired.
 ```
@@ -511,6 +526,9 @@ event object. Synchronous callback throws and asynchronous rejections remain
 isolated and cannot become unhandled rejections. `onTrace` is not marked
 deprecated in this release; the 1.x compatibility window remains open while
 users can migrate transport code to `observability.sinks` at their own pace.
+The copyable stage-by-stage path is in
+[`observability-migration.md`](./observability-migration.md), including direct
+`LegacyCallbackTraceSink`, batching, TraceStore/OTel, and lifecycle ownership.
 
 Span parentage is best-effort and uses the causal structure known to the runtime. In team runs, worker agent spans point to their task span, and LLM/tool/stream spans point to the agent span. Root spans such as top-level agent runs omit `parentId`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6560,7 +6560,7 @@
     },
     "packages/core": {
       "name": "@open-multi-agent/core",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
@@ -6632,7 +6632,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@open-multi-agent/core": "^1.10.0"
+        "@open-multi-agent/core": "^1.11.0"
       },
       "devDependencies": {
         "@opentelemetry/api": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "test:watch": "npm run test:watch -w @open-multi-agent/core",
     "test:coverage": "npm run test:coverage -w @open-multi-agent/core",
     "test:e2e": "npm run test:e2e -w @open-multi-agent/core",
+    "bench:observability:ci": "node scripts/observability-benchmark-ci.mjs",
+    "test:observability-examples": "node scripts/observability-example-smoke.mjs",
+    "test:observability-pack": "node scripts/observability-tarball-smoke.mjs",
     "test:scaffold": "npm run test:scaffold --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present"
   },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -360,6 +360,32 @@ Most TypeScript teams picking a multi-agent layer are really choosing between OM
                          └──────────────────────┘
 ```
 
+Observability is a parallel, optional data plane across every execution mode;
+stable identity and status remain part of the run result even when no sink is
+configured:
+
+```
+Execution runtime (runAgent / runTeam / runTasks / restore)
+├─ RunIdentity + RunStatus ─────────────────────────► result / checkpoint continuation
+├─ legacy TraceEvent ────────────────────────────► onTrace / LegacyCallbackTraceSink
+└─ TraceRecord v2 (start / event / end + links)
+   └─ metadata-only privacy processor (default)
+      └─ TraceSink (fast emit + stats / diagnostics)
+         ├─ BatchingTraceSink ─► TraceExporter
+         │                      ├─ custom backend
+         │                      └─ TraceStoreExporter
+         │                         ├─ InMemoryTraceStore
+         │                         └─ FileTraceStore (/observability/file)
+         └─ @open-multi-agent/otel ─► application-owned TracerProvider
+```
+
+These stores have deliberately different responsibilities: a `TraceStore`
+holds queryable telemetry, a checkpoint store holds resumable execution state,
+and the dashboard renders a post-run artifact. The application owns
+`forceFlush()` / `shutdown()`, file-store `flush()` / `close()`, and shutdown of
+any supplied OpenTelemetry provider. See the [observability guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)
+and [migration guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability-migration.md).
+
 ## Supported Providers
 
 Change `provider`, `model`, and set the env var. The agent config shape stays the same.
@@ -439,7 +465,7 @@ Before going live, wire up the controls that protect token spend, recover from f
 | Hard-cap token spend | `maxTokenBudget` on the orchestrator | `OrchestratorConfig` |
 | Cap estimated cost | `maxCostBudget` + `estimateCost`; you own the per-model price table, and checks happen at turn/task boundaries rather than cent-exact mid-call stops | `OrchestratorConfig` |
 | Catch stuck agents | `loopDetection` with `onLoopDetected: 'terminate'` (or a custom handler) | `AgentConfig` |
-| Trace and audit | `onTrace` to your tracing backend; persist `renderTeamRunDashboard(result)` | `OrchestratorConfig` |
+| Trace and audit | Keep legacy `onTrace`, or configure `observability.sinks` with batching + an exporter, TraceStore, or OTel adapter; persist `renderTeamRunDashboard(result)` and explicitly flush/shut down application-owned telemetry | `OrchestratorConfig` + application lifecycle |
 | Redact secrets | Automatic — API keys, tokens, and Authorization headers stripped from traces, bash output, and dashboard payloads | built-in (on by default) |
 | Grant tools deliberately | Built-in tools are opt-in (default-deny): an agent gets only what it lists in `tools` / `toolPreset`; list neither and it gets none. `bash` stays unsandboxed once granted, and every tool result is sent to your model provider — so grant read/exec access on purpose. `defaultToolPreset` restores the old "all tools" behavior in one line | `AgentConfig` / `OrchestratorConfig` |
 | Bound filesystem reach | `cwd` / `defaultCwd` (default `.agent-workspace` subdir; widen with `process.cwd()`, disable with `null`) | `AgentConfig` / `OrchestratorConfig` |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -311,7 +311,7 @@ Most TypeScript teams picking a multi-agent layer are really choosing between OM
 
 **vs. Mastra.** Both are TypeScript-native; the difference is who drives orchestration. Mastra has you wire the workflow by hand. OMA is goal-driven: hand its Coordinator a goal and it builds the task DAG at runtime. `runTeam(team, goal)` in one call.
 
-**vs. CrewAI.** CrewAI is the established multi-agent option in Python. OMA brings goal-driven decomposition to TypeScript backends with a lean runtime (three core dependencies, plus opt-in peers you install only when you use them) and direct Node.js embedding, with no separate Python service to stand up alongside your stack.
+**vs. CrewAI.** CrewAI is the established multi-agent option in Python. OMA brings goal-driven decomposition to TypeScript backends with a deliberately governed dependency surface and direct Node.js embedding, with no separate Python service to stand up alongside your stack. New dependencies must justify their security, size, maintenance, and compatibility cost; optional or platform-specific SDKs remain isolated when that boundary is useful.
 
 **vs. Vercel AI SDK.** AI SDK is the LLM-call layer (provider abstraction, streaming, tool calls, and structured outputs), not a multi-agent orchestrator. Use it alone for single-agent calls; reach for OMA the moment you need a coordinated team. OMA even ships an optional AI SDK bridge.
 
@@ -386,6 +386,11 @@ See [docs/providers.md](https://github.com/open-multi-agent/open-multi-agent/blo
 
 At present, `@open-multi-agent/core` directly installs `@anthropic-ai/sdk`, `openai`, and `zod`; this is an implementation detail, not a fixed dependency-count policy. Anthropic, OpenAI, and every OpenAI-compatible endpoint use those packages today.
 
+Dependency changes are governed by demonstrated value plus security, install
+size, maintenance, and compatibility cost. Optional or platform-specific
+capabilities remain isolated when that keeps unused SDKs out of the root import;
+the boundary is architectural, not a permanent numeric cap.
+
 Other provider integrations are opt-in peer dependencies that load lazily, so a project that never uses one never installs it. OpenTelemetry integration is a separately installable package: OTel APIs, SDKs, semantic-convention mappings, and exporter integrations live in `@open-multi-agent/otel`, so importing or running core does not require OpenTelemetry.
 
 | Capability | Install | Trigger |
@@ -443,7 +448,7 @@ Before going live, wire up the controls that protect token spend, recover from f
 
 - [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) — env vars, model examples, local tool-calling, timeouts, troubleshooting.
 - [Tool configuration](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) — tool presets, custom tools, the filesystem sandbox, and MCP.
-- [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — stable run identity and outcome semantics on every top-level result, plus `onProgress`, `onTrace`, and the post-run dashboard. [`@open-multi-agent/otel`](https://github.com/open-multi-agent/open-multi-agent/blob/main/packages/otel/README.md) is the optional adapter for applications with an explicitly configured OpenTelemetry provider.
+- [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — stable identity/status, TraceRecord v2, bounded sink/exporter lifecycle, InMemory/File TraceStore, and the post-run dashboard. Existing callbacks have a staged [`onTrace` migration guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability-migration.md); [`@open-multi-agent/otel`](https://github.com/open-multi-agent/open-multi-agent/blob/main/packages/otel/README.md) uses an application-owned provider.
 - [Shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — the default store and custom `MemoryStore` backends.
 - [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — checkpoint v2 identity rules, v1 compatibility, and restore over any `MemoryStore`.
 - [Context management](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — sliding window, summarization, compaction, and custom compressors.

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -360,6 +360,30 @@ await orchestrator.runTeam(team, goal, {
                          └──────────────────────┘
 ```
 
+可观测性是跨越所有执行模式的并行、可选数据面；即使没有配置 sink，
+稳定的 identity 与 status 仍属于运行结果契约：
+
+```
+执行运行时 (runAgent / runTeam / runTasks / restore)
+├─ RunIdentity + RunStatus ─────────────────────────► 结果 / checkpoint 延续
+├─ legacy TraceEvent ────────────────────────────► onTrace / LegacyCallbackTraceSink
+└─ TraceRecord v2 (start / event / end + links)
+   └─ metadata-only 隐私处理器（默认）
+      └─ TraceSink（快速 emit + stats / diagnostics）
+         ├─ BatchingTraceSink ─► TraceExporter
+         │                      ├─ 自定义后端
+         │                      └─ TraceStoreExporter
+         │                         ├─ InMemoryTraceStore
+         │                         └─ FileTraceStore (/observability/file)
+         └─ @open-multi-agent/otel ─► 应用自有 TracerProvider
+```
+
+这些存储的职责刻意分离：`TraceStore` 保存可查询的 telemetry，checkpoint
+store 保存可恢复的执行状态，dashboard 则渲染运行后产物。应用负责
+`forceFlush()` / `shutdown()`、文件 store 的 `flush()` / `close()`，以及关闭
+自己传入的 OpenTelemetry provider。详见[可观测性指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)
+与[迁移指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability-migration.md)。
+
 ## 支持的 Provider
 
 修改 `provider`、`model`，并设置对应的环境变量。agent 配置结构不变。
@@ -436,7 +460,7 @@ await oma.runAgent(
 | token 用量封顶 | orchestrator 上设 `maxTokenBudget` | `OrchestratorConfig` |
 | 预估成本封顶 | `maxCostBudget` + `estimateCost`；每个模型的价格表由应用侧维护，校验发生在轮次/任务边界，而非精确到分的调用中途中止 | `OrchestratorConfig` |
 | 卡死检测 | `loopDetection` + `onLoopDetected: 'terminate'`（或自定义 handler） | `AgentConfig` |
-| 追踪与审计 | `onTrace` 接你的 tracing 后端；落盘 `renderTeamRunDashboard(result)` | `OrchestratorConfig` |
+| 追踪与审计 | 保留 legacy `onTrace`，或在 `observability.sinks` 中配置 batching + exporter、TraceStore 或 OTel adapter；落盘 `renderTeamRunDashboard(result)`，并显式 flush/shutdown 应用自有 telemetry | `OrchestratorConfig` + 应用生命周期 |
 | 脱敏密钥 | 自动：API key、token、Authorization header 从 trace、bash 输出、dashboard payload 中剥除 | 内置（默认开启） |
 | 按需授予工具 | 内置工具默认拒绝（default-deny）：agent 只拿到自己在 `tools` / `toolPreset` 里列出的工具，都不写则一个都没有。`bash` 一旦授予仍无沙箱，且每次工具结果都会发给你的模型 provider，因此读取/执行权限需刻意授予。`defaultToolPreset` 可一行恢复旧的「全部工具」行为 | `AgentConfig` / `OrchestratorConfig` |
 | 限定 agent 文件操作范围 | `cwd` / `defaultCwd`（默认 `.agent-workspace` 子目录；用 `process.cwd()` 放宽、`null` 关闭） | `AgentConfig` / `OrchestratorConfig` |

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -311,7 +311,7 @@ await orchestrator.runTeam(team, goal, {
 
 **对比 Mastra。** 两者均为原生 TypeScript，差异在于由谁驱动编排。Mastra 需手工连接工作流；OMA 则是目标驱动：将目标交给 Coordinator，即可在运行时自动构建任务 DAG。`runTeam(team, goal)` 一行调用即可。
 
-**对比 CrewAI。** CrewAI 是 Python 生态中成熟的多智能体方案。OMA 将目标驱动的任务拆解引入 TypeScript 后端，运行时精简（三个核心依赖，外加按需安装的可选 peer），直接嵌入 Node.js，无需在既有技术栈之外另行部署独立的 Python 服务。
+**对比 CrewAI。** CrewAI 是 Python 生态中成熟的多智能体方案。OMA 将目标驱动的任务拆解引入 TypeScript 后端，以受治理的依赖边界直接嵌入 Node.js，无需在既有技术栈之外另行部署独立的 Python 服务。新增依赖必须证明安全、体积、维护与兼容成本合理；可选或平台特定 SDK 在边界有价值时继续隔离。
 
 **对比 Vercel AI SDK。** AI SDK 是 LLM 调用层（provider 抽象、流式、tool call、结构化输出），而非多智能体编排器。单 agent 调用单独用它即可；一旦需要协同的团队，则选用 OMA。OMA 亦提供可选的 AI SDK bridge。
 
@@ -386,6 +386,8 @@ const agent: AgentConfig = {
 
 目前安装 `@open-multi-agent/core` 会直接引入 `@anthropic-ai/sdk`、`openai`、`zod`；这是实现细节，而非固定依赖数量的承诺。Anthropic、OpenAI 及所有 OpenAI 兼容端点目前即由这些包支撑。
 
+依赖变更按明确价值以及安全、安装体积、维护和兼容成本治理。可选或平台特定能力在有助于避免主入口 eager import 未使用 SDK 时继续隔离；这个边界是架构选择，不是永久数字上限。
+
 其余 provider 集成均为可选 peer 依赖，按需安装；每个都是懒加载，未用到的项目不会引入。OpenTelemetry 集成是独立安装的包：OTel API、SDK、semantic convention 映射和 exporter 集成都在 `@open-multi-agent/otel` 中，导入或运行 core 不需要 OpenTelemetry。
 
 | 能力 | 安装 | 触发 |
@@ -443,7 +445,7 @@ await oma.runAgent(
 
 - [Provider](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) — 环境变量、模型示例、本地模型工具调用、超时、常见问题。
 - [工具配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) — 工具预设、自定义工具、文件系统沙箱、MCP。
-- [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — 每个顶层结果都包含稳定的运行标识（identity）与结果（outcome）语义，并提供 `onProgress`、`onTrace` 和运行后 dashboard。[`@open-multi-agent/otel`](https://github.com/open-multi-agent/open-multi-agent/blob/main/packages/otel/README.md) 是面向已显式配置 OpenTelemetry provider 的应用的可选适配器。
+- [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md) — 稳定 identity/status、TraceRecord v2、有界 sink/exporter 生命周期、InMemory/File TraceStore 与运行后 dashboard。旧 callback 可按 [`onTrace` 分阶段迁移指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability-migration.md) 无停机迁移；[`@open-multi-agent/otel`](https://github.com/open-multi-agent/open-multi-agent/blob/main/packages/otel/README.md) 使用应用自有 provider。
 - [共享记忆](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md) — 默认存储与自定义 `MemoryStore` 后端。
 - [Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md) — checkpoint v2 identity 规则、v1 兼容，以及基于任意 `MemoryStore` 的恢复流程。
 - [上下文管理](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) — 滑动窗口、摘要、压缩、自定义压缩器。

--- a/packages/core/benchmarks/observability-no-sink.mjs
+++ b/packages/core/benchmarks/observability-no-sink.mjs
@@ -26,13 +26,26 @@ async function load(indexPath, label) {
   }
   const oma = new OpenMultiAgent({ defaultModel: 'benchmark-model' })
   const agent = { name: 'benchmark', model: 'benchmark-model', adapter }
-  return async (count) => {
+  const run = async (count) => {
     const start = performance.now()
     for (let index = 0; index < count; index++) {
       await oma.runAgent(agent, 'ping')
     }
     return performance.now() - start
   }
+  run.retainedBytesPerRun = async (count) => {
+    if (!global.gc) return null
+    global.gc()
+    const before = process.memoryUsage().heapUsed
+    const held = []
+    for (let index = 0; index < count; index++) held.push(await oma.runAgent(agent, 'ping'))
+    global.gc()
+    const bytes = Math.max(0, process.memoryUsage().heapUsed - before) / count
+    held.length = 0
+    global.gc()
+    return bytes
+  }
+  return run
 }
 
 const baseline = await load(baselinePath, 'baseline')
@@ -56,6 +69,24 @@ const median = (values) => [...values].sort((a, b) => a - b)[Math.floor(values.l
 const baselineMedianMs = median(baselineMs)
 const candidateMedianMs = median(candidateMs)
 const regressionPercent = ((candidateMedianMs / baselineMedianMs) - 1) * 100
+const retainedIterations = Number(process.env.OMA_BENCH_MEMORY_ITERATIONS ?? 2_000)
+const retainedRounds = Number(process.env.OMA_BENCH_MEMORY_ROUNDS ?? 3)
+const baselineRetained = []
+const candidateRetained = []
+for (let round = 0; round < retainedRounds; round++) {
+  if (round % 2 === 0) {
+    baselineRetained.push(await baseline.retainedBytesPerRun(retainedIterations))
+    candidateRetained.push(await candidate.retainedBytesPerRun(retainedIterations))
+  } else {
+    candidateRetained.push(await candidate.retainedBytesPerRun(retainedIterations))
+    baselineRetained.push(await baseline.retainedBytesPerRun(retainedIterations))
+  }
+}
+const validMedian = (values) => values.some((value) => value === null)
+  ? null
+  : median(values)
+const baselineRetainedBytesPerRun = validMedian(baselineRetained)
+const candidateRetainedBytesPerRun = validMedian(candidateRetained)
 
 console.log(JSON.stringify({
   iterations,
@@ -63,7 +94,16 @@ console.log(JSON.stringify({
   baselineMedianMs,
   candidateMedianMs,
   regressionPercent,
+  retainedMemory: {
+    iterations: retainedIterations,
+    rounds: retainedRounds,
+    baselineBytesPerRun: baselineRetainedBytesPerRun,
+    candidateBytesPerRun: candidateRetainedBytesPerRun,
+    additionalBytesPerRun: baselineRetainedBytesPerRun === null || candidateRetainedBytesPerRun === null
+      ? null
+      : candidateRetainedBytesPerRun - baselineRetainedBytesPerRun,
+    note: global.gc ? 'Retained result arrays; median of alternating same-process rounds.' : 'Run with --expose-gc.',
+  },
   baselineSamplesMs: baselineMs,
   candidateSamplesMs: candidateMs,
 }, null, 2))
-

--- a/packages/core/benchmarks/observability-sinks.mjs
+++ b/packages/core/benchmarks/observability-sinks.mjs
@@ -1,14 +1,17 @@
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath, pathToFileURL } from 'node:url'
 import { performance } from 'node:perf_hooks'
+import { cpus } from 'node:os'
+import { dirname, resolve } from 'node:path'
 
-const [candidatePath] = process.argv.slice(2)
+const [candidatePath, otelCandidatePath] = process.argv.slice(2)
 if (!candidatePath) {
-  throw new Error('Usage: node observability-sinks.mjs <candidate-index.js>')
+  throw new Error('Usage: node observability-sinks.mjs <candidate-index.js> [otel-index.js]')
 }
 
 const iterations = Number(process.env.OMA_BENCH_ITERATIONS ?? 2_000)
 const rounds = Number(process.env.OMA_BENCH_ROUNDS ?? 9)
 const core = await import(`${pathToFileURL(candidatePath).href}?obs2-benchmark`)
+const traceUtils = await import(`${pathToFileURL(resolve(dirname(candidatePath), 'utils/trace.js')).href}?legacy-benchmark`)
 
 const adapter = {
   name: 'obs2-benchmark',
@@ -59,6 +62,7 @@ for (let round = 0; round < rounds; round++) {
 }
 
 const median = (values) => [...values].sort((a, b) => a - b)[Math.floor(values.length / 2)]
+const percentile = (values, fraction) => [...values].sort((a, b) => a - b)[Math.floor(values.length * fraction)]
 const medians = Object.fromEntries(Object.entries(samples).map(([name, values]) => [name, median(values)]))
 
 const sampleRecord = {
@@ -107,9 +111,205 @@ for (let index = 0; index < emitIterations; index++) {
   emitSink.emit({ ...sampleRecord, sequence: index + 1 })
   emitMicros.push((performance.now() - started) * 1_000)
 }
-emitMicros.sort((a, b) => a - b)
-const emitP95Micros = emitMicros[Math.floor(emitMicros.length * 0.95)]
+const emitP95Micros = percentile(emitMicros, 0.95)
 await emitSink.shutdown({ timeoutMs: 5_000 })
+
+const legacyEvent = {
+  type: 'agent', runId: 'legacy-benchmark', spanId: '00000000-0000-4000-8000-000000000001',
+  agent: 'benchmark', turns: 1, tokens: { input_tokens: 1, output_tokens: 1 }, toolCalls: 0,
+  startMs: 1, endMs: 2, durationMs: 1,
+}
+const legacyDispatchMicros = []
+for (let index = 0; index < emitIterations; index++) {
+  const started = performance.now()
+  traceUtils.emitTrace(() => {}, legacyEvent)
+  legacyDispatchMicros.push((performance.now() - started) * 1_000)
+}
+
+function storeRecords(count, prefix) {
+  return Array.from({ length: count }, (_, index) => {
+    const runIndex = Math.floor(index / 2)
+    const isEnd = index % 2 === 1
+    const traceId = (runIndex + 1).toString(16).padStart(32, '0')
+    const spanId = (runIndex + 1).toString(16).padStart(16, '0')
+    const startUnixMs = 1_700_000_000_000 + runIndex
+    return {
+      schemaVersion: 2,
+      recordId: `${prefix}-${index}`,
+      sequence: isEnd ? 2 : 1,
+      timestampUnixMs: startUnixMs + (isEnd ? 1 : 0),
+      runId: `${prefix}-run-${runIndex}`,
+      attempt: 1,
+      traceId,
+      spanId,
+      recordType: isEnd ? 'span_end' : 'span_start',
+      kind: 'run',
+      name: 'oma.run',
+      startUnixMs,
+      ...(isEnd ? {
+        endUnixMs: startUnixMs + 1,
+        durationMs: 1,
+        status: { code: 'ok' },
+      } : {}),
+      attributes: {},
+    }
+  })
+}
+
+const inMemoryStore = []
+for (const count of [1_000, 10_000]) {
+  global.gc?.()
+  const store = new core.InMemoryTraceStore()
+  const records = storeRecords(count, `memory-${count}`)
+  const heapBefore = process.memoryUsage().heapUsed
+  const appendStarted = performance.now()
+  await store.append(records)
+  const appendMs = performance.now() - appendStarted
+  global.gc?.()
+  const heapAfter = process.memoryUsage().heapUsed
+  const queryStarted = performance.now()
+  const page = await store.queryRuns({ limit: 500 })
+  inMemoryStore.push({
+    records: count,
+    appendMs,
+    firstPageQueryMs: performance.now() - queryStarted,
+    firstPageRuns: page.items.length,
+    estimatedHeapBytes: Math.max(0, heapAfter - heapBefore),
+  })
+}
+
+function workloadRecords(agentCount) {
+  const traceId = 'a'.repeat(32)
+  const records = []
+  let localSequence = 0
+  const rootId = '1'.repeat(16)
+  records.push({ ...sampleRecord, recordId: `workload-root-start-${agentCount}`,
+    sequence: ++localSequence, traceId, spanId: rootId, recordType: 'span_start', kind: 'run' })
+  for (let index = 0; index < agentCount; index++) {
+    const spanId = (index + 2).toString(16).padStart(16, '0')
+    records.push({ ...sampleRecord, recordId: `workload-agent-start-${agentCount}-${index}`,
+      sequence: ++localSequence, traceId, spanId, parentSpanId: rootId, recordType: 'span_start' })
+    records.push({ ...sampleRecord, recordId: `workload-agent-end-${agentCount}-${index}`,
+      sequence: ++localSequence, traceId, spanId, parentSpanId: rootId })
+  }
+  records.push({ ...sampleRecord, recordId: `workload-root-end-${agentCount}`,
+    sequence: ++localSequence, traceId, spanId: rootId, kind: 'run' })
+  return records
+}
+
+async function measureEnqueue(records) {
+  const repeats = Math.max(1, Math.ceil(1_000 / records.length))
+  const measurementRecords = Array.from({ length: repeats }, (_, repeat) =>
+    records.map((record, index) => ({ ...record, recordId: `${record.recordId}-sample-${repeat}-${index}` }))).flat()
+  const sink = makeBatchSink({
+    maxQueueRecords: measurementRecords.length + 1,
+    maxQueueBytes: 64 * 1024 * 1024,
+    maxBatchRecords: measurementRecords.length + 1,
+    scheduledDelayMs: 60_000,
+  })
+  const micros = []
+  for (const record of measurementRecords) {
+    const started = performance.now()
+    sink.emit(record)
+    micros.push((performance.now() - started) * 1_000)
+  }
+  const stats = sink.getStats()
+  await sink.shutdown({ timeoutMs: 5_000 })
+  return {
+    records: records.length,
+    measurementSamples: measurementRecords.length,
+    bytes: records.reduce((sum, record) => sum + Buffer.byteLength(JSON.stringify(record)), 0),
+    enqueueP95Micros: percentile(micros, 0.95),
+    queuedBytes: stats.queuedBytes,
+  }
+}
+
+const equivalentAgentWorkloads = []
+for (const agents of [1, 10, 100]) {
+  equivalentAgentWorkloads.push({ agents, ...(await measureEnqueue(workloadRecords(agents))) })
+}
+
+const streamingMetadata = Array.from({ length: 10_000 }, (_, index) => ({
+  ...sampleRecord,
+  recordId: `stream-${index}`,
+  sequence: index + 1,
+  recordType: 'span_event',
+  name: 'stream_chunk',
+  attributes: { 'oma.stream.type': 'text', 'oma.stream.index': index },
+}))
+const streamingMetadataResult = await measureEnqueue(streamingMetadata)
+
+const pressureByCount = makeBatchSink({
+  maxQueueRecords: 100,
+  maxQueueBytes: 64 * 1024 * 1024,
+  scheduledDelayMs: 60_000,
+})
+for (const record of streamingMetadata.slice(0, 1_000)) pressureByCount.emit(record)
+const queuePressureRecords = pressureByCount.getStats()
+await pressureByCount.shutdown({ timeoutMs: 5_000 })
+
+const sampleBytes = Buffer.byteLength(JSON.stringify(sampleRecord))
+const pressureByBytes = makeBatchSink({
+  maxQueueRecords: 1_000,
+  maxQueueBytes: sampleBytes * 4,
+  maxRecordBytes: sampleBytes * 2,
+  scheduledDelayMs: 60_000,
+})
+for (let index = 0; index < 100; index++) pressureByBytes.emit({ ...sampleRecord, recordId: `bytes-${index}` })
+const queuePressureBytes = pressureByBytes.getStats()
+await pressureByBytes.shutdown({ timeoutMs: 5_000 })
+
+const resolvedOtelPath = otelCandidatePath
+  ?? fileURLToPath(new URL('../../otel/dist/index.js', import.meta.url))
+const otel = await import(`${pathToFileURL(resolvedOtelPath).href}?otel-benchmark`)
+const { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } =
+  await import('@opentelemetry/sdk-trace-base')
+
+function otelRecord(index, prefix) {
+  return {
+    ...sampleRecord,
+    recordId: `${prefix}-${index}`,
+    runId: `${prefix}-${index}`,
+    traceId: (index + 1).toString(16).padStart(32, '0'),
+    spanId: (index + 1).toString(16).padStart(16, '0'),
+    sequence: 1,
+    kind: 'run',
+    name: 'oma.run',
+  }
+}
+
+const otelExporter = new InMemorySpanExporter()
+const otelProvider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(otelExporter)],
+})
+const otelAdapter = otel.createOtelTraceExporter({ tracerProvider: otelProvider })
+const otelMicros = []
+for (let index = 0; index < 200; index++) {
+  await otelAdapter.export([otelRecord(index, 'otel-warmup')], new AbortController().signal)
+}
+otelExporter.reset()
+for (let index = 0; index < 1_000; index++) {
+  const started = performance.now()
+  await otelAdapter.export([otelRecord(index + 10_000, 'otel-p95')], new AbortController().signal)
+  otelMicros.push((performance.now() - started) * 1_000)
+}
+await otelAdapter.forceFlush(new AbortController().signal)
+await otelAdapter.shutdown(new AbortController().signal)
+await otelProvider.shutdown()
+
+const otelScales = []
+for (const count of [1_000, 10_000]) {
+  const exporter = new InMemorySpanExporter()
+  const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] })
+  const adapter = otel.createOtelTraceExporter({ tracerProvider: provider })
+  const records = Array.from({ length: count }, (_, index) => otelRecord(index, `otel-${count}`))
+  const started = performance.now()
+  const result = await adapter.export(records, new AbortController().signal)
+  await adapter.forceFlush(new AbortController().signal)
+  otelScales.push({ records: count, totalMs: performance.now() - started, exported: result.exported })
+  await adapter.shutdown(new AbortController().signal)
+  await provider.shutdown()
+}
 
 console.log(JSON.stringify({
   iterations,
@@ -123,6 +323,25 @@ console.log(JSON.stringify({
     Object.entries(medians).map(([name, value]) => [name, value * 1_000 / iterations]),
   ),
   batchEmitP95Micros: emitP95Micros,
+  legacyDispatchP95Micros: percentile(legacyDispatchMicros, 0.95),
+  otelConvertAndProcessP95Micros: percentile(otelMicros, 0.95),
+  inMemoryStore,
+  equivalentAgentWorkloads,
+  streamingMetadata: streamingMetadataResult,
+  queuePressure: {
+    records: queuePressureRecords,
+    bytes: queuePressureBytes,
+  },
+  otelScales,
+  contentCapture: {
+    status: 'non-goal',
+    reason: 'This release exposes no content-on mode; metadata-only is the only product baseline.',
+  },
+  environment: {
+    node: process.version,
+    platform: `${process.platform}-${process.arch}`,
+    cpu: cpus()[0]?.model ?? 'unknown',
+  },
   samplesMs: samples,
   representative100AgentEnvelope: {
     records: representativeRecords.length,

--- a/packages/core/examples/README.md
+++ b/packages/core/examples/README.md
@@ -85,6 +85,7 @@ Hooking the framework up to outside-the-box tooling.
 | Example | Integrates with |
 |---------|-----------------|
 | [`integrations/trace-observability`](integrations/trace-observability.ts) | `onTrace` spans for LLM calls, tools, and tasks. |
+| [`integrations/observability-v2/`](integrations/observability-v2/) | No-key runnable v2 batching, InMemory/File TraceStore, OTel in-memory provider, CLI, SIGTERM server, and FaaS lifecycle examples. |
 | [`integrations/mcp-github`](integrations/mcp-github.ts) | An MCP server's tools exposed to an agent via `connectMCPTools()`. |
 | [`integrations/mcp-bilig-workpaper`](integrations/mcp-bilig-workpaper.ts) | Bilig WorkPaper MCP tools for formula readback, recalculation, and persisted workbook JSON. |
 | [`integrations/mcp-open-design`](integrations/mcp-open-design.ts) | Batch fan-out over an MCP server's async jobs: N Open Design runs generated in parallel via `runTasks()`, each polling `get_run` to completion with code-driven orchestration. |

--- a/packages/core/examples/integrations/README.md
+++ b/packages/core/examples/integrations/README.md
@@ -19,6 +19,10 @@ contributed them. Current:
 - `external-agent-process.ts`: deterministic local subprocesses as team members
   via the `process` backend.
 - `trace-observability.ts`: the `onTrace` API.
+- `observability-v2/`: no-network examples for batching/custom exporters,
+  InMemory/File TraceStore, an application-owned OTel provider, and explicit
+  CLI/server/serverless lifecycle handling. The original
+  `trace-observability.ts` remains the legacy callback example.
 - `with-vercel-ai-sdk/`: Next.js + AI SDK + `runTeam()`.
 - `express-customer-support/`: Express REST API + `runTasks()`. Contributed
   by [@CodingBangboo](https://github.com/CodingBangboo) via #191.

--- a/packages/core/examples/integrations/observability-v2/README.md
+++ b/packages/core/examples/integrations/observability-v2/README.md
@@ -1,0 +1,23 @@
+# Observability v2 examples
+
+These examples exercise the real public package/subpath APIs with a
+deterministic local adapter. They need no model API key, network request,
+global OpenTelemetry provider, or external collector. Build the workspaces
+first, then run any file with `npx tsx`.
+
+| Example | Ownership and lifecycle |
+|---|---|
+| [`batching-exporter.ts`](./batching-exporter.ts) | application-owned custom exporter and batching sink |
+| [`in-memory-store.ts`](./in-memory-store.ts) | non-durable in-memory store; application shuts down the sink |
+| [`file-trace-store.ts`](./file-trace-store.ts) | drain sink, fsync store, shut down sink, close store |
+| [`otel-provider.ts`](./otel-provider.ts) | official in-memory exporter; OMA sink drains before application provider shutdown |
+| [`cli-lifecycle.ts`](./cli-lifecycle.ts) | short-lived natural exit with explicit flush/shutdown/close |
+| [`server-lifecycle.ts`](./server-lifecycle.ts) | application registers SIGTERM, stops intake, drains telemetry |
+| [`serverless-lifecycle.ts`](./serverless-lifecycle.ts) | short per-invocation flush; warm singleton is not shut down |
+
+[`public-snippets.ts`](./public-snippets.ts) is compile-only. It mirrors the
+copyable migration guide API combinations and is included in the automated
+TypeScript check.
+
+The separate [`trace-observability.ts`](../trace-observability.ts) intentionally
+remains the legacy `onTrace` example.

--- a/packages/core/examples/integrations/observability-v2/batching-exporter.ts
+++ b/packages/core/examples/integrations/observability-v2/batching-exporter.ts
@@ -1,0 +1,30 @@
+/**
+ * BatchingTraceSink + custom TraceExporter
+ *
+ * Run after building the workspaces:
+ *   npx tsx packages/core/examples/integrations/observability-v2/batching-exporter.ts
+ *
+ * Prerequisites: none. The application owns both exporter and sink.
+ */
+import {
+  BatchingTraceSink,
+  type TraceExporter,
+} from '@open-multi-agent/core/observability'
+import { runDemo } from './demo-runtime.js'
+
+let exported = 0
+const exporter: TraceExporter = {
+  async export(records) {
+    exported += records.length
+    return { status: 'success', exported: records.length }
+  },
+}
+const sink = new BatchingTraceSink(exporter, { diagnostics: 'silent' })
+
+try {
+  const result = await runDemo(sink, 'example-batching-exporter')
+  const delivery = await sink.forceFlush({ timeoutMs: 1_000 })
+  console.log({ runId: result.identity?.runId, exported, delivery: delivery.status })
+} finally {
+  await sink.shutdown({ timeoutMs: 1_000 })
+}

--- a/packages/core/examples/integrations/observability-v2/cli-lifecycle.ts
+++ b/packages/core/examples/integrations/observability-v2/cli-lifecycle.ts
@@ -1,0 +1,31 @@
+/**
+ * Short-lived CLI graceful shutdown
+ *
+ * Run after building the workspaces:
+ *   npx tsx packages/core/examples/integrations/observability-v2/cli-lifecycle.ts
+ *
+ * Prerequisites: none. No signal handler is registered by OMA or this CLI.
+ */
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { BatchingTraceSink, TraceStoreExporter } from '@open-multi-agent/core/observability'
+import { FileTraceStore } from '@open-multi-agent/core/observability/file'
+import { runDemo } from './demo-runtime.js'
+
+const directory = await mkdtemp(join(tmpdir(), 'oma-observability-cli-'))
+const store = await FileTraceStore.open(join(directory, 'traces.ndjson'))
+const sink = new BatchingTraceSink(new TraceStoreExporter(store), { diagnostics: 'silent' })
+
+try {
+  const result = await runDemo(sink, 'example-cli-lifecycle')
+  console.log({ success: result.success, runId: result.identity?.runId })
+} finally {
+  // A CLI owns the whole lifecycle: drain OMA, fsync storage, close the sink,
+  // then close the store before allowing natural process exit.
+  await sink.forceFlush({ timeoutMs: 2_000 })
+  await store.flush()
+  await sink.shutdown({ timeoutMs: 2_000 })
+  await store.close()
+  await rm(directory, { recursive: true, force: true })
+}

--- a/packages/core/examples/integrations/observability-v2/demo-runtime.ts
+++ b/packages/core/examples/integrations/observability-v2/demo-runtime.ts
@@ -1,0 +1,35 @@
+import {
+  OpenMultiAgent,
+  type AgentConfig,
+  type LLMAdapter,
+  type LLMResponse,
+  type TraceSink,
+} from '@open-multi-agent/core'
+
+function response(text: string): LLMResponse {
+  return {
+    id: 'observability-demo-response',
+    content: [{ type: 'text', text }],
+    model: 'deterministic-local-adapter',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 3, output_tokens: 2 },
+  }
+}
+
+const adapter: LLMAdapter = {
+  name: 'deterministic-local-adapter',
+  async chat() { return response('observability plumbing completed') },
+  async *stream() {},
+}
+
+const agent: AgentConfig = {
+  name: 'observability-demo',
+  model: 'deterministic-local-adapter',
+  adapter,
+}
+
+/** Exercise the real OMA instrumentation without network access or an API key. */
+export async function runDemo(sink: TraceSink, runId: string) {
+  const oma = new OpenMultiAgent({ observability: { sinks: [sink] } })
+  return oma.runAgent(agent, 'Run the deterministic observability demo.', { runId })
+}

--- a/packages/core/examples/integrations/observability-v2/file-trace-store.ts
+++ b/packages/core/examples/integrations/observability-v2/file-trace-store.ts
@@ -1,0 +1,33 @@
+/**
+ * FileTraceStore
+ *
+ * Run after building the workspaces:
+ *   npx tsx packages/core/examples/integrations/observability-v2/file-trace-store.ts
+ *
+ * Prerequisites: none. The application owns sink and store.
+ */
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  BatchingTraceSink,
+  TraceStoreExporter,
+} from '@open-multi-agent/core/observability'
+import { FileTraceStore } from '@open-multi-agent/core/observability/file'
+import { runDemo } from './demo-runtime.js'
+
+const directory = await mkdtemp(join(tmpdir(), 'oma-observability-example-'))
+const store = await FileTraceStore.open(join(directory, 'traces.ndjson'))
+const sink = new BatchingTraceSink(new TraceStoreExporter(store), { diagnostics: 'silent' })
+
+try {
+  const result = await runDemo(sink, 'example-file-trace-store')
+  await sink.forceFlush({ timeoutMs: 1_000 }) // queue -> exporter -> store
+  await store.flush()                         // store -> filesystem fsync
+  const stored = await store.getRun(result.identity!.runId)
+  console.log({ runId: stored?.runId, status: stored?.status, spans: stored?.spans.length })
+} finally {
+  await sink.shutdown({ timeoutMs: 1_000 })
+  await store.close()
+  await rm(directory, { recursive: true, force: true })
+}

--- a/packages/core/examples/integrations/observability-v2/in-memory-store.ts
+++ b/packages/core/examples/integrations/observability-v2/in-memory-store.ts
@@ -1,0 +1,26 @@
+/**
+ * InMemoryTraceStore
+ *
+ * Run after building the workspaces:
+ *   npx tsx packages/core/examples/integrations/observability-v2/in-memory-store.ts
+ *
+ * Prerequisites: none. The application owns the sink and non-durable store.
+ */
+import {
+  BatchingTraceSink,
+  InMemoryTraceStore,
+  TraceStoreExporter,
+} from '@open-multi-agent/core/observability'
+import { runDemo } from './demo-runtime.js'
+
+const store = new InMemoryTraceStore()
+const sink = new BatchingTraceSink(new TraceStoreExporter(store), { diagnostics: 'silent' })
+
+try {
+  const result = await runDemo(sink, 'example-in-memory-store')
+  await sink.forceFlush({ timeoutMs: 1_000 })
+  const stored = await store.getRun(result.identity!.runId)
+  console.log({ runId: stored?.runId, status: stored?.status, spans: stored?.spans.length })
+} finally {
+  await sink.shutdown({ timeoutMs: 1_000 })
+}

--- a/packages/core/examples/integrations/observability-v2/otel-provider.ts
+++ b/packages/core/examples/integrations/observability-v2/otel-provider.ts
@@ -1,0 +1,36 @@
+/**
+ * @open-multi-agent/otel + application-owned provider
+ *
+ * Run after building the workspaces:
+ *   npx tsx packages/core/examples/integrations/observability-v2/otel-provider.ts
+ *
+ * Prerequisites: workspace dev dependencies only; no collector or API key.
+ */
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base'
+import { createOtelTraceSink } from '@open-multi-agent/otel'
+import { runDemo } from './demo-runtime.js'
+
+const exporter = new InMemorySpanExporter()
+const provider = new BasicTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(exporter)],
+})
+const sink = createOtelTraceSink({
+  tracerProvider: provider,
+  metadata: { environment: 'example' },
+})
+
+try {
+  const result = await runDemo(sink, 'example-otel-provider')
+  await sink.forceFlush({ timeoutMs: 1_000 })
+  const spans = exporter.getFinishedSpans()
+  console.log({ runId: result.identity?.runId, spans: spans.length, root: spans.at(-1)?.name })
+} finally {
+  // The adapter does not own the provider by default. Drain OMA first, then
+  // close the application-owned provider explicitly.
+  await sink.shutdown({ timeoutMs: 1_000 })
+  await provider.shutdown()
+}

--- a/packages/core/examples/integrations/observability-v2/public-snippets.ts
+++ b/packages/core/examples/integrations/observability-v2/public-snippets.ts
@@ -1,0 +1,50 @@
+/** Compile-only mirrors of the copyable migration-guide snippets. */
+import { OpenMultiAgent, type AgentConfig, type TraceEvent } from '@open-multi-agent/core'
+import {
+  BatchingTraceSink,
+  InMemoryTraceStore,
+  LegacyCallbackTraceSink,
+  TraceStoreExporter,
+  type TraceExporter,
+} from '@open-multi-agent/core/observability'
+import { FileTraceStore } from '@open-multi-agent/core/observability/file'
+import { createOtelTraceSink, type OTelTracerProvider } from '@open-multi-agent/otel'
+
+declare const agent: AgentConfig
+declare const prompt: string
+declare const provider: OTelTracerProvider
+declare const legacyCollector: { write(event: TraceEvent): void }
+declare function sendBatch(records: readonly unknown[], options: { signal: AbortSignal }): Promise<number>
+
+export const stage0 = new OpenMultiAgent({
+  onTrace(event) { legacyCollector.write(event) },
+})
+
+export const stage1Sink = new LegacyCallbackTraceSink((event) => legacyCollector.write(event))
+export const stage1 = new OpenMultiAgent({ observability: { sinks: [stage1Sink] } })
+
+const exporter: TraceExporter = {
+  async export(records, signal) {
+    const delivered = await sendBatch(records, { signal })
+    return { status: 'success', exported: delivered }
+  },
+}
+export const stage2Sink = new BatchingTraceSink(exporter)
+export const stage2 = new OpenMultiAgent({ observability: { sinks: [stage2Sink] } })
+
+export const memoryStore = new InMemoryTraceStore()
+export const stage3StoreSink = new BatchingTraceSink(new TraceStoreExporter(memoryStore))
+export const stage3OtelSink = createOtelTraceSink({ tracerProvider: provider })
+
+export async function fileLifecycle(path: string): Promise<void> {
+  const store = await FileTraceStore.open(path)
+  const sink = new BatchingTraceSink(new TraceStoreExporter(store))
+  try {
+    await new OpenMultiAgent({ observability: { sinks: [sink] } }).runAgent(agent, prompt)
+    await sink.forceFlush({ timeoutMs: 1_000 })
+    await store.flush()
+  } finally {
+    await sink.shutdown({ timeoutMs: 1_000 })
+    await store.close()
+  }
+}

--- a/packages/core/examples/integrations/observability-v2/server-lifecycle.ts
+++ b/packages/core/examples/integrations/observability-v2/server-lifecycle.ts
@@ -1,0 +1,48 @@
+/**
+ * Long-lived server SIGTERM lifecycle
+ *
+ * Run after building the workspaces:
+ *   npx tsx packages/core/examples/integrations/observability-v2/server-lifecycle.ts
+ *
+ * Prerequisites: none. The application explicitly registers the handler.
+ */
+import { createServer, type Server } from 'node:http'
+import { BatchingTraceSink, InMemoryTraceStore, TraceStoreExporter } from '@open-multi-agent/core/observability'
+import { runDemo } from './demo-runtime.js'
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+}
+
+function close(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => error ? reject(error) : resolve())
+  })
+}
+
+const store = new InMemoryTraceStore()
+const sink = new BatchingTraceSink(new TraceStoreExporter(store), { diagnostics: 'silent' })
+const server = createServer((_request, response) => response.end('ok'))
+let resolveStopped!: () => void
+const stopped = new Promise<void>((resolve) => { resolveStopped = resolve })
+
+async function stop(): Promise<void> {
+  // Stop accepting requests and wait for in-flight work before cutting off emit.
+  await close(server)
+  await sink.forceFlush({ timeoutMs: 2_000 })
+  await sink.shutdown({ timeoutMs: 2_000 })
+  resolveStopped()
+}
+
+process.once('SIGTERM', () => { void stop().catch((error) => { console.error(error); resolveStopped() }) })
+await listen(server)
+await runDemo(sink, 'example-server-lifecycle')
+setTimeout(() => process.kill(process.pid, 'SIGTERM'), 10).unref()
+await stopped
+console.log('server and telemetry stopped')

--- a/packages/core/examples/integrations/observability-v2/serverless-lifecycle.ts
+++ b/packages/core/examples/integrations/observability-v2/serverless-lifecycle.ts
@@ -1,0 +1,36 @@
+/**
+ * Serverless/FaaS short flush
+ *
+ * Run after building the workspaces:
+ *   npx tsx packages/core/examples/integrations/observability-v2/serverless-lifecycle.ts
+ *
+ * Prerequisites: none. A warm singleton is flushed, not shut down per request.
+ */
+import { BatchingTraceSink, type TraceExporter } from '@open-multi-agent/core/observability'
+import { runDemo } from './demo-runtime.js'
+
+const hangingExporter: TraceExporter = {
+  async export() { return new Promise(() => {}) },
+}
+const sharedSink = new BatchingTraceSink(hangingExporter, {
+  diagnostics: 'silent',
+  exportTimeoutMs: 100,
+  maxRetries: 0,
+})
+
+export async function handler() {
+  const result = await runDemo(sharedSink, 'example-serverless-lifecycle')
+  const telemetry = await sharedSink.forceFlush({ timeoutMs: 5 })
+  // Do not call shutdown here: a warm runtime may reuse the singleton.
+  return { success: result.success, telemetry: telemetry.status }
+}
+
+// A real FaaS host keeps the invocation alive while its returned promise is
+// pending. The standalone demo uses one temporary referenced handle to model
+// that host; BatchingTraceSink's own timers intentionally remain unref'ed.
+const invocationHost = setInterval(() => {}, 1_000)
+try {
+  console.log(await handler())
+} finally {
+  clearInterval(invocationHost)
+}

--- a/packages/core/examples/integrations/observability-v2/tsconfig.json
+++ b/packages/core/examples/integrations/observability-v2/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": "../../../..",
+    "rootDir": "../../../..",
+    "paths": {
+      "@open-multi-agent/core": ["packages/core/src/index.ts"],
+      "@open-multi-agent/core/observability": ["packages/core/src/observability/index.ts"],
+      "@open-multi-agent/core/observability/file": ["packages/core/src/observability/file.ts"],
+      "@open-multi-agent/otel": ["packages/otel/src/index.ts"]
+    }
+  },
+  "include": ["./*.ts"]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "TypeScript multi-agent framework: one runTeam() call from goal to result. Auto task decomposition and parallel execution for multi-step LLM jobs. Deploys anywhere Node.js runs.",
   "files": [
     "dist",

--- a/packages/core/src/observability/runtime.ts
+++ b/packages/core/src/observability/runtime.ts
@@ -21,6 +21,13 @@ import { CompositeSink } from './composite.js'
 
 export type TraceRecordObserver = (record: TraceRecord) => void
 
+/**
+ * Internal marker used when a public LegacyCallbackTraceSink is configured as
+ * a v2 sink. Call sites still build the unchanged legacy event metadata, while
+ * TraceRuntime avoids installing a second callback sink.
+ */
+export const LEGACY_TRACE_METADATA_ONLY = (): void => {}
+
 /** Internal-only hook used by contract tests until OBS-2 introduces TraceSink. */
 export const TRACE_RECORD_OBSERVER = Symbol('oma.traceRecordObserver')
 
@@ -84,7 +91,9 @@ export class TraceRuntime {
     sink?: TraceSink,
   ) {
     this.identity = identity
-    const legacySink = legacyCallback ? new LegacyCallbackTraceSink(legacyCallback) : undefined
+    const legacySink = legacyCallback && legacyCallback !== LEGACY_TRACE_METADATA_ONLY
+      ? new LegacyCallbackTraceSink(legacyCallback)
+      : undefined
     this.sink = sink && legacySink
       ? new CompositeSink([sink, legacySink], { diagnostics: 'silent' })
       : sink ?? legacySink

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -98,6 +98,7 @@ import { createRestoreIdentity, createRunIdentity } from '../observability/ident
 import { classifyRunFailure, statusOnly } from '../observability/status.js'
 import {
   createTraceRuntime,
+  LEGACY_TRACE_METADATA_ONLY,
   traceRecordObserverFrom,
   type TraceRecordObserver,
   type TraceRuntime,
@@ -106,6 +107,7 @@ import {
 import { CompositeSink } from '../observability/composite.js'
 import type { TraceSink } from '../observability/sink.js'
 import { SensitiveDataProcessor } from '../observability/processors.js'
+import { LegacyCallbackTraceSink } from '../observability/legacy-callback.js'
 import { extractKeywords, keywordScore } from '../utils/keywords.js'
 
 // ---------------------------------------------------------------------------
@@ -2012,9 +2014,14 @@ export class OpenMultiAgent {
     }
 
     this.traceRecordObserver = traceRecordObserverFrom(config)
+    const hasExplicitLegacyBridge = config.observability?.sinks.some(
+      (sink) => sink instanceof LegacyCallbackTraceSink,
+    ) ?? false
     this.traceSink = config.observability && config.observability.sinks.length > 0
       ? new CompositeSink(config.observability.sinks.map((sink) =>
-          new SensitiveDataProcessor(sink, { capture: config.observability?.capture })), {
+          sink instanceof LegacyCallbackTraceSink
+            ? sink
+            : new SensitiveDataProcessor(sink, { capture: config.observability?.capture })), {
           onDiagnostic: config.observability.onDiagnostic,
           sinkName: 'OpenMultiAgent',
         })
@@ -2040,7 +2047,7 @@ export class OpenMultiAgent {
       onAgentStream: config.onAgentStream,
       onProgress: config.onProgress,
       observability: config.observability,
-      onTrace: config.onTrace,
+      onTrace: config.onTrace ?? (hasExplicitLegacyBridge ? LEGACY_TRACE_METADATA_ONLY : undefined),
       onToolCall: config.onToolCall,
     }
   }

--- a/packages/core/tests/observability-doc-examples.test.ts
+++ b/packages/core/tests/observability-doc-examples.test.ts
@@ -1,0 +1,29 @@
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+describe('public Observability v2 examples', () => {
+  it('typechecks every snippet through public package and subpath imports', () => {
+    const configPath = fileURLToPath(new URL(
+      '../examples/integrations/observability-v2/tsconfig.json',
+      import.meta.url,
+    ))
+    const loaded = ts.readConfigFile(configPath, ts.sys.readFile)
+    expect(loaded.error).toBeUndefined()
+    const parsed = ts.parseJsonConfigFileContent(
+      loaded.config,
+      ts.sys,
+      fileURLToPath(new URL('../examples/integrations/observability-v2', import.meta.url)),
+      undefined,
+      configPath,
+    )
+    const program = ts.createProgram(parsed.fileNames, parsed.options)
+    const diagnostics = ts.getPreEmitDiagnostics(program)
+    const formatted = ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+      getCanonicalFileName: (fileName) => fileName,
+      getCurrentDirectory: ts.sys.getCurrentDirectory,
+      getNewLine: () => ts.sys.newLine,
+    })
+    expect(formatted).toBe('')
+  })
+})

--- a/packages/core/tests/observability-v2-privacy.test.ts
+++ b/packages/core/tests/observability-v2-privacy.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { BatchingTraceSink } from '../src/observability/batching.js'
+import { InMemoryTraceStore } from '../src/observability/in-memory-store.js'
+import { TraceStoreExporter } from '../src/observability/store-exporter.js'
+import { defineTool } from '../src/tool/framework.js'
+import type { LLMAdapter, LLMResponse } from '../src/types.js'
+
+const PROMPT = 'private prompt obs5-privacy'
+const COMPLETION = 'private completion obs5-privacy'
+const TOOL_ARGUMENT = 'private tool argument obs5-privacy'
+const TOOL_RESULT = 'private tool result obs5-privacy'
+const REASONING = 'private chain of thought obs5-privacy'
+
+function toolCall(): LLMResponse {
+  return {
+    id: 'tool-call',
+    content: [{
+      type: 'tool_use',
+      id: 'tool-use-1',
+      name: 'private_lookup',
+      input: { query: TOOL_ARGUMENT },
+    }],
+    model: 'privacy-test',
+    stop_reason: 'tool_use',
+    usage: { input_tokens: 3, output_tokens: 2 },
+  }
+}
+
+function completion(): LLMResponse {
+  return {
+    id: 'completion',
+    content: [{ type: 'text', text: `${COMPLETION} <thinking>${REASONING}</thinking>` }],
+    model: 'privacy-test',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 5, output_tokens: 4, reasoning_output_tokens: 2 },
+  }
+}
+
+describe('Observability v2 default privacy boundary', () => {
+  it('keeps prompt, completion, tool payloads, and reasoning out of sink/store records', async () => {
+    let call = 0
+    const adapter: LLMAdapter = {
+      name: 'privacy-test',
+      async chat() { return call++ === 0 ? toolCall() : completion() },
+      async *stream() {},
+    }
+    const tool = defineTool({
+      name: 'private_lookup',
+      description: 'Privacy test tool.',
+      inputSchema: z.object({ query: z.string() }),
+      execute: async () => ({ data: TOOL_RESULT }),
+    })
+    const store = new InMemoryTraceStore()
+    const sink = new BatchingTraceSink(new TraceStoreExporter(store), {
+      diagnostics: 'silent',
+      scheduledDelayMs: 60_000,
+    })
+    const result = await new OpenMultiAgent({ observability: { sinks: [sink] } }).runAgent({
+      name: 'worker',
+      model: 'privacy-test',
+      adapter,
+      customTools: [tool],
+    }, PROMPT)
+
+    expect(result.success).toBe(true)
+    await expect(sink.forceFlush({ timeoutMs: 500 })).resolves.toMatchObject({ status: 'ok' })
+    const stored = await store.getRun(result.identity!.runId, { includeRecords: true })
+    const serialized = JSON.stringify(stored?.records)
+    for (const secret of [PROMPT, COMPLETION, TOOL_ARGUMENT, TOOL_RESULT, REASONING]) {
+      expect(serialized).not.toContain(secret)
+    }
+    expect(serialized).not.toContain('<thinking>')
+    expect(stored?.tokens).toMatchObject({
+      input_tokens: 8,
+      output_tokens: 6,
+    })
+    await sink.shutdown({ timeoutMs: 500 })
+  })
+})

--- a/packages/core/tests/observability-v2-sink.test.ts
+++ b/packages/core/tests/observability-v2-sink.test.ts
@@ -434,6 +434,32 @@ describe('OBS-2 composition, privacy, diagnostics, and compatibility', () => {
     expect(received).toEqual(events)
   })
 
+  it('supports a direct LegacyCallbackTraceSink migration without also configuring onTrace', async () => {
+    const received: TraceEvent[] = []
+    const bridge = new LegacyCallbackTraceSink((event) => { received.push(event) }, {
+      diagnostics: 'silent',
+    })
+    const adapter: LLMAdapter = {
+      name: 'legacy-migration-test',
+      async chat() {
+        return {
+          id: 'ok', content: [{ type: 'text', text: 'done' }], model: 'test',
+          stop_reason: 'end_turn', usage: { input_tokens: 1, output_tokens: 1 },
+        }
+      },
+      async *stream() {},
+    }
+    const result = await new OpenMultiAgent({
+      defaultModel: 'test',
+      observability: { sinks: [bridge] },
+    }).runAgent({ name: 'worker', model: 'test', adapter }, 'hello')
+
+    expect(result.success).toBe(true)
+    await expect(bridge.forceFlush({ timeoutMs: 100 })).resolves.toMatchObject({ status: 'ok' })
+    expect(received.map((event) => event.type)).toEqual(['llm_call', 'agent'])
+    expect(received.every((event) => /^[0-9a-f-]{36}$/.test(event.spanId))).toBe(true)
+  })
+
   it('keeps sink failures isolated from Agent results through Orchestrator observability', async () => {
     const broken: TraceSink = {
       emit: () => { throw new Error('telemetry failed') },

--- a/packages/create-oma-app/template/package.json
+++ b/packages/create-oma-app/template/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.10.0"
+    "@open-multi-agent/core": "1.11.0"
   },
   "devDependencies": {
     "tsx": "^4.21.0"

--- a/packages/create-oma-app/templates/demo/package.json
+++ b/packages/create-oma-app/templates/demo/package.json
@@ -8,7 +8,7 @@
     "demo": "tsx src/index.ts"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.10.0"
+    "@open-multi-agent/core": "1.11.0"
   },
   "devDependencies": {
     "tsx": "^4.21.0"

--- a/packages/create-oma-app/templates/pr-review/package.json
+++ b/packages/create-oma-app/templates/pr-review/package.json
@@ -8,7 +8,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.10.0",
+    "@open-multi-agent/core": "1.11.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/create-oma-app/templates/security/package.json
+++ b/packages/create-oma-app/templates/security/package.json
@@ -8,7 +8,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.10.0",
+    "@open-multi-agent/core": "1.11.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -6,9 +6,13 @@ provide. The package never reads, registers, or replaces the global
 `TracerProvider`.
 
 ```bash
-npm install @open-multi-agent/core @open-multi-agent/otel
+npm install @open-multi-agent/core@^1.11.0 @open-multi-agent/otel@^0.1.0
 # Install and configure the OpenTelemetry SDK/exporter chosen by your application.
 ```
+
+Core `1.11.0` is the first release containing the public TraceRecord v2,
+sink/exporter, and TraceStore APIs required by this package. Core `1.10.0` is
+not compatible.
 
 ## Use an application-owned provider
 
@@ -54,6 +58,23 @@ The caller owns the tracer/provider in every mode.
 
 Use a `BatchingTraceSink` directly via `createOtelTraceExporter()` when the
 application owns batching configuration itself.
+
+For a complete no-network example with the official `InMemorySpanExporter`, see
+[`otel-provider.ts`](../core/examples/integrations/observability-v2/otel-provider.ts).
+
+### Process lifecycle
+
+- **Serverless/FaaS:** call `sink.forceFlush()` with a short invocation budget;
+  do not shut down a warm shared sink/provider per invocation.
+- **CLI:** run, force-flush the sink, shut down the sink, then shut down the
+  application-owned provider before natural process exit.
+- **Long-lived server:** stop intake and await in-flight work before the sink
+  cutoff; then force-flush/shut down the sink and finally shut down the provider.
+
+This package and core register no process signal handlers. The application owns
+that integration. Keep `shutdownOnShutdown` at its default `false` when the
+provider is shared with other instrumentation; set it to `true` only when this
+adapter is the provider owner.
 
 ## Mapping
 

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -52,7 +52,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@open-multi-agent/core": "^1.10.0"
+    "@open-multi-agent/core": "^1.11.0"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0"

--- a/packages/otel/tests/version-sync.test.ts
+++ b/packages/otel/tests/version-sync.test.ts
@@ -9,4 +9,12 @@ describe('package version constant', () => {
     const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { version: string }
     expect(PACKAGE_VERSION).toBe(manifest.version)
   })
+
+  it('requires the first core release that actually contains Observability v2', () => {
+    const manifestPath = fileURLToPath(new URL('../package.json', import.meta.url))
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as {
+      dependencies: Record<string, string>
+    }
+    expect(manifest.dependencies['@open-multi-agent/core']).toBe('^1.11.0')
+  })
 })

--- a/scripts/observability-benchmark-ci.mjs
+++ b/scripts/observability-benchmark-ci.mjs
@@ -1,0 +1,40 @@
+import { execFile } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+
+const exec = promisify(execFile)
+const root = fileURLToPath(new URL('..', import.meta.url))
+const benchmark = join(root, 'packages/core/benchmarks/observability-sinks.mjs')
+const core = join(root, 'packages/core/dist/index.js')
+const otel = join(root, 'packages/otel/dist/index.js')
+const { stdout } = await exec(process.execPath, ['--expose-gc', benchmark, core, otel], {
+  cwd: root,
+  env: {
+    ...process.env,
+    OMA_BENCH_ITERATIONS: process.env.OMA_BENCH_ITERATIONS ?? '500',
+    OMA_BENCH_ROUNDS: process.env.OMA_BENCH_ROUNDS ?? '5',
+  },
+  maxBuffer: 20 * 1024 * 1024,
+})
+const result = JSON.parse(stdout)
+const failures = []
+
+// CI deliberately uses 10x the dedicated RFC microsecond budgets. This catches
+// order-of-magnitude regressions without turning shared-runner jitter into a
+// release blocker. Dedicated benchmark snapshots use the strict budgets.
+if (result.legacyDispatchP95Micros >= 100) failures.push('legacy dispatch p95 >= 100 us')
+if (result.batchEmitP95Micros >= 200) failures.push('batch emit p95 >= 200 us')
+if (result.otelConvertAndProcessP95Micros >= 500) failures.push('OTel conversion p95 >= 500 us')
+for (const [name, value] of Object.entries(result.overheadVsNoSinkPercent)) {
+  if (value >= 1_000) failures.push(`${name} whole-run overhead >= 1000% vs no sink`)
+}
+if (failures.length > 0) throw new Error(`Observability benchmark CI gate failed:\n- ${failures.join('\n- ')}`)
+console.log(JSON.stringify({
+  gate: 'pass',
+  policy: '10x microsecond budgets and <1000% same-host overhead vs no sink',
+  legacyDispatchP95Micros: result.legacyDispatchP95Micros,
+  batchEmitP95Micros: result.batchEmitP95Micros,
+  otelConvertAndProcessP95Micros: result.otelConvertAndProcessP95Micros,
+  overheadVsNoSinkPercent: result.overheadVsNoSinkPercent,
+}, null, 2))

--- a/scripts/observability-example-smoke.mjs
+++ b/scripts/observability-example-smoke.mjs
@@ -1,0 +1,33 @@
+import { spawn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { join } from 'node:path'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+const tsx = join(root, 'node_modules', 'tsx', 'dist', 'cli.mjs')
+const directory = join(root, 'packages', 'core', 'examples', 'integrations', 'observability-v2')
+const examples = [
+  'batching-exporter.ts',
+  'in-memory-store.ts',
+  'file-trace-store.ts',
+  'otel-provider.ts',
+  'cli-lifecycle.ts',
+  'server-lifecycle.ts',
+  'serverless-lifecycle.ts',
+]
+
+for (const example of examples) {
+  await new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [tsx, join(directory, example)], {
+      cwd: root,
+      stdio: 'inherit',
+      env: { ...process.env, NO_COLOR: '1' },
+    })
+    child.once('error', reject)
+    child.once('exit', (code, signal) => {
+      if (code === 0) resolve()
+      else reject(new Error(`${example} failed with code ${code ?? 'null'} signal ${signal ?? 'none'}`))
+    })
+  })
+}
+
+console.log(`observability example smoke: ${examples.length} passed`)

--- a/scripts/observability-tarball-smoke.mjs
+++ b/scripts/observability-tarball-smoke.mjs
@@ -1,0 +1,206 @@
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const exec = promisify(execFile)
+const root = fileURLToPath(new URL('..', import.meta.url))
+const temporaryRoot = await mkdtemp(join(tmpdir(), 'oma-observability-pack-'))
+const cache = join(temporaryRoot, 'npm-cache')
+
+async function command(file, args, cwd = root) {
+  const { stdout, stderr } = await exec(file, args, {
+    cwd,
+    env: { ...process.env, npm_config_cache: cache },
+    maxBuffer: 20 * 1024 * 1024,
+  })
+  if (stderr.trim()) process.stderr.write(stderr)
+  return stdout
+}
+
+async function pack(workspaceDirectory) {
+  const stdout = await command('npm', [
+    'pack', '--json', '--pack-destination', temporaryRoot,
+  ], join(root, workspaceDirectory))
+  const result = JSON.parse(stdout)[0]
+  if (!result?.filename || !Array.isArray(result.files)) throw new Error(`Invalid npm pack result for ${workspaceDirectory}`)
+  const paths = result.files.map((entry) => entry.path)
+  const unexpected = paths.filter((path) =>
+    !path.startsWith('dist/') && !['README.md', 'LICENSE', 'package.json'].includes(path))
+  if (unexpected.length > 0) throw new Error(`Unexpected tarball files: ${unexpected.join(', ')}`)
+  return { tarball: join(temporaryRoot, result.filename), paths }
+}
+
+function assertExportsInstalled(packageRoot, manifest) {
+  const targets = []
+  for (const value of Object.values(manifest.exports ?? {})) {
+    if (typeof value === 'string') targets.push(value)
+    else if (value && typeof value === 'object') targets.push(...Object.values(value))
+  }
+  return Promise.all(targets
+    .filter((target) => typeof target === 'string' && target.startsWith('./'))
+    .map(async (target) => {
+      await readFile(resolve(packageRoot, target), 'utf8')
+    }))
+}
+
+async function installConsumer(name, tarballs, extra = []) {
+  const directory = join(temporaryRoot, name)
+  await mkdir(directory, { recursive: true })
+  await writeFile(join(directory, 'package.json'), JSON.stringify({ name, private: true, type: 'module' }))
+  await command('npm', [
+    'install', '--ignore-scripts', '--no-audit', '--no-fund',
+    ...tarballs, ...extra,
+  ], directory)
+  return directory
+}
+
+async function runFixture(directory, source) {
+  const fixture = join(directory, 'smoke.mjs')
+  await writeFile(fixture, source)
+  await command(process.execPath, [fixture], directory)
+}
+
+async function staticImportGraph(entry) {
+  const visited = new Set()
+  const specifiers = new Set()
+  async function visit(file) {
+    if (visited.has(file)) return
+    visited.add(file)
+    const source = (await readFile(file, 'utf8'))
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '')
+    const pattern = /\b(?:import|export)\s+(?:[^'";]*?\s+from\s+)?['"]([^'"]+)['"]/g
+    for (const match of source.matchAll(pattern)) {
+      const specifier = match[1]
+      specifiers.add(specifier)
+      if (specifier.startsWith('.')) await visit(resolve(dirname(file), specifier))
+    }
+  }
+  await visit(entry)
+  return { specifiers, visited }
+}
+
+try {
+  const core = await pack('packages/core')
+  const otel = await pack('packages/otel')
+
+  const coreOnly = await installConsumer('core-only', [core.tarball])
+  await runFixture(coreOnly, `
+    import { mkdtemp, rm } from 'node:fs/promises'
+    import { tmpdir } from 'node:os'
+    import { join } from 'node:path'
+    import { OpenMultiAgent } from '@open-multi-agent/core'
+    import { InMemoryTraceStore } from '@open-multi-agent/core/observability'
+    import { FileTraceStore } from '@open-multi-agent/core/observability/file'
+    if (typeof OpenMultiAgent !== 'function') throw new Error('core root import failed')
+    const records = [{
+      schemaVersion: 2, recordId: 'start', sequence: 1, timestampUnixMs: 1,
+      runId: 'pack-core-only', attempt: 1, traceId: '1'.repeat(32), spanId: '2'.repeat(16),
+      recordType: 'span_start', kind: 'run', name: 'oma.run', startUnixMs: 1, attributes: {},
+    }, {
+      schemaVersion: 2, recordId: 'end', sequence: 2, timestampUnixMs: 2,
+      runId: 'pack-core-only', attempt: 1, traceId: '1'.repeat(32), spanId: '2'.repeat(16),
+      recordType: 'span_end', kind: 'run', name: 'oma.run', startUnixMs: 1,
+      endUnixMs: 2, durationMs: 1, status: { code: 'ok' }, attributes: {},
+    }]
+    const memory = new InMemoryTraceStore()
+    await memory.append(records)
+    if ((await memory.getRun('pack-core-only'))?.status !== 'ok') throw new Error('memory store failed')
+    const directory = await mkdtemp(join(tmpdir(), 'oma-core-only-'))
+    const file = await FileTraceStore.open(join(directory, 'traces.ndjson'))
+    await file.append(records); await file.flush(); await file.close()
+    await rm(directory, { recursive: true, force: true })
+  `)
+  const coreManifest = JSON.parse(await readFile(join(coreOnly, 'node_modules/@open-multi-agent/core/package.json'), 'utf8'))
+  const installedCore = join(coreOnly, 'node_modules/@open-multi-agent/core')
+  await assertExportsInstalled(installedCore, coreManifest)
+  for (const entry of ['dist/index.js', 'dist/observability/index.js']) {
+    const graph = await staticImportGraph(join(installedCore, entry))
+    if ([...graph.specifiers].some((specifier) => specifier.startsWith('@opentelemetry/'))) {
+      throw new Error(`${entry} eagerly reaches OpenTelemetry`)
+    }
+    if ([...graph.visited].some((file) => file.endsWith('/dist/observability/file-store.js'))) {
+      throw new Error(`${entry} eagerly reaches FileTraceStore`)
+    }
+    if (entry === 'dist/observability/index.js'
+      && [...graph.specifiers].some((specifier) => specifier === 'node:fs' || specifier.startsWith('node:fs/'))) {
+      throw new Error(`${entry} eagerly reaches node:fs`)
+    }
+  }
+  const fileGraph = await staticImportGraph(join(installedCore, 'dist/observability/file.js'))
+  if (![...fileGraph.specifiers].some((specifier) => specifier === 'node:fs' || specifier.startsWith('node:fs/'))) {
+    throw new Error('observability/file did not reach its Node-only implementation')
+  }
+  await readdir(join(coreOnly, 'node_modules/@open-multi-agent')).then((names) => {
+    if (names.includes('otel')) throw new Error('core-only consumer unexpectedly installed OTel')
+  })
+
+  const combined = await installConsumer('core-otel', [core.tarball, otel.tarball], [
+    '@opentelemetry/api@1.9.0',
+    '@opentelemetry/sdk-trace-base@2.9.0',
+  ])
+  await runFixture(combined, `
+    import { SpanStatusCode } from '@opentelemetry/api'
+    import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+    import { createOtelTraceSink } from '@open-multi-agent/otel'
+    const exporter = new InMemorySpanExporter()
+    const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] })
+    const sink = createOtelTraceSink({ tracerProvider: provider })
+    const traceId = 'a'.repeat(32), rootId = '1'.repeat(16), firstId = '2'.repeat(16), secondId = '3'.repeat(16)
+    let sequence = 0
+    const base = (recordId, spanId) => ({ schemaVersion: 2, recordId, sequence: ++sequence,
+      timestampUnixMs: sequence, runId: 'pack-otel', attempt: 1, traceId, spanId })
+    const start = (id, name, parentSpanId, links) => ({ ...base('start-' + id, id), recordType: 'span_start',
+      kind: id === rootId ? 'run' : 'task', name, startUnixMs: sequence,
+      ...(parentSpanId ? { parentSpanId } : {}), ...(links ? { links } : {}), attributes: {} })
+    const end = (id, name, parentSpanId, status, links) => ({ ...base('end-' + id, id), recordType: 'span_end',
+      kind: id === rootId ? 'run' : 'task', name, startUnixMs: 1, endUnixMs: sequence,
+      durationMs: sequence - 1, status, ...(parentSpanId ? { parentSpanId } : {}),
+      ...(links ? { links } : {}), attributes: {} })
+    const link = { traceId, spanId: firstId, relation: 'depends_on' }
+    for (const record of [
+      start(rootId, 'oma.run'), start(firstId, 'first', rootId), end(firstId, 'first', rootId, { code: 'ok' }),
+      start(secondId, 'second', rootId, [link]), end(secondId, 'second', rootId, { code: 'error' }, [link]),
+      end(rootId, 'oma.run', undefined, { code: 'error' }),
+    ]) sink.emit(record)
+    const flushed = await sink.forceFlush({ timeoutMs: 2000 })
+    if (flushed.status !== 'ok') throw new Error('OTel flush failed: ' + flushed.status)
+    const spans = exporter.getFinishedSpans(), first = spans.find((span) => span.name === 'first')
+    const second = spans.find((span) => span.name === 'second')
+    if (!first || !second || second.links[0]?.context.spanId !== first.spanContext().spanId) throw new Error('link mapping failed')
+    if (second.status.code !== SpanStatusCode.ERROR || second.attributes['oma.status'] !== 'error') throw new Error('status mapping failed')
+    await sink.shutdown({ timeoutMs: 2000 }); await provider.shutdown()
+  `)
+  const otelManifest = JSON.parse(await readFile(join(combined, 'node_modules/@open-multi-agent/otel/package.json'), 'utf8'))
+  await assertExportsInstalled(join(combined, 'node_modules/@open-multi-agent/otel'), otelManifest)
+
+  const minimumTarball = process.env.OMA_OBSERVABILITY_MIN_CORE_TARBALL ?? core.tarball
+  const minimum = await installConsumer('minimum-core', [minimumTarball, otel.tarball], [
+    '@opentelemetry/api@1.9.0',
+  ])
+  await runFixture(minimum, `
+    import * as core from '@open-multi-agent/core/observability'
+    import { createOtelTraceSink } from '@open-multi-agent/otel'
+    for (const name of ['BatchingTraceSink', 'InMemoryTraceStore', 'TraceStoreExporter']) {
+      if (typeof core[name] !== 'function') throw new Error('minimum core misses ' + name)
+    }
+    if (typeof createOtelTraceSink !== 'function') throw new Error('OTel entry missing')
+    const coreManifest = JSON.parse(await (await import('node:fs/promises')).readFile(
+      new URL('./node_modules/@open-multi-agent/core/package.json', import.meta.url), 'utf8'))
+    const otelManifest = JSON.parse(await (await import('node:fs/promises')).readFile(
+      new URL('./node_modules/@open-multi-agent/otel/package.json', import.meta.url), 'utf8'))
+    if (coreManifest.version !== '1.11.0') throw new Error('minimum core must be 1.11.0')
+    if (otelManifest.dependencies['@open-multi-agent/core'] !== '^1.11.0') throw new Error('incorrect OTel core range')
+  `)
+
+  console.log(JSON.stringify({
+    coreTarball: core.tarball,
+    otelTarball: otel.tarball,
+    scenarios: ['core-only', 'core+otel', 'minimum-core'],
+  }, null, 2))
+} finally {
+  await rm(temporaryRoot, { recursive: true, force: true })
+}


### PR DESCRIPTION
## Summary

- finish the Observability v2 public documentation, migration path, runnable lifecycle examples, performance baseline, failure matrix, privacy evidence, and release notes
- add compile, example, benchmark, package-content, and real tarball consumer smoke automation
- prepare @open-multi-agent/core 1.11.0 and @open-multi-agent/otel 0.1.0 with the adapter requiring core ^1.11.0
- make direct LegacyCallbackTraceSink migration work without also configuring onTrace

## Motivation

OBS-5 is the final release-readiness package for the already merged Observability v2 implementation. It resolves the package compatibility blocker where the unpublished OTel adapter claimed compatibility with core 1.10.0 even though that release does not contain the required v2 APIs, and gives production users an evidence-backed adoption and lifecycle guide.

## Scope and impact

- Workspaces and areas: core, otel, create-oma-app templates, docs, examples, benchmarks, package CI, release smoke guidance
- Public behavior: onTrace remains supported and is not deprecated; LegacyCallbackTraceSink can now be configured directly as a sink while preserving the seven legacy event shapes
- Compatibility: first complete v2 core is 1.11.0; OTel remains 0.1.0 and now requires core ^1.11.0
- Privacy: v2 remains metadata-only by default; tests prove prompt, completion, tool payloads, credentials, and reasoning content are excluded
- Dependency governance: removes the fixed three-runtime-dependency promise while keeping OTel as an optional package and lifecycle boundary
- Intentional non-goals: no hosted backend, Live Studio, SQLite, new TraceStore contract, OTel mapping redesign, default content capture, signal auto-registration, publish, tag, or GitHub Release
- Known release condition: the pre-existing core root remains Node-oriented and already reaches filesystem modules through FileStore and built-in file tools. This PR keeps the new FileTraceStore behind core/observability/file and does not perform an unrelated root export redesign.

## Validation

- required baseline ancestor check against 6339ee50515e149eb1fb5a073f44024d3ab821a3
- npm run lint
- npm test on Node 18.20.8, 20.19.4, and 22.22.3: core 1,350; create-oma-app 26; OTel 15 tests on each matrix
- npm run build
- targeted observability, TraceStore, FileTraceStore, OTel, legacy, failure-injection, privacy, and docs/example suites
- seven no-network and no-key runnable examples
- dedicated performance gates: no-sink -0.530%, retained -1.18 B/run, legacy 0.125 us p95, batching 1.250 us p95, OTel 15.208 us p95
- npm pack --dry-run for core and OTel
- clean consumer tarball scenarios: core-only, core plus OTel, and minimum declared core
- workflow YAML parse and git diff --check

Not run: current-branch GitHub Actions, registry publication, registry-installed post-publish smoke, tag, GitHub Release, and optional real OTLP collector canary. These remain remote or manual release steps.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING