### PR TITLE
feat(core): add eval gates and CI enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,31 @@ jobs:
         run: |
           node -e "Promise.all([import('./dist/index.js'), import('./dist/observability/index.js'), import('./dist/observability/file.js'), import('./dist/acp.js'), import('./dist/process.js'), import('./dist/mcp.js'), import('./dist/ai-sdk.js'), import('./dist/eval/index.js'), import('./dist/eval/file.js')]).then(() => console.log('entry points import OK')).catch((e) => { console.error(e); process.exit(1); })"
           node dist/cli/oma.js help | grep -q "oma eval run"
+          node dist/cli/oma.js help | grep -q "oma eval gate"
           echo "CLI help runs OK"
+      - name: Run the no-network evaluation gate pass and fail paths
+        working-directory: packages/core
+        run: |
+          eval_gate_out=$(mktemp -d)
+          node dist/cli/oma.js eval run \
+            --set tests/fixtures/eval/set.json \
+            --target tests/fixtures/eval/target.mjs \
+            --gate tests/fixtures/eval/gate.json \
+            --baseline tests/fixtures/eval/baseline.json \
+            --out "$eval_gate_out/pass" > "$eval_gate_out/pass-summary.json"
+          jq -e '.verdict.pass == true' "$eval_gate_out/pass-summary.json"
+
+          set +e
+          node dist/cli/oma.js eval run \
+            --set tests/fixtures/eval/set.json \
+            --target tests/fixtures/eval/target-gate-fail.mjs \
+            --gate tests/fixtures/eval/gate.json \
+            --baseline tests/fixtures/eval/baseline.json \
+            --out "$eval_gate_out/fail" > "$eval_gate_out/fail-summary.json"
+          eval_gate_status=$?
+          set -e
+          test "$eval_gate_status" -eq 1
+          jq -e '.verdict.pass == false' "$eval_gate_out/fail-summary.json"
       - name: Assert the create-oma-app template pins the current core version
         run: |
           core_version=$(jq -r .version packages/core/package.json)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -92,15 +92,16 @@ Global flags: [`--pretty`](#output-flags), [`--include-messages`](#output-flags)
 
 ### `oma eval run`
 
-Runs a versioned EvalSet against a user-supplied target and writes one or more
-offline reports without invoking a built-in gate:
+Runs a versioned EvalSet against a user-supplied target, writes one or more
+offline reports, and optionally applies a quality gate:
 
 ```bash
 oma eval run --set ./evals/greetings.json --target ./evals/target.mjs \
   [--scorers ./evals/scorers.mjs] \
   [--repeats 3] [--concurrency 2] [--tags smoke,regression] \
   [--report json] [--report markdown] [--report junit] \
-  [--out ./eval-results] [--meta prompt_version=v2] [--pretty]
+  [--out ./eval-results] [--meta prompt_version=v2] \
+  [--gate ./evals/gate.json] [--baseline ./evals/baseline.json] [--pretty]
 ```
 
 `--set` and `--target` are required. The EvalSet file is parsed as JSON and
@@ -139,10 +140,33 @@ Every invocation writes into `<out>/<evalRunId>/`, using `report.json`,
 and failure details. JUnit maps `pass: false` to `<failure>` and target/scorer
 errors to `<error>`.
 
-A completed evaluation exits 0 even when it contains low or failing scores.
-It exits 1 only when every selected case/repeat target invocation failed. File,
-module, argument, and contract errors exit 2. Score gates and baseline
-comparison are not part of `oma eval run`.
+A completed evaluation without `--gate` exits 0 even when it contains low or
+failing scores. With `--gate`, the CLI loads a validated `GatePolicy`, applies
+threshold, scorer/target-health, and optional baseline-regression checks, adds
+`verdict` and `verdictPath` to the stdout summary, and writes the exact verdict
+to `<out>/<evalRunId>/verdict.json`. A failed gate or every selected target
+failing exits 1. File, module, argument, and contract errors exit 2.
+
+`--baseline` loads a prior JSON `EvalRunReport` and requires `--gate`. A policy
+with baseline rules but no `--baseline` still runs threshold and health checks,
+then reports a warning that regression checks were skipped.
+
+### `oma eval gate`
+
+Applies a gate to an existing authoritative JSON report without rerunning the
+target:
+
+```bash
+oma eval gate --report ./candidate/report.json --gate ./evals/gate.json \
+  [--baseline ./evals/baseline.json] [--pretty]
+```
+
+`--report` and `--gate` are required. The command prints the exact
+`GateVerdict` JSON (`pass`, `failures`, and `warnings`) to stdout. It exits 0
+when the verdict passes, 1 when it fails, and 2 when a report, policy, baseline,
+or argument is invalid. See [Evaluation](evaluation.md#gate-quality-in-ci) for
+the GatePolicy reference, baseline workflow, deterministic gate example, and
+GitHub Actions wiring.
 
 ### `oma provider`
 
@@ -363,8 +387,8 @@ separate progress stream; for live telemetry use the TypeScript API with
 
 | Code | Meaning |
 |------|---------|
-| **0** | Success: `run`/`task` succeeded; dashboard export completed; eval completed without every target failing; or help / `provider` completed normally. Low eval scores alone still exit 0. |
-| **1** | `run`/`task` reported failure, or every selected eval target invocation failed. |
+| **0** | Success: `run`/`task` succeeded; dashboard export completed; eval completed without every target failing and any configured gate passed; or help / `provider` completed normally. Low eval scores alone still exit 0 when no gate is configured. |
+| **1** | `run`/`task` reported failure, every selected eval target invocation failed, or an eval gate failed. |
 | **2** | Usage, validation, readable JSON errors, module-load errors, or file access issues (e.g. missing file). |
 | **3** | Unexpected error, including typical LLM/API failures surfaced as thrown errors. |
 
@@ -387,7 +411,7 @@ esac
 
 - Long options only: `--goal`, `--team`, `--file`, etc.
 - Values may be attached with `=`: `--team=./team.json`.
-- `oma eval run` accepts repeated `--report` and `--meta` options in either attached or separate-value form.
+- `oma eval run` accepts repeated `--report` and `--meta` options in either attached or separate-value form. Gate, baseline, and report-file options accept one path each.
 - Boolean-style flags (`--pretty`, `--include-messages`) take no value; if the next token does not start with `--`, it is treated as the value of the previous option (standard `getopt`-style pairing).
 
 ---

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -123,7 +123,9 @@ entry point.
 
 ```ts
 import {
+  loadEvalReport,
   loadEvalSet,
+  loadGatePolicy,
   writeEvalReport,
 } from '@open-multi-agent/core/eval/file'
 
@@ -133,6 +135,9 @@ const fileReport = await runEvalSet(setFromJson, target, { scorers: [exact] })
 await writeEvalReport(fileReport, { format: 'json', path: './report.json' })
 await writeEvalReport(fileReport, { format: 'markdown', path: './report.md' })
 await writeEvalReport(fileReport, { format: 'junit', path: './report.junit.xml' })
+
+const policy = await loadGatePolicy('./evals/gate.json')
+const baseline = await loadEvalReport('./evals/baseline.json')
 ```
 
 `loadEvalSet()` parses JSON, applies the same validation and deep freezing as
@@ -148,6 +153,10 @@ needed and supports:
   and without an error are successful testcases. XML names and messages are
   fully escaped.
 
+`loadGatePolicy()` and `loadEvalReport()` validate their schema-versioned JSON
+contracts and report the resolved file path plus the first invalid field. Loaded
+objects are defensively copied and deeply frozen.
+
 ## Run evaluations from the CLI
 
 After building or installing the package, a no-network target can be evaluated
@@ -156,6 +165,7 @@ from a shell or CI job:
 ```bash
 oma eval run --set ./evals/greetings.json --target ./evals/target.mjs \
   --report json --report junit --out ./eval-results \
+  --gate ./evals/gate.json --baseline ./evals/baseline.json \
   --meta prompt_version=v2
 ```
 
@@ -171,10 +181,112 @@ key=value` is also repeatable and all values are strings. See
 [the CLI reference](cli.md#oma-eval-run) for the complete argument and exit-code
 contract.
 
-Low scores and `pass: false` records do not change the exit code in this
-command. A normal completed evaluation exits 0, every selected target failing
-exits 1, and usage/file/module errors exit 2. Baseline comparison and quality
-gates are intentionally separate from this command.
+Without `--gate`, low scores and `pass: false` records do not change the exit
+code. With `--gate`, the stdout summary includes the verdict and its path, and
+the exact `{ pass, failures, warnings }` object is written to
+`<out>/<evalRunId>/verdict.json`. A failed gate or every selected target failing
+exits 1. Usage/file/module errors exit 2. `--baseline` requires `--gate`.
+
+## Gate quality in CI
+
+`evaluateGate()` is pure logic exported from `@open-multi-agent/core/eval`:
+
+```ts
+import { evaluateGate } from '@open-multi-agent/core/eval'
+
+const verdict = evaluateGate(report, {
+  schemaVersion: 1,
+  thresholds: [
+    // A rule scorer plus passRate=1 is a deterministic quality gate.
+    { scorer: 'exact', metric: 'passRate', min: 1 },
+    { scorer: 'relevancy', metric: 'avg', min: 0.8 },
+    { scorer: 'relevancy', metric: 'p50', min: 0.85, tag: 'critical' },
+  ],
+  maxScorerErrorRate: 0.1,
+  maxTargetErrorRate: 0,
+  baseline: {
+    maxRegression: 0.05,
+    perScorer: { exact: 0 },
+  },
+}, baseline)
+
+if (!verdict.pass) process.exitCode = 1
+```
+
+The equivalent JSON policy is:
+
+```json
+{
+  "schemaVersion": 1,
+  "thresholds": [
+    { "scorer": "exact", "metric": "passRate", "min": 1 },
+    { "scorer": "relevancy", "metric": "avg", "min": 0.8 },
+    { "scorer": "relevancy", "metric": "p50", "min": 0.85, "tag": "critical" }
+  ],
+  "maxScorerErrorRate": 0.1,
+  "maxTargetErrorRate": 0,
+  "baseline": {
+    "maxRegression": 0.05,
+    "perScorer": { "exact": 0 }
+  }
+}
+```
+
+Thresholds support `avg`, `p50`, `p95`, `min`, and `passRate`, with optional
+tag scoping and inclusive `min`/`max` boundaries. A missing scorer, tag, or
+`passRate` source is a configuration failure rather than a silent pass. The
+health defaults fail when scorer errors exceed 10% of scored plus scorer-error
+records, or when any selected target fails.
+
+Every verdict contains only `pass`, `failures`, and `warnings`. A failure has a
+stable `kind`, optional scorer/metric/tag coordinates, the observed `actual`,
+the configured `limit`, and a human-readable `message`. For failures about
+availability rather than a measured score, `missing_scorer` uses `actual: 0`
+and `limit: 1`, while `baseline_mismatch` uses `actual: 1` and `limit: 0`.
+
+A baseline is an ordinary JSON `EvalRunReport`, not a second file format. The
+recommended workflow is:
+
+1. Run the accepted target with `--report json` and copy its `report.json` to a
+   reviewed location such as `evals/baseline.json`.
+2. Commit that report together with its versioned EvalSet and gate policy.
+3. In CI, compare the candidate report with `--baseline`.
+4. Update the baseline only after intentionally reviewing and accepting the
+   behavior change; the CLI never updates it automatically.
+
+Set name or version mismatches fail by default. Set
+`baseline.allowSetMismatch` to `true` only when a warning plus skipped
+regression checks is intended. When a scorer version differs, OMA warns and
+skips that scorer's regression checks because a changed judge prompt or model
+does not produce a comparable score. Threshold and health checks still run.
+If baseline rules are configured but no baseline report is supplied, OMA warns
+and skips regression checks.
+
+Use `oma eval gate` when report generation and quality enforcement are separate
+CI stages. It prints the exact verdict JSON to stdout:
+
+```bash
+oma eval gate --report ./candidate/report.json --gate ./evals/gate.json \
+  --baseline ./evals/baseline.json
+```
+
+A GitHub Actions job can preserve both machine-readable reports while letting
+the gate control the step status:
+
+```yaml
+- name: Run deterministic evaluation gate
+  run: |
+    oma eval run --set ./evals/set.json --target ./evals/target.mjs \
+      --gate ./evals/gate.json --baseline ./evals/baseline.json \
+      --report json --report junit --out ./eval-results || exit 1
+
+- name: Upload evaluation JUnit report
+  if: always()
+  uses: actions/upload-artifact@v4
+  with:
+    name: evaluation-junit
+    path: eval-results/**/report.junit.xml
+```
 
 ## Payload privacy
 

--- a/packages/core/src/cli/oma.ts
+++ b/packages/core/src/cli/oma.ts
@@ -6,7 +6,7 @@
  *
  * Exit codes:
  *   0 — finished; team run succeeded
- *   1 — finished; team run reported failure (agents/tasks)
+ *   1 — finished; run, eval targets, or an eval gate reported failure
  *   2 — invalid usage, I/O, or JSON validation
  *   3 — unexpected runtime error (including LLM errors)
  */
@@ -18,7 +18,14 @@ import { fileURLToPath, pathToFileURL } from 'node:url'
 
 import { OpenMultiAgent } from '../orchestrator/orchestrator.js'
 import { renderRunViewer } from '../dashboard/render-run-viewer.js'
-import { loadEvalSet, writeEvalReport, type EvalReportFormat } from '../eval/file.js'
+import {
+  loadEvalReport,
+  loadEvalSet,
+  loadGatePolicy,
+  writeEvalReport,
+  type EvalReportFormat,
+} from '../eval/file.js'
+import { evaluateGate, type GateVerdict } from '../eval/gate.js'
 import { runEvalSet } from '../eval/runner.js'
 import type { Scorer } from '../eval/scorer.js'
 import type { EvalTarget } from '../eval/target.js'
@@ -366,12 +373,19 @@ export async function runEvalCli(argv: {
   const scorersPath = getOpt(argv.kv, argv.flags, 'scorers')
   const tags = getOpt(argv.kv, argv.flags, 'tags')
   const out = getOpt(argv.kv, argv.flags, 'out')
+  const gatePath = getOpt(argv.kv, argv.flags, 'gate')
+  const baselinePath = getOpt(argv.kv, argv.flags, 'baseline')
   if (!setPath || !targetPath) {
     throw new OmaValidationError('oma eval run requires --set and --target')
   }
   if (scorersPath === '') throw new OmaValidationError('--scorers requires a non-empty path')
   if (tags === '') throw new OmaValidationError('--tags requires a comma-separated value')
   if (out === '') throw new OmaValidationError('--out requires a non-empty path')
+  if (gatePath === '') throw new OmaValidationError('--gate requires a non-empty path')
+  if (baselinePath === '') throw new OmaValidationError('--baseline requires a non-empty path')
+  if (baselinePath !== undefined && gatePath === undefined) {
+    throw new OmaValidationError('--baseline requires --gate')
+  }
 
   let set
   try {
@@ -381,6 +395,12 @@ export async function runEvalCli(argv: {
     if (code === 'ENOENT' || code === 'EACCES') throw error
     throw new OmaValidationError(error instanceof Error ? error.message : String(error))
   }
+  const gatePolicy = gatePath === undefined
+    ? undefined
+    : await loadEvalCliFile(gatePath, loadGatePolicy)
+  const baseline = baselinePath === undefined
+    ? undefined
+    : await loadEvalCliFile(baselinePath, loadEvalReport)
   const targetModule = await loadEvalTarget(targetPath)
   const explicitScorers = scorersPath === undefined
     ? []
@@ -417,9 +437,17 @@ export async function runEvalCli(argv: {
   ])) as Partial<Record<EvalReportFormat, string>>
   await Promise.all(formats.map((format) =>
     writeEvalReport(report, { format, path: reports[format]! })))
+  const verdict = gatePolicy === undefined
+    ? undefined
+    : evaluateGate(report, gatePolicy, baseline)
+  const verdictPath = verdict === undefined ? undefined : join(outputDirectory, 'verdict.json')
+  if (verdict !== undefined) {
+    await writeFile(verdictPath!, JSON.stringify(verdict, null, 2), 'utf8')
+  }
   const sampleCount = report.caseCount * report.repeats
   return {
-    exit: sampleCount > 0 && report.totals.targetErrors === sampleCount
+    exit: verdict?.pass === false
+      || (sampleCount > 0 && report.totals.targetErrors === sampleCount)
       ? EXIT.RUN_FAILED
       : EXIT.SUCCESS,
     summary: {
@@ -437,7 +465,46 @@ export async function runEvalCli(argv: {
         errorCount: aggregate.errorCount,
       })),
       reports,
+      ...(verdict !== undefined ? { verdict, verdictPath } : {}),
     },
+  }
+}
+
+async function loadEvalCliFile<T>(
+  filePath: string,
+  loader: (path: string) => Promise<T>,
+): Promise<T> {
+  try {
+    return await loader(filePath)
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === 'ENOENT' || code === 'EACCES') throw error
+    throw new OmaValidationError(error instanceof Error ? error.message : String(error))
+  }
+}
+
+export async function runEvalGateCli(argv: {
+  readonly _: readonly string[]
+  readonly flags: ReadonlySet<string>
+  readonly kv: ReadonlyMap<string, string>
+}): Promise<{ readonly exit: number; readonly verdict: GateVerdict }> {
+  const reportPath = getOpt(argv.kv, argv.flags, 'report')
+  const gatePath = getOpt(argv.kv, argv.flags, 'gate')
+  const baselinePath = getOpt(argv.kv, argv.flags, 'baseline')
+  if (!reportPath || !gatePath) {
+    throw new OmaValidationError('oma eval gate requires --report and --gate')
+  }
+  if (baselinePath === '') throw new OmaValidationError('--baseline requires a non-empty path')
+
+  const report = await loadEvalCliFile(reportPath, loadEvalReport)
+  const gatePolicy = await loadEvalCliFile(gatePath, loadGatePolicy)
+  const baseline = baselinePath === undefined
+    ? undefined
+    : await loadEvalCliFile(baselinePath, loadEvalReport)
+  const verdict = evaluateGate(report, gatePolicy, baseline)
+  return {
+    exit: verdict.pass ? EXIT.SUCCESS : EXIT.RUN_FAILED,
+    verdict,
   }
 }
 
@@ -593,6 +660,8 @@ function help(): string {
     '  oma eval run --set <evalset.json> --target <target.mjs> [--scorers <scorers.mjs>]',
     '               [--repeats <n>] [--concurrency <n>] [--tags <a,b>]',
     '               [--report <json|markdown|junit>]... [--out <dir>] [--meta key=value]...',
+    '               [--gate <gate.json>] [--baseline <report.json>]',
+    '  oma eval gate --report <report.json> --gate <gate.json> [--baseline <report.json>]',
     '  oma provider [list | template <provider>]',
     '',
     'Flags:',
@@ -607,7 +676,7 @@ function help(): string {
     'tasks.json: { "team": TeamConfig, "tasks": [ ... ], "orchestrator"?: { ... } }.',
     '  Optional --team overrides the embedded team object.',
     '',
-    'Exit codes: 0 success, 1 run/all eval targets failed, 2 usage/validation, 3 internal',
+    'Exit codes: 0 success, 1 run/eval gate failed, 2 usage/validation, 3 internal',
   ].join('\n')
 }
 
@@ -812,20 +881,27 @@ async function main(): Promise<number> {
 
   try {
     if (cmd === 'eval') {
-      if (argv._[1] !== 'run') {
+      if (argv._[1] === 'run') {
+        const evaluated = await runEvalCli(argv)
+        printJson(evaluated.summary, pretty)
+        return evaluated.exit
+      }
+      if (argv._[1] === 'gate') {
+        const gated = await runEvalGateCli(argv)
+        printJson(gated.verdict, pretty)
+        return gated.exit
+      }
+      if (argv._[1] !== 'run' && argv._[1] !== 'gate') {
         printJson({
           error: {
             kind: 'usage',
             message: argv._[1] === undefined
-              ? 'usage: oma eval run --set <evalset.json> --target <target.mjs>'
+              ? 'usage: oma eval <run|gate>'
               : `unknown eval subcommand: ${argv._[1]}`,
           },
         }, pretty)
         return EXIT.USAGE
       }
-      const evaluated = await runEvalCli(argv)
-      printJson(evaluated.summary, pretty)
-      return evaluated.exit
     }
 
     if (cmd === 'dashboard') {

--- a/packages/core/src/eval/file.ts
+++ b/packages/core/src/eval/file.ts
@@ -1,15 +1,135 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
-import { ZodError } from 'zod'
+import { z, ZodError } from 'zod'
 
 import { defineEvalSet, type EvalSet } from './evalset.js'
+import { gatePolicySchema, type GatePolicy } from './gate.js'
 import type { EvalRunReport, ScorerAggregate } from './report.js'
 import type { EvalRecord } from './record.js'
 
 export type EvalReportFormat = 'json' | 'markdown' | 'junit'
 
 const REASON_MAX_CHARS = 200
+
+const traceAttributeValueSchema = z.union([
+  z.string(),
+  z.number().finite(),
+  z.boolean(),
+  z.array(z.string()),
+  z.array(z.number().finite()),
+  z.array(z.boolean()),
+])
+
+const scorerIdentitySchema = z.object({
+  name: z.string().trim().min(1),
+  version: z.string().optional(),
+})
+
+const tokenUsageSchema = z.object({
+  input_tokens: z.number().int().nonnegative(),
+  output_tokens: z.number().int().nonnegative(),
+})
+
+const costSchema = z.object({
+  amount: z.number().finite().nonnegative(),
+  currency: z.string().trim().min(1),
+})
+
+const structuredTraceErrorSchema = z.object({
+  kind: z.enum([
+    'auth',
+    'rate_limit',
+    'provider',
+    'validation',
+    'timeout',
+    'cancellation',
+    'budget',
+    'store',
+    'exporter',
+    'unknown',
+  ]),
+  code: z.string().optional(),
+  name: z.string().optional(),
+  message: z.string().optional(),
+  retryable: z.boolean().optional(),
+  httpStatus: z.number().int().optional(),
+  provider: z.string().optional(),
+  attempt: z.number().int().positive().optional(),
+})
+
+const evalRecordSchema = z.object({
+  schemaVersion: z.literal(1),
+  recordId: z.string().trim().min(1),
+  evalRunId: z.string().trim().min(1),
+  source: z.enum(['offline', 'online']),
+  timestampUnixMs: z.number().int().nonnegative(),
+  evalSet: z.object({
+    name: z.string().trim().min(1),
+    version: z.string().trim().min(1),
+  }).optional(),
+  caseId: z.string().optional(),
+  repeat: z.number().int().positive().optional(),
+  scorer: scorerIdentitySchema,
+  status: z.enum(['scored', 'scorer_error', 'target_error', 'skipped']),
+  score: z.number().finite().min(0).max(1).optional(),
+  pass: z.boolean().optional(),
+  reason: z.string().optional(),
+  details: z.record(traceAttributeValueSchema).optional(),
+  runRef: z.object({
+    runId: z.string().trim().min(1),
+    attempt: z.number().int().positive(),
+    traceId: z.string().trim().min(1),
+    rootSpanId: z.string().trim().min(1),
+  }).optional(),
+  metadata: z.record(traceAttributeValueSchema),
+  usage: z.object({
+    tokens: tokenUsageSchema.optional(),
+    cost: costSchema.optional(),
+    durationMs: z.number().finite().nonnegative().optional(),
+  }).optional(),
+  error: structuredTraceErrorSchema.optional(),
+  payload: z.object({
+    input: z.string().optional(),
+    output: z.string().optional(),
+    expected: z.string().optional(),
+  }).optional(),
+})
+
+const scorerAggregateSchema: z.ZodTypeAny = z.lazy(() => z.object({
+  scorer: scorerIdentitySchema,
+  scoredCount: z.number().int().nonnegative(),
+  errorCount: z.number().int().nonnegative(),
+  avg: z.number().finite().min(0).max(1),
+  p50: z.number().finite().min(0).max(1),
+  p95: z.number().finite().min(0).max(1),
+  min: z.number().finite().min(0).max(1),
+  max: z.number().finite().min(0).max(1),
+  passRate: z.number().finite().min(0).max(1).optional(),
+  byTag: z.record(scorerAggregateSchema).optional(),
+}))
+
+const evalRunReportSchema = z.object({
+  schemaVersion: z.literal(1),
+  evalRunId: z.string().trim().min(1),
+  startedAtUnixMs: z.number().int().nonnegative(),
+  durationMs: z.number().finite().nonnegative(),
+  evalSet: z.object({
+    name: z.string().trim().min(1),
+    version: z.string().trim().min(1),
+  }),
+  metadata: z.record(traceAttributeValueSchema),
+  caseCount: z.number().int().nonnegative(),
+  repeats: z.number().int().positive(),
+  aborted: z.boolean().optional(),
+  records: z.array(evalRecordSchema),
+  aggregates: z.array(scorerAggregateSchema),
+  totals: z.object({
+    tokens: tokenUsageSchema.optional(),
+    costs: z.array(costSchema).optional(),
+    targetErrors: z.number().int().nonnegative(),
+  }),
+})
 
 function truncateReason(value: string): string {
   if (value.length <= REASON_MAX_CHARS) return value
@@ -21,6 +141,13 @@ function firstZodIssue(error: ZodError): string {
   if (issue === undefined) return error.message
   const path = issue.path.length === 0 ? '' : `${issue.path.join('.')}: `
   return `${path}${issue.message}`
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value === null || typeof value !== 'object' || Object.isFrozen(value)) return value
+  Object.freeze(value)
+  for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child)
+  return value
 }
 
 /** Load, validate, defensively copy, and freeze an EvalSet JSON file. */
@@ -42,6 +169,50 @@ export async function loadEvalSet(filePath: string): Promise<EvalSet> {
       ? firstZodIssue(error)
       : error instanceof Error ? error.message : String(error)
     throw new Error(`Invalid EvalSet in ${absolutePath}: ${message}`)
+  }
+}
+
+/** Load and validate a GatePolicy JSON file. */
+export async function loadGatePolicy(filePath: string): Promise<GatePolicy> {
+  const absolutePath = resolve(filePath)
+  const raw = await readFile(absolutePath, 'utf8')
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw) as unknown
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid GatePolicy JSON in ${absolutePath}: ${message}`)
+  }
+
+  try {
+    return deepFreeze(gatePolicySchema.parse(parsed) as GatePolicy)
+  } catch (error) {
+    const message = error instanceof ZodError
+      ? firstZodIssue(error)
+      : error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid GatePolicy in ${absolutePath}: ${message}`)
+  }
+}
+
+/** Load and validate an authoritative EvalRunReport JSON file. */
+export async function loadEvalReport(filePath: string): Promise<EvalRunReport> {
+  const absolutePath = resolve(filePath)
+  const raw = await readFile(absolutePath, 'utf8')
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw) as unknown
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid EvalRunReport JSON in ${absolutePath}: ${message}`)
+  }
+
+  try {
+    return deepFreeze(evalRunReportSchema.parse(parsed) as EvalRunReport)
+  } catch (error) {
+    const message = error instanceof ZodError
+      ? firstZodIssue(error)
+      : error instanceof Error ? error.message : String(error)
+    throw new Error(`Invalid EvalRunReport in ${absolutePath}: ${message}`)
   }
 }
 

