### PR TITLE
feat(core): add EvalSet offline runner

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -31,9 +31,97 @@ Scores must be finite numbers from `0` through `1`. `pass` is optional so a late
 
 ## Scorer failures are not zero scores
 
-A scorer that throws, rejects, or exceeds its timeout has not measured quality. Callers must record that outcome as an `EvalRecord` with `status: 'scorer_error'`, normalize the error with `classifyRunFailure()`, and exclude it from score averages, percentiles, and pass rates. Do not replace scorer failures with `{ score: 0 }`.
+A scorer that throws, rejects, or exceeds its timeout has not measured quality. `runEvalSet()` records that outcome as an `EvalRecord` with `status: 'scorer_error'`, normalizes the error, continues to later scorers, and excludes the failure from score averages, percentiles, and pass rates. Do not replace scorer failures with `{ score: 0 }`.
 
-The eval subpath defines the `EvalRecord` shape and schema major version. Eval runners and stores are separate, later capabilities.
+If the target itself throws, the sample produces one `target_error` record under the reserved scorer name `_target`; its scorers do not run. The eval subpath also defines the `EvalRecord` shape and schema major version.
+
+## Run an EvalSet offline
+
+```ts
+import {
+  defineEvalSet,
+  defineScorer,
+  runEvalSet,
+  type EvalTarget,
+} from '@open-multi-agent/core/eval'
+
+const set = defineEvalSet({
+  name: 'greetings',
+  version: '1.0.0',
+  cases: [
+    { id: 'a', input: 'hi', expected: 'HI', tags: ['upper'] },
+    { id: 'b', input: 'yo', expected: 'YO', tags: ['upper'] },
+  ],
+  defaults: { concurrency: 2 },
+})
+
+const target: EvalTarget = async (input) => ({
+  output: String(input).toUpperCase(),
+})
+
+const exact = defineScorer({
+  name: 'exact',
+  score({ output, evalCase }) {
+    const pass = output === evalCase.expected
+    return { score: pass ? 1 : 0, pass }
+  },
+})
+
+const report = await runEvalSet(set, target, {
+  scorers: [exact],
+  repeats: 2,
+  metadata: { prompt_version: 'v2' },
+})
+
+console.log(report.records.length)          // 4
+console.log(report.aggregates[0]?.avg)      // 1
+console.log(report.aggregates[0]?.passRate) // 1
+```
+
+`defineEvalSet()` validates non-empty names, versions, and cases; requires case IDs to be unique; and returns a deeply frozen copy. Treat `version` as the content version and bump it whenever cases change. `filterTags` selects cases matching any requested tag. `repeats` and `concurrency` override the set defaults.
+
+Each case/repeat target runs once, then that sample's scorers run serially. Different samples run in parallel up to `concurrency` (default `2`). Aborting stops new samples from being scheduled, waits for already-started samples, and returns a partial report with `aborted: true`.
+
+Report percentiles use the nearest-rank method. For two sorted scores, p50 is the lower score and p95 is the higher score. `passRate` only includes scored records that explicitly contain `pass`; scorer errors are excluded from every score denominator. `byTag` repeats the same aggregation for each case tag. Target token usage is counted once per sample, even when multiple scorers run, and costs are summed only within the same currency.
+
+## Evaluate OMA runs
+
+Use the convenience targets when the system under evaluation is an OMA agent, team, or fixed plan:
+
+```ts
+import { Team, type AgentConfig, type PlanArtifact } from '@open-multi-agent/core'
+import {
+  targetFromAgent,
+  targetFromPlan,
+  targetFromTeam,
+} from '@open-multi-agent/core/eval'
+
+declare const agent: AgentConfig
+declare const team: Team
+declare const plan: PlanArtifact
+
+const agentTarget = targetFromAgent(agent, {
+  metadata: { prompt_version: 'v2' },
+})
+const teamTarget = targetFromTeam(team)
+const planTarget = targetFromPlan(team, plan)
+
+void agentTarget
+void teamTarget
+void planTarget
+```
+
+Agent and team targets convert non-string input with `String(input)` and use it as the prompt or goal. Plan targets replay the supplied `PlanArtifact`; the plan fixes the tasks and goal. These wrappers return the OMA result alongside the primary output, inject `eval_case` and one-based `eval_repeat` run metadata, and add available model/provider fingerprints. The runner uses the result identity for `runRef` and the result usage for report totals. When `traceStore` is provided, it also loads the matching `StoredRun` into `ScorerContext.trace`.
+
+Record metadata merges in this order, with later values winning: case metadata, `runEvalSet()` metadata, then metadata echoed by a convenience target (including its configuration fingerprint).
+
+## Payload privacy
+
+EvalSet cases may contain private user data. `storePayloads` therefore defaults to `'none'`, so records contain scores, reasons, metadata, and run references but no input/output snapshots. `'redacted'` serializes each payload field, caps it at 8 KiB, and applies OMA's existing secret redaction. `'full'` keeps the serialized text without redaction but still applies the 8 KiB cap; opt into it only for data you are prepared to retain. A model-based judge necessarily sends the evaluated output to the configured judge model regardless of record payload storage.
+
+## Why there is no seed
+
+OMA's current provider contract has no cross-provider seed parameter or LLM response recording. Adding a seed to `EvalSet` would therefore promise determinism the framework cannot provide. Use `repeats` to sample nondeterministic behavior and compare the aggregate statistics. `targetFromPlan()` fixes the orchestration plan, but model responses can still vary.
 
 ## Use OMA agents as judges
 

--- a/packages/core/src/eval/evalset.ts
+++ b/packages/core/src/eval/evalset.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod'
+import type { TraceAttributeValue } from '../types.js'
+import type { EvalCase } from './evalcase.js'
+
+const traceAttributeValueSchema: z.ZodType<TraceAttributeValue> = z.union([
+  z.string(),
+  z.number().finite(),
+  z.boolean(),
+  z.array(z.string()),
+  z.array(z.number().finite()),
+  z.array(z.boolean()),
+])
+
+const evalCaseSchema = z.object({
+  id: z.string().trim().min(1),
+  input: z.unknown(),
+  expected: z.unknown().optional(),
+  tags: z.array(z.string()).optional(),
+  metadata: z.record(traceAttributeValueSchema).optional(),
+})
+
+const evalSetSchema = z.object({
+  name: z.string().trim().min(1),
+  version: z.string().trim().min(1),
+  description: z.string().optional(),
+  cases: z.array(evalCaseSchema).min(1),
+  defaults: z.object({
+    repeats: z.number().int().positive().optional(),
+    concurrency: z.number().int().positive().optional(),
+  }).optional(),
+})
+
+/** A versioned collection of evaluation cases. Bump `version` whenever cases change. */
+export interface EvalSet {
+  readonly name: string
+  readonly version: string
+  readonly description?: string
+  readonly cases: readonly EvalCase[]
+  readonly defaults?: {
+    readonly repeats?: number
+    readonly concurrency?: number
+  }
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) return value
+  Object.freeze(value)
+  for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child)
+  return value
+}
+
+/** Validate, defensively copy, and freeze an EvalSet definition. */
+export function defineEvalSet(set: EvalSet): EvalSet {
+  const parsed = evalSetSchema.parse(set) as EvalSet
+  const ids = new Set<string>()
+  for (const evalCase of parsed.cases) {
+    if (ids.has(evalCase.id)) {
+      throw new Error(`EvalSet case id "${evalCase.id}" must be unique.`)
+    }
+    ids.add(evalCase.id)
+  }
+  return deepFreeze(parsed)
+}

