### PR TITLE
chore: release core v1.11.0 + otel v0.1.0 + create-oma-app v0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6613,7 +6613,7 @@
       }
     },
     "packages/create-oma-app": {
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "bin": {
         "create-oma-app": "dist/index.js"

--- a/packages/create-oma-app/package.json
+++ b/packages/create-oma-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-oma-app",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Scaffold PR review, security analysis, and multi-agent DAG starters on @open-multi-agent/core.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Motivation

Weekly release for 2026-07-18: core 1.11.0, the first release of @open-multi-agent/otel 0.1.0, and create-oma-app 0.4.0.

## Scope

Single change: bump create-oma-app from 0.3.1 to 0.4.0. The published 0.3.1 pins core 1.10.0 and must be republished; 0.4.0 is a feature bump for the production starters from #370.

core 1.11.0 and otel 0.1.0 were pre-staged by #385 (version fields, template pins, readiness guards), so no further version edits are needed in this PR.

## Validation

- `npm run build` and `npm run lint` clean across the workspace
- `npm test`: 1391 passed (core 1350, create-oma-app 26, otel 15)
- `npm run test:scaffold`: every starter packs; cloud and Ollama run gates reached
- `npm run test:observability-pack`: core-only, core+otel, and minimum-core clean-consumer scenarios pass against the 1.11.0 / 0.1.0 tarballs

## Release plan after merge

npm publish order: core, then otel (depends on core ^1.11.0), then create-oma-app. Tag v1.11.0 and the GitHub Release go last, since release-smoke.yml asserts that create-oma-app@latest pins the tagged core version. otel ships npm-only, following the secondary-package convention.