--- a/packages/core/src/eval/gate.ts
+++ b/packages/core/src/eval/gate.ts
@@ -1,0 +1,288 @@
+import { z } from 'zod'
+
+import type { EvalRunReport, ScorerAggregate } from './report.js'
+
+export type GateMetric = 'avg' | 'p50' | 'p95' | 'min' | 'passRate'
+
+export interface GateThreshold {
+  readonly scorer: string
+  readonly metric: GateMetric
+  readonly min?: number
+  readonly max?: number
+  readonly tag?: string
+}
+
+export interface GatePolicy {
+  readonly schemaVersion: 1
+  readonly thresholds: readonly GateThreshold[]
+  /** Fail when scorer errors exceed this share of scored plus scorer-error records. Default 0.1. */
+  readonly maxScorerErrorRate?: number
+  /** Fail when target errors exceed this share of selected samples. Default 0. */
+  readonly maxTargetErrorRate?: number
+  readonly baseline?: {
+    /** Maximum allowed absolute score drop from the baseline. */
+    readonly maxRegression?: number
+    readonly perScorer?: Readonly<Record<string, number>>
+    /** Warn and skip regression checks when the EvalSet identity differs. Default false. */
+    readonly allowSetMismatch?: boolean
+  }
+}
+
+export interface GateFailure {
+  readonly kind:
+    | 'threshold'
+    | 'regression'
+    | 'scorer_health'
+    | 'target_health'
+    | 'baseline_mismatch'
+    | 'missing_scorer'
+  readonly scorer?: string
+  readonly metric?: string
+  readonly tag?: string
+  readonly actual: number
+  readonly limit: number
+  readonly message: string
+}
+
+export interface GateVerdict {
+  readonly pass: boolean
+  readonly failures: readonly GateFailure[]
+  readonly warnings: readonly string[]
+}
+
+const unitInterval = z.number().finite().min(0).max(1)
+
+const gateThresholdSchema = z.object({
+  scorer: z.string().trim().min(1),
+  metric: z.enum(['avg', 'p50', 'p95', 'min', 'passRate']),
+  min: unitInterval.optional(),
+  max: unitInterval.optional(),
+  tag: z.string().trim().min(1).optional(),
+}).superRefine((threshold, context) => {
+  if (threshold.min === undefined && threshold.max === undefined) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'at least one of min or max is required',
+    })
+  }
+  if (
+    threshold.min !== undefined
+    && threshold.max !== undefined
+    && threshold.min > threshold.max
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'min must be less than or equal to max',
+    })
+  }
+})
+
+/** @internal Shared by the Node-only GatePolicy loader. */
+export const gatePolicySchema = z.object({
+  schemaVersion: z.literal(1),
+  thresholds: z.array(gateThresholdSchema),
+  maxScorerErrorRate: unitInterval.optional(),
+  maxTargetErrorRate: unitInterval.optional(),
+  baseline: z.object({
+    maxRegression: unitInterval.optional(),
+    perScorer: z.record(unitInterval).optional(),
+    allowSetMismatch: z.boolean().optional(),
+  }).optional(),
+})
+
+function aggregateFor(
+  report: EvalRunReport,
+  threshold: GateThreshold,
+): ScorerAggregate | undefined {
+  const aggregate = report.aggregates.find((candidate) =>
+    candidate.scorer.name === threshold.scorer)
+  if (aggregate === undefined || threshold.tag === undefined) return aggregate
+  return aggregate.byTag?.[threshold.tag]
+}
+
+function aggregateMetric(
+  aggregate: ScorerAggregate | undefined,
+  metric: GateMetric,
+): number | undefined {
+  if (aggregate === undefined) return undefined
+  return aggregate[metric]
+}
+
+function thresholdTarget(threshold: GateThreshold): string {
+  return threshold.tag === undefined
+    ? `scorer "${threshold.scorer}"`
+    : `scorer "${threshold.scorer}" for tag "${threshold.tag}"`
+}
+
+function missingThresholdFailure(threshold: GateThreshold): GateFailure {
+  const aggregateTarget = thresholdTarget(threshold)
+  const suffix = threshold.metric === 'passRate'
+    ? ' or has no scored records with a pass value'
+    : ''
+  return {
+    kind: 'missing_scorer',
+    scorer: threshold.scorer,
+    metric: threshold.metric,
+    ...(threshold.tag !== undefined ? { tag: threshold.tag } : {}),
+    actual: 0,
+    limit: 1,
+    message: `Gate threshold references ${aggregateTarget}, but the metric "${threshold.metric}" is unavailable${suffix}.`,
+  }
+}
+
+function thresholdFailures(
+  report: EvalRunReport,
+  threshold: GateThreshold,
+): readonly GateFailure[] {
+  const actual = aggregateMetric(aggregateFor(report, threshold), threshold.metric)
+  if (actual === undefined) return [missingThresholdFailure(threshold)]
+
+  const target = thresholdTarget(threshold)
+  const failures: GateFailure[] = []
+  if (threshold.min !== undefined && actual < threshold.min) {
+    failures.push({
+      kind: 'threshold',
+      scorer: threshold.scorer,
+      metric: threshold.metric,
+      ...(threshold.tag !== undefined ? { tag: threshold.tag } : {}),
+      actual,
+      limit: threshold.min,
+      message: `Gate metric "${threshold.metric}" for ${target} is ${actual}, below minimum ${threshold.min}.`,
+    })
+  }
+  if (threshold.max !== undefined && actual > threshold.max) {
+    failures.push({
+      kind: 'threshold',
+      scorer: threshold.scorer,
+      metric: threshold.metric,
+      ...(threshold.tag !== undefined ? { tag: threshold.tag } : {}),
+      actual,
+      limit: threshold.max,
+      message: `Gate metric "${threshold.metric}" for ${target} is ${actual}, above maximum ${threshold.max}.`,
+    })
+  }
+  return failures
+}
+
+function scorerVersion(report: EvalRunReport, scorer: string): string | undefined {
+  return report.aggregates.find((aggregate) => aggregate.scorer.name === scorer)?.scorer.version
+}
+
+function displayVersion(version: string | undefined): string {
+  return version === undefined ? '(unversioned)' : `"${version}"`
+}
+
+function sameEvalSet(current: EvalRunReport, baseline: EvalRunReport): boolean {
+  return current.evalSet.name === baseline.evalSet.name
+    && current.evalSet.version === baseline.evalSet.version
+}
+
+function evalSetIdentity(report: EvalRunReport): string {
+  return `${report.evalSet.name}@${report.evalSet.version}`
+}
+
+function exceedsComputedLimit(actual: number, limit: number): boolean {
+  const tolerance = Number.EPSILON * 4 * Math.max(1, Math.abs(actual), Math.abs(limit))
+  return actual - limit > tolerance
+}
+
+/** Evaluate thresholds, scorer/target health, and an optional one-report baseline. */
+export function evaluateGate(
+  report: EvalRunReport,
+  policy: GatePolicy,
+  baseline?: EvalRunReport,
+): GateVerdict {
+  const validatedPolicy = gatePolicySchema.parse(policy) as GatePolicy
+  const failures = validatedPolicy.thresholds.flatMap((threshold) =>
+    thresholdFailures(report, threshold)) as GateFailure[]
+  const warnings = new Set<string>()
+
+  const scorerRecords = report.records.filter((record) =>
+    record.status === 'scored' || record.status === 'scorer_error')
+  const scorerErrors = scorerRecords.filter((record) => record.status === 'scorer_error').length
+  const scorerErrorRate = scorerRecords.length === 0 ? 0 : scorerErrors / scorerRecords.length
+  const maxScorerErrorRate = validatedPolicy.maxScorerErrorRate ?? 0.1
+  if (scorerErrorRate > maxScorerErrorRate) {
+    failures.push({
+      kind: 'scorer_health',
+      actual: scorerErrorRate,
+      limit: maxScorerErrorRate,
+      message: `Scorer error rate ${scorerErrorRate} exceeds maximum ${maxScorerErrorRate}.`,
+    })
+  }
+
+  const sampleCount = report.caseCount * report.repeats
+  const targetErrorRate = sampleCount === 0 ? 0 : report.totals.targetErrors / sampleCount
+  const maxTargetErrorRate = validatedPolicy.maxTargetErrorRate ?? 0
+  if (targetErrorRate > maxTargetErrorRate) {
+    failures.push({
+      kind: 'target_health',
+      actual: targetErrorRate,
+      limit: maxTargetErrorRate,
+      message: `Target error rate ${targetErrorRate} exceeds maximum ${maxTargetErrorRate}.`,
+    })
+  }
+
+  if (baseline === undefined) {
+    if (validatedPolicy.baseline !== undefined) {
+      warnings.add(
+        'Baseline policy is configured but no baseline report was provided; regression checks were skipped.',
+      )
+    }
+  } else if (!sameEvalSet(report, baseline)) {
+    const message = `Baseline EvalSet mismatch: current is ${evalSetIdentity(report)}, baseline is ${evalSetIdentity(baseline)}; regression checks were skipped.`
+    if (validatedPolicy.baseline?.allowSetMismatch === true) {
+      warnings.add(message)
+    } else {
+      failures.push({
+        kind: 'baseline_mismatch',
+        actual: 1,
+        limit: 0,
+        message,
+      })
+    }
+  } else {
+    for (const threshold of validatedPolicy.thresholds) {
+      const maxRegression = validatedPolicy.baseline?.perScorer?.[threshold.scorer]
+        ?? validatedPolicy.baseline?.maxRegression
+      if (maxRegression === undefined) continue
+
+      const currentVersion = scorerVersion(report, threshold.scorer)
+      const baselineVersion = scorerVersion(baseline, threshold.scorer)
+      if (currentVersion !== baselineVersion) {
+        warnings.add(
+          `Scorer version drift for "${threshold.scorer}": current ${displayVersion(currentVersion)}, baseline ${displayVersion(baselineVersion)}; regression checks were skipped for this scorer.`,
+        )
+        continue
+      }
+
+      const currentValue = aggregateMetric(aggregateFor(report, threshold), threshold.metric)
+      const baselineValue = aggregateMetric(aggregateFor(baseline, threshold), threshold.metric)
+      if (currentValue === undefined || baselineValue === undefined) {
+        warnings.add(
+          `Baseline metric "${threshold.metric}" for ${thresholdTarget(threshold)} is unavailable; regression check was skipped.`,
+        )
+        continue
+      }
+
+      const regression = baselineValue - currentValue
+      if (exceedsComputedLimit(regression, maxRegression)) {
+        failures.push({
+          kind: 'regression',
+          scorer: threshold.scorer,
+          metric: threshold.metric,
+          ...(threshold.tag !== undefined ? { tag: threshold.tag } : {}),
+          actual: regression,
+          limit: maxRegression,
+          message: `Gate metric "${threshold.metric}" for ${thresholdTarget(threshold)} regressed by ${regression} (baseline ${baselineValue}, current ${currentValue}), exceeding ${maxRegression}.`,
+        })
+      }
+    }
+  }
+
+  return {
+    pass: failures.length === 0,
+    failures,
+    warnings: [...warnings],
+  }
+}