--- a/packages/core/src/eval/index.ts
+++ b/packages/core/src/eval/index.ts
@@ -6,3 +6,15 @@ export { EVAL_STORE_SCHEMA_MAJOR } from './record.js'
 export type { EvalRecord } from './record.js'
 export type { EvalCase } from './evalcase.js'
 export type { MemoryExtractionSample, MemoryRetrievalSample } from './memory-types.js'
+export { defineEvalSet } from './evalset.js'
+export type { EvalSet } from './evalset.js'
+export { targetFromAgent, targetFromPlan, targetFromTeam } from './target.js'
+export type {
+  EvalTarget,
+  EvalTargetContext,
+  TargetFromRunOptions,
+  TargetOutput,
+} from './target.js'
+export { runEvalSet } from './runner.js'
+export type { EvalProgressEvent, RunEvalOptions } from './runner.js'
+export type { EvalRunReport, ScorerAggregate } from './report.js'

--- a/packages/core/src/eval/report.ts
+++ b/packages/core/src/eval/report.ts
@@ -1,0 +1,93 @@
+import type { RunCostSummary } from '../observability/store.js'
+import type { TokenUsage, TraceAttributeValue } from '../types.js'
+import type { EvalRecord } from './record.js'
+import type { Scorer } from './scorer.js'
+
+/** Score statistics for one scorer, excluding scorer failures from score denominators. */
+export interface ScorerAggregate {
+  readonly scorer: { readonly name: string; readonly version?: string }
+  readonly scoredCount: number
+  readonly errorCount: number
+  readonly avg: number
+  readonly p50: number
+  readonly p95: number
+  readonly min: number
+  readonly max: number
+  readonly passRate?: number
+  readonly byTag?: Readonly<Record<string, ScorerAggregate>>
+}
+
+/** Complete result of one offline EvalSet execution. */
+export interface EvalRunReport {
+  readonly schemaVersion: 1
+  readonly evalRunId: string
+  readonly startedAtUnixMs: number
+  readonly durationMs: number
+  readonly evalSet: { readonly name: string; readonly version: string }
+  readonly metadata: Readonly<Record<string, TraceAttributeValue>>
+  readonly caseCount: number
+  readonly repeats: number
+  readonly aborted?: boolean
+  readonly records: readonly EvalRecord[]
+  readonly aggregates: readonly ScorerAggregate[]
+  readonly totals: {
+    readonly tokens?: TokenUsage
+    readonly costs?: readonly RunCostSummary[]
+    readonly targetErrors: number
+  }
+}
+
+function nearestRank(sorted: readonly number[], percentile: number): number {
+  if (sorted.length === 0) return 0
+  const rank = Math.max(1, Math.ceil(percentile * sorted.length))
+  return sorted[Math.min(rank - 1, sorted.length - 1)]!
+}
+
+function aggregateOne(
+  scorer: Pick<Scorer, 'name' | 'version'>,
+  records: readonly EvalRecord[],
+): ScorerAggregate {
+  const matching = records.filter((record) =>
+    record.scorer.name === scorer.name && record.scorer.version === scorer.version)
+  const scored = matching.filter((record) => record.status === 'scored' && record.score !== undefined)
+  const scores = scored.map((record) => record.score!).sort((a, b) => a - b)
+  const passed = scored.filter((record) => record.pass !== undefined)
+  const identity = {
+    name: scorer.name,
+    ...(scorer.version !== undefined ? { version: scorer.version } : {}),
+  }
+
+  return {
+    scorer: identity,
+    scoredCount: scores.length,
+    errorCount: matching.filter((record) => record.status === 'scorer_error').length,
+    avg: scores.length === 0 ? 0 : scores.reduce((sum, score) => sum + score, 0) / scores.length,
+    p50: nearestRank(scores, 0.5),
+    p95: nearestRank(scores, 0.95),
+    min: scores[0] ?? 0,
+    max: scores[scores.length - 1] ?? 0,
+    ...(passed.length > 0
+      ? { passRate: passed.filter((record) => record.pass === true).length / passed.length }
+      : {}),
+  }
+}
+
+/** @internal Build deterministic per-scorer and per-tag aggregates. */
+export function aggregateEvalRecords(
+  records: readonly EvalRecord[],
+  scorers: readonly Scorer[],
+  tagsByCase: ReadonlyMap<string, readonly string[]>,
+): readonly ScorerAggregate[] {
+  const tags = [...new Set([...tagsByCase.values()].flat())]
+  return scorers.map((scorer) => {
+    const aggregate = aggregateOne(scorer, records)
+    if (tags.length === 0) return aggregate
+
+    const byTag = Object.fromEntries(tags.map((tag) => [
+      tag,
+      aggregateOne(scorer, records.filter((record) =>
+        record.caseId !== undefined && tagsByCase.get(record.caseId)?.includes(tag))),
+    ]))
+    return { ...aggregate, byTag }
+  })
+}

--- a/packages/core/src/eval/runner.ts
+++ b/packages/core/src/eval/runner.ts
@@ -1,0 +1,437 @@
+import { classifyRunFailure } from '../observability/status.js'
+import type { RunCostSummary, StoredRun, TraceStore } from '../observability/store.js'
+import type {
+  AgentRunResult,
+  ConsensusResult,
+  RunIdentity,
+  TeamRunResult,
+  TokenUsage,
+  TraceAttributeValue,
+} from '../types.js'
+import { redactSensitiveText } from '../utils/redaction.js'
+import type { EvalCase } from './evalcase.js'
+import type { EvalSet } from './evalset.js'
+import { aggregateEvalRecords } from './report.js'
+import type { EvalRunReport } from './report.js'
+import type { EvalRecord } from './record.js'
+import type { ScoreResult, Scorer, ScorerContext } from './scorer.js'
+import type { EvalTarget, TargetOutput } from './target.js'
+
+const DEFAULT_REPEATS = 1
+const DEFAULT_CONCURRENCY = 2
+const TARGET_SCORER_NAME = '_target'
+const PAYLOAD_MAX_CHARS = 8 * 1024
+
+export interface EvalProgressEvent {
+  readonly type: 'case_start' | 'case_done' | 'scorer_error' | 'target_error'
+  readonly caseId: string
+  readonly repeat: number
+  readonly scorer?: string
+}
+
+export interface RunEvalOptions {
+  readonly scorers: readonly Scorer[]
+  readonly repeats?: number
+  readonly concurrency?: number
+  readonly filterTags?: readonly string[]
+  readonly metadata?: Readonly<Record<string, TraceAttributeValue>>
+  readonly traceStore?: TraceStore
+  readonly evalRunId?: string
+  readonly storePayloads?: 'none' | 'redacted' | 'full'
+  readonly signal?: AbortSignal
+  readonly onProgress?: (event: EvalProgressEvent) => void
+}
+
+interface SampleResult {
+  readonly records: readonly EvalRecord[]
+  readonly tokens?: TokenUsage
+  readonly costs: readonly RunCostSummary[]
+  readonly targetError: boolean
+}
+
+class ScorerTimeoutError extends Error {
+  constructor(scorer: string, timeoutMs: number) {
+    super(`Scorer "${scorer}" timed out after ${timeoutMs}ms.`)
+    this.name = 'TimeoutError'
+  }
+}
+
+function positiveInteger(value: number, name: string): number {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new RangeError(`${name} must be a positive integer.`)
+  }
+  return value
+}
+
+function createId(prefix: string): string {
+  const uuid = globalThis.crypto?.randomUUID?.()
+  return uuid === undefined
+    ? `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`
+    : `${prefix}_${uuid}`
+}
+
+function emitProgress(options: RunEvalOptions, event: EvalProgressEvent): void {
+  try {
+    options.onProgress?.(event)
+  } catch {
+    // Progress observation is best-effort and must not change evaluation results.
+  }
+}
+
+function identityRunRef(identity: RunIdentity | undefined): EvalRecord['runRef'] {
+  if (identity === undefined) return undefined
+  return {
+    runId: identity.runId,
+    attempt: identity.attempt,
+    traceId: identity.traceId,
+    rootSpanId: identity.rootSpanId,
+  }
+}
+
+function resultTokens(
+  result: AgentRunResult | TeamRunResult | ConsensusResult | undefined,
+): TokenUsage | undefined {
+  if (result === undefined) return undefined
+  if ('totalTokenUsage' in result) return result.totalTokenUsage
+  return result.tokenUsage
+}
+
+function resultCosts(
+  result: AgentRunResult | TeamRunResult | ConsensusResult | undefined,
+): readonly RunCostSummary[] {
+  if (result === undefined) return []
+  const structural = result as unknown as {
+    readonly cost?: RunCostSummary
+    readonly costs?: readonly RunCostSummary[]
+  }
+  if (Array.isArray(structural.costs)) return structural.costs
+  return structural.cost === undefined ? [] : [structural.cost]
+}
+
+function targetMetadata(
+  evalCase: EvalCase,
+  options: RunEvalOptions,
+  output: TargetOutput | undefined,
+): Readonly<Record<string, TraceAttributeValue>> {
+  return Object.freeze({
+    ...evalCase.metadata,
+    ...options.metadata,
+    ...output?.result?.metadata,
+  })
+}
+
+function stringifyPayload(value: unknown): string {
+  if (typeof value === 'string') return value
+  try {
+    const json = JSON.stringify(value)
+    return json === undefined ? String(value) : json
+  } catch {
+    return String(value)
+  }
+}
+
+function truncatePayload(value: string): string {
+  if (value.length <= PAYLOAD_MAX_CHARS) return value
+  const marker = `\n[truncated at ${PAYLOAD_MAX_CHARS} characters]`
+  return `${value.slice(0, PAYLOAD_MAX_CHARS - marker.length)}${marker}`
+}
+
+function payloadFor(
+  mode: NonNullable<RunEvalOptions['storePayloads']>,
+  input: unknown,
+  output: unknown,
+  expected: unknown,
+): EvalRecord['payload'] {
+  if (mode === 'none') return undefined
+  const serialize = (value: unknown): string => {
+    const bounded = truncatePayload(stringifyPayload(value))
+    return mode === 'redacted'
+      ? truncatePayload(redactSensitiveText(bounded))
+      : bounded
+  }
+  return {
+    ...(input !== undefined ? { input: serialize(input) } : {}),
+    ...(output !== undefined ? { output: serialize(output) } : {}),
+    ...(expected !== undefined ? { expected: serialize(expected) } : {}),
+  }
+}
+
+async function scoreWithTimeout(
+  scorer: Scorer,
+  context: ScorerContext,
+): Promise<ScoreResult> {
+  if (scorer.timeoutMs === undefined) return scorer.score(context)
+
+  const timeoutMs = Math.max(0, scorer.timeoutMs)
+  const controller = new AbortController()
+  const abort = (): void => controller.abort(context.signal.reason)
+  if (context.signal.aborted) abort()
+  else context.signal.addEventListener('abort', abort, { once: true })
+
+  return new Promise<ScoreResult>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      const error = new ScorerTimeoutError(scorer.name, timeoutMs)
+      controller.abort(error)
+      context.signal.removeEventListener('abort', abort)
+      reject(error)
+    }, timeoutMs)
+
+    Promise.resolve().then(() => scorer.score({ ...context, signal: controller.signal })).then(
+      (value) => {
+        clearTimeout(timer)
+        context.signal.removeEventListener('abort', abort)
+        resolve(value)
+      },
+      (error: unknown) => {
+        clearTimeout(timer)
+        context.signal.removeEventListener('abort', abort)
+        reject(error)
+      },
+    )
+  })
+}
+
+function baseRecord(
+  evalRunId: string,
+  set: EvalSet,
+  evalCase: EvalCase,
+  repeat: number,
+  metadata: Readonly<Record<string, TraceAttributeValue>>,
+): Pick<EvalRecord,
+  'schemaVersion' | 'recordId' | 'evalRunId' | 'source' | 'timestampUnixMs'
+  | 'evalSet' | 'caseId' | 'repeat' | 'metadata'> {
+  return {
+    schemaVersion: 1,
+    recordId: createId('eval_record'),
+    evalRunId,
+    source: 'offline',
+    timestampUnixMs: Date.now(),
+    evalSet: { name: set.name, version: set.version },
+    caseId: evalCase.id,
+    repeat,
+    metadata,
+  }
+}
+
+async function runSample(
+  set: EvalSet,
+  evalCase: EvalCase,
+  repeat: number,
+  target: EvalTarget,
+  options: RunEvalOptions,
+  evalRunId: string,
+  signal: AbortSignal,
+): Promise<SampleResult> {
+  emitProgress(options, { type: 'case_start', caseId: evalCase.id, repeat })
+  const contextMetadata = Object.freeze({ ...evalCase.metadata, ...options.metadata })
+  const targetStartedAt = Date.now()
+  let targetOutput: TargetOutput
+
+  try {
+    targetOutput = await target(evalCase.input, {
+      caseId: evalCase.id,
+      repeat,
+      signal,
+      metadata: contextMetadata,
+    })
+    if (targetOutput === null || typeof targetOutput !== 'object' || !('output' in targetOutput)) {
+      throw new TypeError('EvalTarget must return a TargetOutput object with an output field.')
+    }
+  } catch (error) {
+    const metadata = targetMetadata(evalCase, options, undefined)
+    const payload = payloadFor(
+      options.storePayloads ?? 'none',
+      evalCase.input,
+      undefined,
+      evalCase.expected,
+    )
+    const record: EvalRecord = {
+      ...baseRecord(evalRunId, set, evalCase, repeat, metadata),
+      scorer: { name: TARGET_SCORER_NAME },
+      status: 'target_error',
+      usage: { durationMs: Date.now() - targetStartedAt },
+      error: classifyRunFailure(error).errorInfo,
+      ...(payload !== undefined ? { payload } : {}),
+    }
+    emitProgress(options, { type: 'target_error', caseId: evalCase.id, repeat })
+    emitProgress(options, { type: 'case_done', caseId: evalCase.id, repeat })
+    return { records: [record], costs: [], targetError: true }
+  }
+
+  const durationMs = Date.now() - targetStartedAt
+  const result = targetOutput.result
+  const tokens = resultTokens(result)
+  const costs = resultCosts(result)
+  const metadata = targetMetadata(evalCase, options, targetOutput)
+  const runRef = identityRunRef(result?.identity)
+  const payload = payloadFor(
+    options.storePayloads ?? 'none',
+    evalCase.input,
+    targetOutput.output,
+    evalCase.expected,
+  )
+  const trace: StoredRun | undefined = options.traceStore !== undefined && result?.identity !== undefined
+    ? (await options.traceStore.getRun(result.identity.runId)) ?? undefined
+    : undefined
+  const records: EvalRecord[] = []
+
+  for (const scorer of options.scorers) {
+    try {
+      const scored = await scoreWithTimeout(scorer, {
+        evalCase,
+        output: targetOutput.output,
+        ...(result !== undefined ? { result } : {}),
+        ...(trace !== undefined ? { trace } : {}),
+        metadata,
+        signal,
+      })
+      records.push({
+        ...baseRecord(evalRunId, set, evalCase, repeat, metadata),
+        scorer: {
+          name: scorer.name,
+          ...(scorer.version !== undefined ? { version: scorer.version } : {}),
+        },
+        status: 'scored',
+        score: scored.score,
+        ...(scored.pass !== undefined ? { pass: scored.pass } : {}),
+        ...(scored.reason !== undefined ? { reason: scored.reason } : {}),
+        ...(scored.details !== undefined ? { details: scored.details } : {}),
+        ...(runRef !== undefined ? { runRef } : {}),
+        ...(tokens !== undefined || costs.length === 1
+          ? { usage: {
+              ...(tokens !== undefined ? { tokens } : {}),
+              ...(costs.length === 1 ? { cost: costs[0] } : {}),
+              durationMs,
+            } }
+          : { usage: { durationMs } }),
+        ...(payload !== undefined ? { payload } : {}),
+      })
+    } catch (error) {
+      const timeout = error instanceof ScorerTimeoutError
+      records.push({
+        ...baseRecord(evalRunId, set, evalCase, repeat, metadata),
+        scorer: {
+          name: scorer.name,
+          ...(scorer.version !== undefined ? { version: scorer.version } : {}),
+        },
+        status: 'scorer_error',
+        ...(runRef !== undefined ? { runRef } : {}),
+        ...(tokens !== undefined || costs.length === 1
+          ? { usage: {
+              ...(tokens !== undefined ? { tokens } : {}),
+              ...(costs.length === 1 ? { cost: costs[0] } : {}),
+              durationMs,
+            } }
+          : { usage: { durationMs } }),
+        error: classifyRunFailure(error, timeout
+          ? { kind: 'timeout', statusCode: 'timeout' }
+          : {}).errorInfo,
+        ...(payload !== undefined ? { payload } : {}),
+      })
+      emitProgress(options, {
+        type: 'scorer_error',
+        caseId: evalCase.id,
+        repeat,
+        scorer: scorer.name,
+      })
+    }
+  }
+
+  emitProgress(options, { type: 'case_done', caseId: evalCase.id, repeat })
+  return { records, ...(tokens !== undefined ? { tokens } : {}), costs, targetError: false }
+}
+
+function sumTokens(samples: readonly SampleResult[]): TokenUsage | undefined {
+  const usages = samples.flatMap((sample) => sample.tokens === undefined ? [] : [sample.tokens])
+  if (usages.length === 0) return undefined
+  return usages.reduce<TokenUsage>((sum, usage) => ({
+    input_tokens: sum.input_tokens + usage.input_tokens,
+    output_tokens: sum.output_tokens + usage.output_tokens,
+  }), { input_tokens: 0, output_tokens: 0 })
+}
+
+function sumCosts(samples: readonly SampleResult[]): readonly RunCostSummary[] | undefined {
+  const totals = new Map<string, number>()
+  for (const cost of samples.flatMap((sample) => sample.costs)) {
+    totals.set(cost.currency, (totals.get(cost.currency) ?? 0) + cost.amount)
+  }
+  if (totals.size === 0) return undefined
+  return [...totals.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([currency, amount]) => ({ currency, amount }))
+}
+
+/** Execute an EvalSet offline with bounded sample concurrency and serial per-sample scoring. */
+export async function runEvalSet(
+  set: EvalSet,
+  target: EvalTarget,
+  options: RunEvalOptions,
+): Promise<EvalRunReport> {
+  const startedAtUnixMs = Date.now()
+  const repeats = positiveInteger(options.repeats ?? set.defaults?.repeats ?? DEFAULT_REPEATS, 'repeats')
+  const concurrency = positiveInteger(
+    options.concurrency ?? set.defaults?.concurrency ?? DEFAULT_CONCURRENCY,
+    'concurrency',
+  )
+  if (options.evalRunId !== undefined && options.evalRunId.trim().length === 0) {
+    throw new TypeError('evalRunId must be a non-empty string when provided.')
+  }
+  const evalRunId = options.evalRunId ?? createId('eval_run')
+  const filter = options.filterTags === undefined || options.filterTags.length === 0
+    ? undefined
+    : new Set(options.filterTags)
+  const cases = set.cases.filter((evalCase) =>
+    filter === undefined || evalCase.tags?.some((tag) => filter.has(tag)) === true)
+  const jobs = cases.flatMap((evalCase) =>
+    Array.from({ length: repeats }, (_, index) => ({ evalCase, repeat: index + 1 })))
+  const signal = options.signal ?? new AbortController().signal
+  const samples = new Array<SampleResult | undefined>(jobs.length)
+  let cursor = 0
+
+  const worker = async (): Promise<void> => {
+    while (!signal.aborted) {
+      const index = cursor++
+      const job = jobs[index]
+      if (job === undefined) return
+      samples[index] = await runSample(
+        set,
+        job.evalCase,
+        job.repeat,
+        target,
+        options,
+        evalRunId,
+        signal,
+      )
+    }
+  }
+
+  await Promise.all(Array.from(
+    { length: Math.min(concurrency, jobs.length) },
+    () => worker(),
+  ))
+
+  const completed = samples.filter((sample): sample is SampleResult => sample !== undefined)
+  const records = completed.flatMap((sample) => sample.records)
+  const tagsByCase = new Map(cases.map((evalCase) => [evalCase.id, evalCase.tags ?? []]))
+  const tokens = sumTokens(completed)
+  const costs = sumCosts(completed)
+
+  return {
+    schemaVersion: 1,
+    evalRunId,
+    startedAtUnixMs,
+    durationMs: Date.now() - startedAtUnixMs,
+    evalSet: { name: set.name, version: set.version },
+    metadata: Object.freeze({ ...options.metadata }),
+    caseCount: cases.length,
+    repeats,
+    ...(signal.aborted ? { aborted: true } : {}),
+    records,
+    aggregates: aggregateEvalRecords(records, options.scorers, tagsByCase),
+    totals: {
+      ...(tokens !== undefined ? { tokens } : {}),
+      ...(costs !== undefined ? { costs } : {}),
+      targetErrors: completed.filter((sample) => sample.targetError).length,
+    },
+  }
+}

--- a/packages/core/src/eval/target.ts
+++ b/packages/core/src/eval/target.ts
@@ -1,0 +1,126 @@
+import type { Team } from '../team/team.js'
+import type {
+  AgentConfig,
+  AgentRunResult,
+  ConsensusResult,
+  PlanArtifact,
+  TeamRunResult,
+  TraceAttributeValue,
+} from '../types.js'
+
+/** Per-sample context passed to an EvalTarget. */
+export interface EvalTargetContext {
+  readonly caseId: string
+  readonly repeat: number
+  readonly signal: AbortSignal
+  readonly metadata: Readonly<Record<string, TraceAttributeValue>>
+}
+
+/** Output scored by the runner, plus an optional OMA result for trace and usage linkage. */
+export interface TargetOutput {
+  readonly output: unknown
+  readonly result?: AgentRunResult | TeamRunResult | ConsensusResult
+}
+
+/** A framework-agnostic evaluation target. */
+export type EvalTarget = (
+  input: unknown,
+  context: EvalTargetContext,
+) => Promise<TargetOutput>
+
+export interface TargetFromRunOptions {
+  /** Extra per-run metadata merged into RunIdentityOptions.metadata. */
+  readonly metadata?: Readonly<Record<string, TraceAttributeValue>>
+}
+
+function targetPrompt(input: unknown): string {
+  return typeof input === 'string' ? input : String(input)
+}
+
+function compactFingerprint(
+  config: Pick<AgentConfig, 'model' | 'provider'>,
+): Readonly<Record<string, TraceAttributeValue>> {
+  return {
+    ...(config.model !== undefined ? { model: config.model } : {}),
+    ...(config.provider !== undefined ? { provider: config.provider } : {}),
+  }
+}
+
+function teamFingerprint(team: Team): Readonly<Record<string, TraceAttributeValue>> {
+  const agents = team.getAgents()
+  const models = [...new Set(agents.flatMap((agent) => agent.model === undefined ? [] : [agent.model]))]
+  const providers = [...new Set(agents.flatMap((agent) => agent.provider === undefined ? [] : [agent.provider]))]
+  return {
+    ...(models.length > 0 ? { models } : {}),
+    ...(providers.length > 0 ? { providers } : {}),
+  }
+}
+
+function runMetadata(
+  context: EvalTargetContext,
+  options: TargetFromRunOptions | undefined,
+  fingerprint: Readonly<Record<string, TraceAttributeValue>>,
+): Readonly<Record<string, TraceAttributeValue>> {
+  return {
+    eval_case: context.caseId,
+    eval_repeat: String(context.repeat),
+    ...options?.metadata,
+    ...fingerprint,
+  }
+}
+
+function teamOutput(result: TeamRunResult): string {
+  const synthesis = result.agentResults.get('coordinator')?.output
+  if (synthesis !== undefined) return synthesis
+  return [...result.agentResults.values()]
+    .map((agentResult) => agentResult.output)
+    .filter((output) => output.length > 0)
+    .join('\n\n---\n\n')
+}
+
+/** Wrap one OMA agent as an EvalTarget. */
+export function targetFromAgent(
+  agent: AgentConfig,
+  options?: TargetFromRunOptions,
+): EvalTarget {
+  return async (input, context) => {
+    // Keep the eval subpath free of a static orchestrator (and its Node runtime imports).
+    const { OpenMultiAgent } = await import('../orchestrator/orchestrator.js')
+    const result = await new OpenMultiAgent().runAgent(agent, targetPrompt(input), {
+      abortSignal: context.signal,
+      metadata: runMetadata(context, options, compactFingerprint(agent)),
+    })
+    return { output: result.output, result }
+  }
+}
+
+/** Wrap an OMA team run as an EvalTarget. */
+export function targetFromTeam(
+  team: Team,
+  options?: TargetFromRunOptions,
+): EvalTarget {
+  return async (input, context) => {
+    const { OpenMultiAgent } = await import('../orchestrator/orchestrator.js')
+    const result = await new OpenMultiAgent().runTeam(team, targetPrompt(input), {
+      abortSignal: context.signal,
+      metadata: runMetadata(context, options, teamFingerprint(team)),
+    })
+    return { output: teamOutput(result), result }
+  }
+}
+
+/** Wrap deterministic plan replay as an EvalTarget. The plan, rather than input, fixes execution. */
+export function targetFromPlan(
+  team: Team,
+  plan: PlanArtifact,
+  options?: TargetFromRunOptions,
+): EvalTarget {
+  return async (_input, context) => {
+    const { OpenMultiAgent } = await import('../orchestrator/orchestrator.js')
+    const result = await new OpenMultiAgent().runFromPlan(team, plan, {
+      abortSignal: context.signal,
+      metadata: runMetadata(context, options, teamFingerprint(team)),
+    })
+    return { output: teamOutput(result), result }
+  }
+}

