### PR TITLE
test(e2e): add credential-aware DeepSeek canary

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,11 +32,16 @@ Unit tests live in each workspace's `tests/` directory: currently `packages/core
 npm test
 ```
 
-Core E2E tests are separate because they require `RUN_E2E=1` and real provider credentials:
+Core E2E tests are separate because they require `RUN_E2E=1` and real provider credentials. Each provider suite runs only when its matching credential is present, so a single-key canary does not fail on unrelated providers:
 
 ```bash
+# Runs only the suites whose credentials are set.
+# Supported keys: OPENAI_API_KEY, ANTHROPIC_API_KEY,
+# GEMINI_API_KEY / GOOGLE_API_KEY, and DEEPSEEK_API_KEY.
 npm run test:e2e
 ```
+
+Set `DEEPSEEK_E2E_MODEL` to override the DeepSeek canary model; it defaults to `deepseek-v4-flash`.
 
 Run checks that match the surface you changed and record the commands and results in the PR description. For code changes, start with `npm run lint && npm test`; also run `npm run build` when package output or public entry points may be affected, and `npm run test:scaffold` when changing `create-oma-app` scaffolding or templates.
 

--- a/packages/core/tests/e2e/anthropic-e2e.test.ts
+++ b/packages/core/tests/e2e/anthropic-e2e.test.ts
@@ -4,15 +4,21 @@
  * Skipped by default. Run with: npm run test:e2e
  * Requires: ANTHROPIC_API_KEY environment variable
  */
-import { describe, it, expect } from 'vitest'
+import { beforeAll, describe, it, expect } from 'vitest'
 import { AnthropicAdapter } from '../../src/llm/anthropic.js'
 import type { LLMResponse, StreamEvent, ToolUseBlock } from '../../src/types.js'
 
-const describeE2E = process.env['RUN_E2E'] ? describe : describe.skip
+const describeE2E = process.env['RUN_E2E'] && process.env['ANTHROPIC_API_KEY']
+  ? describe
+  : describe.skip
 
 describeE2E('AnthropicAdapter E2E', () => {
-  const adapter = new AnthropicAdapter()
+  let adapter: AnthropicAdapter
   const model = 'claude-haiku-4-5-20251001'
+
+  beforeAll(() => {
+    adapter = new AnthropicAdapter()
+  })
 
   const weatherTool = {
     name: 'get_weather',

--- a/packages/core/tests/e2e/coordinator-dependency-widening.test.ts
+++ b/packages/core/tests/e2e/coordinator-dependency-widening.test.ts
@@ -25,7 +25,9 @@ import { describe, it, expect } from 'vitest'
 import { OpenMultiAgent } from '../../src/orchestrator/orchestrator.js'
 import type { AgentConfig, TeamConfig } from '../../src/types.js'
 
-const describeE2E = process.env['RUN_E2E'] ? describe : describe.skip
+const describeE2E = process.env['RUN_E2E'] && process.env['ANTHROPIC_API_KEY']
+  ? describe
+  : describe.skip
 
 // Match the model used in the original reproducer.
 const MODEL = 'claude-sonnet-4-6'

--- a/packages/core/tests/e2e/deepseek-e2e.test.ts
+++ b/packages/core/tests/e2e/deepseek-e2e.test.ts
@@ -1,0 +1,105 @@
+/**
+ * E2E tests for DeepSeekAdapter against the real API.
+ *
+ * Skipped by default. Run with: npm run test:e2e
+ * Requires: DEEPSEEK_API_KEY environment variable
+ * Optional: DEEPSEEK_E2E_MODEL (defaults to deepseek-v4-flash)
+ */
+import { beforeAll, describe, it, expect } from 'vitest'
+import { z } from 'zod'
+import { OpenMultiAgent } from '../../src/orchestrator/orchestrator.js'
+import { DeepSeekAdapter } from '../../src/llm/deepseek.js'
+import { defineTool } from '../../src/tool/framework.js'
+import type { LLMResponse, StreamEvent } from '../../src/types.js'
+
+const describeE2E = process.env['RUN_E2E'] && process.env['DEEPSEEK_API_KEY']
+  ? describe
+  : describe.skip
+
+describeE2E('DeepSeekAdapter E2E', () => {
+  let adapter: DeepSeekAdapter
+  const model = process.env['DEEPSEEK_E2E_MODEL'] ?? 'deepseek-v4-flash'
+
+  beforeAll(() => {
+    adapter = new DeepSeekAdapter()
+  })
+
+  it('chat() returns a text response with usage', async () => {
+    const result = await adapter.chat(
+      [{ role: 'user', content: [{ type: 'text', text: 'Reply with exactly CHAT_OK.' }] }],
+      { model, maxTokens: 256 },
+    )
+
+    const text = result.content
+      .filter(block => block.type === 'text')
+      .map(block => block.text)
+      .join('')
+
+    expect(result.id).toBeTruthy()
+    expect(text).toContain('CHAT_OK')
+    expect(result.usage.input_tokens).toBeGreaterThan(0)
+    expect(result.usage.output_tokens).toBeGreaterThan(0)
+  }, 60_000)
+
+  it('stream() yields text, reasoning, and one done event', async () => {
+    const events: StreamEvent[] = []
+    for await (const event of adapter.stream(
+      [{ role: 'user', content: [{ type: 'text', text: 'Reply with exactly STREAM_OK.' }] }],
+      { model, maxTokens: 256 },
+    )) {
+      events.push(event)
+    }
+
+    const text = events
+      .filter(event => event.type === 'text')
+      .map(event => event.data)
+      .join('')
+    const reasoningEvents = events.filter(event => event.type === 'reasoning')
+    const doneEvents = events.filter(event => event.type === 'done')
+
+    expect(text).toContain('STREAM_OK')
+    expect(reasoningEvents.length).toBeGreaterThan(0)
+    expect(doneEvents).toHaveLength(1)
+    expect((doneEvents[0].data as LLMResponse).usage.input_tokens).toBeGreaterThan(0)
+  }, 60_000)
+
+  it('runAgent completes a thinking-mode tool loop', async () => {
+    let executions = 0
+    const markerTool = defineTool({
+      name: 'release_marker',
+      description: 'Return a fixed marker for the provider E2E test.',
+      inputSchema: z.object({ token: z.string() }),
+      execute: async ({ token }) => {
+        executions += 1
+        return {
+          data: token === 'probe' ? 'TOOL_OK' : 'BAD_TOKEN',
+          isError: token !== 'probe',
+        }
+      },
+    })
+    const oma = new OpenMultiAgent({
+      defaultProvider: 'deepseek',
+      defaultModel: model,
+      maxConcurrency: 1,
+    })
+
+    const result = await oma.runAgent(
+      {
+        name: 'deepseek-e2e',
+        systemPrompt: 'Follow the user instruction exactly and use the provided tool when requested.',
+        customTools: [markerTool],
+        maxTurns: 4,
+        maxTokens: 512,
+        callTimeoutMs: 90_000,
+      },
+      'Call release_marker exactly once with token probe, then answer with exactly TOOL_OK.',
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.status.code).toBe('ok')
+    expect(executions).toBe(1)
+    expect(result.toolCalls).toHaveLength(1)
+    expect(result.toolCalls[0].toolName).toBe('release_marker')
+    expect(result.output).toContain('TOOL_OK')
+  }, 120_000)
+})

--- a/packages/core/tests/e2e/gemini-e2e.test.ts
+++ b/packages/core/tests/e2e/gemini-e2e.test.ts
@@ -4,15 +4,22 @@
  * Skipped by default. Run with: npm run test:e2e
  * Requires: GEMINI_API_KEY or GOOGLE_API_KEY environment variable
  */
-import { describe, it, expect } from 'vitest'
+import { beforeAll, describe, it, expect } from 'vitest'
 import { GeminiAdapter } from '../../src/llm/gemini.js'
 import type { LLMResponse, StreamEvent, ToolUseBlock } from '../../src/types.js'
 
-const describeE2E = process.env['RUN_E2E'] ? describe : describe.skip
+const hasGeminiCredentials = process.env['GEMINI_API_KEY'] || process.env['GOOGLE_API_KEY']
+const describeE2E = process.env['RUN_E2E'] && hasGeminiCredentials
+  ? describe
+  : describe.skip
 
 describeE2E('GeminiAdapter E2E', () => {
-  const adapter = new GeminiAdapter()
+  let adapter: GeminiAdapter
   const model = 'gemini-2.0-flash'
+
+  beforeAll(() => {
+    adapter = new GeminiAdapter()
+  })
 
   const weatherTool = {
     name: 'get_weather',

--- a/packages/core/tests/e2e/openai-e2e.test.ts
+++ b/packages/core/tests/e2e/openai-e2e.test.ts
@@ -4,15 +4,21 @@
  * Skipped by default. Run with: npm run test:e2e
  * Requires: OPENAI_API_KEY environment variable
  */
-import { describe, it, expect } from 'vitest'
+import { beforeAll, describe, it, expect } from 'vitest'
 import { OpenAIAdapter } from '../../src/llm/openai.js'
 import type { LLMResponse, StreamEvent, ToolUseBlock } from '../../src/types.js'
 
-const describeE2E = process.env['RUN_E2E'] ? describe : describe.skip
+const describeE2E = process.env['RUN_E2E'] && process.env['OPENAI_API_KEY']
+  ? describe
+  : describe.skip
 
 describeE2E('OpenAIAdapter E2E', () => {
-  const adapter = new OpenAIAdapter()
+  let adapter: OpenAIAdapter
   const model = 'gpt-4o-mini'
+
+  beforeAll(() => {
+    adapter = new OpenAIAdapter()
+  })
 
   const weatherTool = {
     name: 'get_weather',


### PR DESCRIPTION
## Summary

- Add a real DeepSeek V4 E2E canary for chat, streaming reasoning, and a thinking-mode tool loop.
- Gate every provider E2E suite on its matching credential so single-key runs skip unrelated providers.
- Defer provider client construction until an enabled suite starts, keeping no-key runs quiet and offline.
- Document supported E2E credentials and the optional DeepSeek model override.

## Motivation

The v1.11.0 release audit could validate DeepSeek only with an ad hoc script. The checked-in E2E command also enabled every provider suite whenever RUN_E2E was set, so a DeepSeek-only canary would fail on missing OpenAI, Anthropic, and Gemini credentials.

This makes the release canary reproducible without changing runtime behavior or requiring an all-provider secret bundle.

## Validation

- npm run lint
- npm test — 96 test files and 1,392 tests passed
- npm run build
- npm run test:e2e with all provider keys empty — 15 tests skipped, no provider clients or network calls
- npm run test:e2e with only DEEPSEEK_API_KEY — 3 DeepSeek tests passed and 12 unrelated tests skipped
- git diff --check

## Scope and compatibility

Tests and contributor documentation only. No runtime, dependency, public API, package version, or release changes.

AI assistance: OpenAI Codex implemented and validated this focused E2E hardening change.