--- a/packages/core/src/eval/index.ts
+++ b/packages/core/src/eval/index.ts
@@ -18,3 +18,11 @@ export type {
 export { runEvalSet } from './runner.js'
 export type { EvalProgressEvent, RunEvalOptions } from './runner.js'
 export type { EvalRunReport, ScorerAggregate } from './report.js'
+export { evaluateGate } from './gate.js'
+export type {
+  GateFailure,
+  GateMetric,
+  GatePolicy,
+  GateThreshold,
+  GateVerdict,
+} from './gate.js'

--- a/packages/core/tests/eval-file.test.ts
+++ b/packages/core/tests/eval-file.test.ts
@@ -4,7 +4,12 @@ import { join, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
 
-import { loadEvalSet, writeEvalReport } from '../src/eval/file.js'
+import {
+  loadEvalReport,
+  loadEvalSet,
+  loadGatePolicy,
+  writeEvalReport,
+} from '../src/eval/file.js'
 import type { EvalRunReport } from '../src/eval/report.js'
 
 async function temporaryDirectory(): Promise<string> {
@@ -170,6 +175,74 @@ describe('loadEvalSet', () => {
 
     await expect(loadEvalSet(path)).rejects.toThrow(
       `Invalid EvalSet in ${resolve(path)}: EvalSet case id "a" must be unique.`,
+    )
+  })
+})
+
+describe('loadGatePolicy', () => {
+  it('loads, validates, and freezes a gate policy', async () => {
+    const path = join(await temporaryDirectory(), 'gate.json')
+    await writeFile(path, JSON.stringify({
+      schemaVersion: 1,
+      thresholds: [{ scorer: 'exact', metric: 'passRate', min: 1 }],
+      baseline: { maxRegression: 0.05 },
+    }), 'utf8')
+
+    const policy = await loadGatePolicy(path)
+
+    expect(policy).toEqual({
+      schemaVersion: 1,
+      thresholds: [{ scorer: 'exact', metric: 'passRate', min: 1 }],
+      baseline: { maxRegression: 0.05 },
+    })
+    expect(Object.isFrozen(policy)).toBe(true)
+    expect(Object.isFrozen(policy.thresholds)).toBe(true)
+  })
+
+  it('rejects malformed JSON and reports schema issue paths', async () => {
+    const directory = await temporaryDirectory()
+    const broken = join(directory, 'broken-gate.json')
+    const invalid = join(directory, 'invalid-gate.json')
+    await writeFile(broken, '{', 'utf8')
+    await writeFile(invalid, JSON.stringify({
+      schemaVersion: 1,
+      thresholds: [{ scorer: 'exact', metric: 'avg' }],
+    }), 'utf8')
+
+    await expect(loadGatePolicy(broken)).rejects.toThrow(
+      `Invalid GatePolicy JSON in ${resolve(broken)}`,
+    )
+    await expect(loadGatePolicy(invalid)).rejects.toThrow(
+      `Invalid GatePolicy in ${resolve(invalid)}: thresholds.0:`,
+    )
+  })
+})
+
+describe('loadEvalReport', () => {
+  it('round-trips and freezes an authoritative report', async () => {
+    const path = join(await temporaryDirectory(), 'report.json')
+    const fixture = reportFixture()
+    await writeFile(path, JSON.stringify(fixture), 'utf8')
+
+    const loaded = await loadEvalReport(path)
+
+    expect(loaded).toEqual(fixture)
+    expect(Object.isFrozen(loaded)).toBe(true)
+    expect(Object.isFrozen(loaded.records)).toBe(true)
+  })
+
+  it('rejects malformed JSON and unsupported schema versions', async () => {
+    const directory = await temporaryDirectory()
+    const broken = join(directory, 'broken-report.json')
+    const invalid = join(directory, 'invalid-report.json')
+    await writeFile(broken, '{', 'utf8')
+    await writeFile(invalid, JSON.stringify({ ...reportFixture(), schemaVersion: 2 }), 'utf8')
+
+    await expect(loadEvalReport(broken)).rejects.toThrow(
+      `Invalid EvalRunReport JSON in ${resolve(broken)}`,
+    )
+    await expect(loadEvalReport(invalid)).rejects.toThrow(
+      `Invalid EvalRunReport in ${resolve(invalid)}: schemaVersion:`,
     )
   })
 })

--- a/packages/core/tests/eval-gate-cli.test.ts
+++ b/packages/core/tests/eval-gate-cli.test.ts
@@ -1,0 +1,209 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+import { describe, expect, it } from 'vitest'
+
+const cliSource = fileURLToPath(new URL('../src/cli/oma.ts', import.meta.url))
+const tsxBinary = fileURLToPath(new URL('../../../node_modules/.bin/tsx', import.meta.url))
+const fixtures = fileURLToPath(new URL('./fixtures/eval/', import.meta.url))
+const setPath = join(fixtures, 'set.json')
+const targetPath = join(fixtures, 'target.mjs')
+const failingTargetPath = join(fixtures, 'target-gate-fail.mjs')
+const gatePath = join(fixtures, 'gate.json')
+const baselinePath = join(fixtures, 'baseline.json')
+
+interface CliRun {
+  readonly status: number | null
+  readonly stdout: string
+  readonly stderr: string
+}
+
+function temporaryDirectory(): string {
+  return mkdtempSync(join(tmpdir(), 'oma-eval-gate-cli-'))
+}
+
+function runCli(args: readonly string[], cwd = temporaryDirectory()): CliRun {
+  const result = spawnSync(tsxBinary, [cliSource, ...args], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, NO_COLOR: '1' },
+  })
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  }
+}
+
+function output(run: CliRun): Record<string, unknown> {
+  return JSON.parse(run.stdout) as Record<string, unknown>
+}
+
+function failingReportPath(): string {
+  const report = JSON.parse(readFileSync(baselinePath, 'utf8')) as {
+    records: Array<Record<string, unknown>>
+    aggregates: Array<Record<string, unknown>>
+  }
+  report.records = report.records.map((record) => ({
+    ...record,
+    score: 0,
+    pass: false,
+    reason: 'mismatch',
+  }))
+  report.aggregates = report.aggregates.map((aggregate) => ({
+    ...aggregate,
+    avg: 0,
+    p50: 0,
+    p95: 0,
+    min: 0,
+    max: 0,
+    passRate: 0,
+  }))
+  const path = join(temporaryDirectory(), 'failing-report.json')
+  writeFileSync(path, JSON.stringify(report), 'utf8')
+  return path
+}
+
+describe('oma eval run quality gate', () => {
+  it('runs a no-network gate+baseline flow with pass and fail exit paths', () => {
+    const passingOut = temporaryDirectory()
+    const passing = runCli([
+      'eval', 'run',
+      '--set', setPath,
+      '--target', targetPath,
+      '--gate', gatePath,
+      '--baseline', baselinePath,
+      '--report', 'junit',
+      '--out', passingOut,
+    ])
+
+    expect(passing.status, passing.stderr).toBe(0)
+    const passingSummary = output(passing)
+    expect(passingSummary['verdict']).toEqual({ pass: true, failures: [], warnings: [] })
+    const passingVerdictPath = passingSummary['verdictPath'] as string
+    expect(passingVerdictPath).toBe(join(
+      passingOut,
+      String(passingSummary['evalRunId']),
+      'verdict.json',
+    ))
+    expect(JSON.parse(readFileSync(passingVerdictPath, 'utf8'))).toEqual(
+      passingSummary['verdict'],
+    )
+
+    const failingOut = temporaryDirectory()
+    const failing = runCli([
+      'eval', 'run',
+      '--set', setPath,
+      '--target', failingTargetPath,
+      '--gate', gatePath,
+      '--baseline', baselinePath,
+      '--out', failingOut,
+    ])
+
+    expect(failing.status, failing.stderr).toBe(1)
+    const failingSummary = output(failing)
+    const verdict = failingSummary['verdict'] as {
+      pass: boolean
+      failures: Array<{ kind: string }>
+    }
+    expect(verdict.pass).toBe(false)
+    expect(verdict.failures.map((failure) => failure.kind)).toEqual([
+      'threshold',
+      'regression',
+    ])
+    expect(JSON.parse(readFileSync(failingSummary['verdictPath'] as string, 'utf8'))).toEqual(
+      verdict,
+    )
+  })
+
+  it('supports --gate without a baseline and rejects --baseline without --gate', () => {
+    const gated = runCli([
+      'eval', 'run',
+      '--set', setPath,
+      '--target', targetPath,
+      '--gate', gatePath,
+      '--out', temporaryDirectory(),
+    ])
+
+    expect(gated.status, gated.stderr).toBe(0)
+    expect(output(gated)['verdict']).toMatchObject({
+      pass: true,
+      warnings: [expect.stringContaining('no baseline report was provided')],
+    })
+
+    const baselineOnly = runCli([
+      'eval', 'run',
+      '--set', setPath,
+      '--target', targetPath,
+      '--baseline', baselinePath,
+    ])
+    expect(baselineOnly.status).toBe(2)
+    expect(output(baselineOnly)).toEqual({
+      error: { kind: 'validation', message: '--baseline requires --gate' },
+    })
+  })
+})
+
+describe('oma eval gate', () => {
+  it('evaluates existing reports with pass and fail exit paths', () => {
+    const passing = runCli([
+      'eval', 'gate',
+      '--report', baselinePath,
+      '--gate', gatePath,
+      '--baseline', baselinePath,
+    ])
+    expect(passing.status, passing.stderr).toBe(0)
+    expect(output(passing)).toEqual({ pass: true, failures: [], warnings: [] })
+
+    const failing = runCli([
+      'eval', 'gate',
+      '--report', failingReportPath(),
+      '--gate', gatePath,
+      '--baseline', baselinePath,
+    ])
+    expect(failing.status, failing.stderr).toBe(1)
+    expect(output(failing)).toMatchObject({
+      pass: false,
+      failures: [
+        { kind: 'threshold' },
+        { kind: 'regression' },
+      ],
+    })
+  })
+
+  it('maps invalid gate and report files to usage exit code 2', () => {
+    const directory = temporaryDirectory()
+    const invalidGate = join(directory, 'invalid-gate.json')
+    const invalidReport = join(directory, 'invalid-report.json')
+    writeFileSync(invalidGate, JSON.stringify({ schemaVersion: 2, thresholds: [] }), 'utf8')
+    writeFileSync(invalidReport, JSON.stringify({ schemaVersion: 2 }), 'utf8')
+
+    const gateFailure = runCli([
+      'eval', 'gate',
+      '--report', baselinePath,
+      '--gate', invalidGate,
+    ])
+    expect(gateFailure.status).toBe(2)
+    expect(output(gateFailure)).toMatchObject({ error: { kind: 'validation' } })
+
+    const reportFailure = runCli([
+      'eval', 'gate',
+      '--report', invalidReport,
+      '--gate', gatePath,
+    ])
+    expect(reportFailure.status).toBe(2)
+    expect(output(reportFailure)).toMatchObject({ error: { kind: 'validation' } })
+  })
+
+  it('is documented in CLI help', () => {
+    const run = runCli(['help'])
+    expect(run.status).toBe(0)
+    expect(run.stdout).toContain(
+      'oma eval gate --report <report.json> --gate <gate.json> [--baseline <report.json>]',
+    )
+  })
+})