--- a/packages/core/tests/eval-evalset.test.ts
+++ b/packages/core/tests/eval-evalset.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { defineEvalSet } from '../src/eval/index.js'
+import type { EvalSet } from '../src/eval/index.js'
+
+describe('defineEvalSet', () => {
+  it('validates, defensively copies, and deeply freezes a versioned set', () => {
+    const source = {
+      name: 'greetings',
+      version: '1.0.0',
+      description: 'Uppercase checks',
+      cases: [{
+        id: 'hello',
+        input: 'hello',
+        expected: 'HELLO',
+        tags: ['upper'],
+        metadata: { split: 'holdout' },
+      }],
+      defaults: { repeats: 2, concurrency: 3 },
+    }
+
+    const set = defineEvalSet(source)
+    source.cases[0]!.tags.push('mutated')
+
+    expect(set).toEqual({
+      name: 'greetings',
+      version: '1.0.0',
+      description: 'Uppercase checks',
+      cases: [{
+        id: 'hello',
+        input: 'hello',
+        expected: 'HELLO',
+        tags: ['upper'],
+        metadata: { split: 'holdout' },
+      }],
+      defaults: { repeats: 2, concurrency: 3 },
+    })
+    expect(Object.isFrozen(set)).toBe(true)
+    expect(Object.isFrozen(set.cases)).toBe(true)
+    expect(Object.isFrozen(set.cases[0])).toBe(true)
+    expect(Object.isFrozen(set.cases[0]!.tags)).toBe(true)
+    expect(Object.isFrozen(set.defaults)).toBe(true)
+  })
+
+  it.each([
+    ['duplicate case ids', {
+      name: 'set', version: '1', cases: [{ id: 'same', input: 1 }, { id: 'same', input: 2 }],
+    }],
+    ['empty version', { name: 'set', version: ' ', cases: [{ id: 'a', input: 1 }] }],
+    ['empty name', { name: '', version: '1', cases: [{ id: 'a', input: 1 }] }],
+    ['empty cases', { name: 'set', version: '1', cases: [] }],
+    ['non-string tag', {
+      name: 'set', version: '1', cases: [{ id: 'a', input: 1, tags: [1] }],
+    }],
+    ['invalid defaults', {
+      name: 'set', version: '1', cases: [{ id: 'a', input: 1 }], defaults: { repeats: 0 },
+    }],
+  ])('rejects %s', (_label, value) => {
+    expect(() => defineEvalSet(value as unknown as EvalSet)).toThrow()
+  })
+})

--- a/packages/core/tests/eval-runner.test.ts
+++ b/packages/core/tests/eval-runner.test.ts
@@ -1,0 +1,356 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  defineEvalSet,
+  defineScorer,
+  runEvalSet,
+} from '../src/eval/index.js'
+import type {
+  EvalProgressEvent,
+  EvalTarget,
+  ScorerContext,
+} from '../src/eval/index.js'
+import type { RunCostSummary, StoredRun, TraceStore } from '../src/observability/store.js'
+import type { AgentRunResult, RunIdentity } from '../src/types.js'
+
+function identity(runId = 'run-1'): RunIdentity {
+  return {
+    runId,
+    attempt: 1,
+    traceId: 'a'.repeat(32),
+    rootSpanId: 'b'.repeat(16),
+  }
+}
+
+function agentResult(
+  overrides: Partial<AgentRunResult> = {},
+): AgentRunResult {
+  return {
+    success: true,
+    output: 'output',
+    messages: [],
+    tokenUsage: { input_tokens: 2, output_tokens: 3 },
+    toolCalls: [],
+    identity: identity(),
+    ...overrides,
+  }
+}
+
+const exact = defineScorer({
+  name: 'exact',
+  score: ({ output, evalCase }) => ({
+    score: output === evalCase.expected ? 1 : 0,
+    pass: output === evalCase.expected,
+  }),
+})
+
+describe('runEvalSet', () => {
+  it('satisfies the public two-case, two-repeat contract', async () => {
+    const set = defineEvalSet({
+      name: 'greetings',
+      version: '1.0.0',
+      cases: [
+        { id: 'a', input: 'hi', expected: 'HI', tags: ['upper'] },
+        { id: 'b', input: 'yo', expected: 'YO', tags: ['upper'] },
+      ],
+    })
+    const target: EvalTarget = async (input) => ({ output: String(input).toUpperCase() })
+
+    const report = await runEvalSet(set, target, { scorers: [exact], repeats: 2 })
+
+    expect(report.records).toHaveLength(4)
+    expect(report.aggregates[0]).toMatchObject({
+      avg: 1,
+      passRate: 1,
+      scoredCount: 4,
+      errorCount: 0,
+    })
+    expect(report).toMatchObject({
+      schemaVersion: 1,
+      evalSet: { name: 'greetings', version: '1.0.0' },
+      caseCount: 2,
+      repeats: 2,
+      totals: { targetErrors: 0 },
+    })
+  })
+
+  it('honors repeats, tag filtering, bounded concurrency, and serial scorers', async () => {
+    const set = defineEvalSet({
+      name: 'filtered', version: '1',
+      cases: [
+        { id: 'a', input: 'a', tags: ['keep'] },
+        { id: 'b', input: 'b', tags: ['drop'] },
+        { id: 'c', input: 'c', tags: ['keep', 'also'] },
+      ],
+      defaults: { repeats: 4, concurrency: 3 },
+    })
+    let active = 0
+    let maxActive = 0
+    const order: string[] = []
+    const target: EvalTarget = async (input, context) => {
+      active++
+      maxActive = Math.max(maxActive, active)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      active--
+      return { output: `${input}-${context.repeat}` }
+    }
+    const first = defineScorer({ name: 'first', async score({ evalCase }) {
+      order.push(`${evalCase.id}:first:start`)
+      await new Promise((resolve) => setTimeout(resolve, 2))
+      order.push(`${evalCase.id}:first:done`)
+      return { score: 1 }
+    } })
+    const second = defineScorer({ name: 'second', score({ evalCase }) {
+      order.push(`${evalCase.id}:second`)
+      return { score: 1 }
+    } })
+
+    const report = await runEvalSet(set, target, {
+      scorers: [first, second],
+      repeats: 2,
+      concurrency: 2,
+      filterTags: ['keep'],
+    })
+
+    expect(report.caseCount).toBe(2)
+    expect(report.repeats).toBe(2)
+    expect(report.records).toHaveLength(8)
+    expect(new Set(report.records.map((record) => record.caseId))).toEqual(new Set(['a', 'c']))
+    expect(maxActive).toBe(2)
+    for (const caseId of ['a', 'c']) {
+      const starts = order.reduce<number[]>((indexes, value, index) =>
+        value === `${caseId}:first:done` ? [...indexes, index] : indexes, [])
+      const seconds = order.reduce<number[]>((indexes, value, index) =>
+        value === `${caseId}:second` ? [...indexes, index] : indexes, [])
+      expect(starts).toHaveLength(2)
+      expect(seconds).toHaveLength(2)
+      expect(seconds[0]).toBeGreaterThan(starts[0]!)
+      expect(seconds[1]).toBeGreaterThan(starts[1]!)
+    }
+  })
+
+  it('records one target_error per failed sample and isolates scorer_error records', async () => {
+    const set = defineEvalSet({
+      name: 'errors', version: '1',
+      cases: [
+        { id: 'ok', input: 'ok', expected: 'ok' },
+        { id: 'score-fails', input: 'score-fails', expected: 'score-fails' },
+        { id: 'target-fails', input: 'target-fails' },
+      ],
+    })
+    const flaky = defineScorer({
+      name: 'flaky',
+      score({ evalCase }) {
+        if (evalCase.id === 'score-fails') throw new Error('scorer secret')
+        return { score: 0.5 }
+      },
+    })
+    const progress: EvalProgressEvent[] = []
+
+    const report = await runEvalSet(set, async (input) => {
+      if (input === 'target-fails') throw new Error('target failed')
+      return { output: input }
+    }, { scorers: [exact, flaky], concurrency: 1, onProgress: (event) => progress.push(event) })
+
+    const targetErrors = report.records.filter((record) => record.status === 'target_error')
+    const scorerErrors = report.records.filter((record) => record.status === 'scorer_error')
+    expect(report.records).toHaveLength(5)
+    expect(targetErrors).toHaveLength(1)
+    expect(targetErrors[0]).toMatchObject({
+      caseId: 'target-fails', scorer: { name: '_target' }, status: 'target_error',
+    })
+    expect(targetErrors[0]?.score).toBeUndefined()
+    expect(scorerErrors).toHaveLength(1)
+    expect(scorerErrors[0]).toMatchObject({
+      caseId: 'score-fails', scorer: { name: 'flaky' }, status: 'scorer_error',
+    })
+    expect(scorerErrors[0]?.score).toBeUndefined()
+    expect(report.totals.targetErrors).toBe(1)
+    expect(report.aggregates).toEqual(expect.arrayContaining([
+      expect.objectContaining({ scorer: { name: 'exact' }, scoredCount: 2, errorCount: 0, avg: 1 }),
+      expect.objectContaining({ scorer: { name: 'flaky' }, scoredCount: 1, errorCount: 1, avg: 0.5 }),
+    ]))
+    expect(progress).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'target_error', caseId: 'target-fails' }),
+      expect.objectContaining({ type: 'scorer_error', caseId: 'score-fails', scorer: 'flaky' }),
+    ]))
+  })
+
+  it('turns scorer timeouts into scorer_error and continues to later scorers', async () => {
+    const slow = defineScorer({
+      name: 'slow', timeoutMs: 5,
+      async score() {
+        await new Promise((resolve) => setTimeout(resolve, 30))
+        return { score: 1 }
+      },
+    })
+    const later = defineScorer({ name: 'later', score: () => ({ score: 0.75 }) })
+    const set = defineEvalSet({ name: 'timeout', version: '1', cases: [{ id: 'a', input: 'a' }] })
+
+    const report = await runEvalSet(set, async (input) => ({ output: input }), {
+      scorers: [slow, later],
+    })
+
+    expect(report.records).toEqual([
+      expect.objectContaining({
+        scorer: { name: 'slow' }, status: 'scorer_error',
+        error: expect.objectContaining({ kind: 'timeout', name: 'TimeoutError' }),
+      }),
+      expect.objectContaining({ scorer: { name: 'later' }, status: 'scored', score: 0.75 }),
+    ])
+  })
+
+  it('stops scheduling after abort, waits for the in-flight sample, and returns a partial report', async () => {
+    const controller = new AbortController()
+    const set = defineEvalSet({
+      name: 'abort', version: '1',
+      cases: Array.from({ length: 5 }, (_, index) => ({ id: String(index), input: index })),
+    })
+    let calls = 0
+    const report = await runEvalSet(set, async (input) => {
+      calls++
+      await new Promise((resolve) => setTimeout(resolve, 2))
+      controller.abort()
+      return { output: input }
+    }, { scorers: [exact], concurrency: 1, signal: controller.signal })
+
+    expect(calls).toBe(1)
+    expect(report.aborted).toBe(true)
+    expect(report.records).toHaveLength(1)
+    expect(report.records[0]?.caseId).toBe('0')
+  })
+
+  it('uses nearest-rank percentiles, explicit pass denominators, and per-tag buckets', async () => {
+    const set = defineEvalSet({
+      name: 'math', version: '1',
+      cases: [
+        { id: 'a', input: 0.2, tags: ['pair', 'single'], metadata: { pass: true } },
+        { id: 'b', input: 0.8, tags: ['pair'], metadata: { pass: false } },
+        { id: 'c', input: 1, tags: ['other'] },
+      ],
+    })
+    const numeric = defineScorer({ name: 'numeric', score({ output, evalCase }) {
+      return {
+        score: Number(output),
+        ...(evalCase.metadata?.['pass'] !== undefined
+          ? { pass: evalCase.metadata['pass'] as boolean }
+          : {}),
+      }
+    } })
+
+    const report = await runEvalSet(set, async (input) => ({ output: input }), { scorers: [numeric] })
+    const aggregate = report.aggregates[0]!
+
+    expect(aggregate).toMatchObject({
+      scoredCount: 3,
+      errorCount: 0,
+      avg: 2 / 3,
+      p50: 0.8,
+      p95: 1,
+      min: 0.2,
+      max: 1,
+      passRate: 0.5,
+    })
+    expect(aggregate.byTag?.['single']).toMatchObject({ p50: 0.2, p95: 0.2, scoredCount: 1 })
+    expect(aggregate.byTag?.['pair']).toMatchObject({ p50: 0.2, p95: 0.8, scoredCount: 2 })
+  })
+
+  it('links StoredRun traces and run identity into scorer context and records', async () => {
+    const runIdentity = identity('trace-run')
+    const stored = { runId: 'trace-run', spans: [] } as unknown as StoredRun
+    const getRun = vi.fn(async () => stored)
+    const traceStore = { getRun } as unknown as TraceStore
+    let received: StoredRun | undefined
+    const scorer = defineScorer({ name: 'trace-aware', score(context: ScorerContext) {
+      received = context.trace
+      return { score: context.trace === stored ? 1 : 0 }
+    } })
+    const set = defineEvalSet({ name: 'trace', version: '1', cases: [{ id: 'a', input: 'a' }] })
+
+    const report = await runEvalSet(set, async () => ({
+      output: 'a', result: agentResult({ identity: runIdentity }),
+    }), { scorers: [scorer], traceStore })
+
+    expect(getRun).toHaveBeenCalledWith('trace-run')
+    expect(received).toBe(stored)
+    expect(report.records[0]?.runRef).toEqual(runIdentity)
+  })
+
+  it('leaves trace undefined without a TraceStore', async () => {
+    let received: StoredRun | undefined
+    const scorer = defineScorer({ name: 'no-trace', score(context) {
+      received = context.trace
+      return { score: 1 }
+    } })
+    const set = defineEvalSet({ name: 'trace', version: '1', cases: [{ id: 'a', input: 'a' }] })
+    await runEvalSet(set, async () => ({ output: 'a', result: agentResult() }), { scorers: [scorer] })
+    expect(received).toBeUndefined()
+  })
+
+  it('applies payload none/redacted/full policies and the 8 KiB cap', async () => {
+    const secret = 'password="secret value"'
+    const long = `${secret}-${'x'.repeat(70_000)}`
+    const set = defineEvalSet({
+      name: 'payload', version: '1', cases: [{ id: 'a', input: long, expected: secret }],
+    })
+    const target: EvalTarget = async () => ({ output: `sk-abcdefghijklmnop-${long}` })
+
+    const none = await runEvalSet(set, target, { scorers: [exact] })
+    const redacted = await runEvalSet(set, target, { scorers: [exact], storePayloads: 'redacted' })
+    const full = await runEvalSet(set, target, { scorers: [exact], storePayloads: 'full' })
+
+    expect(Object.hasOwn(none.records[0]!, 'payload')).toBe(false)
+    expect(JSON.stringify(redacted.records[0]?.payload)).toContain('[redacted]')
+    expect(JSON.stringify(redacted.records[0]?.payload)).not.toContain('secret value')
+    expect(full.records[0]?.payload?.input).toContain('secret value')
+    expect(full.records[0]?.payload?.input.length).toBeLessThanOrEqual(8 * 1024)
+    expect(full.records[0]?.payload?.input).toContain('[truncated at 8192 characters]')
+  })
+
+  it('sums target usage once per sample and keeps currencies separate', async () => {
+    const costs: readonly RunCostSummary[] = [
+      { amount: 0.25, currency: 'USD' },
+      { amount: 0.1, currency: 'EUR' },
+    ]
+    const set = defineEvalSet({ name: 'usage', version: '1', cases: [{ id: 'a', input: 'a' }] })
+    const result = { ...agentResult(), costs } as AgentRunResult & { costs: readonly RunCostSummary[] }
+
+    const report = await runEvalSet(set, async () => ({ output: 'a', result }), {
+      scorers: [exact, defineScorer({ name: 'second', score: () => ({ score: 1 }) })],
+      repeats: 2,
+    })
+
+    expect(report.records).toHaveLength(4)
+    expect(report.totals.tokens).toEqual({ input_tokens: 4, output_tokens: 6 })
+    expect(report.totals.costs).toEqual([
+      { amount: 0.2, currency: 'EUR' },
+      { amount: 0.5, currency: 'USD' },
+    ])
+  })
+
+  it('merges metadata as case then runner options then target result fingerprint', async () => {
+    const set = defineEvalSet({
+      name: 'metadata', version: '1',
+      cases: [{ id: 'a', input: 'a', metadata: { shared: 'case', case_only: true } }],
+    })
+    let contextMetadata: ScorerContext['metadata'] | undefined
+    const scorer = defineScorer({ name: 'capture', score(context) {
+      contextMetadata = context.metadata
+      return { score: 1 }
+    } })
+
+    const report = await runEvalSet(set, async () => ({
+      output: 'a',
+      result: agentResult({ metadata: { shared: 'target', model: 'actual-model' } }),
+    }), { scorers: [scorer], metadata: { shared: 'runner', runner_only: true } })
+
+    const expected = {
+      shared: 'target',
+      case_only: true,
+      runner_only: true,
+      model: 'actual-model',
+    }
+    expect(contextMetadata).toEqual(expected)
+    expect(report.records[0]?.metadata).toEqual(expected)
+    expect(report.metadata).toEqual({ shared: 'runner', runner_only: true })
+  })
+})

--- a/packages/core/tests/eval-target.test.ts
+++ b/packages/core/tests/eval-target.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  defineEvalSet,
+  defineScorer,
+  runEvalSet,
+  targetFromAgent,
+  targetFromPlan,
+  targetFromTeam,
+} from '../src/eval/index.js'
+import type { EvalTargetContext } from '../src/eval/index.js'
+import { Team } from '../src/team/team.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMMessage,
+  LLMResponse,
+  PlanArtifact,
+} from '../src/types.js'
+
+function response(text: string): LLMResponse {
+  return {
+    id: `response-${text}`,
+    content: [{ type: 'text', text }],
+    model: 'test-model',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 2, output_tokens: 1 },
+  }
+}
+
+function adapter(text: string, seen?: LLMMessage[][]): LLMAdapter {
+  return {
+    name: 'eval-target-test',
+    async chat(messages) {
+      seen?.push(messages)
+      return response(text)
+    },
+    async *stream() { /* unused */ },
+  }
+}
+
+function agent(llm: LLMAdapter = adapter('agent output')): AgentConfig {
+  return {
+    name: 'worker',
+    model: 'test-model',
+    provider: 'openai',
+    adapter: llm,
+  }
+}
+
+function context(caseId = 'case-a', repeat = 2): EvalTargetContext {
+  return {
+    caseId,
+    repeat,
+    signal: new AbortController().signal,
+    metadata: { runner: 'v1' },
+  }
+}
+
+describe('OMA EvalTarget conveniences', () => {
+  it('targetFromAgent converts input to a prompt, injects metadata, and returns the run result', async () => {
+    const seen: LLMMessage[][] = []
+    const target = targetFromAgent(agent(adapter('agent output', seen)), {
+      metadata: { prompt_version: 'v2', model: 'caller-value' },
+    })
+
+    const output = await target(42, context())
+
+    expect(output.output).toBe('agent output')
+    expect(output.result).toMatchObject({
+      success: true,
+      output: 'agent output',
+      tokenUsage: { input_tokens: 2, output_tokens: 1 },
+      metadata: {
+        eval_case: 'case-a',
+        eval_repeat: '2',
+        prompt_version: 'v2',
+        model: 'test-model',
+        provider: 'openai',
+      },
+    })
+    expect(output.result?.identity).toBeDefined()
+    expect(JSON.stringify(seen)).toContain('42')
+  })
+
+  it('propagates the convenience target identity into EvalRecord.runRef', async () => {
+    const base = targetFromAgent(agent())
+    let capturedIdentity: unknown
+    const target = async (...args: Parameters<typeof base>) => {
+      const output = await base(...args)
+      capturedIdentity = output.result?.identity
+      return output
+    }
+    const set = defineEvalSet({ name: 'agent', version: '1', cases: [{ id: 'a', input: 'hi' }] })
+    const scorer = defineScorer({ name: 'ok', score: () => ({ score: 1 }) })
+
+    const report = await runEvalSet(set, target, { scorers: [scorer] })
+
+    expect(report.records[0]?.runRef).toEqual(capturedIdentity)
+    expect(report.records[0]?.metadata).toMatchObject({
+      eval_case: 'a', eval_repeat: '1', model: 'test-model', provider: 'openai',
+    })
+  })
+
+  it('targetFromTeam returns the synthesized or primary team output and team fingerprints', async () => {
+    const team = new Team({ name: 'team', agents: [agent(adapter('team output'))] })
+    const output = await targetFromTeam(team, { metadata: { experiment: 'team-v1' } })('hello', context())
+
+    expect(output.output).toBe('team output')
+    expect(output.result?.metadata).toEqual({
+      eval_case: 'case-a',
+      eval_repeat: '2',
+      experiment: 'team-v1',
+      models: ['test-model'],
+      providers: ['openai'],
+    })
+    expect(output.result?.identity).toBeDefined()
+  })
+
+  it('targetFromPlan replays the fixed plan without a coordinator and returns task output', async () => {
+    const chat = vi.fn(async () => response('planned output'))
+    const llm: LLMAdapter = { name: 'plan-test', chat, async *stream() { /* unused */ } }
+    const team = new Team({ name: 'team', agents: [agent(llm)] })
+    const plan: PlanArtifact = {
+      version: 1,
+      goal: 'fixed goal',
+      tasks: [{ id: 'task-a', title: 'Task A', description: 'Do fixed work', assignee: 'worker' }],
+    }
+
+    const output = await targetFromPlan(team, plan)('ignored input', context('plan-case', 1))
+
+    expect(chat).toHaveBeenCalledTimes(1)
+    expect(output.output).toBe('planned output')
+    expect(output.result).toMatchObject({
+      success: true,
+      metadata: {
+        eval_case: 'plan-case',
+        eval_repeat: '1',
+        models: ['test-model'],
+        providers: ['openai'],
+      },
+    })
+    expect(output.result?.identity).toBeDefined()
+  })
+})

--- a/packages/core/tests/subpath-exports.test.ts
+++ b/packages/core/tests/subpath-exports.test.ts
@@ -22,4 +22,11 @@ describe('subpath export barrels', () => {
     const mod = await import('../src/ai-sdk.js')
     expect(typeof mod.AISdkAdapter).toBe('function')
   })
+
+  it('/eval exposes EvalSet and offline runner entry points', async () => {
+    const mod = await import('../src/eval/index.js')
+    expect(typeof mod.defineEvalSet).toBe('function')
+    expect(typeof mod.runEvalSet).toBe('function')
+    expect(typeof mod.targetFromAgent).toBe('function')
+  })
 })


### PR DESCRIPTION
## Summary

- add the versioned `EvalSet` contract with Zod validation and frozen definitions
- add framework-agnostic `EvalTarget` plus Agent, Team, and Plan convenience targets
- add bounded-concurrency `runEvalSet()` execution, error records, trace linkage, payload policies, usage totals, and per-scorer/per-tag aggregates
- document the offline workflow, privacy defaults, percentile semantics, and why the API does not expose a seed

## Motivation

The eval subpath already defines scorer and record contracts. This adds the offline regression execution layer needed to run repeatable case sets, sample nondeterministic model behavior with repeats, and produce comparable reports without changing live business execution.

## Scope and impact

- Workspace: `@open-multi-agent/core` and `docs/evaluation.md`
- Public API: additive exports from `@open-multi-agent/core/eval`
- Compatibility: no breaking changes and no dependency changes
- Privacy: payload storage remains opt-in; `none` is the default, `redacted` uses the existing redactor, and all stored payload fields are capped at 8 KiB
- Package boundary: `./eval` has no Node-only I/O; OMA convenience targets load the orchestrator only when executed
- Intentional non-goals: file loading, CLI/report serialization, gates, EvalStore persistence, online sampling, and reference scorers

## Validation

- `npm run lint` — passed
- `npm test` — passed: core 98 files / 1427 tests, create-oma-app 4 / 26, OTel 3 / 15
- `npm run build` — passed
- eval-focused suite — 7 files / 52 tests passed
- `npm pack --dry-run -w @open-multi-agent/core` — passed; new eval artifacts included
- built `dist/eval/index.js` smoke import — passed
- `git diff --check` — passed
- Local runtime: Node 22.22.3; Node 18 and 20 are left to the repository CI matrix

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING