### PR TITLE
fix(process): clean descendants after parent exit

### DIFF
--- a/packages/core/src/agent/process-backend.ts
+++ b/packages/core/src/agent/process-backend.ts
@@ -97,11 +97,7 @@ export class ProcessBackend implements AgentBackend {
     })
 
     const exit = waitForExit(child)
-    let exited = false
-    void exit.then(
-      () => { exited = true },
-      () => { exited = true },
-    )
+    let completed = false
 
     try {
       while (true) {
@@ -119,6 +115,7 @@ export class ProcessBackend implements AgentBackend {
         while (chunks.length > 0) {
           yield { type: 'text', data: chunks.shift()! }
         }
+        completed = true
 
         if (abort?.aborted) {
           yield { type: 'done', data: cancelledResult(label, stdout) }
@@ -152,8 +149,12 @@ export class ProcessBackend implements AgentBackend {
     } finally {
       abort?.removeEventListener('abort', onAbort)
       wakeReader()
-      if (!exited) {
-        await killProcessTreeAndWait(child, exit)
+      if (!completed) {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          killProcessTree(child)
+        } else {
+          await killProcessTreeAndWait(child, exit)
+        }
       }
     }
   }

--- a/packages/core/tests/process-backend-lifecycle.test.ts
+++ b/packages/core/tests/process-backend-lifecycle.test.ts
@@ -34,6 +34,22 @@ async function waitForFile(path: string, timeoutMs = 1_000): Promise<void> {
   }
 }
 
+async function waitForProcessExit(pid: number, timeoutMs = 1_000): Promise<void> {
+  const start = Date.now()
+  while (true) {
+    try {
+      process.kill(pid, 0)
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ESRCH') return
+      throw err
+    }
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Timed out waiting for process ${pid} to exit`)
+    }
+    await delay(10)
+  }
+}
+
 function descendantMarkerScript(
   markerPath: string,
   options: { readyPath?: string; writeReady?: boolean } = {},
@@ -56,6 +72,25 @@ function descendantMarkerScript(
     ${options.readyPath ? `fs.writeFileSync(${JSON.stringify(options.readyPath)}, 'ready')` : ''}
     ${options.writeReady ? "process.stdout.write('ready\\n')" : ''}
     setTimeout(() => {}, 10_000)
+  `
+}
+
+function exitedParentDescendantScript(markerPath: string): string {
+  const childScript = `
+    const fs = require('node:fs')
+    process.on('SIGHUP', () => {})
+    process.on('SIGTERM', () => {})
+    setTimeout(() => fs.writeFileSync(${JSON.stringify(markerPath)}, 'alive'), 350)
+    setTimeout(() => {}, 10_000)
+  `
+  return `
+    const { spawn } = require('node:child_process')
+    const child = spawn(process.execPath, [
+      '-e',
+      ${JSON.stringify(childScript)}
+    ], { stdio: 'ignore' })
+    child.unref()
+    process.stdout.write(String(process.pid) + '\\n')
   `
 }
 
@@ -96,5 +131,23 @@ describe('process backend lifecycle cleanup', () => {
 
     expect(existsSync(marker)).toBe(false)
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'kills descendants after the direct child exits before stream closure',
+    async () => {
+      const marker = join(tmpdir(), `oma-process-exited-parent-${process.pid}-${Date.now()}`)
+      await rm(marker, { force: true })
+      const agent = makeAgent(exitedParentDescendantScript(marker))
+
+      for await (const event of agent.stream('wait')) {
+        if (event.type !== 'text') continue
+        await waitForProcessExit(Number(event.data.trim()))
+        break
+      }
+      await delay(700)
+
+      expect(existsSync(marker)).toBe(false)
+    },
+  )
 
 })


### PR DESCRIPTION
## Summary

- Clean the detached process group when stream consumption stops after the direct child has already exited.
- Add a POSIX regression that waits for the parent to exit before closing the stream and verifies its descendant is terminated.

## Motivation

Fixes #387.

Stream finalization used the direct child's exit state as a proxy for completed stream consumption. That skipped process-group cleanup when the parent exited first while a descendant remained alive.

## Scope and impact

Affected area: the `@open-multi-agent/core` process backend and its lifecycle tests.

There are no public API, dependency, documentation, compatibility, or migration changes. The existing Windows `taskkill` fallback is unchanged; the new regression is POSIX-only because cleanup by an exited parent's process-group ID is a POSIX behavior.

## Validation

- `npm run lint`
- `npm test` - 96 test files and 1,392 tests passed on Linux with Node 22.22.0
- `npm run build`
- Focused process-backend tests - 10 tests passed
- The new regression failed before the implementation and passed afterward

## Checklist

- [x] Tests were added or updated for changed behavior
- [x] User-facing documentation and examples are not applicable
- [x] Compatibility, breaking changes, and migration requirements are not applicable
- [x] No dependency changes

AI assistance: OpenAI Codex assisted with reproduction, implementation, and tests. Its scope is the two files changed in this PR. This draft is pending final contributor review.
