### PR TITLE
refactor(core): dedupe agent-default expansion into applyAgentDefaults()

### DIFF
--- a/packages/core/src/orchestrator/agent-config.ts
+++ b/packages/core/src/orchestrator/agent-config.ts
@@ -18,6 +18,28 @@ import { ToolRegistry } from '../tool/framework.js'
 import { ToolExecutor } from '../tool/executor.js'
 import { registerBuiltInTools } from '../tool/built-in/index.js'
 
+export interface AgentDefaultsSource {
+  readonly defaultModel?: OrchestratorConfig['defaultModel']
+  readonly defaultProvider?: OrchestratorConfig['defaultProvider']
+  readonly defaultBaseURL?: OrchestratorConfig['defaultBaseURL']
+  readonly defaultApiKey?: OrchestratorConfig['defaultApiKey']
+  readonly defaultCwd?: OrchestratorConfig['defaultCwd']
+  readonly onToolCall?: OrchestratorConfig['onToolCall']
+}
+
+/** Apply the orchestrator-level defaults shared by ephemeral agent configs. */
+export function applyAgentDefaults(config: AgentConfig, src: AgentDefaultsSource): AgentConfig {
+  return {
+    ...config,
+    model: config.model ?? src.defaultModel,
+    provider: config.provider ?? src.defaultProvider,
+    baseURL: config.baseURL ?? src.defaultBaseURL,
+    apiKey: config.apiKey ?? src.defaultApiKey,
+    cwd: config.cwd === undefined ? src.defaultCwd : config.cwd,
+    onToolCall: config.onToolCall ?? src.onToolCall,
+  }
+}
+
 /**
  * Build a minimal {@link Agent} with its own fresh registry/executor.
  * Pool workers pass `includeDelegateTool` so `delegate_to_agent` is available during `runTeam` / `runTasks`.

--- a/packages/core/src/orchestrator/consensus.ts
+++ b/packages/core/src/orchestrator/consensus.ts
@@ -32,7 +32,7 @@ import {
   type RunContext,
 } from './run-context.js'
 import { recordRunUsage, buildCostEstimateContext } from './budget.js'
-import { buildAgent } from './agent-config.js'
+import { applyAgentDefaults, buildAgent } from './agent-config.js'
 
 /** Orchestrator-level defaults applied to ephemeral consensus agents. */
 export interface ConsensusAgentDefaults {
@@ -69,15 +69,7 @@ export const VERDICT_INSTRUCTION =
 
 /** Apply orchestrator defaults to a consensus agent config, mirroring buildPool. */
 export function applyConsensusDefaults(config: AgentConfig, defaults: ConsensusAgentDefaults): AgentConfig {
-  return {
-    ...config,
-    model: config.model ?? defaults.defaultModel,
-    provider: config.provider ?? defaults.defaultProvider,
-    baseURL: config.baseURL ?? defaults.defaultBaseURL,
-    apiKey: config.apiKey ?? defaults.defaultApiKey,
-    cwd: config.cwd === undefined ? defaults.defaultCwd : config.cwd,
-    onToolCall: config.onToolCall ?? defaults.onToolCall,
-  }
+  return applyAgentDefaults(config, defaults)
 }
 
 /** Build the user prompt sent to a single judge, always including the original question. */

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -121,6 +121,7 @@ import {
 } from './budget.js'
 import {
   buildAgent,
+  applyAgentDefaults,
   applyDefaultToolPreset,
   routeMatches,
   withModelRoute,
@@ -283,14 +284,8 @@ export class OpenMultiAgent {
     const traceRuntime = this.startTrace(identity, metadata)
     const effectiveBudget = resolveTokenBudget(config.maxTokenBudget, this.config.maxTokenBudget)
     const effective: AgentConfig = applyDefaultToolPreset({
-      ...config,
-      model: config.model ?? this.config.defaultModel,
-      provider: config.provider ?? this.config.defaultProvider,
-      baseURL: config.baseURL ?? this.config.defaultBaseURL,
-      apiKey: config.apiKey ?? this.config.defaultApiKey,
-      cwd: config.cwd === undefined ? this.config.defaultCwd : config.cwd,
+      ...applyAgentDefaults(config, this.config),
       maxTokenBudget: effectiveBudget,
-      onToolCall: config.onToolCall ?? this.config.onToolCall,
     }, this.config.defaultToolPreset)
     const agent = buildAgent(effective)
     this.config.onProgress?.({
@@ -454,14 +449,8 @@ export class OpenMultiAgent {
       // Events are emitted here; counting is handled by buildTeamRunResult().
       const effectiveBudget = resolveTokenBudget(bestAgent.maxTokenBudget, this.config.maxTokenBudget)
       const effective: AgentConfig = withModelRoute(applyDefaultToolPreset({
-        ...bestAgent,
-        model: bestAgent.model ?? this.config.defaultModel,
-        provider: bestAgent.provider ?? this.config.defaultProvider,
-        baseURL: bestAgent.baseURL ?? this.config.defaultBaseURL,
-        apiKey: bestAgent.apiKey ?? this.config.defaultApiKey,
-        cwd: bestAgent.cwd === undefined ? this.config.defaultCwd : bestAgent.cwd,
+        ...applyAgentDefaults(bestAgent, this.config),
         maxTokenBudget: effectiveBudget,
-        onToolCall: bestAgent.onToolCall ?? this.config.onToolCall,
       }, this.config.defaultToolPreset), routeMatches(options?.modelRouting, { phase: 'short-circuit', agent: bestAgent.name }))
       const agent = buildAgent(effective)
 
@@ -1580,15 +1569,10 @@ export class OpenMultiAgent {
   private buildPool(agentConfigs: AgentConfig[]): AgentPool {
     const pool = new AgentPool(this.config.maxConcurrency)
     for (const config of agentConfigs) {
-      const effective: AgentConfig = applyDefaultToolPreset({
-        ...config,
-        model: config.model ?? this.config.defaultModel,
-        provider: config.provider ?? this.config.defaultProvider,
-        baseURL: config.baseURL ?? this.config.defaultBaseURL,
-        apiKey: config.apiKey ?? this.config.defaultApiKey,
-        cwd: config.cwd === undefined ? this.config.defaultCwd : config.cwd,
-        onToolCall: config.onToolCall ?? this.config.onToolCall,
-      }, this.config.defaultToolPreset)
+      const effective: AgentConfig = applyDefaultToolPreset(
+        applyAgentDefaults(config, this.config),
+        this.config.defaultToolPreset,
+      )
       pool.add(buildAgent(effective, { includeDelegateTool: true }))
     }
     return pool

--- a/packages/core/src/orchestrator/task-execution.ts
+++ b/packages/core/src/orchestrator/task-execution.ts
@@ -38,7 +38,13 @@ import {
   type RevealCoordinatorContext,
 } from './run-context.js'
 import { recordRunUsage, buildCostEstimateContext } from './budget.js'
-import { routeMatches, withModelRoute, applyDefaultToolPreset, buildAgent } from './agent-config.js'
+import {
+  routeMatches,
+  withModelRoute,
+  applyAgentDefaults,
+  applyDefaultToolPreset,
+  buildAgent,
+} from './agent-config.js'
 import { executeWithRetry } from './retry.js'
 import { runTaskVerify } from './consensus.js'
 
@@ -101,15 +107,10 @@ export function buildTaskAgentTeamInfo(
       task: ctx.taskById.get(taskId),
       leaf: ctx.taskLeafById.get(taskId),
     })
-    const effective: AgentConfig = withModelRoute(applyDefaultToolPreset({
-      ...targetConfig,
-      model: targetConfig.model ?? ctx.config.defaultModel,
-      provider: targetConfig.provider ?? ctx.config.defaultProvider,
-      baseURL: targetConfig.baseURL ?? ctx.config.defaultBaseURL,
-      apiKey: targetConfig.apiKey ?? ctx.config.defaultApiKey,
-      cwd: targetConfig.cwd === undefined ? ctx.config.defaultCwd : targetConfig.cwd,
-      onToolCall: targetConfig.onToolCall ?? ctx.config.onToolCall,
-    }, ctx.config.defaultToolPreset), route)
+    const effective: AgentConfig = withModelRoute(applyDefaultToolPreset(
+      applyAgentDefaults(targetConfig, ctx.config),
+      ctx.config.defaultToolPreset,
+    ), route)
     const tempAgent = buildAgent(effective, { includeDelegateTool: true })
 
     const delegatedParentId = traceBase.traceSpanId ?? traceBase.traceParentId
@@ -404,15 +405,10 @@ export async function executeQueue(
           task,
           leaf: ctx.taskLeafById.get(task.id),
         })
-        const workerEffectiveConfig = withModelRoute(applyDefaultToolPreset({
-          ...agentConfig,
-          model: agentConfig.model ?? config.defaultModel,
-          provider: agentConfig.provider ?? config.defaultProvider,
-          baseURL: agentConfig.baseURL ?? config.defaultBaseURL,
-          apiKey: agentConfig.apiKey ?? config.defaultApiKey,
-          cwd: agentConfig.cwd === undefined ? config.defaultCwd : agentConfig.cwd,
-          onToolCall: agentConfig.onToolCall ?? config.onToolCall,
-        }, config.defaultToolPreset), workerRoute)
+        const workerEffectiveConfig = withModelRoute(applyDefaultToolPreset(
+          applyAgentDefaults(agentConfig, config),
+          config.defaultToolPreset,
+        ), workerRoute)
         const routedAgent = workerRoute
           ? buildAgent(workerEffectiveConfig, { includeDelegateTool: true })
           : undefined


### PR DESCRIPTION
## Summary

- add an internal `AgentDefaultsSource` contract and `applyAgentDefaults()` helper
- replace the six repeated agent-default expansions across orchestrator, task execution, and consensus
- preserve the existing `defaultToolPreset`, token-budget, and model-routing asymmetries at each call site

## Context

This is the behavior-equivalent cleanup after the orchestrator split in #397, #400, and #401. Adding another orchestrator-level agent default now requires changing one expansion instead of keeping six copies synchronized.

No new behavior or public API is introduced. Consensus proposer/judge agents still do not inherit `defaultToolPreset`, while the other five call sites still do. `maxTokenBudget` remains local to `runAgent` and the short-circuit path, and existing `withModelRoute()` wrapping remains unchanged.

## Verification

- `npm run lint`
- `npm test` — core: 93 files / 1385 tests; create-oma-app: 4 files / 26 tests; otel: 3 files / 15 tests
- focused tests: token-budget, consensus, default-deny-tools, runteam-verify, short-circuit — 5 files / 95 tests
- `npm run build`
- `packages/core/dist/index.d.ts` is byte-for-byte identical to the pre-change main build (SHA-256: `c2f09d57b8482265346611a55f63223bdb2a0801b71410ff757244677b437e46`)
- `git diff -- packages/core/tests` is empty
- `git diff --check`
