### PR TITLE
feat(core): add per-run metadata channel

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -40,6 +40,47 @@ For source compatibility in the first 1.x release, the new result fields are
 optional in TypeScript declarations, but every runtime result from these APIs
 includes `identity` and `status`.
 
+### Per-run metadata
+
+Use `metadata` on any top-level execution to attach bounded evaluation or
+correlation facts to that run, such as a prompt version, experiment arm, or
+dataset tag:
+
+```typescript
+const result = await orchestrator.runTasks(team, tasks, {
+  metadata: {
+    prompt_version: 'v3',
+    experiment: 'routing_ab',
+    dataset_tag: 'support_holdout',
+  },
+})
+
+result.metadata // the validated metadata, even without observability sinks
+```
+
+Metadata keys must match `[a-z0-9_.]{1,64}`, each run may contain at most 32
+keys, and the `oma.` prefix is reserved for the framework. Values use the
+`TraceAttributeValue` contract: a string, finite number, boolean, or a
+homogeneous array of one of those scalar types. Strings, including strings in
+arrays, are truncated to 1,024 characters. Invalid metadata rejects the call
+before execution starts. The framework also reserves the exact `_overridden`
+key for restore provenance.
+
+When tracing is active, metadata is written on the root span as
+`oma.meta.<key>` and is echoed from the top-level result after validation. A v2
+checkpoint persists it; `restore()` inherits the checkpoint metadata unless
+the caller supplies a different set. An explicit difference wins and the new
+attempt's root span records `oma.meta._overridden=true`. Existing checkpoints
+without metadata remain readable.
+
+`TraceStore` materializes the latest attempt's root metadata into
+`RunSummary.metadata`, so `getRun()` and `queryRuns()` results expose it.
+`TraceQuery` intentionally does not provide metadata filtering.
+
+This per-run channel is distinct from `ObservabilityResource`: use resource
+fields for instance-level facts such as service, release, and deployment
+environment; use run metadata for dimensions that may change on every call.
+
 ## TraceRecord schema v2
 
 The core package exports the `TraceRecord` schema used by the internal

--- a/packages/core/src/memory/checkpoint.ts
+++ b/packages/core/src/memory/checkpoint.ts
@@ -7,6 +7,7 @@
  */
 
 import type { CheckpointOptions, CheckpointSnapshot, MemoryStore } from '../types.js'
+import { validateRunMetadata } from '../observability/identity.js'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -98,6 +99,13 @@ export class Checkpoint {
     if (snapshot['mode'] !== 'runTeam' && snapshot['mode'] !== 'runTasks') return false
     if (typeof snapshot['createdAt'] !== 'string') return false
     if (!Array.isArray(snapshot['completedTaskResults'])) return false
+    if (snapshot['metadata'] !== undefined) {
+      try {
+        validateRunMetadata(snapshot['metadata'] as CheckpointSnapshot['metadata'])
+      } catch {
+        return false
+      }
+    }
 
     if (snapshot['version'] === 2) {
       const identity = snapshot['identity']

--- a/packages/core/src/observability/identity.ts
+++ b/packages/core/src/observability/identity.ts
@@ -3,7 +3,110 @@ import type {
   CheckpointSnapshot,
   RunIdentity,
   RunIdentityOptions,
+  TraceAttributeValue,
 } from '../types.js'
+
+const RUN_METADATA_KEY = /^[a-z0-9_.]{1,64}$/
+const MAX_RUN_METADATA_ENTRIES = 32
+const MAX_RUN_METADATA_STRING_LENGTH = 1_024
+const RUN_METADATA_OVERRIDE_KEY = '_overridden'
+
+function normalizeMetadataValue(value: unknown, key: string): TraceAttributeValue {
+  if (typeof value === 'string') return value.slice(0, MAX_RUN_METADATA_STRING_LENGTH)
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+
+  if (Array.isArray(value)) {
+    let elementType: 'string' | 'number' | 'boolean' | undefined
+    const normalized: Array<string | number | boolean> = []
+    for (const item of value) {
+      const itemType = typeof item
+      if (itemType !== 'string' && itemType !== 'number' && itemType !== 'boolean') {
+        throw new Error(`metadata value for "${key}" is not a supported trace attribute.`)
+      }
+      if (itemType === 'number' && !Number.isFinite(item)) {
+        throw new Error(`metadata value for "${key}" is not a supported trace attribute.`)
+      }
+      if (elementType !== undefined && itemType !== elementType) {
+        throw new Error(`metadata value for "${key}" must be a homogeneous scalar array.`)
+      }
+      elementType = itemType
+      normalized.push(itemType === 'string'
+        ? (item as string).slice(0, MAX_RUN_METADATA_STRING_LENGTH)
+        : item as number | boolean)
+    }
+    return Object.freeze(normalized) as TraceAttributeValue
+  }
+
+  throw new Error(`metadata value for "${key}" is not a supported trace attribute.`)
+}
+
+/** Validate and defensively copy caller-provided per-run metadata. */
+export function validateRunMetadata(
+  metadata: RunIdentityOptions['metadata'],
+): Readonly<Record<string, TraceAttributeValue>> | undefined {
+  if (metadata === undefined) return undefined
+  if (metadata === null || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    throw new Error('metadata must be a record of trace attribute values.')
+  }
+
+  const entries = Object.entries(metadata as Readonly<Record<string, unknown>>)
+  if (entries.length > MAX_RUN_METADATA_ENTRIES) {
+    throw new Error(`metadata must contain at most ${MAX_RUN_METADATA_ENTRIES} entries.`)
+  }
+
+  const normalized: Array<readonly [string, TraceAttributeValue]> = []
+  for (const [key, value] of entries) {
+    if (key.startsWith('oma.')) {
+      throw new Error(`metadata key "${key}" uses the reserved "oma." prefix.`)
+    }
+    if (key === RUN_METADATA_OVERRIDE_KEY) {
+      throw new Error(`metadata key "${key}" is reserved for framework restore state.`)
+    }
+    if (!RUN_METADATA_KEY.test(key)) {
+      throw new Error(`metadata key "${key}" must match [a-z0-9_.]{1,64}.`)
+    }
+    normalized.push([key, normalizeMetadataValue(value, key)])
+  }
+  return Object.freeze(Object.fromEntries(normalized))
+}
+
+function metadataValueEqual(a: TraceAttributeValue, b: TraceAttributeValue): boolean {
+  if (!Array.isArray(a) || !Array.isArray(b)) return Object.is(a, b)
+  return a.length === b.length && a.every((value, index) => Object.is(value, b[index]))
+}
+
+function metadataEqual(
+  a: Readonly<Record<string, TraceAttributeValue>>,
+  b: Readonly<Record<string, TraceAttributeValue>>,
+): boolean {
+  const aKeys = Object.keys(a)
+  const bKeys = Object.keys(b)
+  return aKeys.length === bKeys.length
+    && aKeys.every((key) => Object.hasOwn(b, key) && metadataValueEqual(a[key]!, b[key]!))
+}
+
+export interface RestoreMetadataResolution {
+  readonly metadata?: Readonly<Record<string, TraceAttributeValue>>
+  readonly overridden: boolean
+}
+
+/** Resolve checkpoint inheritance and explicit restore-time metadata precedence. */
+export function resolveRestoreMetadata(
+  snapshot: CheckpointSnapshot,
+  options: RunIdentityOptions = {},
+): RestoreMetadataResolution {
+  const inherited = validateRunMetadata(snapshot.metadata)
+  if (options.metadata === undefined) {
+    return { ...(inherited !== undefined ? { metadata: inherited } : {}), overridden: false }
+  }
+
+  const requested = validateRunMetadata(options.metadata)!
+  return {
+    metadata: requested,
+    overridden: inherited !== undefined && !metadataEqual(inherited, requested),
+  }
+}
 
 function randomHex(bytes: number): string {
   let value = randomBytes(bytes).toString('hex')
@@ -22,6 +125,7 @@ export function validateRunId(runId: string): string {
 
 /** Create the identity for a new logical run. */
 export function createRunIdentity(options: RunIdentityOptions = {}): RunIdentity {
+  validateRunMetadata(options.metadata)
   return {
     runId: options.runId === undefined ? randomUUID() : validateRunId(options.runId),
     attempt: 1,
@@ -35,6 +139,7 @@ export function createRestoreIdentity(
   snapshot: CheckpointSnapshot,
   options: RunIdentityOptions = {},
 ): RunIdentity {
+  validateRunMetadata(options.metadata)
   const checkpointRunId = snapshot.version === 2
     ? snapshot.identity.runId
     : snapshot.runId

--- a/packages/core/src/observability/materialize.ts
+++ b/packages/core/src/observability/materialize.ts
@@ -17,6 +17,8 @@ const CACHE_CREATE_KEYS = ['oma.usage.cache_creation_input_tokens']
 const REASONING_KEYS = ['oma.usage.reasoning_output_tokens', 'oma.reasoning.output_tokens']
 const MODEL_KEYS = ['oma.llm.model', 'oma.model', 'gen_ai.request.model', 'gen_ai.response.model']
 const PROVIDER_KEYS = ['oma.llm.provider', 'oma.provider', 'gen_ai.provider.name', 'gen_ai.system']
+const RUN_METADATA_PREFIX = 'oma.meta.'
+const RUN_METADATA_OVERRIDE_ATTRIBUTE = 'oma.meta._overridden'
 
 function numberAttribute(
   attributes: Readonly<Record<string, TraceAttributeValue>>,
@@ -168,6 +170,27 @@ export function materializeRun(recordsInput: readonly TraceRecord[], includeReco
   }
   attempts.sort((a, b) => a.attempt - b.attempt || a.traceId.localeCompare(b.traceId))
   const latest = attempts.at(-1)!
+  const latestRootStart = records.find((record): record is SpanStartRecord =>
+    record.traceId === latest.traceId
+    && record.recordType === 'span_start'
+    && record.kind === 'run'
+    && !record.parentSpanId)
+  const latestRootEnd = records.find((record): record is SpanEndRecord =>
+    record.traceId === latest.traceId
+    && record.recordType === 'span_end'
+    && record.kind === 'run'
+    && !record.parentSpanId)
+  const rootAttributes = { ...latestRootStart?.attributes, ...latestRootEnd?.attributes }
+  const metadataEntries: Array<readonly [string, TraceAttributeValue]> = []
+  for (const [key, value] of Object.entries(rootAttributes)) {
+    if (!key.startsWith(RUN_METADATA_PREFIX) || key === RUN_METADATA_OVERRIDE_ATTRIBUTE) continue
+    const metadataKey = key.slice(RUN_METADATA_PREFIX.length)
+    metadataEntries.push([
+      metadataKey,
+      Array.isArray(value) ? [...value] as TraceAttributeValue : value,
+    ])
+  }
+  const metadata = Object.fromEntries(metadataEntries) as Record<string, TraceAttributeValue>
   const startedAtMs = Math.min(...attempts.map((attempt) => Date.parse(attempt.startedAt)))
   const endedAttempts = attempts.filter((attempt) => attempt.endedAt !== undefined)
   const endedAtMs = endedAttempts.length > 0
@@ -194,6 +217,7 @@ export function materializeRun(recordsInput: readonly TraceRecord[], includeReco
       durationMs: Math.max(0, endedAtMs - startedAtMs),
     } : {}),
     ...(latest.status ? { status: latest.status } : {}),
+    ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
     agents: sorted(agents),
     taskIds: sorted(tasks),
     models: sorted(models),

--- a/packages/core/src/observability/runtime.ts
+++ b/packages/core/src/observability/runtime.ts
@@ -89,6 +89,7 @@ export class TraceRuntime {
     private readonly observer?: TraceRecordObserver,
     legacyCallback?: (event: TraceEvent) => void | Promise<void>,
     sink?: TraceSink,
+    rootAttributes: Readonly<Record<string, TraceAttributeValue>> = {},
   ) {
     this.identity = identity
     const legacySink = legacyCallback && legacyCallback !== LEGACY_TRACE_METADATA_ONLY
@@ -105,6 +106,7 @@ export class TraceRuntime {
       attributes: {
         'oma.run.id': identity.runId,
         'oma.run.attempt': identity.attempt,
+        ...rootAttributes,
       },
     })
   }
@@ -255,8 +257,9 @@ export function createTraceRuntime(
   legacyCallback?: (event: TraceEvent) => void | Promise<void>,
   observer?: TraceRecordObserver,
   sink?: TraceSink,
+  rootAttributes?: Readonly<Record<string, TraceAttributeValue>>,
 ): TraceRuntime | undefined {
   return legacyCallback || observer || sink
-    ? new TraceRuntime(identity, observer, legacyCallback, sink)
+    ? new TraceRuntime(identity, observer, legacyCallback, sink, rootAttributes)
     : undefined
 }

--- a/packages/core/src/observability/store.ts
+++ b/packages/core/src/observability/store.ts
@@ -113,6 +113,8 @@ export interface RunSummary {
   readonly durationMs?: number
   /** Absent when no terminal run record exists. Never inferred as ok. */
   readonly status?: RunStatusCode
+  /** Validated per-run metadata materialized from the latest attempt's root span. */
+  readonly metadata?: Readonly<Record<string, TraceAttributeValue>>
   readonly agents: readonly string[]
   readonly taskIds: readonly string[]
   readonly models: readonly string[]

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -60,6 +60,7 @@ import type {
   RestoreOptions,
   RunAgentOptions,
   RunIdentity,
+  RunIdentityOptions,
   RunStatus,
   StructuredTraceError,
   RunMetrics,
@@ -75,6 +76,7 @@ import type {
   TeamInfo,
   TeamRunResult,
   TokenUsage,
+  TraceAttributeValue,
 } from '../types.js'
 import type { ZodSchema } from 'zod'
 import type { RunOptions } from '../agent/runner.js'
@@ -94,7 +96,13 @@ import { extractJSON, validateOutput } from '../agent/structured-output.js'
 import { Scheduler } from './scheduler.js'
 import { CostBudgetExceededError, TokenBudgetExceededError, isRetryableError } from '../errors.js'
 import { abortableDelay } from '../utils/abort.js'
-import { createRestoreIdentity, createRunIdentity } from '../observability/identity.js'
+import {
+  createRestoreIdentity,
+  createRunIdentity,
+  resolveRestoreMetadata,
+  validateRunMetadata,
+  type RestoreMetadataResolution,
+} from '../observability/identity.js'
 import { classifyRunFailure, statusOnly } from '../observability/status.js'
 import {
   createTraceRuntime,
@@ -119,7 +127,14 @@ const DEFAULT_MAX_CONCURRENCY = 5
 const DEFAULT_MAX_DELEGATION_DEPTH = 3
 const DEFAULT_MODEL = 'claude-opus-4-6'
 
-function identityOptionsForRun(options?: RunTasksOptions): { runId?: string } {
+type RunMetadata = Readonly<Record<string, TraceAttributeValue>>
+
+interface RunFacts {
+  readonly identity: RunIdentity
+  readonly metadata?: RunMetadata
+}
+
+function identityOptionsForRun(options?: RunTasksOptions): RunIdentityOptions {
   const checkpointRunId = options?.checkpoint && typeof options.checkpoint === 'object'
     ? options.checkpoint.runId
     : undefined
@@ -133,7 +148,30 @@ function identityOptionsForRun(options?: RunTasksOptions): { runId?: string } {
     )
   }
   const runId = options?.runId ?? checkpointRunId
-  return runId === undefined ? {} : { runId }
+  return {
+    ...(runId !== undefined ? { runId } : {}),
+    ...(options?.metadata !== undefined ? { metadata: options.metadata } : {}),
+  }
+}
+
+function createRunFacts(options: RunIdentityOptions = {}): RunFacts {
+  const metadata = validateRunMetadata(options.metadata)
+  return {
+    identity: createRunIdentity(options),
+    ...(metadata !== undefined ? { metadata } : {}),
+  }
+}
+
+function metadataAttributes(
+  metadata: RunMetadata | undefined,
+  overridden = false,
+): Readonly<Record<string, TraceAttributeValue>> {
+  const attributes: Record<string, TraceAttributeValue> = {}
+  for (const [key, value] of Object.entries(metadata ?? {})) {
+    attributes[`oma.meta.${key}`] = value
+  }
+  if (overridden) attributes['oma.meta._overridden'] = true
+  return attributes
 }
 
 // ---------------------------------------------------------------------------
@@ -858,6 +896,8 @@ interface RunContext {
   readonly checkpoint?: ActiveCheckpoint
   /** Stable top-level execution identity, independent of trace callbacks. */
   readonly identity: RunIdentity
+  /** Validated facts echoed on the result and persisted with checkpoints. */
+  readonly metadata?: RunMetadata
   /** Legacy trace correlation alias. */
   readonly runId: string
   readonly traceRuntime?: TraceRuntime
@@ -1044,6 +1084,7 @@ async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Promise<voi
       version: 2,
       mode: active.mode,
       createdAt: new Date().toISOString(),
+      ...(ctx.metadata !== undefined ? { metadata: ctx.metadata } : {}),
       identity: {
         runId: ctx.identity.runId,
         attempt: ctx.identity.attempt,
@@ -2052,8 +2093,18 @@ export class OpenMultiAgent {
     }
   }
 
-  private startTrace(identity: RunIdentity): TraceRuntime | undefined {
-    return createTraceRuntime(identity, this.config.onTrace, this.traceRecordObserver, this.traceSink)
+  private startTrace(
+    identity: RunIdentity,
+    metadata?: RunMetadata,
+    metadataOverridden = false,
+  ): TraceRuntime | undefined {
+    return createTraceRuntime(
+      identity,
+      this.config.onTrace,
+      this.traceRecordObserver,
+      this.traceSink,
+      metadataAttributes(metadata, metadataOverridden),
+    )
   }
 
   // -------------------------------------------------------------------------
@@ -2101,8 +2152,8 @@ export class OpenMultiAgent {
     prompt: string,
     options?: RunAgentOptions,
   ): Promise<AgentRunResult> {
-    const identity = createRunIdentity(options)
-    const traceRuntime = this.startTrace(identity)
+    const { identity, metadata } = createRunFacts(options)
+    const traceRuntime = this.startTrace(identity, metadata)
     const effectiveBudget = resolveTokenBudget(config.maxTokenBudget, this.config.maxTokenBudget)
     const effective: AgentConfig = applyDefaultToolPreset({
       ...config,
@@ -2201,11 +2252,15 @@ export class OpenMultiAgent {
       this.completedTaskCount++
     }
 
+    const completedResult: AgentRunResult = {
+      ...finalResult,
+      ...(metadata !== undefined ? { metadata } : {}),
+    }
     traceRuntime?.close({
-      status: finalResult.status ?? statusOnly(finalResult.success ? 'ok' : 'error'),
-      ...(finalResult.errorInfo ? { error: finalResult.errorInfo } : {}),
+      status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
+      ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
     })
-    return finalResult
+    return completedResult
   }
 
   // -------------------------------------------------------------------------
@@ -2238,14 +2293,18 @@ export class OpenMultiAgent {
     goal: string,
     options?: RunTeamOptions,
   ): Promise<TeamRunResult> {
-    const identity = createRunIdentity(identityOptionsForRun(options))
-    const traceRuntime = this.startTrace(identity)
+    const { identity, metadata } = createRunFacts(identityOptionsForRun(options))
+    const traceRuntime = this.startTrace(identity, metadata)
     const finish = (result: TeamRunResult): TeamRunResult => {
+      const completedResult: TeamRunResult = {
+        ...result,
+        ...(metadata !== undefined ? { metadata } : {}),
+      }
       traceRuntime?.close({
-        status: result.status ?? statusOnly(result.success ? 'ok' : 'error'),
-        ...(result.errorInfo ? { error: result.errorInfo } : {}),
+        status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
+        ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
       })
-      return result
+      return completedResult
     }
     const agentConfigs = team.getAgents()
     const coordinatorOverrides = options?.coordinator
@@ -2502,6 +2561,7 @@ export class OpenMultiAgent {
       ...(activeCheckpoint ? { checkpoint: activeCheckpoint } : {}),
       runId,
       identity,
+      ...(metadata !== undefined ? { metadata } : {}),
       ...(traceRuntime ? { traceRuntime } : {}),
       taskSpans: new Map(),
       abortSignal: options?.abortSignal,
@@ -2778,6 +2838,7 @@ export class OpenMultiAgent {
   ): Promise<TeamRunResult> {
     const hasTaskSource = Array.isArray(tasksOrOptions) || this.isPlanArtifact(tasksOrOptions)
     const options = hasTaskSource ? maybeOptions : tasksOrOptions as RestoreOptions | undefined
+    validateRunMetadata(options?.metadata)
     const activeCheckpoint = this.createActiveCheckpoint(
       team,
       options?.checkpoint ?? this.config.checkpoint ?? true,
@@ -2856,11 +2917,9 @@ export class OpenMultiAgent {
       team.restoreMessageBus(snapshot.messageBus)
     }
 
-    const requestedRunId = identityOptionsForRun(options).runId
-    const identity = createRestoreIdentity(
-      snapshot,
-      requestedRunId === undefined ? {} : { runId: requestedRunId },
-    )
+    const restoreIdentityOptions = identityOptionsForRun(options)
+    const restoreMetadata = resolveRestoreMetadata(snapshot, restoreIdentityOptions)
+    const identity = createRestoreIdentity(snapshot, restoreIdentityOptions)
 
     const queue = TaskQueue.fromSnapshot(snapshot.queue, { resetInProgress: true })
     const agentResults = this.agentResultsFromCheckpoint(snapshot, queue)
@@ -2882,6 +2941,7 @@ export class OpenMultiAgent {
       checkpointForResume,
       options?.coordinator,
       identity,
+      restoreMetadata,
     )
   }
 
@@ -2941,7 +3001,7 @@ export class OpenMultiAgent {
     prompt: string,
     options: ConsensusOptions,
   ): Promise<ConsensusResult> {
-    const identity = createRunIdentity(options)
+    const { identity, metadata } = createRunFacts(options)
     const proposers = Array.isArray(options.proposer) ? options.proposer : [options.proposer]
     if (proposers.length === 0) {
       throw new Error('runConsensus: at least one proposer is required.')
@@ -2950,7 +3010,7 @@ export class OpenMultiAgent {
       throw new Error('runConsensus: at least one judge is required.')
     }
 
-    const traceRuntime = this.startTrace(identity)
+    const traceRuntime = this.startTrace(identity, metadata)
     const consensusSpan = traceRuntime?.startSpan({
       kind: 'consensus',
       name: 'verify_consensus',
@@ -2958,20 +3018,24 @@ export class OpenMultiAgent {
       attributes: { 'oma.consensus.scope': 'top_level' },
     })
     const finish = (result: ConsensusResult): ConsensusResult => {
-      const status = result.status ?? statusOnly('ok')
+      const completedResult: ConsensusResult = {
+        ...result,
+        ...(metadata !== undefined ? { metadata } : {}),
+      }
+      const status = completedResult.status ?? statusOnly('ok')
       consensusSpan?.end({
         status,
-        ...(result.errorInfo ? { error: result.errorInfo } : {}),
+        ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
         attributes: {
-          'oma.consensus.verdict': result.verdict,
-          'oma.consensus.rounds': result.rounds,
+          'oma.consensus.verdict': completedResult.verdict,
+          'oma.consensus.rounds': completedResult.rounds,
         },
       })
       traceRuntime?.close({
         status,
-        ...(result.errorInfo ? { error: result.errorInfo } : {}),
+        ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
       })
-      return result
+      return completedResult
     }
 
     const mode = options.mode ?? 'refute'
@@ -3486,9 +3550,14 @@ export class OpenMultiAgent {
     activeCheckpoint?: ActiveCheckpoint,
     coordinatorForSynthesis?: CoordinatorConfig,
     identity?: RunIdentity,
+    restoreMetadata?: RestoreMetadataResolution,
   ): Promise<TeamRunResult> {
-    const runIdentity = identity ?? createRunIdentity(identityOptionsForRun(options))
-    const traceRuntime = this.startTrace(runIdentity)
+    const newRunFacts = identity === undefined
+      ? createRunFacts(identityOptionsForRun(options))
+      : undefined
+    const runIdentity = identity ?? newRunFacts!.identity
+    const metadata = restoreMetadata?.metadata ?? newRunFacts?.metadata
+    const traceRuntime = this.startTrace(runIdentity, metadata, restoreMetadata?.overridden)
     const agentConfigs = team.getAgents()
     const scheduler = new Scheduler('dependency-first')
     scheduler.autoAssign(queue, agentConfigs)
@@ -3509,6 +3578,7 @@ export class OpenMultiAgent {
       config: this.config,
       ...(checkpoint ? { checkpoint } : {}),
       identity: runIdentity,
+      ...(metadata !== undefined ? { metadata } : {}),
       runId: runIdentity.runId,
       ...(traceRuntime ? { traceRuntime } : {}),
       taskSpans: new Map(),
@@ -3609,11 +3679,15 @@ export class OpenMultiAgent {
       ctx.outcomeStatus,
       ctx.outcomeErrorInfo,
     )
+    const completedResult: TeamRunResult = {
+      ...result,
+      ...(metadata !== undefined ? { metadata } : {}),
+    }
     traceRuntime?.close({
-      status: result.status ?? statusOnly(result.success ? 'ok' : 'error'),
-      ...(result.errorInfo ? { error: result.errorInfo } : {}),
+      status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
+      ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
     })
-    return result
+    return completedResult
   }
 
   private createActiveCheckpoint(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -199,6 +199,12 @@ export type RunIdentityLink = TraceLink
 export interface RunIdentityOptions {
   /** Optional logical run identifier (1-128 characters). */
   readonly runId?: string
+  /**
+   * Per-run metadata, e.g. promptVersion / experiment / datasetTag.
+   * Validated, written to root span attributes as `oma.meta.<key>`,
+   * and echoed on the run result.
+   */
+  readonly metadata?: Readonly<Record<string, TraceAttributeValue>>
 }
 
 /** Per-call options for {@link OpenMultiAgent.runAgent}. */
@@ -257,6 +263,8 @@ export interface RunOutcomeFields {
   /** Runtime results always include this field; see {@link identity}. */
   readonly status?: RunStatus
   readonly errorInfo?: StructuredTraceError
+  /** Echo of validated metadata; present at runtime whenever the caller provided it. */
+  readonly metadata?: Readonly<Record<string, TraceAttributeValue>>
 }
 
 /** Context passed to user-supplied cost estimators. */
@@ -1577,6 +1585,8 @@ export interface CompletedTaskCheckpoint {
 interface CheckpointSnapshotBase {
   readonly mode: 'runTeam' | 'runTasks'
   readonly createdAt: string
+  /** Validated per-run metadata inherited by future restore attempts. */
+  readonly metadata?: Readonly<Record<string, TraceAttributeValue>>
   readonly goal?: string
   readonly queue: TaskQueueSnapshot
   readonly sharedMemory?: SharedMemorySnapshot

--- a/packages/core/tests/eval-run-metadata.test.ts
+++ b/packages/core/tests/eval-run-metadata.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Checkpoint } from '../src/memory/checkpoint.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import { InMemoryTraceStore } from '../src/observability/in-memory-store.js'
+import type { SpanEndRecord, TraceRecord } from '../src/observability/records.js'
+import { TRACE_RECORD_OBSERVER } from '../src/observability/runtime.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { TaskQueue } from '../src/task/queue.js'
+import { createTask } from '../src/task/task.js'
+import { Team } from '../src/team/team.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMChatOptions,
+  LLMMessage,
+  LLMResponse,
+  OrchestratorConfig,
+  RunOutcomeFields,
+  TraceAttributeValue,
+} from '../src/types.js'
+
+const METADATA = { prompt_version: 'v3', experiment: 'routing_ab' } as const
+
+function response(text: string): LLMResponse {
+  return {
+    id: `response-${text}`,
+    content: [{ type: 'text', text }],
+    model: 'test-model',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function adapter(
+  chat: (messages: LLMMessage[], options: LLMChatOptions) => Promise<LLMResponse>,
+): LLMAdapter {
+  return { name: 'run-metadata-test', chat, async *stream() { /* unused */ } }
+}
+
+function staticAdapter(text = 'ok'): LLMAdapter {
+  return adapter(async () => response(text))
+}
+
+function agentConfig(name = 'worker', llm: LLMAdapter = staticAdapter()): AgentConfig {
+  return { name, model: 'test-model', adapter: llm }
+}
+
+function teamWith(llm: LLMAdapter = staticAdapter()): Team {
+  return new Team({ name: 'team', agents: [agentConfig('worker', llm)] })
+}
+
+function tracedOrchestrator(records: TraceRecord[]): OpenMultiAgent {
+  return new OpenMultiAgent({
+    defaultModel: 'test-model',
+    [TRACE_RECORD_OBSERVER]: (record: TraceRecord) => records.push(record),
+  } as OrchestratorConfig & { [TRACE_RECORD_OBSERVER]: (record: TraceRecord) => void })
+}
+
+function rootEnd(records: readonly TraceRecord[], traceId: string | undefined): SpanEndRecord {
+  const record = records.find((candidate): candidate is SpanEndRecord =>
+    candidate.traceId === traceId
+    && candidate.recordType === 'span_end'
+    && candidate.kind === 'run'
+    && candidate.parentSpanId === undefined)
+  expect(record).toBeDefined()
+  return record!
+}
+
+function expectMetadata(
+  result: RunOutcomeFields,
+  records: readonly TraceRecord[],
+  expected: Readonly<Record<string, TraceAttributeValue>>,
+): void {
+  expect(result.metadata).toEqual(expected)
+  const attributes = rootEnd(records, result.identity?.traceId).attributes
+  for (const [key, value] of Object.entries(expected)) {
+    expect(attributes[`oma.meta.${key}`]).toEqual(value)
+  }
+}
+
+function expectNoMetadata(result: RunOutcomeFields, records: readonly TraceRecord[]): void {
+  expect(Object.hasOwn(result, 'metadata')).toBe(false)
+  expect(Object.keys(rootEnd(records, result.identity?.traceId).attributes)
+    .some((key) => key.startsWith('oma.meta.'))).toBe(false)
+}
+
+async function runTopLevelEntries(
+  oma: OpenMultiAgent,
+  metadata: Readonly<Record<string, TraceAttributeValue>> | undefined,
+): Promise<RunOutcomeFields[]> {
+  const options = metadata === undefined ? {} : { metadata }
+  const runAgent = await oma.runAgent(agentConfig(), 'hello', options)
+  const runTeam = await oma.runTeam(teamWith(), 'Say hello', options)
+  const runTasks = await oma.runTasks(teamWith(), [
+    { title: 'task', description: 'work', assignee: 'worker' },
+  ], options)
+  const runFromPlan = await oma.runFromPlan(teamWith(), {
+    version: 1,
+    tasks: [{ id: 'planned', title: 'planned', description: 'work', assignee: 'worker' }],
+  }, options)
+
+  let consensusCall = 0
+  const consensusAdapter = adapter(async () => response(
+    consensusCall++ === 0 ? 'answer' : '{"accept":true,"critique":""}',
+  ))
+  const runConsensus = await oma.runConsensus(teamWith(), 'question', {
+    proposer: agentConfig('proposer', consensusAdapter),
+    judges: [agentConfig('judge', consensusAdapter)],
+    maxRounds: 1,
+    ...options,
+  })
+
+  const store = new InMemoryStore()
+  await oma.runTasks(teamWith(), [
+    { title: 'checkpointed', description: 'work', assignee: 'worker' },
+  ], { checkpoint: { store, runId: 'metadata-restore' }, ...options })
+  const restore = await oma.restore(teamWith(), {
+    checkpoint: { store, runId: 'metadata-restore' },
+  })
+
+  return [runAgent, runTeam, runTasks, runFromPlan, runConsensus, restore]
+}
+
+describe('per-run metadata', () => {
+  it('echoes metadata and writes root attributes for all six top-level entries', async () => {
+    const records: TraceRecord[] = []
+    const results = await runTopLevelEntries(tracedOrchestrator(records), METADATA)
+
+    expect(results).toHaveLength(6)
+    for (const result of results) expectMetadata(result, records, METADATA)
+  })
+
+  it('omits metadata from results and root spans for all six entries when absent', async () => {
+    const records: TraceRecord[] = []
+    const results = await runTopLevelEntries(tracedOrchestrator(records), undefined)
+
+    expect(results).toHaveLength(6)
+    for (const result of results) expectNoMetadata(result, records)
+  })
+
+  it('rejects invalid keys, counts, reserved prefixes, and values before a run starts', async () => {
+    const chat = vi.fn(async () => response('unused'))
+    const oma = new OpenMultiAgent({ defaultModel: 'test-model' })
+    const invalidMetadata: unknown[] = [
+      { 'Prompt.Version': 'v1' },
+      { 'invalid-key': 'v1' },
+      { ['x'.repeat(65)]: 'v1' },
+      { '': 'v1' },
+      { 'oma.reserved': 'v1' },
+      { _overridden: false },
+      Object.fromEntries(Array.from({ length: 33 }, (_, index) => [`key_${index}`, index])),
+      { nested: { value: true } },
+      { mixed: ['a', 1] },
+      { invalid_number: Number.NaN },
+      { invalid_array_number: [Number.POSITIVE_INFINITY] },
+      null,
+      [],
+    ]
+
+    for (const metadata of invalidMetadata) {
+      await expect(oma.runAgent(agentConfig('worker', adapter(chat)), 'hello', {
+        metadata: metadata as never,
+      })).rejects.toThrow(/metadata|reserved|oma\./)
+    }
+    expect(chat).not.toHaveBeenCalled()
+  })
+
+  it('truncates string values to 1024 characters and echoes without observability configured', async () => {
+    const long = 'x'.repeat(1_100)
+    const result = await new OpenMultiAgent({ defaultModel: 'test-model' }).runAgent(
+      agentConfig(),
+      'hello',
+      { metadata: { scalar: long, strings: [long, 'short'] } },
+    )
+
+    expect(result.metadata).toEqual({ scalar: 'x'.repeat(1_024), strings: ['x'.repeat(1_024), 'short'] })
+  })
+
+  it('persists metadata, inherits it on restore, and marks a different explicit override', async () => {
+    const records: TraceRecord[] = []
+    const store = new InMemoryStore()
+    const oma = tracedOrchestrator(records)
+    const initial = await oma.runTasks(teamWith(), [
+      { title: 'task', description: 'work', assignee: 'worker' },
+    ], {
+      metadata: METADATA,
+      checkpoint: { store, runId: 'logical-metadata-run' },
+    })
+
+    const stored = await new Checkpoint(store, { runId: 'logical-metadata-run' }).loadLatest()
+    expect(stored?.metadata).toEqual(METADATA)
+
+    const inherited = await oma.restore(teamWith(), {
+      checkpoint: { store, runId: 'logical-metadata-run' },
+    })
+    expectMetadata(inherited, records, METADATA)
+    expect(rootEnd(records, inherited.identity?.traceId).attributes['oma.meta._overridden']).toBeUndefined()
+
+    const overriddenMetadata = { prompt_version: 'v4', dataset_tag: 'holdout' } as const
+    const overridden = await oma.restore(teamWith(), {
+      metadata: overriddenMetadata,
+      checkpoint: { store, runId: 'logical-metadata-run' },
+    })
+    expectMetadata(overridden, records, overriddenMetadata)
+    expect(rootEnd(records, overridden.identity?.traceId).attributes['oma.meta._overridden']).toBe(true)
+    expect(overridden.identity?.attempt).toBe(3)
+    expect(overridden.identity?.runId).toBe(initial.identity?.runId)
+
+    const updated = await new Checkpoint(store, { runId: 'logical-metadata-run' }).loadLatest()
+    expect(updated?.metadata).toEqual(overriddenMetadata)
+
+    const traceStore = new InMemoryTraceStore()
+    await traceStore.append(records)
+    expect((await traceStore.getRun('logical-metadata-run'))?.metadata).toEqual(overriddenMetadata)
+  })
+
+  it('reads legacy checkpoints without metadata', async () => {
+    const store = new InMemoryStore()
+    const queue = new TaskQueue()
+    const task = { ...createTask({ title: 'task', description: 'work', assignee: 'worker' }), id: 'task' }
+    queue.add(task)
+    queue.complete('task', 'done')
+    await new Checkpoint(store, { runId: 'legacy-metadata-run' }).save({
+      version: 1,
+      mode: 'runTasks',
+      createdAt: new Date().toISOString(),
+      runId: 'legacy-metadata-run',
+      queue: queue.snapshot(),
+      completedTaskResults: [{ taskId: 'task', assignee: 'worker', result: 'done' }],
+    })
+
+    const result = await new OpenMultiAgent({ defaultModel: 'test-model' }).restore(teamWith(), {
+      checkpoint: { store, runId: 'legacy-metadata-run' },
+    })
+    expect(Object.hasOwn(result, 'metadata')).toBe(false)
+  })
+
+  it('materializes latest root metadata into RunSummary without adding query filters', async () => {
+    const records: TraceRecord[] = []
+    const oma = tracedOrchestrator(records)
+    const withMetadata = await oma.runTasks(teamWith(), [], {
+      runId: 'summary-with-metadata',
+      metadata: METADATA,
+    })
+    const withoutMetadata = await oma.runTasks(teamWith(), [], { runId: 'summary-without-metadata' })
+    const store = new InMemoryTraceStore()
+    await store.append(records)
+
+    expect((await store.getRun(withMetadata.identity!.runId))?.metadata).toEqual(METADATA)
+    expect((await store.getRun(withoutMetadata.identity!.runId))?.metadata).toBeUndefined()
+    const page = await store.queryRuns({ order: 'started_asc' })
+    expect(page.items).toHaveLength(2)
+    expect(page.items.find((run) => run.runId === withMetadata.identity!.runId)?.metadata).toEqual(METADATA)
+    expect(page.items.find((run) => run.runId === withoutMetadata.identity!.runId)?.metadata).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- add validated per-run metadata to every top-level execution API and echo normalized values on results
- write metadata to root span attributes, persist it in checkpoints, and support inherit/override semantics on restore
- materialize root metadata into `RunSummary` while leaving `TraceQuery` and resource-level observability unchanged
- document the public contract and cover all execution paths, validation boundaries, restore compatibility, and trace storage

## Contract

- keys match `[a-z0-9_.]{1,64}`, with at most 32 entries per run
- `oma.` and the framework restore key `_overridden` are reserved
- values use `TraceAttributeValue`; strings are truncated to 1,024 characters
- explicit restore metadata takes precedence over checkpoint metadata and records `oma.meta._overridden=true`
- legacy checkpoints without metadata remain readable

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- targeted identity, span, checkpoint, TraceStore, FileTraceStore, documentation, and per-run metadata tests after rebasing onto the latest `main`
- `npm pack --dry-run --json -w @open-multi-agent/core`
- `git diff --check`