--- a/packages/core/tests/eval-gate.test.ts
+++ b/packages/core/tests/eval-gate.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest'
+
+import { evaluateGate, type GatePolicy } from '../src/eval/gate.js'
+import type { EvalRunReport, ScorerAggregate } from '../src/eval/report.js'
+import type { EvalRecord } from '../src/eval/record.js'
+
+function record(status: 'scored' | 'scorer_error', index: number): EvalRecord {
+  return {
+    schemaVersion: 1,
+    recordId: `record-${index}`,
+    evalRunId: 'run-1',
+    source: 'offline',
+    timestampUnixMs: index,
+    evalSet: { name: 'fixture', version: '1' },
+    caseId: `case-${index}`,
+    repeat: 1,
+    scorer: { name: 'exact', version: '1' },
+    status,
+    ...(status === 'scored' ? { score: 0.8, pass: true } : {}),
+    metadata: {},
+  }
+}
+
+function aggregate(options: {
+  readonly name?: string
+  readonly version?: string
+  readonly avg?: number
+  readonly passRate?: number | null
+  readonly byTag?: Readonly<Record<string, ScorerAggregate>>
+} = {}): ScorerAggregate {
+  const avg = options.avg ?? 0.8
+  const passRate = options.passRate === undefined ? 0.8 : options.passRate
+  return {
+    scorer: { name: options.name ?? 'exact', version: options.version ?? '1' },
+    scoredCount: 10,
+    errorCount: 0,
+    avg,
+    p50: avg,
+    p95: avg,
+    min: avg,
+    max: avg,
+    ...(passRate !== null ? { passRate } : {}),
+    ...(options.byTag !== undefined ? { byTag: options.byTag } : {}),
+  }
+}
+
+function report(options: {
+  readonly name?: string
+  readonly version?: string
+  readonly aggregate?: ScorerAggregate
+  readonly records?: readonly EvalRecord[]
+  readonly caseCount?: number
+  readonly repeats?: number
+  readonly targetErrors?: number
+} = {}): EvalRunReport {
+  return {
+    schemaVersion: 1,
+    evalRunId: 'run-1',
+    startedAtUnixMs: 1,
+    durationMs: 1,
+    evalSet: { name: options.name ?? 'fixture', version: options.version ?? '1' },
+    metadata: {},
+    caseCount: options.caseCount ?? 10,
+    repeats: options.repeats ?? 1,
+    records: options.records ?? [],
+    aggregates: [options.aggregate ?? aggregate()],
+    totals: { targetErrors: options.targetErrors ?? 0 },
+  }
+}
+
+function policy(
+  thresholds: GatePolicy['thresholds'],
+  options: Omit<GatePolicy, 'schemaVersion' | 'thresholds'> = {},
+): GatePolicy {
+  return { schemaVersion: 1, thresholds, ...options }
+}
+
+describe('evaluateGate thresholds', () => {
+  it('rejects a threshold without min or max', () => {
+    expect(() => evaluateGate(report(), {
+      schemaVersion: 1,
+      thresholds: [{ scorer: 'exact', metric: 'avg' }],
+    })).toThrow('at least one of min or max is required')
+  })
+
+  it('fails min, max, and tag-scoped thresholds while equality passes', () => {
+    const tagged = aggregate({ avg: 0.4, passRate: 0.4 })
+    const current = report({
+      aggregate: aggregate({ byTag: { critical: tagged } }),
+    })
+
+    const verdict = evaluateGate(current, policy([
+      { scorer: 'exact', metric: 'avg', min: 0.8 },
+      { scorer: 'exact', metric: 'avg', max: 0.8 },
+      { scorer: 'exact', metric: 'p50', min: 0.9 },
+      { scorer: 'exact', metric: 'p95', max: 0.7 },
+      { scorer: 'exact', metric: 'avg', min: 0.5, tag: 'critical' },
+    ]))
+
+    expect(verdict.pass).toBe(false)
+    expect(verdict.failures).toHaveLength(3)
+    expect(verdict.failures).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'threshold', metric: 'p50', actual: 0.8, limit: 0.9 }),
+      expect.objectContaining({ kind: 'threshold', metric: 'p95', actual: 0.8, limit: 0.7 }),
+      expect.objectContaining({ kind: 'threshold', metric: 'avg', tag: 'critical', actual: 0.4 }),
+    ]))
+  })
+
+  it('fails visibly for a missing scorer, tag, or passRate source', () => {
+    const noPassRate = report({ aggregate: aggregate({ passRate: null }) })
+    const verdict = evaluateGate(noPassRate, policy([
+      { scorer: 'missing', metric: 'avg', min: 0.5 },
+      { scorer: 'exact', metric: 'avg', min: 0.5, tag: 'missing' },
+      { scorer: 'exact', metric: 'passRate', min: 1 },
+    ]))
+
+    expect(verdict.failures.map((failure) => failure.kind)).toEqual([
+      'missing_scorer',
+      'missing_scorer',
+      'missing_scorer',
+    ])
+    expect(verdict.failures[0]?.message).toContain('missing')
+    expect(verdict.failures[1]?.message).toContain('tag "missing"')
+    expect(verdict.failures[2]?.message).toContain('no scored records with a pass value')
+  })
+})
+
+describe('evaluateGate baseline regression', () => {
+  it('passes an equal-limit regression and improvements, but fails a larger drop', () => {
+    const current = report({ aggregate: aggregate({ avg: 0.7 }) })
+    const equal = evaluateGate(
+      current,
+      policy([{ scorer: 'exact', metric: 'avg', min: 0 }], {
+        baseline: { maxRegression: 0.1 },
+      }),
+      report({ aggregate: aggregate({ avg: 0.8 }) }),
+    )
+    const regressed = evaluateGate(
+      current,
+      policy([{ scorer: 'exact', metric: 'avg', min: 0 }], {
+        baseline: { maxRegression: 0.1 },
+      }),
+      report({ aggregate: aggregate({ avg: 0.81 }) }),
+    )
+    const improved = evaluateGate(
+      report({ aggregate: aggregate({ avg: 0.8 }) }),
+      policy([{ scorer: 'exact', metric: 'avg', min: 0 }], {
+        baseline: { maxRegression: 0.1 },
+      }),
+      report({ aggregate: aggregate({ avg: 0.7 }) }),
+    )
+
+    expect(equal.pass).toBe(true)
+    expect(regressed.failures).toEqual([
+      expect.objectContaining({ kind: 'regression', scorer: 'exact', metric: 'avg', limit: 0.1 }),
+    ])
+    expect(improved.pass).toBe(true)
+  })
+
+  it('uses a per-scorer regression limit instead of the global limit', () => {
+    const verdict = evaluateGate(
+      report({ aggregate: aggregate({ avg: 0.8 }) }),
+      policy([{ scorer: 'exact', metric: 'avg', min: 0 }], {
+        baseline: { maxRegression: 0.1, perScorer: { exact: 0.02 } },
+      }),
+      report({ aggregate: aggregate({ avg: 0.83 }) }),
+    )
+
+    expect(verdict.failures).toEqual([
+      expect.objectContaining({ kind: 'regression', limit: 0.02 }),
+    ])
+  })
+
+  it('fails name or version mismatches unless allowSetMismatch downgrades them', () => {
+    for (const baseline of [report({ name: 'other' }), report({ version: '2' })]) {
+      const failed = evaluateGate(report(), policy([], { baseline: {} }), baseline)
+      const allowed = evaluateGate(
+        report(),
+        policy([], { baseline: { allowSetMismatch: true } }),
+        baseline,
+      )
+
+      expect(failed.failures).toEqual([
+        expect.objectContaining({ kind: 'baseline_mismatch', actual: 1, limit: 0 }),
+      ])
+      expect(allowed.pass).toBe(true)
+      expect(allowed.warnings[0]).toContain('Baseline EvalSet mismatch')
+    }
+  })
+
+  it('warns once and skips regression when the scorer version drifts', () => {
+    const verdict = evaluateGate(
+      report({ aggregate: aggregate({ version: '2', avg: 0.5 }) }),
+      policy([
+        { scorer: 'exact', metric: 'avg', min: 0 },
+        { scorer: 'exact', metric: 'p50', min: 0 },
+      ], { baseline: { maxRegression: 0 } }),
+      report({ aggregate: aggregate({ version: '1', avg: 1 }) }),
+    )
+
+    expect(verdict.pass).toBe(true)
+    expect(verdict.failures).toEqual([])
+    expect(verdict.warnings).toHaveLength(1)
+    expect(verdict.warnings[0]).toContain('Scorer version drift')
+  })
+})
+
+describe('evaluateGate health and warnings', () => {
+  it('applies scorer health defaults, explicit limits, and equality boundaries', () => {
+    const records = Array.from({ length: 10 }, (_, index) =>
+      record(index === 0 ? 'scorer_error' : 'scored', index))
+    const boundary = evaluateGate(report({ records }), policy([]))
+    const failed = evaluateGate(
+      report({ records: records.map((entry, index) =>
+        index === 1 ? record('scorer_error', index) : entry) }),
+      policy([]),
+    )
+    const explicitBoundary = evaluateGate(
+      report({ records: records.map((entry, index) =>
+        index === 1 ? record('scorer_error', index) : entry) }),
+      policy([], { maxScorerErrorRate: 0.2 }),
+    )
+
+    expect(boundary.pass).toBe(true)
+    expect(failed.failures).toEqual([
+      expect.objectContaining({ kind: 'scorer_health', actual: 0.2, limit: 0.1 }),
+    ])
+    expect(explicitBoundary.pass).toBe(true)
+  })
+
+  it('applies target health defaults, explicit limits, and equality boundaries', () => {
+    const failed = evaluateGate(report({ targetErrors: 1 }), policy([]))
+    const explicitBoundary = evaluateGate(
+      report({ targetErrors: 1 }),
+      policy([], { maxTargetErrorRate: 0.1 }),
+    )
+
+    expect(failed.failures).toEqual([
+      expect.objectContaining({ kind: 'target_health', actual: 0.1, limit: 0 }),
+    ])
+    expect(explicitBoundary.pass).toBe(true)
+  })
+
+  it('allows an empty threshold list and warns when baseline rules lack a report', () => {
+    const verdict = evaluateGate(
+      report(),
+      policy([], { baseline: { maxRegression: 0.05 } }),
+    )
+
+    expect(verdict.pass).toBe(true)
+    expect(verdict.failures).toEqual([])
+    expect(verdict.warnings).toEqual([
+      'Baseline policy is configured but no baseline report was provided; regression checks were skipped.',
+    ])
+  })
+})

--- a/packages/core/tests/fixtures/eval/baseline.json
+++ b/packages/core/tests/fixtures/eval/baseline.json
@@ -1,0 +1,92 @@
+{
+  "schemaVersion": 1,
+  "evalRunId": "baseline-uppercase-1",
+  "startedAtUnixMs": 1784332800000,
+  "durationMs": 1,
+  "evalSet": {
+    "name": "uppercase",
+    "version": "1.0.0"
+  },
+  "metadata": {},
+  "caseCount": 2,
+  "repeats": 1,
+  "records": [
+    {
+      "schemaVersion": 1,
+      "recordId": "baseline-hello-exact",
+      "evalRunId": "baseline-uppercase-1",
+      "source": "offline",
+      "timestampUnixMs": 1784332800000,
+      "evalSet": {
+        "name": "uppercase",
+        "version": "1.0.0"
+      },
+      "caseId": "hello",
+      "repeat": 1,
+      "scorer": {
+        "name": "exact",
+        "version": "1"
+      },
+      "status": "scored",
+      "score": 1,
+      "pass": true,
+      "metadata": {}
+    },
+    {
+      "schemaVersion": 1,
+      "recordId": "baseline-world-exact",
+      "evalRunId": "baseline-uppercase-1",
+      "source": "offline",
+      "timestampUnixMs": 1784332800001,
+      "evalSet": {
+        "name": "uppercase",
+        "version": "1.0.0"
+      },
+      "caseId": "world",
+      "repeat": 1,
+      "scorer": {
+        "name": "exact",
+        "version": "1"
+      },
+      "status": "scored",
+      "score": 1,
+      "pass": true,
+      "metadata": {}
+    }
+  ],
+  "aggregates": [
+    {
+      "scorer": {
+        "name": "exact",
+        "version": "1"
+      },
+      "scoredCount": 2,
+      "errorCount": 0,
+      "avg": 1,
+      "p50": 1,
+      "p95": 1,
+      "min": 1,
+      "max": 1,
+      "passRate": 1,
+      "byTag": {
+        "upper": {
+          "scorer": {
+            "name": "exact",
+            "version": "1"
+          },
+          "scoredCount": 2,
+          "errorCount": 0,
+          "avg": 1,
+          "p50": 1,
+          "p95": 1,
+          "min": 1,
+          "max": 1,
+          "passRate": 1
+        }
+      }
+    }
+  ],
+  "totals": {
+    "targetErrors": 0
+  }
+}

--- a/packages/core/tests/fixtures/eval/gate.json
+++ b/packages/core/tests/fixtures/eval/gate.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "thresholds": [
+    {
+      "scorer": "exact",
+      "metric": "passRate",
+      "min": 1
+    }
+  ],
+  "maxScorerErrorRate": 0,
+  "maxTargetErrorRate": 0,
+  "baseline": {
+    "maxRegression": 0
+  }
+}

--- a/packages/core/tests/fixtures/eval/target-gate-fail.mjs
+++ b/packages/core/tests/fixtures/eval/target-gate-fail.mjs
@@ -1,0 +1,12 @@
+const target = async (input) => ({ output: String(input).toLowerCase() })
+
+const exact = {
+  name: 'exact',
+  version: '1',
+  score({ output, evalCase }) {
+    const pass = output === evalCase.expected
+    return { score: pass ? 1 : 0, pass, reason: pass ? 'matched' : 'mismatch' }
+  },
+}
+
+export default { target, scorers: [exact] }

--- a/packages/core/tests/subpath-exports.test.ts
+++ b/packages/core/tests/subpath-exports.test.ts
@@ -28,11 +28,14 @@ describe('subpath export barrels', () => {
     expect(typeof mod.defineEvalSet).toBe('function')
     expect(typeof mod.runEvalSet).toBe('function')
     expect(typeof mod.targetFromAgent).toBe('function')
+    expect(typeof mod.evaluateGate).toBe('function')
   })
 
   it('/eval/file exposes Node-only EvalSet and report file helpers', async () => {
     const mod = await import('../src/eval/file.js')
     expect(typeof mod.loadEvalSet).toBe('function')
+    expect(typeof mod.loadEvalReport).toBe('function')
+    expect(typeof mod.loadGatePolicy).toBe('function')
     expect(typeof mod.writeEvalReport).toBe('function')
   })
 })


### PR DESCRIPTION
## Summary

- Add the public `evaluateGate()` contract for score thresholds, scorer and target health, baseline regression checks, set mismatch handling, and scorer-version drift warnings.
- Add validated `GatePolicy` and `EvalRunReport` file loaders plus `oma eval run --gate/--baseline` and the offline `oma eval gate` command.
- Persist `verdict.json`, add no-network pass/fail fixtures and CI smoke coverage, and document deterministic gates, baseline maintenance, and GitHub Actions wiring.

## Motivation

Offline evaluation reports need an enforceable quality boundary so CI can fail on low scores, unhealthy scorers or targets, and regressions from an accepted baseline.

## Scope and impact

- Affected areas: `@open-multi-agent/core/eval`, `@open-multi-agent/core/eval/file`, the `oma` CLI, evaluation docs, tests, and the package CI smoke job.
- Public API changes are additive: new gate types and `evaluateGate()`, plus `loadGatePolicy()` and `loadEvalReport()`.
- CLI behavior is additive: a configured gate returns exit code 1 on failure and writes `<out>/<evalRunId>/verdict.json`; `oma eval gate` prints the verdict for an existing report.
- Compatibility: threshold and regression equality pass; missing scorers or tags fail visibly; scorer-version drift warns and skips only the incomparable regression check.
- Dependencies and privacy: no dependency changes; root and `./eval` imports remain free of Node-only file I/O; fixtures are deterministic and require no network or credentials.
- Intentional non-goals: trend aggregation, EvalStore integration, online sampling, automatic baseline updates, and real-LLM evaluation in this repository's CI.

## Validation

- `npm run lint` passed on Node 20 and Node 22.
- `npm test` passed on Node 18, Node 20, and Node 22: core 102 files / 1462 tests, create-oma-app 4 / 26, and OTel 3 / 15 on each version.
- `npm run build` passed on Node 20 and Node 22.
- Targeted evaluation tests passed: 5 files / 39 tests.
- Built CLI pass/fail gate paths, exit codes, help output, and `verdict.json` persistence passed without network access.
- `npm pack --dry-run` assertions passed on Node 20 and Node 22, including the new gate runtime and declaration files.
- `git diff --check`, package boundary checks, and the three-runtime-dependency assertion passed.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING
