### PR TITLE
feat(core): add evaluation scorer contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Smoke-test that the built entry points import and the CLI runs
         working-directory: packages/core
         run: |
-          node -e "Promise.all([import('./dist/index.js'), import('./dist/observability/index.js'), import('./dist/observability/file.js'), import('./dist/acp.js'), import('./dist/process.js'), import('./dist/mcp.js'), import('./dist/ai-sdk.js')]).then(() => console.log('entry points import OK')).catch((e) => { console.error(e); process.exit(1); })"
+          node -e "Promise.all([import('./dist/index.js'), import('./dist/observability/index.js'), import('./dist/observability/file.js'), import('./dist/acp.js'), import('./dist/process.js'), import('./dist/mcp.js'), import('./dist/ai-sdk.js'), import('./dist/eval/index.js')]).then(() => console.log('entry points import OK')).catch((e) => { console.error(e); process.exit(1); })"
           node dist/cli/oma.js help > /dev/null
           echo "CLI help runs OK"
       - name: Assert the create-oma-app template pins the current core version
@@ -99,7 +99,7 @@ jobs:
             exit 1
           fi
           missing=""
-          for f in dist/index.js dist/index.d.ts dist/observability/index.js dist/observability/index.d.ts dist/observability/file.js dist/observability/file.d.ts dist/cli/oma.js dist/acp.js dist/acp.d.ts dist/process.js dist/process.d.ts dist/mcp.js dist/mcp.d.ts dist/ai-sdk.js dist/ai-sdk.d.ts; do
+          for f in dist/index.js dist/index.d.ts dist/observability/index.js dist/observability/index.d.ts dist/observability/file.js dist/observability/file.d.ts dist/cli/oma.js dist/acp.js dist/acp.d.ts dist/process.js dist/process.d.ts dist/mcp.js dist/mcp.d.ts dist/ai-sdk.js dist/ai-sdk.d.ts dist/eval/index.js dist/eval/index.d.ts; do
             echo "$paths" | grep -qxF "$f" || missing="$missing $f"
           done
           if [ -n "$missing" ]; then

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,0 +1,70 @@
+# Evaluation
+
+The experimental `@open-multi-agent/core/eval` subpath defines quality scorers for offline regression checks and future online sampling. Evaluation runs outside the business execution path: it observes a result but never changes that result.
+
+## Define a scorer
+
+```ts
+import { defineScorer, type ScorerContext } from '@open-multi-agent/core/eval'
+
+const exact = defineScorer({
+  name: 'exact-match',
+  version: '1',
+  score({ output, evalCase }) {
+    const hit = output === evalCase.expected
+    return { score: hit ? 1 : 0, pass: hit }
+  },
+})
+
+const context: ScorerContext = {
+  evalCase: { id: 'capital-france', input: 'Capital of France?', expected: 'Paris' },
+  output: 'Paris',
+  metadata: { promptVersion: 'v2' },
+  signal: new AbortController().signal,
+}
+
+const result = await exact.score(context)
+console.log(result.score) // 1
+```
+
+Scores must be finite numbers from `0` through `1`. `pass` is optional so a later gate can apply its own threshold. `defineScorer()` freezes the scorer definition and validates both synchronous and asynchronous results.
+
+## Scorer failures are not zero scores
+
+A scorer that throws, rejects, or exceeds its timeout has not measured quality. Callers must record that outcome as an `EvalRecord` with `status: 'scorer_error'`, normalize the error with `classifyRunFailure()`, and exclude it from score averages, percentiles, and pass rates. Do not replace scorer failures with `{ score: 0 }`.
+
+The eval subpath defines the `EvalRecord` shape and schema major version. Eval runners and stores are separate, later capabilities.
+
+## Use OMA agents as judges
+
+```ts
+import { z } from 'zod'
+import { createJudgeScorer } from '@open-multi-agent/core/eval'
+
+const relevancy = createJudgeScorer({
+  name: 'relevancy',
+  version: 'prompt-v1',
+  judges: [
+    { name: 'judge-a', model: 'claude-sonnet-4-6', provider: 'anthropic' },
+    { name: 'judge-b', model: 'gpt-5', provider: 'openai' },
+  ],
+  quorum: 2,
+  timeoutMs: 30_000,
+  verdictSchema: z.object({
+    score: z.number().min(0).max(1),
+    pass: z.boolean(),
+    reason: z.string(),
+  }),
+})
+
+const result = await relevancy.score(context)
+console.log(result.score, result.pass)
+```
+
+Judge scores are averaged. When the verdict schema returns a boolean `pass`, the scorer returns `pass: true` after the configured quorum is reached. The default verdict schema contains only `score` and `reason`, so the default result leaves `pass` undefined.
+
+`result.details.judges`, `result.details.models`, and `result.details.scores` are parallel arrays: values at the same index describe one judge. This flat representation remains compatible with trace attribute values while preserving model-drift evidence. Bump the scorer `version` whenever judge models, configuration, or prompts change.
+
+## Runtime verification versus evaluation
+
+Use `runConsensus()` or per-task `verify` to accept, revise, or reject a result during a live business run. Use scorers to measure regressions and trends after or alongside a run. Runtime verification can affect the business result; evaluation never does. The two mechanisms can be used together.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,10 @@
       "types": "./dist/classifiers.d.ts",
       "import": "./dist/classifiers.js"
     },
+    "./eval": {
+      "types": "./dist/eval/index.d.ts",
+      "import": "./dist/eval/index.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/core/src/eval/evalcase.ts
+++ b/packages/core/src/eval/evalcase.ts
@@ -1,0 +1,10 @@
+import type { TraceAttributeValue } from '../types.js'
+
+/** One input/output expectation evaluated by one or more scorers. */
+export interface EvalCase {
+  readonly id: string
+  readonly input: unknown
+  readonly expected?: unknown
+  readonly tags?: readonly string[]
+  readonly metadata?: Readonly<Record<string, TraceAttributeValue>>
+}

--- a/packages/core/src/eval/index.ts
+++ b/packages/core/src/eval/index.ts
@@ -1,0 +1,8 @@
+export { defineScorer } from './scorer.js'
+export type { ScoreResult, Scorer, ScorerContext } from './scorer.js'
+export { createJudgeScorer } from './judge.js'
+export type { JudgeScorerOptions } from './judge.js'
+export { EVAL_STORE_SCHEMA_MAJOR } from './record.js'
+export type { EvalRecord } from './record.js'
+export type { EvalCase } from './evalcase.js'
+export type { MemoryExtractionSample, MemoryRetrievalSample } from './memory-types.js'

--- a/packages/core/src/eval/judge.ts
+++ b/packages/core/src/eval/judge.ts
@@ -1,0 +1,225 @@
+import { z, type ZodSchema } from 'zod'
+import type { AgentConfig } from '../types.js'
+import {
+  buildStructuredOutputInstruction,
+  extractJSON,
+  validateOutput,
+} from '../agent/structured-output.js'
+import { defineScorer, type Scorer, type ScorerContext } from './scorer.js'
+
+export interface JudgeScorerOptions {
+  readonly name: string
+  readonly version?: string
+  readonly judges: readonly AgentConfig[]
+  readonly quorum?: number
+  readonly verdictSchema?: ZodSchema
+  readonly judgePrompt?: string | ((context: ScorerContext) => string)
+  readonly timeoutMs?: number
+}
+
+interface JudgeVerdict {
+  readonly judge: string
+  readonly model: string
+  readonly score: number
+  readonly pass?: boolean
+  readonly reason?: string
+}
+
+const DEFAULT_VERDICT_SCHEMA = z.object({
+  score: z.number().min(0).max(1),
+  reason: z.string(),
+})
+
+const DEFAULT_JUDGE_INSTRUCTION =
+  'You are an impartial quality evaluator. Score how well the candidate output satisfies the case input and expected result.'
+
+function formatValue(value: unknown): string {
+  if (value === undefined) return '(not provided)'
+  if (typeof value === 'string') return value
+  const serialized = JSON.stringify(value, null, 2)
+  return serialized === undefined ? String(value) : serialized
+}
+
+function buildPrompt(
+  context: ScorerContext,
+  instruction: string,
+  verdictSchema: ZodSchema,
+): string {
+  return [
+    instruction,
+    '',
+    '## Case input',
+    formatValue(context.evalCase.input),
+    '',
+    '## Expected output',
+    formatValue(context.evalCase.expected),
+    '',
+    '## Candidate output',
+    formatValue(context.output),
+    '',
+    '## Evaluation metadata',
+    formatValue(context.metadata),
+    buildStructuredOutputInstruction(verdictSchema),
+  ].join('\n')
+}
+
+function parseVerdict(output: string, schema: ZodSchema, judge: AgentConfig): JudgeVerdict {
+  const validated = validateOutput(schema, extractJSON(output))
+  if (typeof validated !== 'object' || validated === null || Array.isArray(validated)) {
+    throw new TypeError(`Judge "${judge.name}" verdict must be an object.`)
+  }
+
+  const verdict = validated as Record<string, unknown>
+  if (
+    typeof verdict['score'] !== 'number'
+    || !Number.isFinite(verdict['score'])
+    || verdict['score'] < 0
+    || verdict['score'] > 1
+  ) {
+    throw new RangeError(`Judge "${judge.name}" verdict.score must be in the range [0, 1].`)
+  }
+  if (verdict['pass'] !== undefined && typeof verdict['pass'] !== 'boolean') {
+    throw new TypeError(`Judge "${judge.name}" verdict.pass must be a boolean when provided.`)
+  }
+  if (verdict['reason'] !== undefined && typeof verdict['reason'] !== 'string') {
+    throw new TypeError(`Judge "${judge.name}" verdict.reason must be a string when provided.`)
+  }
+
+  return {
+    judge: judge.name,
+    model: judge.model ?? (judge.backend ? `${judge.backend.kind}-backend` : 'unknown'),
+    score: verdict['score'],
+    ...(typeof verdict['pass'] === 'boolean' ? { pass: verdict['pass'] } : {}),
+    ...(typeof verdict['reason'] === 'string' ? { reason: verdict['reason'] } : {}),
+  }
+}
+
+function abortError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) return signal.reason
+  const error = new Error('Judge scorer was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+function createDeadline(
+  callerSignal: AbortSignal,
+  timeoutMs: number | undefined,
+): { readonly signal: AbortSignal; dispose(): void } {
+  const controller = new AbortController()
+  const onCallerAbort = () => controller.abort(callerSignal.reason)
+  callerSignal.addEventListener('abort', onCallerAbort, { once: true })
+  if (callerSignal.aborted) onCallerAbort()
+
+  const timer = timeoutMs === undefined ? undefined : setTimeout(() => {
+    const error = new Error(`Judge scorer exceeded timeout of ${timeoutMs}ms.`)
+    error.name = 'TimeoutError'
+    controller.abort(error)
+  }, timeoutMs)
+
+  return {
+    signal: controller.signal,
+    dispose() {
+      callerSignal.removeEventListener('abort', onCallerAbort)
+      if (timer !== undefined) clearTimeout(timer)
+    },
+  }
+}
+
+async function raceWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) throw abortError(signal)
+
+  let onAbort: (() => void) | undefined
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(abortError(signal))
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+
+  try {
+    return await Promise.race([promise, aborted])
+  } finally {
+    if (onAbort) signal.removeEventListener('abort', onAbort)
+  }
+}
+
+async function runJudge(
+  judge: AgentConfig,
+  prompt: string,
+  schema: ZodSchema,
+  signal: AbortSignal,
+): Promise<JudgeVerdict> {
+  // Keep the eval barrel browser-safe to import. The Node-capable Agent path is
+  // loaded only when a judge scorer actually executes.
+  const { buildAgent } = await import('../orchestrator/agent-config.js')
+  const result = await buildAgent(judge).run(prompt, { abortSignal: signal })
+  if (!result.success) {
+    if (result.error instanceof Error) throw result.error
+    throw new Error(result.errorInfo?.message ?? `Judge "${judge.name}" failed.`)
+  }
+  return parseVerdict(result.output, schema, judge)
+}
+
+/** Create an OMA-agent-backed scorer with mean-score and quorum aggregation. */
+export function createJudgeScorer(options: JudgeScorerOptions): Scorer {
+  if (!Array.isArray(options.judges) || options.judges.length === 0) {
+    throw new TypeError('JudgeScorerOptions.judges must contain at least one judge.')
+  }
+  const judges = options.judges.map((judge) => ({ ...judge }))
+  const quorum = options.quorum ?? Math.ceil(judges.length / 2)
+  if (!Number.isInteger(quorum) || quorum < 1 || quorum > judges.length) {
+    throw new RangeError('JudgeScorerOptions.quorum must be an integer between 1 and judges.length.')
+  }
+  if (
+    options.timeoutMs !== undefined
+    && (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0)
+  ) {
+    throw new RangeError('JudgeScorerOptions.timeoutMs must be a positive finite number.')
+  }
+
+  const schema = options.verdictSchema ?? DEFAULT_VERDICT_SCHEMA
+  const judgePrompt = options.judgePrompt
+  const timeoutMs = options.timeoutMs
+  return defineScorer({
+    name: options.name,
+    ...(options.version !== undefined ? { version: options.version } : {}),
+    ...(options.timeoutMs !== undefined ? { timeoutMs: options.timeoutMs } : {}),
+    async score(context) {
+      const instruction = typeof judgePrompt === 'function'
+        ? judgePrompt(context)
+        : judgePrompt ?? DEFAULT_JUDGE_INSTRUCTION
+      const prompt = buildPrompt(context, instruction, schema)
+      const deadline = createDeadline(context.signal, timeoutMs)
+
+      try {
+        const verdicts: JudgeVerdict[] = []
+        for (const judge of judges) {
+          verdicts.push(await raceWithAbort(
+            runJudge(judge, prompt, schema, deadline.signal),
+            deadline.signal,
+          ))
+        }
+
+        const score = verdicts.reduce((sum, verdict) => sum + verdict.score, 0) / verdicts.length
+        const passVotes = verdicts.filter((verdict) => verdict.pass === true).length
+        const hasPass = verdicts.some((verdict) => verdict.pass !== undefined)
+        const reasons = verdicts
+          .filter((verdict) => verdict.reason)
+          .map((verdict) => `${verdict.judge}: ${verdict.reason}`)
+
+        return {
+          score,
+          ...(hasPass ? { pass: passVotes >= quorum } : {}),
+          ...(reasons.length > 0 ? { reason: reasons.join('\n') } : {}),
+          // Parallel arrays keep the judge/model/score association by index
+          // while remaining valid TraceAttributeValue payloads.
+          details: {
+            judges: verdicts.map((verdict) => verdict.judge),
+            models: verdicts.map((verdict) => verdict.model),
+            scores: verdicts.map((verdict) => verdict.score),
+          },
+        }
+      } finally {
+        deadline.dispose()
+      }
+    },
+  })
+}

--- a/packages/core/src/eval/memory-types.ts
+++ b/packages/core/src/eval/memory-types.ts
@@ -1,0 +1,29 @@
+import type { TokenUsage } from '../types.js'
+
+/** @experimental Input shape reserved for future memory-extraction scorers. */
+export interface MemoryExtractionSample {
+  readonly conversation: unknown
+  readonly extracted: readonly {
+    readonly content: string
+    readonly kind?: string
+    readonly scope?: 'private' | 'team'
+    readonly provenance?: string
+  }[]
+  readonly costs?: {
+    readonly tokens?: TokenUsage
+    readonly durationMs?: number
+  }
+}
+
+/** @experimental Input shape reserved for future memory-retrieval scorers. */
+export interface MemoryRetrievalSample {
+  readonly query: unknown
+  readonly retrieved: readonly {
+    readonly content: string
+    readonly scope?: 'private' | 'team'
+  }[]
+  readonly available?: readonly {
+    readonly content: string
+    readonly scope?: 'private' | 'team'
+  }[]
+}

--- a/packages/core/src/eval/record.ts
+++ b/packages/core/src/eval/record.ts
@@ -1,0 +1,49 @@
+import type { RunCostSummary } from '../observability/store.js'
+import type {
+  StructuredTraceError,
+  TokenUsage,
+  TraceAttributeValue,
+} from '../types.js'
+
+export const EVAL_STORE_SCHEMA_MAJOR = 1 as const
+
+/** Serializable result of one target/scorer evaluation. */
+export interface EvalRecord {
+  readonly schemaVersion: 1
+  readonly recordId: string
+  readonly evalRunId: string
+  readonly source: 'offline' | 'online'
+  readonly timestampUnixMs: number
+  readonly evalSet?: { readonly name: string; readonly version: string }
+  readonly caseId?: string
+  readonly repeat?: number
+  readonly scorer: { readonly name: string; readonly version?: string }
+  /**
+   * `scorer_error` means the scorer threw, rejected, or timed out. It is not a
+   * score of zero and must be excluded from score aggregates.
+   */
+  readonly status: 'scored' | 'scorer_error' | 'target_error' | 'skipped'
+  /** Present only when scoring completed successfully. */
+  readonly score?: number
+  readonly pass?: boolean
+  readonly reason?: string
+  readonly details?: Readonly<Record<string, TraceAttributeValue>>
+  readonly runRef?: {
+    readonly runId: string
+    readonly attempt: number
+    readonly traceId: string
+    readonly rootSpanId: string
+  }
+  readonly metadata: Readonly<Record<string, TraceAttributeValue>>
+  readonly usage?: {
+    readonly tokens?: TokenUsage
+    readonly cost?: RunCostSummary
+    readonly durationMs?: number
+  }
+  readonly error?: StructuredTraceError
+  readonly payload?: {
+    readonly input?: string
+    readonly output?: string
+    readonly expected?: string
+  }
+}

--- a/packages/core/src/eval/scorer.ts
+++ b/packages/core/src/eval/scorer.ts
@@ -1,0 +1,122 @@
+import type {
+  AgentRunResult,
+  ConsensusResult,
+  TeamRunResult,
+  TraceAttributeValue,
+} from '../types.js'
+import type { StoredRun } from '../observability/store.js'
+import type { EvalCase } from './evalcase.js'
+
+/** Inputs available to every rule-based or model-based scorer. */
+export interface ScorerContext {
+  readonly evalCase: EvalCase
+  readonly output: unknown
+  readonly result?: AgentRunResult | TeamRunResult | ConsensusResult
+  readonly trace?: StoredRun
+  readonly metadata: Readonly<Record<string, TraceAttributeValue>>
+  readonly signal: AbortSignal
+}
+
+/** A normalized quality score. Scoring failures are thrown, never represented as score zero. */
+export interface ScoreResult {
+  /** A finite score in the inclusive range [0, 1]. */
+  readonly score: number
+  readonly pass?: boolean
+  readonly reason?: string
+  readonly details?: Readonly<Record<string, TraceAttributeValue>>
+}
+
+/** A named, optionally versioned quality scorer. */
+export interface Scorer {
+  readonly name: string
+  readonly version?: string
+  readonly timeoutMs?: number
+  score(context: ScorerContext): Promise<ScoreResult> | ScoreResult
+}
+
+function isTraceAttributeValue(value: unknown): value is TraceAttributeValue {
+  if (typeof value === 'string' || typeof value === 'boolean') return true
+  if (typeof value === 'number') return Number.isFinite(value)
+  if (!Array.isArray(value)) return false
+  if (value.length === 0) return true
+
+  const itemType = typeof value[0]
+  if (itemType !== 'string' && itemType !== 'number' && itemType !== 'boolean') return false
+  return value.every((item) => typeof item === itemType && (
+    typeof item !== 'number' || Number.isFinite(item)
+  ))
+}
+
+function validateScoreResult(value: unknown): ScoreResult {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new TypeError('Scorer must return a ScoreResult object.')
+  }
+
+  const result = value as Record<string, unknown>
+  if (
+    typeof result['score'] !== 'number'
+    || !Number.isFinite(result['score'])
+    || result['score'] < 0
+    || result['score'] > 1
+  ) {
+    throw new RangeError('ScoreResult.score must be a finite number in the range [0, 1].')
+  }
+  if (result['pass'] !== undefined && typeof result['pass'] !== 'boolean') {
+    throw new TypeError('ScoreResult.pass must be a boolean when provided.')
+  }
+  if (result['reason'] !== undefined && typeof result['reason'] !== 'string') {
+    throw new TypeError('ScoreResult.reason must be a string when provided.')
+  }
+  if (result['details'] !== undefined) {
+    if (
+      typeof result['details'] !== 'object'
+      || result['details'] === null
+      || Array.isArray(result['details'])
+    ) {
+      throw new TypeError('ScoreResult.details must be a trace-attribute record when provided.')
+    }
+    for (const detail of Object.values(result['details'])) {
+      if (!isTraceAttributeValue(detail)) {
+        throw new TypeError('ScoreResult.details values must be valid TraceAttributeValue values.')
+      }
+    }
+  }
+
+  return value as ScoreResult
+}
+
+/**
+ * Validate and freeze a scorer definition.
+ *
+ * The returned wrapper also validates every synchronous or asynchronous result.
+ * Rejections and thrown errors propagate unchanged so callers can record them as
+ * `scorer_error`; they are never converted to a score of zero.
+ */
+export function defineScorer(scorer: Scorer): Scorer {
+  if (typeof scorer !== 'object' || scorer === null) {
+    throw new TypeError('Scorer must be an object.')
+  }
+  if (typeof scorer.name !== 'string' || scorer.name.trim().length === 0) {
+    throw new TypeError('Scorer.name must be a non-empty string.')
+  }
+  if (typeof scorer.score !== 'function') {
+    throw new TypeError('Scorer.score must be a function.')
+  }
+
+  const score = scorer.score
+  const frozen: Scorer = {
+    ...scorer,
+    score(context) {
+      const result = score.call(scorer, context)
+      if (
+        typeof result === 'object'
+        && result !== null
+        && typeof (result as PromiseLike<ScoreResult>).then === 'function'
+      ) {
+        return Promise.resolve(result).then(validateScoreResult)
+      }
+      return validateScoreResult(result)
+    },
+  }
+  return Object.freeze(frozen)
+}

--- a/packages/core/tests/eval-judge.test.ts
+++ b/packages/core/tests/eval-judge.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import {
+  createJudgeScorer,
+  type ScorerContext,
+} from '../src/eval/index.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMMessage,
+  LLMResponse,
+} from '../src/types.js'
+
+function userPrompt(messages: LLMMessage[]): string {
+  const message = [...messages].reverse().find((candidate) => candidate.role === 'user')
+  return (message?.content ?? [])
+    .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n')
+}
+
+function responseAdapter(
+  reply: string | ((prompt: string) => string),
+  captures: string[] = [],
+): LLMAdapter {
+  return {
+    name: 'mock',
+    async chat(messages): Promise<LLMResponse> {
+      const prompt = userPrompt(messages)
+      captures.push(prompt)
+      return {
+        id: `response-${captures.length}`,
+        content: [{ type: 'text', text: typeof reply === 'function' ? reply(prompt) : reply }],
+        model: 'mock-model',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: {} }
+    },
+  }
+}
+
+function judge(name: string, reply: string, model = `model-${name}`): AgentConfig {
+  return { name, model, adapter: responseAdapter(reply) }
+}
+
+function context(overrides: Partial<ScorerContext> = {}): ScorerContext {
+  return {
+    evalCase: { id: 'case-1', input: 'What is 2 + 2?', expected: '4' },
+    output: '4',
+    metadata: { promptVersion: 'v2' },
+    signal: new AbortController().signal,
+    ...overrides,
+  }
+}
+
+const verdictWithPass = z.object({
+  score: z.number().min(0).max(1),
+  pass: z.boolean(),
+  reason: z.string(),
+})
+
+describe('createJudgeScorer', () => {
+  it('runs one judge with the default verdict and omits pass', async () => {
+    const scorer = createJudgeScorer({
+      name: 'relevancy',
+      judges: [judge('judge-1', '{"score":0.8,"reason":"relevant"}')],
+      quorum: 1,
+    })
+
+    const result = await scorer.score(context())
+    expect(result.score).toBe(0.8)
+    expect(result.pass).toBeUndefined()
+    expect(result.reason).toBe('judge-1: relevant')
+    expect(result.details).toEqual({
+      judges: ['judge-1'],
+      models: ['model-judge-1'],
+      scores: [0.8],
+    })
+  })
+
+  it('averages multiple judges and passes exactly at quorum', async () => {
+    const scorer = createJudgeScorer({
+      name: 'quality',
+      judges: [
+        judge('judge-a', '{"score":0.9,"pass":true,"reason":"strong"}'),
+        judge('judge-b', '{"score":0.7,"pass":true,"reason":"adequate"}'),
+        judge('judge-c', '{"score":0.2,"pass":false,"reason":"weak"}'),
+      ],
+      quorum: 2,
+      verdictSchema: verdictWithPass,
+    })
+
+    const result = await scorer.score(context())
+    expect(result.score).toBeCloseTo(0.6)
+    expect(result.pass).toBe(true)
+    expect(result.details?.['models']).toEqual([
+      'model-judge-a',
+      'model-judge-b',
+      'model-judge-c',
+    ])
+    expect(result.details?.['scores']).toEqual([0.9, 0.7, 0.2])
+  })
+
+  it('fails the binary verdict when one vote short of quorum', async () => {
+    const scorer = createJudgeScorer({
+      name: 'quality',
+      judges: [
+        judge('judge-a', '{"score":0.8,"pass":true,"reason":"yes"}'),
+        judge('judge-b', '{"score":0.6,"pass":false,"reason":"no"}'),
+        judge('judge-c', '{"score":0.5,"pass":false,"reason":"no"}'),
+      ],
+      quorum: 2,
+      verdictSchema: verdictWithPass,
+    })
+
+    await expect(scorer.score(context())).resolves.toMatchObject({ pass: false })
+  })
+
+  it('throws when a custom verdict fails Zod validation', async () => {
+    const scorer = createJudgeScorer({
+      name: 'strict',
+      judges: [judge('judge-1', '{"score":"high","pass":true,"reason":"ok"}')],
+      verdictSchema: verdictWithPass,
+    })
+
+    await expect(scorer.score(context())).rejects.toThrow(/validation/i)
+  })
+
+  it('throws when a judge Agent execution fails', async () => {
+    const failing: LLMAdapter = {
+      name: 'failing',
+      async chat() {
+        throw new Error('judge provider unavailable')
+      },
+      async *stream() {
+        yield { type: 'done' as const, data: {} }
+      },
+    }
+    const scorer = createJudgeScorer({
+      name: 'execution-failure',
+      judges: [{ name: 'judge-1', model: 'judge-model', adapter: failing }],
+    })
+
+    await expect(scorer.score(context())).rejects.toThrow('judge provider unavailable')
+  })
+
+  it('uses a context-aware judgePrompt without omitting case data', async () => {
+    const captures: string[] = []
+    const config: AgentConfig = {
+      name: 'judge-1',
+      model: 'judge-model',
+      adapter: responseAdapter('{"score":1,"reason":"correct"}', captures),
+    }
+    let received: ScorerContext | undefined
+    const ctx = context({ output: 'candidate answer' })
+    const scorer = createJudgeScorer({
+      name: 'custom-prompt',
+      judges: [config],
+      judgePrompt(value) {
+        received = value
+        return 'Apply the customer-specific rubric.'
+      },
+    })
+
+    await scorer.score(ctx)
+    expect(received).toBe(ctx)
+    expect(captures[0]).toContain('Apply the customer-specific rubric.')
+    expect(captures[0]).toContain('candidate answer')
+    expect(captures[0]).toContain('What is 2 + 2?')
+  })
+
+  it('throws on an overall judge timeout', async () => {
+    const hanging: LLMAdapter = {
+      name: 'hanging',
+      chat(_messages, options) {
+        return new Promise((_resolve, reject) => {
+          const onAbort = () => reject(options.abortSignal?.reason ?? new Error('aborted'))
+          if (options.abortSignal?.aborted) onAbort()
+          else options.abortSignal?.addEventListener('abort', onAbort, { once: true })
+        })
+      },
+      async *stream() {
+        yield { type: 'done' as const, data: {} }
+      },
+    }
+    const scorer = createJudgeScorer({
+      name: 'timeout',
+      judges: [{ name: 'judge-1', model: 'slow-model', adapter: hanging }],
+      timeoutMs: 20,
+    })
+
+    await expect(scorer.score(context())).rejects.toThrow(/timeout/i)
+  })
+
+  it('aborts judge work when the caller signal is cancelled', async () => {
+    const controller = new AbortController()
+    const hanging: LLMAdapter = {
+      name: 'hanging',
+      chat(_messages, options) {
+        return new Promise((_resolve, reject) => {
+          const onAbort = () => reject(options.abortSignal?.reason ?? new Error('aborted'))
+          if (options.abortSignal?.aborted) onAbort()
+          else options.abortSignal?.addEventListener('abort', onAbort, { once: true })
+        })
+      },
+      async *stream() {
+        yield { type: 'done' as const, data: {} }
+      },
+    }
+    const scorer = createJudgeScorer({
+      name: 'abortable',
+      judges: [{ name: 'judge-1', model: 'slow-model', adapter: hanging }],
+    })
+    const scoring = scorer.score(context({ signal: controller.signal }))
+    setTimeout(() => controller.abort(new Error('cancel evaluation')), 5)
+
+    await expect(scoring).rejects.toThrow('cancel evaluation')
+  })
+
+  it('uses fresh Agent state and does not mutate the caller judge config', async () => {
+    const captures: string[] = []
+    const config = Object.freeze({
+      name: 'judge-1',
+      model: 'judge-model',
+      systemPrompt: 'Judge carefully.',
+      adapter: responseAdapter('{"score":1,"reason":"ok"}', captures),
+    }) satisfies AgentConfig
+    const scorer = createJudgeScorer({ name: 'isolated', judges: [config] })
+
+    await scorer.score(context({ output: 'first' }))
+    await scorer.score(context({ output: 'second' }))
+
+    expect(captures).toHaveLength(2)
+    expect(captures[0]).toContain('first')
+    expect(captures[0]).not.toContain('second')
+    expect(captures[1]).toContain('second')
+    expect(captures[1]).not.toContain('first')
+    expect('outputSchema' in config).toBe(false)
+    expect(config.systemPrompt).toBe('Judge carefully.')
+  })
+
+  it('validates judge roster, quorum, and timeout configuration', () => {
+    expect(() => createJudgeScorer({ name: 'empty', judges: [] })).toThrow(/judge/i)
+    expect(() => createJudgeScorer({
+      name: 'bad-quorum',
+      judges: [judge('one', '{"score":1,"reason":"ok"}')],
+      quorum: 2,
+    })).toThrow(/quorum/i)
+    expect(() => createJudgeScorer({
+      name: 'bad-timeout',
+      judges: [judge('one', '{"score":1,"reason":"ok"}')],
+      timeoutMs: 0,
+    })).toThrow(/timeout/i)
+  })
+})

--- a/packages/core/tests/eval-scorer.test.ts
+++ b/packages/core/tests/eval-scorer.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+import { classifyRunFailure } from '../src/observability/status.js'
+import {
+  EVAL_STORE_SCHEMA_MAJOR,
+  defineScorer,
+  type EvalRecord,
+  type Scorer,
+  type ScorerContext,
+} from '../src/eval/index.js'
+
+function context(overrides: Partial<ScorerContext> = {}): ScorerContext {
+  return {
+    evalCase: { id: 'case-1', input: 'question', expected: 'answer' },
+    output: 'answer',
+    metadata: {},
+    signal: new AbortController().signal,
+    ...overrides,
+  }
+}
+
+describe('defineScorer', () => {
+  it('rejects an empty name and a non-function score', () => {
+    expect(() => defineScorer({ name: '  ', score: () => ({ score: 1 }) })).toThrow(/name/i)
+    expect(() => defineScorer({
+      name: 'broken',
+      score: 1,
+    } as unknown as Scorer)).toThrow(/score/i)
+  })
+
+  it('returns a frozen scorer without freezing the caller definition', () => {
+    const definition: Scorer = { name: 'exact-match', score: () => ({ score: 1 }) }
+    const scorer = defineScorer(definition)
+
+    expect(Object.isFrozen(scorer)).toBe(true)
+    expect(Object.isFrozen(definition)).toBe(false)
+  })
+
+  it('supports synchronous and asynchronous score functions', async () => {
+    const sync = defineScorer({ name: 'sync', score: () => ({ score: 0.25 }) })
+    const asyncScorer = defineScorer({
+      name: 'async',
+      async score() {
+        return { score: 0.75, pass: true }
+      },
+    })
+
+    expect(sync.score(context())).toEqual({ score: 0.25 })
+    await expect(asyncScorer.score(context())).resolves.toEqual({ score: 0.75, pass: true })
+  })
+
+  it('passes the caller AbortSignal through unchanged', () => {
+    const controller = new AbortController()
+    const scorer = defineScorer({
+      name: 'signal-aware',
+      score(ctx) {
+        return { score: ctx.signal === controller.signal ? 1 : 0 }
+      },
+    })
+
+    expect(scorer.score(context({ signal: controller.signal }))).toEqual({ score: 1 })
+  })
+
+  it('validates result shape and normalized score range', async () => {
+    const tooHigh = defineScorer({ name: 'too-high', score: () => ({ score: 1.01 }) })
+    const invalidDetails = defineScorer({
+      name: 'nested-details',
+      score: () => ({ score: 1, details: { nested: { value: 1 } } }),
+    } as unknown as Scorer)
+    const asyncNaN = defineScorer({
+      name: 'nan',
+      async score() {
+        return { score: Number.NaN }
+      },
+    })
+
+    expect(() => tooHigh.score(context())).toThrow(/\[0, 1\]/)
+    expect(() => invalidDetails.score(context())).toThrow(/TraceAttributeValue/)
+    await expect(asyncNaN.score(context())).rejects.toThrow(/\[0, 1\]/)
+  })
+
+  it('propagates scorer failures instead of converting them to score zero', async () => {
+    const failure = new Error('scorer unavailable')
+    const sync = defineScorer({
+      name: 'throws',
+      score() {
+        throw failure
+      },
+    })
+    const asyncScorer = defineScorer({
+      name: 'rejects',
+      async score() {
+        throw failure
+      },
+    })
+
+    expect(() => sync.score(context())).toThrow(failure)
+    await expect(asyncScorer.score(context())).rejects.toBe(failure)
+  })
+})
+
+describe('evaluation public contract', () => {
+  it('supports the documented exact-match scorer through the eval barrel', async () => {
+    const exact = defineScorer({
+      name: 'exact-match',
+      version: '1',
+      score({ output, evalCase }) {
+        const hit = output === evalCase.expected
+        return { score: hit ? 1 : 0, pass: hit }
+      },
+    })
+
+    expect(exact.score(context())).toEqual({ score: 1, pass: true })
+  })
+
+  it('exports the EvalRecord schema contract and keeps scorer errors scoreless', () => {
+    const error = classifyRunFailure(new Error('judge failed')).errorInfo
+    const record: EvalRecord = {
+      schemaVersion: EVAL_STORE_SCHEMA_MAJOR,
+      recordId: 'record-1',
+      evalRunId: 'eval-run-1',
+      source: 'offline',
+      timestampUnixMs: 1,
+      scorer: { name: 'relevancy', version: '1' },
+      status: 'scorer_error',
+      metadata: { promptVersion: 'v2' },
+      error,
+    }
+
+    expect(EVAL_STORE_SCHEMA_MAJOR).toBe(1)
+    expect(record.status).toBe('scorer_error')
+    expect(record.score).toBeUndefined()
+    expect(record.error?.kind).toBe('unknown')
+  })
+
+  it('does not re-export eval symbols from the root entry', async () => {
+    const root = await import('../src/index.js')
+    expect('defineScorer' in root).toBe(false)
+    expect('createJudgeScorer' in root).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- add the experimental `@open-multi-agent/core/eval` subpath with `Scorer`, `ScoreResult`, `EvalCase`, `EvalRecord`, and reserved memory sample types
- add `createJudgeScorer()` using fresh OMA Agent instances, mean-score aggregation, optional quorum verdicts, Zod validation, timeout/cancellation, and flat judge/model/score audit details
- add evaluation documentation, focused scorer/judge tests, package exports, and package-job smoke/tarball assertions

## Behavior and compatibility

- scorer failures propagate to the caller so evaluation runners can record `scorer_error`; failures are never converted to score zero
- the root package does not re-export evaluation APIs
- importing the eval subpath has no static Node-only dependency path
- this is an additive subpath and does not change `runConsensus()` or per-task `verify`

## Validation

- `npm test` on Node 18.20.8, 20.19.4, and 22.22.3: 102 test files / 1,445 tests passed on each version
- `npm run lint` on Node 20
- `npm run build` on Node 20
- built entry-point import smoke on Node 20
- `npm pack --dry-run` tarball assertions on Node 20
- `git diff --check`
- core runtime dependency count remains three
