### PR TITLE
feat(core): add EvalStore contract and reference stores

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -84,6 +84,108 @@ Each case/repeat target runs once, then that sample's scorers run serially. Diff
 
 Report percentiles use the nearest-rank method. For two sorted scores, p50 is the lower score and p95 is the higher score. `passRate` only includes scored records that explicitly contain `pass`; scorer errors are excluded from every score denominator. `byTag` repeats the same aggregation for each case tag. Target token usage is counted once per sample, even when multiple scorers run, and costs are summed only within the same currency.
 
+## Persist evaluation records
+
+Use `InMemoryEvalStore` for short-lived local runs, tests, or an adapter
+prototype. Pass it to `runEvalSet()` to persist one atomic batch per completed
+case/repeat sample:
+
+```ts
+import {
+  InMemoryEvalStore,
+  runEvalSet,
+} from '@open-multi-agent/core/eval'
+
+const store = new InMemoryEvalStore()
+const storedReport = await runEvalSet(set, target, {
+  scorers: [exact],
+  store,
+})
+
+const first = await store.query({
+  evalRunId: storedReport.evalRunId,
+  scorer: ['exact'],
+  order: 'time_asc',
+  limit: 100,
+})
+```
+
+`EvalStore.append()` is atomic per batch and idempotent by `recordId`. Queries
+can filter by evaluation run, referenced OMA run, EvalSet name, scorer, source,
+status, and inclusive `after` / exclusive `before` timestamps. Results use the
+stable `(timestampUnixMs, recordId)` order. The default page limit is 100 and
+the maximum is 1,000.
+
+Cursors are opaque snapshots. Appends after the first page do not create gaps
+or duplicates in that pagination sequence. A cursor is valid only for the same
+store instance and normalized query; changing filters, deleting records, or
+reopening a file store invalidates it. Do not parse or persist cursors as data.
+
+The optional `InMemoryEvalStore({ maxRecords })` capacity is a hard limit. A
+batch that would exceed it is rejected atomically. Use retention explicitly
+when eviction is intended:
+
+```ts
+await store.applyRetention({
+  maxAgeMs: 30 * 24 * 60 * 60 * 1_000,
+  maxRecords: 10_000,
+  sources: ['offline'],
+})
+
+await store.delete({
+  evalSetName: 'greetings',
+  before: new Date('2026-01-01T00:00:00.000Z').toISOString(),
+})
+```
+
+Deletion and retention are idempotent. In their shared `DeleteResult`,
+`runIds` contains affected `evalRunId` values, `runsDeleted` counts distinct
+affected evaluation runs, and `recordsDeleted` counts records. A `sources`
+retention scope applies both age and count limits only to those sources; when it
+is the only field, all records in the selected sources are deleted.
+
+For durable local storage, import the Node-only implementation separately:
+
+```ts
+import { FileEvalStore } from '@open-multi-agent/core/eval/file'
+
+const fileStore = await FileEvalStore.open('./eval-results/history.ndjson', {
+  onDiagnostic(diagnostic) {
+    console.warn(diagnostic.code, diagnostic.message)
+  },
+})
+
+await fileStore.append(storedReport.records)
+await fileStore.flush()
+await fileStore.compact()
+await fileStore.close()
+```
+
+`FileEvalStore` is a single-process reference implementation, not a production
+database or a cross-process coordination layer. It keeps an append-only,
+schema-versioned NDJSON mutation log and rebuilds its in-memory index on open.
+A committed batch is visible in full or not at all; a process or machine crash
+can lose at most the last, not-yet-durable batch. `flush()` is the explicit
+fsync boundary. Recovery truncates only an incomplete final line or batch and
+emits a diagnostic; complete corruption fails loudly.
+
+Compaction writes `<file>.compact.tmp`, fsyncs it, atomically renames it over the
+target, and then fsyncs the parent directory where supported. A stale temp file
+never overrides an existing target. Use a database-backed `EvalStore` adapter
+when multiple processes, large data volumes, or server-side aggregation are
+required.
+
+Stores preserve unknown fields within the supported schema major so future
+minor additions survive a round trip. A higher `schemaVersion` major is
+rejected rather than downgraded. There is intentionally no aggregation method
+on `EvalStore`: calculate trends from queried records in memory. Needing
+aggregation pushdown is a signal to introduce a database adapter, not to add
+file-specific concepts to the interface.
+
+Persistence is fail-open for the evaluation run. If a sample batch cannot be
+stored, `runEvalSet()` still returns its complete records and aggregates and
+adds one payload-free entry to `report.warnings` for that sample.
+
 ## Evaluate OMA runs
 
 Use the convenience targets when the system under evaluation is an OMA agent, team, or fixed plan:

--- a/packages/core/src/eval/file-store.ts
+++ b/packages/core/src/eval/file-store.ts
@@ -1,0 +1,839 @@
+/**
+ * Node-only, single-process reference EvalStore backed by append-only NDJSON.
+ * Import from `@open-multi-agent/core/eval/file`.
+ *
+ * Mutations use start/item/commit envelopes. Recovery accepts a batch only
+ * when its item count and SHA-256 checksum match, so an interrupted final
+ * append is replayed completely or discarded completely.
+ */
+
+import { createHash, randomUUID } from 'node:crypto'
+import {
+  mkdir,
+  open,
+  readFile,
+  rename,
+  stat,
+  type FileHandle,
+} from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { AppendResult, DeleteResult, Page } from '../observability/store.js'
+import { EVAL_STORE_SCHEMA_MAJOR, type EvalRecord } from './record.js'
+import {
+  EVAL_STORE_INTERNALS,
+  EvalStoreError,
+  InMemoryEvalStore,
+  type EvalDeleteQuery,
+  type EvalQuery,
+  type EvalRetentionPolicy,
+  type EvalStore,
+} from './store.js'
+
+export const FILE_EVAL_STORE_FORMAT = 'oma.file_eval_store' as const
+export const FILE_EVAL_STORE_FORMAT_VERSION = 1 as const
+
+export type FileEvalStoreErrorCode =
+  | 'INVALID_PATH'
+  | 'OPEN_FAILED'
+  | 'READ_FAILED'
+  | 'WRITE_FAILED'
+  | 'SYNC_FAILED'
+  | 'CLOSE_FAILED'
+  | 'CORRUPT_FILE'
+  | 'UNSUPPORTED_FILE_FORMAT'
+  | 'UNSUPPORTED_EVAL_SCHEMA'
+  | 'RECOVERY_FAILED'
+  | 'STALE_COMPACTION_FILE'
+  | 'RENAME_FAILED'
+  | 'COMPACTION_FAILED'
+  | 'CLOSED'
+  | 'RECOVERY_REQUIRED'
+
+/** Payload-free, structured FileEvalStore lifecycle or filesystem failure. */
+export class FileEvalStoreError extends Error {
+  readonly name = 'FileEvalStoreError'
+
+  constructor(
+    readonly code: FileEvalStoreErrorCode,
+    message: string,
+    readonly operation?: string,
+    readonly path?: string,
+    readonly lineNumber?: number,
+    readonly causeCode?: string,
+  ) {
+    super(message)
+  }
+}
+
+export type FileEvalStoreDiagnosticCode =
+  | 'trailing_partial_line'
+  | 'incomplete_batch'
+  | 'stale_compaction_file'
+  | 'directory_sync_unsupported'
+  | 'minimal_permissions_not_enforced'
+
+export interface FileEvalStoreDiagnostic {
+  readonly code: FileEvalStoreDiagnosticCode
+  readonly severity: 'warning'
+  readonly message: string
+  readonly lineNumber?: number
+}
+
+export interface FileEvalStoreOptions {
+  /** Injectable wall clock used only by retention. */
+  readonly now?: () => number
+  readonly onDiagnostic?: (diagnostic: FileEvalStoreDiagnostic) => void
+}
+
+export interface FileEvalStoreCompactionResult {
+  readonly recordsWritten: number
+  readonly fileSizeBytes: number
+}
+
+interface FileHeader {
+  readonly type: 'file_header'
+  readonly format: typeof FILE_EVAL_STORE_FORMAT
+  readonly formatVersion: typeof FILE_EVAL_STORE_FORMAT_VERSION
+  readonly evalSchemaMajor: typeof EVAL_STORE_SCHEMA_MAJOR
+}
+
+type MutationOperation = 'append' | 'delete'
+
+interface BatchStart {
+  readonly type: 'batch_start'
+  readonly formatVersion: typeof FILE_EVAL_STORE_FORMAT_VERSION
+  readonly batchId: string
+  readonly operation: MutationOperation
+  readonly itemCount: number
+  readonly payloadSha256: string
+}
+
+interface BatchItem {
+  readonly type: 'batch_item'
+  readonly batchId: string
+  readonly index: number
+  readonly payload: unknown
+}
+
+interface BatchCommit {
+  readonly type: 'batch_commit'
+  readonly batchId: string
+  readonly itemCount: number
+  readonly payloadSha256: string
+}
+
+interface PendingBatch {
+  readonly start: BatchStart
+  readonly payloads: unknown[]
+  readonly startLine: number
+}
+
+interface ParsedFile {
+  readonly memory: InMemoryEvalStore
+  readonly header: FileHeader
+  readonly repairOffset?: number
+}
+
+const HEADER: FileHeader = {
+  type: 'file_header',
+  format: FILE_EVAL_STORE_FORMAT,
+  formatVersion: FILE_EVAL_STORE_FORMAT_VERSION,
+  evalSchemaMajor: EVAL_STORE_SCHEMA_MAJOR,
+}
+
+const DIRECTORY_SYNC_UNSUPPORTED = new Set([
+  'EINVAL', 'ENOTSUP', 'EOPNOTSUPP', 'EISDIR', 'EPERM',
+])
+
+/** @internal Mutable indirection used only for deterministic filesystem failure tests. */
+export const FILE_EVAL_STORE_IO = {
+  mkdir,
+  open,
+  readFile,
+  rename,
+  stat,
+  writeFile: (handle: FileHandle, data: string) => handle.writeFile(data, 'utf8'),
+  sync: (handle: FileHandle) => handle.sync(),
+  close: (handle: FileHandle) => handle.close(),
+  truncate: (handle: FileHandle, length: number) => handle.truncate(length),
+  chmod: (handle: FileHandle, mode: number) => handle.chmod(mode),
+}
+
+function errno(error: unknown): string | undefined {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code
+  return typeof code === 'string' ? code : undefined
+}
+
+function emitSafely(
+  callback: FileEvalStoreOptions['onDiagnostic'],
+  diagnostic: FileEvalStoreDiagnostic,
+): void {
+  try { callback?.(diagnostic) } catch { /* diagnostics never affect storage */ }
+}
+
+function fileError(
+  code: FileEvalStoreErrorCode,
+  message: string,
+  operation: string,
+  path: string,
+  cause?: unknown,
+  lineNumber?: number,
+): FileEvalStoreError {
+  return new FileEvalStoreError(code, message, operation, path, lineNumber, errno(cause))
+}
+
+function parseObject(line: string, path: string, lineNumber: number): Record<string, unknown> {
+  try {
+    const value = JSON.parse(line) as unknown
+    if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('not-object')
+    return value as Record<string, unknown>
+  } catch {
+    throw fileError(
+      'CORRUPT_FILE',
+      'FileEvalStore encountered an invalid complete NDJSON line.',
+      'recover', path, undefined, lineNumber,
+    )
+  }
+}
+
+function nonEmpty(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0
+}
+
+function payloadChecksum(payloads: readonly unknown[]): string {
+  const hash = createHash('sha256')
+  for (const payload of payloads) {
+    hash.update(JSON.stringify(payload))
+    hash.update('\n')
+  }
+  return hash.digest('hex')
+}
+
+function serializeBatch(
+  operation: MutationOperation,
+  payloads: readonly unknown[],
+  batchId: string = randomUUID(),
+): string {
+  const checksum = payloadChecksum(payloads)
+  const start: BatchStart = {
+    type: 'batch_start',
+    formatVersion: FILE_EVAL_STORE_FORMAT_VERSION,
+    batchId,
+    operation,
+    itemCount: payloads.length,
+    payloadSha256: checksum,
+  }
+  const lines = [JSON.stringify(start)]
+  for (let index = 0; index < payloads.length; index++) {
+    lines.push(JSON.stringify({
+      type: 'batch_item', batchId, index, payload: payloads[index],
+    } satisfies BatchItem))
+  }
+  lines.push(JSON.stringify({
+    type: 'batch_commit', batchId, itemCount: payloads.length, payloadSha256: checksum,
+  } satisfies BatchCommit))
+  return `${lines.join('\n')}\n`
+}
+
+function cloneJson<T>(value: T, field: string): T {
+  try {
+    const serialized = JSON.stringify(value)
+    if (serialized === undefined) throw new Error('not serializable')
+    return JSON.parse(serialized) as T
+  } catch {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} must be JSON-serializable.`, field)
+  }
+}
+
+/**
+ * Persistent local EvalStore reference. One instance serializes every read and
+ * write; multiple instances or processes must not write the same file.
+ */
+export class FileEvalStore implements EvalStore {
+  readonly filePath: string
+  readonly compactionTempPath: string
+
+  private memory: InMemoryEvalStore
+  private header: FileHeader
+  private operationChain: Promise<void> = Promise.resolve()
+  private state: 'open' | 'closing' | 'closed' | 'failed' = 'open'
+  private closePromise: Promise<void> | null = null
+  private readonly diagnostics: FileEvalStoreDiagnostic[] = []
+
+  private constructor(
+    filePath: string,
+    memory: InMemoryEvalStore,
+    header: FileHeader,
+    private readonly options: FileEvalStoreOptions,
+  ) {
+    this.filePath = filePath
+    this.compactionTempPath = `${filePath}.compact.tmp`
+    this.memory = memory
+    this.header = header
+  }
+
+  /** Open or create a store, repair only an incomplete tail, and rebuild indexes. */
+  static async open(filePath: string, options: FileEvalStoreOptions = {}): Promise<FileEvalStore> {
+    if (typeof filePath !== 'string' || filePath.length === 0 || filePath.includes('\0')) {
+      throw new FileEvalStoreError(
+        'INVALID_PATH',
+        'FileEvalStore path must be a non-empty filesystem path.',
+        'open',
+      )
+    }
+    const absolute = resolve(filePath)
+    const tempPath = `${absolute}.compact.tmp`
+    const tempExists = await FileEvalStore.pathExists(tempPath, 'open')
+    const targetExists = await FileEvalStore.pathExists(absolute, 'open')
+    if (!targetExists && tempExists) {
+      throw fileError(
+        'STALE_COMPACTION_FILE',
+        'A compaction temp file exists without the target file; refusing to create an empty store.',
+        'open', absolute,
+      )
+    }
+    if (!targetExists) await FileEvalStore.createFile(absolute, options)
+
+    const provisional = new FileEvalStore(
+      absolute,
+      new InMemoryEvalStore({ now: options.now }),
+      HEADER,
+      options,
+    )
+    if (tempExists) provisional.emitFileDiagnostic({
+      code: 'stale_compaction_file',
+      severity: 'warning',
+      message: 'A stale compaction temp file was found; the committed target file remains authoritative.',
+    })
+    const parsed = await provisional.parseFile(true)
+    provisional.memory = parsed.memory
+    provisional.header = parsed.header
+    if (process.platform === 'win32') provisional.emitFileDiagnostic({
+      code: 'minimal_permissions_not_enforced',
+      severity: 'warning',
+      message: 'This platform does not enforce POSIX mode 0600; protect the file with platform access controls.',
+    })
+    return provisional
+  }
+
+  get isClosed(): boolean {
+    return this.state === 'closed'
+  }
+
+  getDiagnostics(): readonly FileEvalStoreDiagnostic[] {
+    return cloneJson(this.diagnostics, 'diagnostics')
+  }
+
+  async append(records: readonly EvalRecord[]): Promise<AppendResult> {
+    const snapshot = cloneJson(records, 'records')
+    return this.enqueue(async () => {
+      const result = await this.memory.append(snapshot)
+      if (snapshot.length > 0) {
+        try {
+          await this.appendMutation('append', snapshot)
+        } catch (error) {
+          await this.rollbackAfterMutationFailure(error)
+          throw error
+        }
+      }
+      return result
+    })
+  }
+
+  async query(query: EvalQuery = {}): Promise<Page<EvalRecord>> {
+    const snapshot = cloneJson(query, 'query')
+    return this.enqueue(() => this.memory.query(snapshot))
+  }
+
+  async delete(query: EvalDeleteQuery): Promise<DeleteResult> {
+    const snapshot = cloneJson(query, 'query')
+    return this.enqueue(async () => {
+      const before = this.currentRecords()
+      const result = await this.memory.delete(snapshot)
+      return this.persistDeleteResult(result, this.deletedRecordIds(before))
+    })
+  }
+
+  async applyRetention(policy: EvalRetentionPolicy): Promise<DeleteResult> {
+    const snapshot = cloneJson(policy, 'policy')
+    return this.enqueue(async () => {
+      const before = this.currentRecords()
+      const result = await this.memory.applyRetention(snapshot)
+      return this.persistDeleteResult(result, this.deletedRecordIds(before))
+    })
+  }
+
+  /** fsync all writes that completed before this call. The store remains open. */
+  async flush(): Promise<void> {
+    return this.enqueue(() => this.syncTarget('flush'))
+  }
+
+  /** Rewrite current records through same-directory temp, fsync, and atomic rename. */
+  async compact(): Promise<FileEvalStoreCompactionResult> {
+    return this.enqueue(async () => {
+      const records = this.currentRecords()
+      const checksum = payloadChecksum(records)
+      const body = records.length > 0
+        ? `${JSON.stringify(this.header)}\n${serializeBatch('append', records, `compact-${checksum.slice(0, 24)}`)}`
+        : `${JSON.stringify(this.header)}\n`
+      let handle: FileHandle | undefined
+      let renamed = false
+      try {
+        handle = await FILE_EVAL_STORE_IO.open(this.compactionTempPath, 'w', 0o600)
+        await FILE_EVAL_STORE_IO.chmod(handle, 0o600)
+        await FILE_EVAL_STORE_IO.writeFile(handle, body)
+        await FILE_EVAL_STORE_IO.sync(handle)
+        await FILE_EVAL_STORE_IO.close(handle)
+        handle = undefined
+        try {
+          await FILE_EVAL_STORE_IO.rename(this.compactionTempPath, this.filePath)
+          renamed = true
+        } catch (error) {
+          throw fileError(
+            'RENAME_FAILED',
+            'FileEvalStore compaction could not atomically replace the target; the original remains authoritative.',
+            'compact.rename', this.filePath, error,
+          )
+        }
+        await this.syncDirectory('compact')
+        const info = await FILE_EVAL_STORE_IO.stat(this.filePath)
+        return { recordsWritten: records.length, fileSizeBytes: info.size }
+      } catch (error) {
+        if (handle) await FILE_EVAL_STORE_IO.close(handle).catch(() => undefined)
+        if (error instanceof FileEvalStoreError) throw error
+        throw fileError(
+          'COMPACTION_FAILED',
+          renamed
+            ? 'FileEvalStore replaced the compacted file but could not confirm the final durability step.'
+            : 'FileEvalStore compaction failed before replacing the committed target file.',
+          'compact', this.filePath, error,
+        )
+      }
+    })
+  }
+
+  /** Idempotently fsync prior writes and reject all later operations. */
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise
+    if (this.state === 'closed') return Promise.resolve()
+    if (this.state === 'failed') {
+      this.state = 'closed'
+      this.closePromise = Promise.reject(fileError(
+        'RECOVERY_REQUIRED',
+        'FileEvalStore cannot close cleanly after an unrecoverable write failure.',
+        'close', this.filePath,
+      ))
+      return this.closePromise
+    }
+    this.state = 'closing'
+    const closing = this.operationChain.then(async () => {
+      if (this.state === 'failed') {
+        throw fileError(
+          'RECOVERY_REQUIRED',
+          'FileEvalStore cannot close cleanly after an unrecoverable write failure.',
+          'close', this.filePath,
+        )
+      }
+      try {
+        await this.syncTarget('close')
+      } catch (error) {
+        if (error instanceof FileEvalStoreError) throw error
+        throw fileError('CLOSE_FAILED', 'FileEvalStore close failed.', 'close', this.filePath, error)
+      }
+    })
+    this.closePromise = closing.then(
+      () => { this.state = 'closed' },
+      (error) => { this.state = 'closed'; throw error },
+    )
+    this.operationChain = this.closePromise.then(() => undefined, () => undefined)
+    return this.closePromise
+  }
+
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.state === 'failed') {
+      return Promise.reject(fileError(
+        'RECOVERY_REQUIRED',
+        'FileEvalStore requires reopen/recovery before further operations.',
+        'operation', this.filePath,
+      ))
+    }
+    if (this.state !== 'open') {
+      return Promise.reject(fileError(
+        'CLOSED',
+        'FileEvalStore is closing or closed.',
+        'operation', this.filePath,
+      ))
+    }
+    const run = this.operationChain.then(operation)
+    this.operationChain = run.then(() => undefined, () => undefined)
+    return run
+  }
+
+  private currentRecords(): EvalRecord[] {
+    return [...this.memory[EVAL_STORE_INTERNALS]().records()]
+  }
+
+  private deletedRecordIds(before: readonly EvalRecord[]): string[] {
+    const remaining = new Set(this.currentRecords().map((record) => record.recordId))
+    return before
+      .filter((record) => !remaining.has(record.recordId))
+      .map((record) => record.recordId)
+  }
+
+  private async persistDeleteResult(
+    result: DeleteResult,
+    recordIds: readonly string[],
+  ): Promise<DeleteResult> {
+    if (recordIds.length === 0) return result
+    try {
+      await this.appendMutation('delete', recordIds.map((recordId) => ({ recordId })))
+      return result
+    } catch (error) {
+      await this.rollbackAfterMutationFailure(error)
+      throw error
+    }
+  }
+
+  private async appendMutation(
+    operation: MutationOperation,
+    payloads: readonly unknown[],
+  ): Promise<void> {
+    let startSize: number
+    try {
+      startSize = (await FILE_EVAL_STORE_IO.stat(this.filePath)).size
+    } catch (error) {
+      throw fileError(
+        'WRITE_FAILED',
+        'FileEvalStore could not inspect its data file before writing.',
+        'append.stat', this.filePath, error,
+      )
+    }
+    let handle: FileHandle | undefined
+    try {
+      handle = await FILE_EVAL_STORE_IO.open(this.filePath, 'a')
+      await FILE_EVAL_STORE_IO.writeFile(handle, serializeBatch(operation, payloads))
+      await FILE_EVAL_STORE_IO.close(handle)
+    } catch (error) {
+      if (handle) await FILE_EVAL_STORE_IO.close(handle).catch(() => undefined)
+      const writeError = fileError(
+        'WRITE_FAILED',
+        'FileEvalStore append did not complete; the mutation was not acknowledged.',
+        'append.write', this.filePath, error,
+      )
+      try {
+        await this.truncateAndSync(startSize)
+      } catch (rollbackError) {
+        this.state = 'failed'
+        throw fileError(
+          'RECOVERY_REQUIRED',
+          'FileEvalStore could not roll back a failed append; reopen is required.',
+          'append.rollback', this.filePath, rollbackError,
+        )
+      }
+      throw writeError
+    }
+  }
+
+  private async rollbackAfterMutationFailure(original: unknown): Promise<void> {
+    if (this.state === 'failed') return
+    try {
+      const parsed = await this.parseFile(false)
+      this.memory = parsed.memory
+      this.header = parsed.header
+    } catch (recoveryError) {
+      this.state = 'failed'
+      throw fileError(
+        'RECOVERY_REQUIRED',
+        'FileEvalStore could not rebuild state after a failed mutation.',
+        'rollback', this.filePath, recoveryError,
+      )
+    }
+    if (original instanceof Error) return
+  }
+
+  private async truncateAndSync(length: number): Promise<void> {
+    let handle: FileHandle | undefined
+    try {
+      handle = await FILE_EVAL_STORE_IO.open(this.filePath, 'r+')
+      await FILE_EVAL_STORE_IO.truncate(handle, length)
+      await FILE_EVAL_STORE_IO.sync(handle)
+      await FILE_EVAL_STORE_IO.close(handle)
+      handle = undefined
+    } finally {
+      if (handle) await FILE_EVAL_STORE_IO.close(handle).catch(() => undefined)
+    }
+  }
+
+  private async syncTarget(operation: string): Promise<void> {
+    let handle: FileHandle | undefined
+    try {
+      handle = await FILE_EVAL_STORE_IO.open(this.filePath, 'r')
+      await FILE_EVAL_STORE_IO.sync(handle)
+      await FILE_EVAL_STORE_IO.close(handle)
+      handle = undefined
+    } catch (error) {
+      if (handle) await FILE_EVAL_STORE_IO.close(handle).catch(() => undefined)
+      throw fileError(
+        'SYNC_FAILED',
+        'FileEvalStore could not fsync its data file.',
+        operation, this.filePath, error,
+      )
+    }
+  }
+
+  private async parseFile(repairTail: boolean): Promise<ParsedFile> {
+    let raw: Buffer
+    try {
+      raw = await FILE_EVAL_STORE_IO.readFile(this.filePath)
+    } catch (error) {
+      throw fileError('READ_FAILED', 'FileEvalStore could not read its data file.', 'recover.read', this.filePath, error)
+    }
+    const memory = new InMemoryEvalStore({ now: this.options.now })
+    let offset = 0
+    let lineNumber = 0
+    let lastCommittedOffset = 0
+    let header: FileHeader | undefined
+    let pending: PendingBatch | undefined
+    while (offset < raw.length) {
+      const newline = raw.indexOf(0x0a, offset)
+      if (newline === -1) {
+        this.emitFileDiagnostic({
+          code: 'trailing_partial_line',
+          severity: 'warning',
+          lineNumber: lineNumber + 1,
+          message: 'A trailing partial NDJSON line was ignored and will be truncated.',
+        })
+        break
+      }
+      lineNumber++
+      const line = raw.subarray(offset, newline).toString('utf8')
+      const nextOffset = newline + 1
+      if (line.length === 0) {
+        throw fileError(
+          'CORRUPT_FILE',
+          'FileEvalStore encountered an empty complete NDJSON line.',
+          'recover', this.filePath, undefined, lineNumber,
+        )
+      }
+      const value = parseObject(line, this.filePath, lineNumber)
+      if (!header) {
+        header = this.parseHeader(value, lineNumber)
+        lastCommittedOffset = nextOffset
+        offset = nextOffset
+        continue
+      }
+      const type = value['type']
+      if (type === 'batch_start') {
+        if (pending) throw this.corruption('A new batch began before the prior batch committed.', lineNumber)
+        pending = { start: this.parseBatchStart(value, lineNumber), payloads: [], startLine: lineNumber }
+      } else if (type === 'batch_item') {
+        if (!pending) throw this.corruption('A batch item appeared without a batch start.', lineNumber)
+        const item = this.parseBatchItem(value, lineNumber)
+        if (item.batchId !== pending.start.batchId || item.index !== pending.payloads.length) {
+          throw this.corruption('A batch item has a mismatched id or non-contiguous index.', lineNumber)
+        }
+        if (pending.payloads.length >= pending.start.itemCount) {
+          throw this.corruption('A batch contains more items than declared.', lineNumber)
+        }
+        pending.payloads.push(item.payload)
+      } else if (type === 'batch_commit') {
+        if (!pending) throw this.corruption('A batch commit appeared without a batch start.', lineNumber)
+        const commit = this.parseBatchCommit(value, lineNumber)
+        const checksum = payloadChecksum(pending.payloads)
+        if (commit.batchId !== pending.start.batchId
+          || commit.itemCount !== pending.start.itemCount
+          || pending.payloads.length !== pending.start.itemCount
+          || commit.payloadSha256 !== pending.start.payloadSha256
+          || checksum !== pending.start.payloadSha256) {
+          throw this.corruption('A committed batch failed its id, count, or checksum validation.', lineNumber)
+        }
+        await this.applyRecoveredBatch(memory, pending, lineNumber)
+        pending = undefined
+        lastCommittedOffset = nextOffset
+      } else {
+        throw this.corruption('FileEvalStore encountered an unknown envelope line type.', lineNumber)
+      }
+      offset = nextOffset
+    }
+    if (!header) {
+      throw fileError(
+        'CORRUPT_FILE',
+        'FileEvalStore has no complete version header.',
+        'recover', this.filePath,
+      )
+    }
+    const hasPartialLine = offset < raw.length
+    if (pending) this.emitFileDiagnostic({
+      code: 'incomplete_batch',
+      severity: 'warning',
+      lineNumber: pending.startLine,
+      message: 'An uncommitted trailing batch was ignored and will be truncated.',
+    })
+    const needsRepair = hasPartialLine || pending !== undefined
+    if (needsRepair && repairTail) {
+      try {
+        await this.truncateAndSync(lastCommittedOffset)
+      } catch (error) {
+        throw fileError(
+          'RECOVERY_FAILED',
+          'FileEvalStore could not truncate an incomplete tail during recovery.',
+          'recover.truncate', this.filePath, error,
+        )
+      }
+    }
+    return { memory, header, ...(needsRepair ? { repairOffset: lastCommittedOffset } : {}) }
+  }
+
+  private parseHeader(value: Record<string, unknown>, lineNumber: number): FileHeader {
+    if (value['type'] !== 'file_header' || value['format'] !== FILE_EVAL_STORE_FORMAT) {
+      throw this.corruption('FileEvalStore header format is invalid.', lineNumber)
+    }
+    if (value['formatVersion'] !== FILE_EVAL_STORE_FORMAT_VERSION) {
+      throw fileError(
+        'UNSUPPORTED_FILE_FORMAT',
+        'FileEvalStore file format version is unsupported.',
+        'recover.header', this.filePath, undefined, lineNumber,
+      )
+    }
+    if (value['evalSchemaMajor'] !== EVAL_STORE_SCHEMA_MAJOR) {
+      throw fileError(
+        'UNSUPPORTED_EVAL_SCHEMA',
+        'FileEvalStore evaluation schema major is unsupported.',
+        'recover.header', this.filePath, undefined, lineNumber,
+      )
+    }
+    return HEADER
+  }
+
+  private parseBatchStart(value: Record<string, unknown>, lineNumber: number): BatchStart {
+    if (value['formatVersion'] !== FILE_EVAL_STORE_FORMAT_VERSION
+      || !nonEmpty(value['batchId'])
+      || (value['operation'] !== 'append' && value['operation'] !== 'delete')
+      || !Number.isInteger(value['itemCount']) || (value['itemCount'] as number) < 0
+      || !nonEmpty(value['payloadSha256'])) {
+      throw this.corruption('A batch_start envelope is malformed.', lineNumber)
+    }
+    return value as unknown as BatchStart
+  }
+
+  private parseBatchItem(value: Record<string, unknown>, lineNumber: number): BatchItem {
+    if (!nonEmpty(value['batchId']) || !Number.isInteger(value['index'])
+      || (value['index'] as number) < 0
+      || !Object.prototype.hasOwnProperty.call(value, 'payload')) {
+      throw this.corruption('A batch_item envelope is malformed.', lineNumber)
+    }
+    return value as unknown as BatchItem
+  }
+
+  private parseBatchCommit(value: Record<string, unknown>, lineNumber: number): BatchCommit {
+    if (!nonEmpty(value['batchId']) || !Number.isInteger(value['itemCount'])
+      || (value['itemCount'] as number) < 0
+      || !nonEmpty(value['payloadSha256'])) {
+      throw this.corruption('A batch_commit envelope is malformed.', lineNumber)
+    }
+    return value as unknown as BatchCommit
+  }
+
+  private async applyRecoveredBatch(
+    memory: InMemoryEvalStore,
+    pending: PendingBatch,
+    lineNumber: number,
+  ): Promise<void> {
+    try {
+      if (pending.start.operation === 'append') {
+        await memory.append(pending.payloads as EvalRecord[])
+      } else {
+        const recordIds = pending.payloads.map((payload) => {
+          if (!payload || typeof payload !== 'object' || Array.isArray(payload)
+            || !nonEmpty((payload as Record<string, unknown>)['recordId'])) {
+            throw new Error('invalid-delete-payload')
+          }
+          return (payload as { recordId: string }).recordId
+        })
+        memory[EVAL_STORE_INTERNALS]().deleteRecordIds(recordIds)
+      }
+    } catch (error) {
+      if (error instanceof EvalStoreError && error.code === 'UNSUPPORTED_SCHEMA_VERSION') {
+        throw fileError(
+          'UNSUPPORTED_EVAL_SCHEMA',
+          'A committed batch contains an unsupported evaluation schema major.',
+          'recover.batch', this.filePath, error, lineNumber,
+        )
+      }
+      throw fileError(
+        'CORRUPT_FILE',
+        'A committed batch contains invalid data.',
+        'recover.batch', this.filePath, error, lineNumber,
+      )
+    }
+  }
+
+  private corruption(message: string, lineNumber: number): FileEvalStoreError {
+    return fileError('CORRUPT_FILE', message, 'recover', this.filePath, undefined, lineNumber)
+  }
+
+  private emitFileDiagnostic(diagnostic: FileEvalStoreDiagnostic): void {
+    this.diagnostics.push(diagnostic)
+    emitSafely(this.options.onDiagnostic, diagnostic)
+  }
+
+  private async syncDirectory(operation: string): Promise<void> {
+    let handle: FileHandle | undefined
+    try {
+      handle = await FILE_EVAL_STORE_IO.open(dirname(this.filePath), 'r')
+      await FILE_EVAL_STORE_IO.sync(handle)
+      await FILE_EVAL_STORE_IO.close(handle)
+      handle = undefined
+    } catch (error) {
+      if (handle) await FILE_EVAL_STORE_IO.close(handle).catch(() => undefined)
+      const code = errno(error)
+      if (code && DIRECTORY_SYNC_UNSUPPORTED.has(code)) {
+        this.emitFileDiagnostic({
+          code: 'directory_sync_unsupported',
+          severity: 'warning',
+          message: 'The platform/filesystem does not support directory fsync; rename durability is best-effort.',
+        })
+        return
+      }
+      throw fileError(
+        'SYNC_FAILED',
+        'FileEvalStore could not fsync the parent directory after an atomic rename.',
+        operation, this.filePath, error,
+      )
+    }
+  }
+
+  private static async pathExists(path: string, operation: string): Promise<boolean> {
+    try {
+      await FILE_EVAL_STORE_IO.stat(path)
+      return true
+    } catch (error) {
+      if (errno(error) === 'ENOENT') return false
+      throw fileError('OPEN_FAILED', 'FileEvalStore could not inspect its filesystem path.', operation, path, error)
+    }
+  }
+
+  private static async createFile(path: string, options: FileEvalStoreOptions): Promise<void> {
+    let handle: FileHandle | undefined
+    try {
+      await FILE_EVAL_STORE_IO.mkdir(dirname(path), { recursive: true })
+      handle = await FILE_EVAL_STORE_IO.open(path, 'wx', 0o600)
+      await FILE_EVAL_STORE_IO.chmod(handle, 0o600)
+      await FILE_EVAL_STORE_IO.writeFile(handle, `${JSON.stringify(HEADER)}\n`)
+      await FILE_EVAL_STORE_IO.sync(handle)
+      await FILE_EVAL_STORE_IO.close(handle)
+      handle = undefined
+      const provisional = new FileEvalStore(
+        path,
+        new InMemoryEvalStore({ now: options.now }),
+        HEADER,
+        options,
+      )
+      await provisional.syncDirectory('open.create')
+    } catch (error) {
+      if (handle) await FILE_EVAL_STORE_IO.close(handle).catch(() => undefined)
+      if (errno(error) === 'EEXIST') return
+      throw fileError('OPEN_FAILED', 'FileEvalStore could not create its data file.', 'open.create', path, error)
+    }
+  }
+}

--- a/packages/core/src/eval/file.ts
+++ b/packages/core/src/eval/file.ts
@@ -8,6 +8,20 @@ import { gatePolicySchema, type GatePolicy } from './gate.js'
 import type { EvalRunReport, ScorerAggregate } from './report.js'
 import type { EvalRecord } from './record.js'
 
+export {
+  FILE_EVAL_STORE_FORMAT,
+  FILE_EVAL_STORE_FORMAT_VERSION,
+  FileEvalStore,
+  FileEvalStoreError,
+} from './file-store.js'
+export type {
+  FileEvalStoreCompactionResult,
+  FileEvalStoreDiagnostic,
+  FileEvalStoreDiagnosticCode,
+  FileEvalStoreErrorCode,
+  FileEvalStoreOptions,
+} from './file-store.js'
+
 export type EvalReportFormat = 'json' | 'markdown' | 'junit'
 
 const REASON_MAX_CHARS = 200
@@ -122,6 +136,7 @@ const evalRunReportSchema = z.object({
   caseCount: z.number().int().nonnegative(),
   repeats: z.number().int().positive(),
   aborted: z.boolean().optional(),
+  warnings: z.array(z.string()).optional(),
   records: z.array(evalRecordSchema),
   aggregates: z.array(scorerAggregateSchema),
   totals: z.object({
@@ -253,6 +268,9 @@ function recordFailureReason(record: EvalRecord): string {
 }
 
 function markdownReport(report: EvalRunReport): string {
+  const warningLines = report.warnings === undefined || report.warnings.length === 0
+    ? []
+    : ['## Warnings', '', ...report.warnings.map((warning) => `- ${warning}`), '']
   const lines = [
     `# Evaluation Report: ${report.evalSet.name}@${report.evalSet.version}`,
     '',
@@ -269,6 +287,7 @@ function markdownReport(report: EvalRunReport): string {
     JSON.stringify(report.metadata, null, 2),
     '```',
     '',
+    ...warningLines,
     '## Scorer aggregates',
     '',
     '| Scorer | Version | Scored | Avg | P50 | P95 | Min | Max | Pass rate | Errors |',

--- a/packages/core/src/eval/index.ts
+++ b/packages/core/src/eval/index.ts
@@ -4,6 +4,15 @@ export { createJudgeScorer } from './judge.js'
 export type { JudgeScorerOptions } from './judge.js'
 export { EVAL_STORE_SCHEMA_MAJOR } from './record.js'
 export type { EvalRecord } from './record.js'
+export { EvalStoreError, InMemoryEvalStore } from './store.js'
+export type {
+  EvalDeleteQuery,
+  EvalQuery,
+  EvalRetentionPolicy,
+  EvalStore,
+  EvalStoreErrorCode,
+  InMemoryEvalStoreOptions,
+} from './store.js'
 export type { EvalCase } from './evalcase.js'
 export type { MemoryExtractionSample, MemoryRetrievalSample } from './memory-types.js'
 export { defineEvalSet } from './evalset.js'

--- a/packages/core/src/eval/report.ts
+++ b/packages/core/src/eval/report.ts
@@ -28,6 +28,8 @@ export interface EvalRunReport {
   readonly caseCount: number
   readonly repeats: number
   readonly aborted?: boolean
+  /** Non-fatal evaluation infrastructure failures, such as persistence errors. */
+  readonly warnings?: readonly string[]
   readonly records: readonly EvalRecord[]
   readonly aggregates: readonly ScorerAggregate[]
   readonly totals: {

--- a/packages/core/src/eval/runner.ts
+++ b/packages/core/src/eval/runner.ts
@@ -15,6 +15,7 @@ import { aggregateEvalRecords } from './report.js'
 import type { EvalRunReport } from './report.js'
 import type { EvalRecord } from './record.js'
 import type { ScoreResult, Scorer, ScorerContext } from './scorer.js'
+import type { EvalStore } from './store.js'
 import type { EvalTarget, TargetOutput } from './target.js'
 
 const DEFAULT_REPEATS = 1
@@ -36,6 +37,8 @@ export interface RunEvalOptions {
   readonly filterTags?: readonly string[]
   readonly metadata?: Readonly<Record<string, TraceAttributeValue>>
   readonly traceStore?: TraceStore
+  /** Optional persistence. Failures are reported as warnings and never fail the run. */
+  readonly store?: EvalStore
   readonly evalRunId?: string
   readonly storePayloads?: 'none' | 'redacted' | 'full'
   readonly signal?: AbortSignal
@@ -386,6 +389,7 @@ export async function runEvalSet(
     Array.from({ length: repeats }, (_, index) => ({ evalCase, repeat: index + 1 })))
   const signal = options.signal ?? new AbortController().signal
   const samples = new Array<SampleResult | undefined>(jobs.length)
+  const storeWarnings = new Array<string | undefined>(jobs.length)
   let cursor = 0
 
   const worker = async (): Promise<void> => {
@@ -393,7 +397,7 @@ export async function runEvalSet(
       const index = cursor++
       const job = jobs[index]
       if (job === undefined) return
-      samples[index] = await runSample(
+      const sample = await runSample(
         set,
         job.evalCase,
         job.repeat,
@@ -402,6 +406,14 @@ export async function runEvalSet(
         evalRunId,
         signal,
       )
+      samples[index] = sample
+      if (options.store !== undefined) {
+        try {
+          await options.store.append(sample.records)
+        } catch {
+          storeWarnings[index] = `Evaluation records for case "${job.evalCase.id}" repeat ${job.repeat} were not persisted.`
+        }
+      }
     }
   }
 
@@ -415,6 +427,7 @@ export async function runEvalSet(
   const tagsByCase = new Map(cases.map((evalCase) => [evalCase.id, evalCase.tags ?? []]))
   const tokens = sumTokens(completed)
   const costs = sumCosts(completed)
+  const warnings = storeWarnings.filter((warning): warning is string => warning !== undefined)
 
   return {
     schemaVersion: 1,
@@ -426,6 +439,7 @@ export async function runEvalSet(
     caseCount: cases.length,
     repeats,
     ...(signal.aborted ? { aborted: true } : {}),
+    ...(warnings.length > 0 ? { warnings } : {}),
     records,
     aggregates: aggregateEvalRecords(records, options.scorers, tagsByCase),
     totals: {

--- a/packages/core/src/eval/store.ts
+++ b/packages/core/src/eval/store.ts
@@ -1,0 +1,626 @@
+import type {
+  AppendResult,
+  DeleteResult,
+  Page,
+} from '../observability/store.js'
+import type { TraceAttributeValue } from '../types.js'
+import { EVAL_STORE_SCHEMA_MAJOR, type EvalRecord } from './record.js'
+
+export type EvalStoreErrorCode =
+  | 'INVALID_ARGUMENT'
+  | 'INVALID_CURSOR'
+  | 'UNSUPPORTED_SCHEMA_VERSION'
+
+/** Structured validation failure shared by every EvalStore implementation. */
+export class EvalStoreError extends Error {
+  readonly name = 'EvalStoreError'
+
+  constructor(
+    readonly code: EvalStoreErrorCode,
+    message: string,
+    readonly field?: string,
+  ) {
+    super(message)
+  }
+}
+
+export interface EvalQuery {
+  readonly evalRunId?: string | readonly string[]
+  /** Match `record.runRef.runId`. */
+  readonly runId?: string | readonly string[]
+  readonly evalSetName?: string
+  readonly scorer?: readonly string[]
+  readonly source?: 'offline' | 'online'
+  readonly status?: readonly EvalRecord['status'][]
+  /** Inclusive ISO-8601 lower bound on `timestampUnixMs`. */
+  readonly after?: string
+  /** Exclusive ISO-8601 upper bound on `timestampUnixMs`. */
+  readonly before?: string
+  readonly limit?: number
+  readonly cursor?: string
+  readonly order?: 'time_desc' | 'time_asc'
+}
+
+export interface EvalDeleteQuery {
+  readonly evalRunId?: string | readonly string[]
+  readonly evalSetName?: string
+  /** Exclusive ISO-8601 upper bound on `timestampUnixMs`. */
+  readonly before?: string
+}
+
+export interface EvalRetentionPolicy {
+  readonly maxAgeMs?: number
+  readonly maxRecords?: number
+  readonly sources?: readonly EvalRecord['source'][]
+}
+
+/** Storage-medium-independent append/query contract for evaluation records. */
+export interface EvalStore {
+  /** Atomic per batch from the caller's view; idempotent by recordId. */
+  append(records: readonly EvalRecord[]): Promise<AppendResult>
+  query(query?: EvalQuery): Promise<Page<EvalRecord>>
+  delete(query: EvalDeleteQuery): Promise<DeleteResult>
+  applyRetention(policy: EvalRetentionPolicy): Promise<DeleteResult>
+}
+
+export interface InMemoryEvalStoreOptions {
+  /** Hard capacity. A batch that would exceed it is rejected atomically. */
+  readonly maxRecords?: number
+  /** Injectable wall clock used only by retention. */
+  readonly now?: () => number
+}
+
+interface StoredRecordEntry {
+  readonly record: EvalRecord
+  readonly revision: number
+  readonly arrival: number
+}
+
+interface CursorState {
+  readonly snapshotRevision: number
+  readonly deleteEpoch: number
+  readonly queryFingerprint: string
+  readonly timestampUnixMs: number
+  readonly recordId: string
+}
+
+interface NormalizedQuery {
+  readonly evalRunIds?: readonly string[]
+  readonly runIds?: readonly string[]
+  readonly evalSetName?: string
+  readonly scorers?: readonly string[]
+  readonly source?: EvalRecord['source']
+  readonly statuses?: readonly EvalRecord['status'][]
+  readonly afterMs?: number
+  readonly beforeMs?: number
+  readonly limit: number
+  readonly order: 'time_desc' | 'time_asc'
+}
+
+const EVAL_STATUSES = new Set<EvalRecord['status']>([
+  'scored', 'scorer_error', 'target_error', 'skipped',
+])
+const EVAL_SOURCES = new Set<EvalRecord['source']>(['offline', 'online'])
+const TRACE_ERROR_KINDS = new Set([
+  'provider', 'tool', 'framework', 'callback', 'validation', 'timeout',
+  'cancellation', 'budget', 'store', 'exporter', 'unknown',
+])
+
+function cloneJson<T>(value: T, field: string): T {
+  try {
+    const serialized = JSON.stringify(value)
+    if (serialized === undefined) throw new Error('not serializable')
+    return JSON.parse(serialized) as T
+  } catch {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} must be JSON-serializable.`, field)
+  }
+}
+
+function fingerprint(value: unknown): string {
+  return JSON.stringify(value)
+}
+
+function hash(value: string): string {
+  let current = 0x811c9dc5
+  for (let index = 0; index < value.length; index++) {
+    current ^= value.charCodeAt(index)
+    current = Math.imul(current, 0x01000193)
+  }
+  return (current >>> 0).toString(36)
+}
+
+function objectValue(value: unknown, field: string): asserts value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} must be an object.`, field)
+  }
+}
+
+function nonEmptyString(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} must be a non-empty string.`, field)
+  }
+}
+
+function optionalString(value: unknown, field: string): void {
+  if (value !== undefined && typeof value !== 'string') {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} must be a string.`, field)
+  }
+}
+
+function finiteNumber(value: unknown, field: string, min = 0): asserts value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < min) {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} must be a finite number >= ${min}.`, field)
+  }
+}
+
+function nonNegativeInteger(value: unknown, field: string): asserts value is number {
+  finiteNumber(value, field)
+  if (!Number.isInteger(value)) {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} must be an integer.`, field)
+  }
+}
+
+function positiveInteger(value: unknown, field: string): asserts value is number {
+  finiteNumber(value, field, 1)
+  if (!Number.isInteger(value)) {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} must be an integer.`, field)
+  }
+}
+
+function traceAttribute(value: unknown): value is TraceAttributeValue {
+  const scalar = typeof value === 'string' || typeof value === 'boolean'
+    || (typeof value === 'number' && Number.isFinite(value))
+  if (scalar) return true
+  if (!Array.isArray(value)) return false
+  const kinds = new Set(value.map((item) => typeof item))
+  return kinds.size <= 1 && value.every((item) =>
+    typeof item === 'string' || typeof item === 'boolean'
+    || (typeof item === 'number' && Number.isFinite(item)))
+}
+
+function traceAttributes(value: unknown, field: string): void {
+  objectValue(value, field)
+  for (const [key, child] of Object.entries(value)) {
+    if (!traceAttribute(child)) {
+      throw new EvalStoreError(
+        'INVALID_ARGUMENT',
+        `${field}.${key} is not a supported trace attribute.`,
+        `${field}.${key}`,
+      )
+    }
+  }
+}
+
+function validateRecord(record: unknown, index: number): asserts record is EvalRecord {
+  const prefix = `records[${index}]`
+  objectValue(record, prefix)
+  if (record['schemaVersion'] !== EVAL_STORE_SCHEMA_MAJOR) {
+    if (typeof record['schemaVersion'] === 'number') {
+      throw new EvalStoreError(
+        'UNSUPPORTED_SCHEMA_VERSION',
+        `Unsupported EvalRecord schema major ${record['schemaVersion']}; supported major is ${EVAL_STORE_SCHEMA_MAJOR}.`,
+        `${prefix}.schemaVersion`,
+      )
+    }
+    throw new EvalStoreError(
+      'INVALID_ARGUMENT',
+      `${prefix}.schemaVersion must be ${EVAL_STORE_SCHEMA_MAJOR}.`,
+      `${prefix}.schemaVersion`,
+    )
+  }
+  nonEmptyString(record['recordId'], `${prefix}.recordId`)
+  nonEmptyString(record['evalRunId'], `${prefix}.evalRunId`)
+  if (!EVAL_SOURCES.has(record['source'] as EvalRecord['source'])) {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${prefix}.source is invalid.`, `${prefix}.source`)
+  }
+  nonNegativeInteger(record['timestampUnixMs'], `${prefix}.timestampUnixMs`)
+  if (record['evalSet'] !== undefined) {
+    objectValue(record['evalSet'], `${prefix}.evalSet`)
+    nonEmptyString(record['evalSet']['name'], `${prefix}.evalSet.name`)
+    nonEmptyString(record['evalSet']['version'], `${prefix}.evalSet.version`)
+  }
+  optionalString(record['caseId'], `${prefix}.caseId`)
+  if (record['repeat'] !== undefined) positiveInteger(record['repeat'], `${prefix}.repeat`)
+  objectValue(record['scorer'], `${prefix}.scorer`)
+  nonEmptyString(record['scorer']['name'], `${prefix}.scorer.name`)
+  optionalString(record['scorer']['version'], `${prefix}.scorer.version`)
+  if (!EVAL_STATUSES.has(record['status'] as EvalRecord['status'])) {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${prefix}.status is invalid.`, `${prefix}.status`)
+  }
+  if (record['score'] !== undefined) {
+    finiteNumber(record['score'], `${prefix}.score`)
+    if (record['score'] > 1) {
+      throw new EvalStoreError('INVALID_ARGUMENT', `${prefix}.score must be <= 1.`, `${prefix}.score`)
+    }
+  }
+  if (record['pass'] !== undefined && typeof record['pass'] !== 'boolean') {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${prefix}.pass must be a boolean.`, `${prefix}.pass`)
+  }
+  optionalString(record['reason'], `${prefix}.reason`)
+  if (record['details'] !== undefined) traceAttributes(record['details'], `${prefix}.details`)
+  if (record['runRef'] !== undefined) {
+    objectValue(record['runRef'], `${prefix}.runRef`)
+    nonEmptyString(record['runRef']['runId'], `${prefix}.runRef.runId`)
+    positiveInteger(record['runRef']['attempt'], `${prefix}.runRef.attempt`)
+    nonEmptyString(record['runRef']['traceId'], `${prefix}.runRef.traceId`)
+    nonEmptyString(record['runRef']['rootSpanId'], `${prefix}.runRef.rootSpanId`)
+  }
+  traceAttributes(record['metadata'], `${prefix}.metadata`)
+  if (record['usage'] !== undefined) {
+    objectValue(record['usage'], `${prefix}.usage`)
+    if (record['usage']['tokens'] !== undefined) {
+      objectValue(record['usage']['tokens'], `${prefix}.usage.tokens`)
+      nonNegativeInteger(record['usage']['tokens']['input_tokens'], `${prefix}.usage.tokens.input_tokens`)
+      nonNegativeInteger(record['usage']['tokens']['output_tokens'], `${prefix}.usage.tokens.output_tokens`)
+    }
+    if (record['usage']['cost'] !== undefined) {
+      objectValue(record['usage']['cost'], `${prefix}.usage.cost`)
+      finiteNumber(record['usage']['cost']['amount'], `${prefix}.usage.cost.amount`)
+      nonEmptyString(record['usage']['cost']['currency'], `${prefix}.usage.cost.currency`)
+    }
+    if (record['usage']['durationMs'] !== undefined) {
+      finiteNumber(record['usage']['durationMs'], `${prefix}.usage.durationMs`)
+    }
+  }
+  if (record['error'] !== undefined) {
+    objectValue(record['error'], `${prefix}.error`)
+    if (!TRACE_ERROR_KINDS.has(record['error']['kind'] as string)) {
+      throw new EvalStoreError('INVALID_ARGUMENT', `${prefix}.error.kind is invalid.`, `${prefix}.error.kind`)
+    }
+    for (const key of ['code', 'name', 'message', 'provider'] as const) {
+      optionalString(record['error'][key], `${prefix}.error.${key}`)
+    }
+    if (record['error']['retryable'] !== undefined && typeof record['error']['retryable'] !== 'boolean') {
+      throw new EvalStoreError('INVALID_ARGUMENT', `${prefix}.error.retryable must be a boolean.`, `${prefix}.error.retryable`)
+    }
+    if (record['error']['httpStatus'] !== undefined) {
+      nonNegativeInteger(record['error']['httpStatus'], `${prefix}.error.httpStatus`)
+    }
+    if (record['error']['attempt'] !== undefined) positiveInteger(record['error']['attempt'], `${prefix}.error.attempt`)
+  }
+  if (record['payload'] !== undefined) {
+    objectValue(record['payload'], `${prefix}.payload`)
+    optionalString(record['payload']['input'], `${prefix}.payload.input`)
+    optionalString(record['payload']['output'], `${prefix}.payload.output`)
+    optionalString(record['payload']['expected'], `${prefix}.payload.expected`)
+  }
+}
+
+function stringList(value: unknown, field: string): readonly string[] | undefined {
+  if (value === undefined) return undefined
+  const values = typeof value === 'string' ? [value] : value
+  if (!Array.isArray(values) || values.length === 0
+    || values.some((item) => typeof item !== 'string' || item.length === 0)) {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} must contain non-empty strings.`, field)
+  }
+  return [...new Set(values)].sort()
+}
+
+function stringArray(value: unknown, field: string): readonly string[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value)) {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} must be an array of non-empty strings.`, field)
+  }
+  return stringList(value, field)
+}
+
+function statusList(value: unknown, field: string): readonly EvalRecord['status'][] | undefined {
+  const values = stringArray(value, field)
+  if (!values) return undefined
+  if (values.some((status) => !EVAL_STATUSES.has(status as EvalRecord['status']))) {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} contains an unsupported status.`, field)
+  }
+  return values as EvalRecord['status'][]
+}
+
+function sourceList(value: unknown, field: string): readonly EvalRecord['source'][] | undefined {
+  const values = stringArray(value, field)
+  if (!values) return undefined
+  if (values.some((source) => !EVAL_SOURCES.has(source as EvalRecord['source']))) {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} contains an unsupported source.`, field)
+  }
+  return values as EvalRecord['source'][]
+}
+
+function parseDate(value: unknown, field: string): number | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'string' || value.length === 0 || !Number.isFinite(Date.parse(value))) {
+    throw new EvalStoreError('INVALID_ARGUMENT', `${field} must be a valid ISO-8601 timestamp.`, field)
+  }
+  return Date.parse(value)
+}
+
+function normalizeQuery(query: EvalQuery = {}): NormalizedQuery {
+  if (!query || typeof query !== 'object' || Array.isArray(query)) {
+    throw new EvalStoreError('INVALID_ARGUMENT', 'query must be an object.', 'query')
+  }
+  const limit = query.limit ?? 100
+  if (!Number.isInteger(limit) || limit < 1 || limit > 1_000) {
+    throw new EvalStoreError('INVALID_ARGUMENT', 'limit must be an integer from 1 through 1000.', 'limit')
+  }
+  if (query.order !== undefined && query.order !== 'time_asc' && query.order !== 'time_desc') {
+    throw new EvalStoreError('INVALID_ARGUMENT', 'order must be time_asc or time_desc.', 'order')
+  }
+  const afterMs = parseDate(query.after, 'after')
+  const beforeMs = parseDate(query.before, 'before')
+  if (afterMs !== undefined && beforeMs !== undefined && afterMs >= beforeMs) {
+    throw new EvalStoreError('INVALID_ARGUMENT', 'after must be before before.', 'after')
+  }
+  if (query.evalSetName !== undefined) nonEmptyString(query.evalSetName, 'evalSetName')
+  if (query.source !== undefined && !EVAL_SOURCES.has(query.source)) {
+    throw new EvalStoreError('INVALID_ARGUMENT', 'source must be offline or online.', 'source')
+  }
+  const evalRunIds = stringList(query.evalRunId, 'evalRunId')
+  const runIds = stringList(query.runId, 'runId')
+  const scorers = stringArray(query.scorer, 'scorer')
+  const statuses = statusList(query.status, 'status')
+  return {
+    ...(evalRunIds ? { evalRunIds } : {}),
+    ...(runIds ? { runIds } : {}),
+    ...(query.evalSetName !== undefined ? { evalSetName: query.evalSetName } : {}),
+    ...(scorers ? { scorers } : {}),
+    ...(query.source !== undefined ? { source: query.source } : {}),
+    ...(statuses ? { statuses } : {}),
+    ...(afterMs !== undefined ? { afterMs } : {}),
+    ...(beforeMs !== undefined ? { beforeMs } : {}),
+    limit,
+    order: query.order ?? 'time_desc',
+  }
+}
+
+function queryIdentity(query: NormalizedQuery): string {
+  const { limit: _limit, ...identity } = query
+  return JSON.stringify(identity)
+}
+
+function matches(record: EvalRecord, query: NormalizedQuery): boolean {
+  return (!query.evalRunIds || query.evalRunIds.includes(record.evalRunId))
+    && (!query.runIds || (record.runRef !== undefined && query.runIds.includes(record.runRef.runId)))
+    && (query.evalSetName === undefined || record.evalSet?.name === query.evalSetName)
+    && (!query.scorers || query.scorers.includes(record.scorer.name))
+    && (query.source === undefined || record.source === query.source)
+    && (!query.statuses || query.statuses.includes(record.status))
+    && (query.afterMs === undefined || record.timestampUnixMs >= query.afterMs)
+    && (query.beforeMs === undefined || record.timestampUnixMs < query.beforeMs)
+}
+
+function compareRecords(
+  left: EvalRecord,
+  right: EvalRecord,
+  order: NormalizedQuery['order'],
+): number {
+  const time = left.timestampUnixMs - right.timestampUnixMs
+  const stable = time || left.recordId.localeCompare(right.recordId)
+  return order === 'time_asc' ? stable : -stable
+}
+
+/** @internal FileEvalStore recovery bridge; intentionally not re-exported. */
+export const EVAL_STORE_INTERNALS: unique symbol = Symbol('oma.eval-store-internals')
+
+/** @internal */
+export interface EvalStoreInternals {
+  records(): readonly EvalRecord[]
+  deleteRecordIds(recordIds: readonly string[]): DeleteResult
+}
+
+/** Non-durable reference EvalStore for tests and short-lived local runs. */
+export class InMemoryEvalStore implements EvalStore {
+  private readonly entries: StoredRecordEntry[] = []
+  private readonly seen = new Map<string, string>()
+  private revision = 0
+  private arrival = 0
+  private deleteEpoch = 0
+  private readonly cursorSecret = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
+  private readonly now: () => number
+  private readonly maxRecords?: number
+
+  constructor(options: InMemoryEvalStoreOptions = {}) {
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+      throw new EvalStoreError('INVALID_ARGUMENT', 'options must be an object.', 'options')
+    }
+    if (options.maxRecords !== undefined) {
+      nonNegativeInteger(options.maxRecords, 'maxRecords')
+      this.maxRecords = options.maxRecords
+    }
+    if (options.now !== undefined && typeof options.now !== 'function') {
+      throw new EvalStoreError('INVALID_ARGUMENT', 'now must be a function.', 'now')
+    }
+    this.now = options.now ?? Date.now
+  }
+
+  async append(records: readonly EvalRecord[]): Promise<AppendResult> {
+    if (!Array.isArray(records)) {
+      throw new EvalStoreError('INVALID_ARGUMENT', 'records must be an array.', 'records')
+    }
+    records.forEach(validateRecord)
+    const snapshots = records.map((record, index) => cloneJson(record, `records[${index}]`))
+    const stagedSeen = new Map(this.seen)
+    const writes: EvalRecord[] = []
+    let deduplicated = 0
+    for (const record of snapshots) {
+      if (stagedSeen.has(record.recordId)) {
+        deduplicated++
+        continue
+      }
+      writes.push(record)
+      stagedSeen.set(record.recordId, fingerprint(record))
+    }
+    if (this.maxRecords !== undefined && this.entries.length + writes.length > this.maxRecords) {
+      throw new EvalStoreError(
+        'INVALID_ARGUMENT',
+        `append would exceed the InMemoryEvalStore maxRecords capacity of ${this.maxRecords}.`,
+        'records',
+      )
+    }
+
+    const revision = writes.length > 0 ? this.revision + 1 : this.revision
+    for (const record of writes) this.entries.push({ record, revision, arrival: ++this.arrival })
+    if (writes.length > 0) this.revision = revision
+    this.seen.clear()
+    for (const [key, value] of stagedSeen) this.seen.set(key, value)
+    return { written: writes.length, deduplicated, diagnostics: [] }
+  }
+
+  async query(query: EvalQuery = {}): Promise<Page<EvalRecord>> {
+    const normalized = normalizeQuery(query)
+    const identity = queryIdentity(normalized)
+    let snapshotRevision = this.revision
+    let after: Pick<CursorState, 'timestampUnixMs' | 'recordId'> | undefined
+    if (query.cursor !== undefined) {
+      const state = this.decodeCursor(query.cursor)
+      if (state.queryFingerprint !== identity || state.deleteEpoch !== this.deleteEpoch) {
+        throw new EvalStoreError(
+          'INVALID_CURSOR',
+          'Cursor does not match this query or is no longer valid.',
+          'cursor',
+        )
+      }
+      snapshotRevision = state.snapshotRevision
+      after = state
+    }
+    const records = this.entries
+      .filter((entry) => entry.revision <= snapshotRevision)
+      .map((entry) => entry.record)
+      .filter((record) => matches(record, normalized))
+      .sort((left, right) => compareRecords(left, right, normalized.order))
+    const startIndex = after
+      ? records.findIndex((record) =>
+        record.timestampUnixMs === after!.timestampUnixMs && record.recordId === after!.recordId) + 1
+      : 0
+    if (after && startIndex === 0) {
+      throw new EvalStoreError(
+        'INVALID_CURSOR',
+        'Cursor position is not present in the query snapshot.',
+        'cursor',
+      )
+    }
+    const items = records.slice(startIndex, startIndex + normalized.limit)
+    const hasMore = startIndex + items.length < records.length
+    const nextCursor = hasMore && items.length > 0
+      ? this.encodeCursor({
+        snapshotRevision,
+        deleteEpoch: this.deleteEpoch,
+        queryFingerprint: identity,
+        timestampUnixMs: items.at(-1)!.timestampUnixMs,
+        recordId: items.at(-1)!.recordId,
+      })
+      : undefined
+    return cloneJson({ items, ...(nextCursor ? { nextCursor } : {}) }, 'page')
+  }
+
+  async delete(query: EvalDeleteQuery): Promise<DeleteResult> {
+    if (!query || typeof query !== 'object' || Array.isArray(query)) {
+      throw new EvalStoreError('INVALID_ARGUMENT', 'query must be an object.', 'query')
+    }
+    const evalRunIds = stringList(query.evalRunId, 'evalRunId')
+    if (query.evalSetName !== undefined) nonEmptyString(query.evalSetName, 'evalSetName')
+    const beforeMs = parseDate(query.before, 'before')
+    const recordIds = this.entries
+      .map((entry) => entry.record)
+      .filter((record) =>
+        (!evalRunIds || evalRunIds.includes(record.evalRunId))
+        && (query.evalSetName === undefined || record.evalSet?.name === query.evalSetName)
+        && (beforeMs === undefined || record.timestampUnixMs < beforeMs))
+      .sort((left, right) => compareRecords(left, right, 'time_asc'))
+      .map((record) => record.recordId)
+    return this.deleteRecordIds(recordIds)
+  }
+
+  async applyRetention(policy: EvalRetentionPolicy): Promise<DeleteResult> {
+    if (!policy || typeof policy !== 'object' || Array.isArray(policy)) {
+      throw new EvalStoreError('INVALID_ARGUMENT', 'policy must be an object.', 'policy')
+    }
+    if (policy.maxAgeMs === undefined && policy.maxRecords === undefined && policy.sources === undefined) {
+      throw new EvalStoreError(
+        'INVALID_ARGUMENT',
+        'Retention policy must set maxAgeMs, maxRecords, or sources.',
+        'policy',
+      )
+    }
+    if (policy.maxAgeMs !== undefined) finiteNumber(policy.maxAgeMs, 'maxAgeMs')
+    if (policy.maxRecords !== undefined) nonNegativeInteger(policy.maxRecords, 'maxRecords')
+    const sources = sourceList(policy.sources, 'sources')
+    let scoped = this.entries
+      .map((entry) => entry.record)
+      .filter((record) => !sources || sources.includes(record.source))
+    const deleteIds = new Set<string>()
+    if (policy.maxAgeMs !== undefined) {
+      const cutoff = this.now() - policy.maxAgeMs
+      for (const record of scoped) {
+        if (record.timestampUnixMs < cutoff) deleteIds.add(record.recordId)
+      }
+    }
+    if (policy.maxRecords !== undefined) {
+      scoped = scoped.sort((left, right) => compareRecords(left, right, 'time_desc'))
+      for (const record of scoped.slice(policy.maxRecords)) deleteIds.add(record.recordId)
+    } else if (policy.maxAgeMs === undefined && sources) {
+      for (const record of scoped) deleteIds.add(record.recordId)
+    }
+    const ordered = this.entries
+      .map((entry) => entry.record)
+      .filter((record) => deleteIds.has(record.recordId))
+      .sort((left, right) => compareRecords(left, right, 'time_asc'))
+      .map((record) => record.recordId)
+    return this.deleteRecordIds(ordered)
+  }
+
+  [EVAL_STORE_INTERNALS](): EvalStoreInternals {
+    return {
+      records: () => cloneJson(
+        [...this.entries]
+          .sort((left, right) => left.arrival - right.arrival)
+          .map((entry) => entry.record),
+        'records',
+      ),
+      deleteRecordIds: (recordIds) => this.deleteRecordIds(recordIds),
+    }
+  }
+
+  private deleteRecordIds(recordIds: readonly string[]): DeleteResult {
+    const requested = new Set(recordIds)
+    if (requested.size === 0) return { runsDeleted: 0, recordsDeleted: 0, runIds: [] }
+    const records = this.entries
+      .map((entry) => entry.record)
+      .filter((record) => requested.has(record.recordId))
+      .sort((left, right) => compareRecords(left, right, 'time_asc'))
+    if (records.length === 0) return { runsDeleted: 0, recordsDeleted: 0, runIds: [] }
+    for (let index = this.entries.length - 1; index >= 0; index--) {
+      if (requested.has(this.entries[index]!.record.recordId)) this.entries.splice(index, 1)
+    }
+    for (const record of records) this.seen.delete(record.recordId)
+    this.deleteEpoch++
+    const runIds = records
+      .map((record) => record.evalRunId)
+      .filter((runId, index, all) => all.indexOf(runId) === index)
+    return cloneJson({
+      runsDeleted: runIds.length,
+      recordsDeleted: records.length,
+      runIds,
+    }, 'deleteResult')
+  }
+
+  private encodeCursor(state: CursorState): string {
+    const body = encodeURIComponent(JSON.stringify(state))
+    return `oma-es1.${body}.${hash(`${this.cursorSecret}:${body}`)}`
+  }
+
+  private decodeCursor(cursor: unknown): CursorState {
+    if (typeof cursor !== 'string' || cursor.length === 0) {
+      throw new EvalStoreError('INVALID_CURSOR', 'cursor must be an opaque non-empty string.', 'cursor')
+    }
+    const match = /^oma-es1\.(.+)\.([a-z0-9]+)$/.exec(cursor)
+    if (!match || hash(`${this.cursorSecret}:${match[1]}`) !== match[2]) {
+      throw new EvalStoreError('INVALID_CURSOR', 'Cursor is invalid or has been tampered with.', 'cursor')
+    }
+    try {
+      const state = JSON.parse(decodeURIComponent(match[1]!)) as Partial<CursorState>
+      if (!Number.isInteger(state.snapshotRevision) || !Number.isInteger(state.deleteEpoch)
+        || typeof state.queryFingerprint !== 'string'
+        || !Number.isInteger(state.timestampUnixMs)
+        || typeof state.recordId !== 'string') throw new Error('invalid')
+      return state as CursorState
+    } catch {
+      throw new EvalStoreError('INVALID_CURSOR', 'Cursor payload is invalid.', 'cursor')
+    }
+  }
+}

--- a/packages/core/tests/eval-file-store.test.ts
+++ b/packages/core/tests/eval-file-store.test.ts
@@ -1,0 +1,353 @@
+import { randomUUID } from 'node:crypto'
+import {
+  appendFile,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  FILE_EVAL_STORE_FORMAT,
+  FILE_EVAL_STORE_IO,
+  FileEvalStore,
+  FileEvalStoreError,
+  type FileEvalStoreDiagnostic,
+} from '../src/eval/file-store.js'
+import type { EvalRecord } from '../src/eval/record.js'
+import type {
+  EvalDeleteQuery,
+  EvalQuery,
+  EvalRetentionPolicy,
+  EvalStore,
+} from '../src/eval/store.js'
+import type { AppendResult, DeleteResult, Page } from '../src/observability/store.js'
+import {
+  evalRecord,
+  runEvalStoreContractSuite,
+  type EvalStoreContractFactoryOptions,
+} from './eval-store-contract.js'
+
+const temporaryRoots: string[] = []
+
+async function temporaryPath(name = 'evaluations.ndjson'): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'oma-file-eval-store-'))
+  temporaryRoots.push(root)
+  return join(root, name)
+}
+
+class DeferredEvalStore implements EvalStore {
+  constructor(private readonly pending: Promise<FileEvalStore>) {}
+
+  append(records: readonly EvalRecord[]): Promise<AppendResult> {
+    return this.pending.then((store) => store.append(records))
+  }
+
+  query(query?: EvalQuery): Promise<Page<EvalRecord>> {
+    return this.pending.then((store) => store.query(query))
+  }
+
+  delete(query: EvalDeleteQuery): Promise<DeleteResult> {
+    return this.pending.then((store) => store.delete(query))
+  }
+
+  applyRetention(policy: EvalRetentionPolicy): Promise<DeleteResult> {
+    return this.pending.then((store) => store.applyRetention(policy))
+  }
+}
+
+function contractStore(options: EvalStoreContractFactoryOptions = {}): EvalStore {
+  const path = join(tmpdir(), `oma-file-eval-contract-${randomUUID()}.ndjson`)
+  temporaryRoots.push(path)
+  return new DeferredEvalStore(FileEvalStore.open(path, { now: options.now }))
+}
+
+runEvalStoreContractSuite('FileEvalStore', contractStore)
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await Promise.all(temporaryRoots.splice(0).map((path) =>
+    rm(path, { recursive: true, force: true })))
+})
+
+describe('FileEvalStore file format and recovery', () => {
+  it('creates a versioned 0600 file with schema-bearing NDJSON and reopens identically', async () => {
+    const path = await temporaryPath()
+    const store = await FileEvalStore.open(path)
+    await store.append([evalRecord({ recordId: 'reopen', status: 'scorer_error' })])
+    const before = await store.query({ status: ['scorer_error'] })
+    await store.flush()
+    await store.close()
+
+    const lines = (await readFile(path, 'utf8')).split('\n')
+    expect(JSON.parse(lines[0]!)).toEqual({
+      type: 'file_header',
+      format: FILE_EVAL_STORE_FORMAT,
+      formatVersion: 1,
+      evalSchemaMajor: 1,
+    })
+    expect(lines.some((line) => line.includes('"schemaVersion":1'))).toBe(true)
+    if (process.platform !== 'win32') expect((await stat(path)).mode & 0o777).toBe(0o600)
+
+    const reopened = await FileEvalStore.open(path)
+    expect(await reopened.query({ status: ['scorer_error'] })).toEqual(before)
+    await reopened.close()
+  })
+
+  it('serializes concurrent same-instance append batches in invocation order', async () => {
+    const path = await temporaryPath()
+    const store = await FileEvalStore.open(path)
+    await Promise.all(['a', 'b', 'c', 'd'].map((recordId, index) =>
+      store.append([evalRecord({ recordId, timestamp: 1_000 + index })])))
+    expect((await store.query({ order: 'time_asc' })).items.map((record) => record.recordId))
+      .toEqual(['a', 'b', 'c', 'd'])
+    const loggedIds = (await readFile(path, 'utf8')).split('\n')
+      .filter((line) => line.includes('"type":"batch_item"'))
+      .map((line) => (JSON.parse(line) as { payload: { recordId: string } }).payload.recordId)
+    expect(loggedIds).toEqual(['a', 'b', 'c', 'd'])
+    await store.close()
+  })
+
+  it('hides an entire batch when the file ends midway through it', async () => {
+    const path = await temporaryPath()
+    const store = await FileEvalStore.open(path)
+    await store.append([
+      evalRecord({ recordId: 'half-a' }),
+      evalRecord({ recordId: 'half-b' }),
+    ])
+    await store.close()
+    const lines = (await readFile(path, 'utf8')).split('\n')
+    await writeFile(path, `${lines.slice(0, 3).join('\n')}\n`, 'utf8')
+
+    const diagnostics: FileEvalStoreDiagnostic[] = []
+    const reopened = await FileEvalStore.open(path, {
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    })
+    expect((await reopened.query()).items).toHaveLength(0)
+    expect(diagnostics).toEqual([expect.objectContaining({ code: 'incomplete_batch' })])
+    expect((await readFile(path, 'utf8')).split('\n')).toHaveLength(2)
+    await reopened.close()
+  })
+
+  it('recovers a trailing partial line with a diagnostic and preserves prior commits', async () => {
+    const path = await temporaryPath()
+    const store = await FileEvalStore.open(path)
+    await store.append([evalRecord({ recordId: 'committed' })])
+    await store.close()
+    const committed = await readFile(path, 'utf8')
+    await appendFile(path, '{"type":"batch_start"', 'utf8')
+
+    const diagnostics: FileEvalStoreDiagnostic[] = []
+    const reopened = await FileEvalStore.open(path, {
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    })
+    expect((await reopened.query()).items.map((record) => record.recordId)).toEqual(['committed'])
+    expect(diagnostics).toEqual([expect.objectContaining({ code: 'trailing_partial_line' })])
+    expect(await readFile(path, 'utf8')).toBe(committed)
+    await reopened.close()
+  })
+
+  it('rejects complete corruption and unsupported file or evaluation schema versions', async () => {
+    const corruptPath = await temporaryPath('corrupt.ndjson')
+    await writeFile(corruptPath, `${JSON.stringify({
+      type: 'file_header', format: FILE_EVAL_STORE_FORMAT,
+      formatVersion: 1, evalSchemaMajor: 1,
+    })}\n{invalid-json}\n`)
+    await expect(FileEvalStore.open(corruptPath)).rejects.toMatchObject({ code: 'CORRUPT_FILE' })
+
+    const formatPath = await temporaryPath('format.ndjson')
+    await writeFile(formatPath, `${JSON.stringify({
+      type: 'file_header', format: FILE_EVAL_STORE_FORMAT,
+      formatVersion: 99, evalSchemaMajor: 1,
+    })}\n`)
+    await expect(FileEvalStore.open(formatPath)).rejects.toMatchObject({ code: 'UNSUPPORTED_FILE_FORMAT' })
+
+    const schemaPath = await temporaryPath('schema.ndjson')
+    await writeFile(schemaPath, `${JSON.stringify({
+      type: 'file_header', format: FILE_EVAL_STORE_FORMAT,
+      formatVersion: 1, evalSchemaMajor: 99,
+    })}\n`)
+    await expect(FileEvalStore.open(schemaPath)).rejects.toMatchObject({ code: 'UNSUPPORTED_EVAL_SCHEMA' })
+  })
+
+  it('preserves deduplication, delete, and retention effects across reopen', async () => {
+    const path = await temporaryPath()
+    const store = await FileEvalStore.open(path, { now: () => 10_000 })
+    const duplicate = evalRecord({
+      recordId: 'dedupe-reopen', evalRunId: 'dedupe', timestamp: 9_500,
+    })
+    await store.append([
+      duplicate,
+      evalRecord({ recordId: 'delete-reopen', evalRunId: 'delete' }),
+      evalRecord({ recordId: 'retention-reopen', evalRunId: 'retention', timestamp: 1_000 }),
+      evalRecord({ recordId: 'keep-reopen', evalRunId: 'keep', timestamp: 9_000 }),
+    ])
+    await store.delete({ evalRunId: 'delete' })
+    await store.applyRetention({ maxAgeMs: 5_000 })
+    await store.close()
+
+    const reopened = await FileEvalStore.open(path, { now: () => 10_000 })
+    await expect(reopened.append([duplicate])).resolves.toMatchObject({ written: 0, deduplicated: 1 })
+    expect((await reopened.query({ order: 'time_asc' })).items.map((record) => record.recordId))
+      .toEqual(['keep-reopen', 'dedupe-reopen'])
+    await reopened.close()
+  })
+
+  it('declares cursors instance-bound by rejecting them after reopen', async () => {
+    const path = await temporaryPath()
+    const store = await FileEvalStore.open(path)
+    await store.append([
+      evalRecord({ recordId: 'cursor-a', timestamp: 1_000 }),
+      evalRecord({ recordId: 'cursor-b', timestamp: 2_000 }),
+    ])
+    const cursor = (await store.query({ limit: 1 })).nextCursor!
+    await store.close()
+    const reopened = await FileEvalStore.open(path)
+    await expect(reopened.query({ limit: 1, cursor })).rejects.toMatchObject({ code: 'INVALID_CURSOR' })
+    await reopened.close()
+  })
+})
+
+describe('FileEvalStore lifecycle and filesystem failures', () => {
+  it('makes flush repeatable, close idempotent, and post-close operations structured errors', async () => {
+    const path = await temporaryPath()
+    const store = await FileEvalStore.open(path)
+    await store.append([evalRecord({ recordId: 'lifecycle' })])
+    await expect(store.flush()).resolves.toBeUndefined()
+    await expect(store.flush()).resolves.toBeUndefined()
+    const first = store.close()
+    const second = store.close()
+    expect(second).toBe(first)
+    await expect(first).resolves.toBeUndefined()
+    await expect(store.close()).resolves.toBeUndefined()
+    await expect(store.query()).rejects.toMatchObject({ code: 'CLOSED' })
+    await expect(store.append([evalRecord({ recordId: 'closed' })])).rejects.toMatchObject({ code: 'CLOSED' })
+    await expect(store.delete({})).rejects.toMatchObject({ code: 'CLOSED' })
+    await expect(store.applyRetention({ maxRecords: 1 })).rejects.toMatchObject({ code: 'CLOSED' })
+    await expect(store.flush()).rejects.toMatchObject({ code: 'CLOSED' })
+    await expect(store.compact()).rejects.toMatchObject({ code: 'CLOSED' })
+  })
+
+  it('rolls back memory and disk state when a write fails', async () => {
+    const path = await temporaryPath()
+    const store = await FileEvalStore.open(path)
+    vi.spyOn(FILE_EVAL_STORE_IO, 'writeFile').mockRejectedValueOnce(
+      Object.assign(new Error('disk full'), { code: 'ENOSPC' }),
+    )
+    await expect(store.append([evalRecord({ recordId: 'write-failed' })])).rejects.toMatchObject({
+      code: 'WRITE_FAILED', causeCode: 'ENOSPC',
+    })
+    expect((await store.query()).items).toHaveLength(0)
+    vi.restoreAllMocks()
+    await store.append([evalRecord({ recordId: 'after-failure' })])
+    await store.close()
+    const reopened = await FileEvalStore.open(path)
+    expect((await reopened.query()).items.map((record) => record.recordId)).toEqual(['after-failure'])
+    await reopened.close()
+  })
+
+  it('keeps the original authoritative when compaction rename fails', async () => {
+    const path = await temporaryPath()
+    const store = await FileEvalStore.open(path)
+    await store.append([evalRecord({ recordId: 'rename-safe' })])
+    const before = await readFile(path, 'utf8')
+    vi.spyOn(FILE_EVAL_STORE_IO, 'rename').mockRejectedValueOnce(
+      Object.assign(new Error('rename denied'), { code: 'EACCES' }),
+    )
+    await expect(store.compact()).rejects.toMatchObject({ code: 'RENAME_FAILED', causeCode: 'EACCES' })
+    expect(await readFile(path, 'utf8')).toBe(before)
+    expect((await store.query()).items.map((record) => record.recordId)).toEqual(['rename-safe'])
+    vi.restoreAllMocks()
+    await store.close()
+  })
+
+  it('keeps the original authoritative when compaction temp fsync fails', async () => {
+    const path = await temporaryPath()
+    const store = await FileEvalStore.open(path)
+    await store.append([evalRecord({ recordId: 'sync-safe' })])
+    const before = await readFile(path, 'utf8')
+    vi.spyOn(FILE_EVAL_STORE_IO, 'sync').mockRejectedValueOnce(
+      Object.assign(new Error('sync denied'), { code: 'EIO' }),
+    )
+    await expect(store.compact()).rejects.toMatchObject({ code: 'COMPACTION_FAILED', causeCode: 'EIO' })
+    expect(await readFile(path, 'utf8')).toBe(before)
+    expect((await store.query()).items.map((record) => record.recordId)).toEqual(['sync-safe'])
+    vi.restoreAllMocks()
+    await store.close()
+  })
+})
+
+describe('FileEvalStore compaction', () => {
+  it('preserves queries, removes deleted data, and is byte-deterministic', async () => {
+    const path = await temporaryPath()
+    const store = await FileEvalStore.open(path)
+    await store.append([
+      evalRecord({ recordId: 'deleted', evalRunId: 'deleted-run', timestamp: 1_000 }),
+      evalRecord({ recordId: 'kept', evalRunId: 'kept-run', timestamp: 2_000 }),
+    ])
+    await store.delete({ evalRunId: 'deleted-run' })
+    const before = await store.query({ order: 'time_asc' })
+    const first = await store.compact()
+    const compactedOnce = await readFile(path, 'utf8')
+    expect(compactedOnce).not.toContain('"recordId":"deleted"')
+    expect(await store.query({ order: 'time_asc' })).toEqual(before)
+    const second = await store.compact()
+    const compactedTwice = await readFile(path, 'utf8')
+    expect(compactedTwice).toBe(compactedOnce)
+    expect(second).toEqual(first)
+    await store.close()
+
+    const reopened = await FileEvalStore.open(path)
+    expect(await reopened.query({ order: 'time_asc' })).toEqual(before)
+    await reopened.close()
+  })
+
+  it('diagnoses a stale temp while keeping the target authoritative', async () => {
+    const path = await temporaryPath()
+    const store = await FileEvalStore.open(path)
+    await store.append([evalRecord({ recordId: 'target-wins' })])
+    await store.close()
+    await writeFile(`${path}.compact.tmp`, 'interrupted compaction', 'utf8')
+
+    const diagnostics: FileEvalStoreDiagnostic[] = []
+    const reopened = await FileEvalStore.open(path, {
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    })
+    expect((await reopened.query()).items.map((record) => record.recordId)).toEqual(['target-wins'])
+    expect(diagnostics).toEqual([expect.objectContaining({ code: 'stale_compaction_file' })])
+    await reopened.close()
+  })
+
+  it('fails loudly when only a stale compaction temp exists', async () => {
+    const path = await temporaryPath()
+    await writeFile(`${path}.compact.tmp`, 'possible committed data', 'utf8')
+    await expect(FileEvalStore.open(path)).rejects.toMatchObject({ code: 'STALE_COMPACTION_FILE' })
+  })
+})
+
+describe('FileEvalStore import boundary', () => {
+  it('is exported only from the Node-only eval/file subpath module', async () => {
+    const root = await import('../src/index.js')
+    const evaluation = await import('../src/eval/index.js')
+    const file = await import('../src/eval/file.js')
+    expect(root).not.toHaveProperty('FileEvalStore')
+    expect(evaluation).not.toHaveProperty('FileEvalStore')
+    expect(file.FileEvalStore).toBe(FileEvalStore)
+  })
+
+  it('uses payload-free structured corruption errors', async () => {
+    const path = await temporaryPath()
+    const secret = 'secret-evaluation-payload'
+    await writeFile(path, `${JSON.stringify({
+      type: 'file_header', format: FILE_EVAL_STORE_FORMAT,
+      formatVersion: 1, evalSchemaMajor: 1,
+    })}\n{${secret}}\n`)
+    const error = await FileEvalStore.open(path).catch((caught) => caught as FileEvalStoreError)
+    expect(error).toBeInstanceOf(FileEvalStoreError)
+    expect(error.code).toBe('CORRUPT_FILE')
+    expect(error.message).not.toContain(secret)
+  })
+})

--- a/packages/core/tests/eval-file.test.ts
+++ b/packages/core/tests/eval-file.test.ts
@@ -26,6 +26,7 @@ function reportFixture(): EvalRunReport {
     metadata: { prompt_version: 'v2' },
     caseCount: 4,
     repeats: 1,
+    warnings: ['Evaluation records for case "failed" repeat 1 were not persisted.'],
     records: [
       {
         schemaVersion: 1,
@@ -269,6 +270,8 @@ describe('writeEvalReport', () => {
     expect(markdown).toContain('## Scorer aggregates')
     expect(markdown).toContain('## Aggregates by tag')
     expect(markdown).toContain('## Failed samples')
+    expect(markdown).toContain('## Warnings')
+    expect(markdown).toContain('were not persisted')
     expect(markdown).toContain('mismatch <&"\'')
     expect(markdown).toContain('- Target errors: 1')
     expect(markdown).toContain('- Tokens: 10 input, 5 output')

--- a/packages/core/tests/eval-in-memory-store.test.ts
+++ b/packages/core/tests/eval-in-memory-store.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { InMemoryEvalStore } from '../src/eval/store.js'
+import { evalRecord, runEvalStoreContractSuite } from './eval-store-contract.js'
+
+runEvalStoreContractSuite(
+  'InMemoryEvalStore',
+  (options = {}) => new InMemoryEvalStore({ now: options.now }),
+)
+
+describe('InMemoryEvalStore capacity', () => {
+  it('rejects a batch atomically when maxRecords would be exceeded', async () => {
+    const store = new InMemoryEvalStore({ maxRecords: 2 })
+    await store.append([evalRecord({ recordId: 'capacity-first' })])
+    await expect(store.append([
+      evalRecord({ recordId: 'capacity-second' }),
+      evalRecord({ recordId: 'capacity-third' }),
+    ])).rejects.toMatchObject({ code: 'INVALID_ARGUMENT', field: 'records' })
+    expect((await store.query()).items.map((record) => record.recordId))
+      .toEqual(['capacity-first'])
+  })
+})

--- a/packages/core/tests/eval-runner.test.ts
+++ b/packages/core/tests/eval-runner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   defineEvalSet,
   defineScorer,
+  InMemoryEvalStore,
   runEvalSet,
 } from '../src/eval/index.js'
 import type {
@@ -352,5 +353,57 @@ describe('runEvalSet', () => {
     expect(contextMetadata).toEqual(expected)
     expect(report.records[0]?.metadata).toEqual(expected)
     expect(report.metadata).toEqual({ shared: 'runner', runner_only: true })
+  })
+
+  it('persists one atomic record batch per completed sample', async () => {
+    const set = defineEvalSet({
+      name: 'stored', version: '1',
+      cases: [
+        { id: 'a', input: 'a', expected: 'a' },
+        { id: 'b', input: 'b', expected: 'b' },
+      ],
+    })
+    const store = new InMemoryEvalStore()
+    const append = vi.spyOn(store, 'append')
+    const report = await runEvalSet(set, async (input) => ({ output: input }), {
+      scorers: [exact, defineScorer({ name: 'second', score: () => ({ score: 1 }) })],
+      store,
+      concurrency: 2,
+    })
+
+    expect(append).toHaveBeenCalledTimes(2)
+    expect(append.mock.calls.map(([records]) => records.length)).toEqual([2, 2])
+    expect((await store.query({ evalRunId: report.evalRunId })).items.map((record) => record.recordId).sort())
+      .toEqual(report.records.map((record) => record.recordId).sort())
+    expect(report.warnings).toBeUndefined()
+  })
+
+  it('keeps the full report and adds deterministic warnings when store batches fail', async () => {
+    const set = defineEvalSet({
+      name: 'store-failure', version: '1',
+      cases: [
+        { id: 'slow', input: 'slow', expected: 'slow' },
+        { id: 'fast', input: 'fast', expected: 'fast' },
+      ],
+    })
+    const append = vi.fn().mockRejectedValue(new Error('store unavailable'))
+    const store = {
+      append,
+      query: vi.fn(),
+      delete: vi.fn(),
+      applyRetention: vi.fn(),
+    }
+    const report = await runEvalSet(set, async (input) => {
+      if (input === 'slow') await new Promise((resolve) => setTimeout(resolve, 10))
+      return { output: input }
+    }, { scorers: [exact], store, concurrency: 2 })
+
+    expect(append).toHaveBeenCalledTimes(2)
+    expect(report.records).toHaveLength(2)
+    expect(report.aggregates[0]).toMatchObject({ scoredCount: 2, avg: 1 })
+    expect(report.warnings).toEqual([
+      'Evaluation records for case "slow" repeat 1 were not persisted.',
+      'Evaluation records for case "fast" repeat 1 were not persisted.',
+    ])
   })
 })

--- a/packages/core/tests/eval-store-contract.ts
+++ b/packages/core/tests/eval-store-contract.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from 'vitest'
+import type { EvalRecord } from '../src/eval/record.js'
+import {
+  EvalStoreError,
+  type EvalStore,
+} from '../src/eval/store.js'
+
+export interface EvalStoreContractFactoryOptions {
+  readonly now?: () => number
+}
+
+export type EvalStoreContractFactory = (
+  options?: EvalStoreContractFactoryOptions,
+) => EvalStore
+
+interface RecordOptions {
+  readonly recordId?: string
+  readonly evalRunId?: string
+  readonly runId?: string
+  readonly evalSetName?: string
+  readonly scorer?: string
+  readonly source?: EvalRecord['source']
+  readonly status?: EvalRecord['status']
+  readonly timestamp?: number
+  readonly metadata?: Readonly<Record<string, string | number | boolean>>
+}
+
+let id = 0
+
+export function evalRecord(options: RecordOptions = {}): EvalRecord {
+  const recordId = options.recordId ?? `eval-contract-${++id}`
+  const runId = options.runId ?? `run-${recordId}`
+  return {
+    schemaVersion: 1,
+    recordId,
+    evalRunId: options.evalRunId ?? `eval-run-${recordId}`,
+    source: options.source ?? 'offline',
+    timestampUnixMs: options.timestamp ?? 1_000,
+    evalSet: { name: options.evalSetName ?? 'contract-set', version: '1.0.0' },
+    caseId: `case-${recordId}`,
+    repeat: 1,
+    scorer: { name: options.scorer ?? 'exact', version: '1.0.0' },
+    status: options.status ?? 'scored',
+    ...(options.status === undefined || options.status === 'scored'
+      ? { score: 1, pass: true, reason: 'matched' }
+      : {}),
+    runRef: {
+      runId,
+      attempt: 1,
+      traceId: `trace-${recordId}`,
+      rootSpanId: `span-${recordId}`,
+    },
+    metadata: options.metadata ?? { suite: 'contract' },
+  }
+}
+
+function ids(records: readonly EvalRecord[]): string[] {
+  return records.map((record) => record.recordId)
+}
+
+/** Reusable behavioral suite for every EvalStore implementation. */
+export function runEvalStoreContractSuite(
+  name: string,
+  createStore: EvalStoreContractFactory,
+): void {
+  describe(`${name} EvalStore contract`, () => {
+    it('makes valid batches atomically visible and rejects invalid batches atomically', async () => {
+      const store = createStore()
+      const first = evalRecord({ recordId: 'atomic-first' })
+      const second = evalRecord({ recordId: 'atomic-second' })
+      await expect(store.append([first, second])).resolves.toEqual({
+        written: 2,
+        deduplicated: 0,
+        diagnostics: [],
+      })
+
+      const valid = evalRecord({ recordId: 'atomic-rejected-valid' })
+      const unsupported = {
+        ...evalRecord({ recordId: 'atomic-rejected-version' }),
+        schemaVersion: 2,
+      } as unknown as EvalRecord
+      await expect(store.append([valid, unsupported])).rejects.toMatchObject({
+        code: 'UNSUPPORTED_SCHEMA_VERSION',
+        field: 'records[1].schemaVersion',
+      })
+      expect((await store.query({ evalRunId: valid.evalRunId })).items).toHaveLength(0)
+    })
+
+    it('deduplicates by recordId, preserves the first payload, and does not leak references', async () => {
+      const store = createStore()
+      const first = evalRecord({ recordId: 'dedupe', metadata: { value: 'first' } })
+      await store.append([first])
+      ;(first.metadata as Record<string, string>)['value'] = 'mutated'
+      const collision = evalRecord({ recordId: 'dedupe', metadata: { value: 'second' } })
+      await expect(store.append([collision])).resolves.toMatchObject({
+        written: 0,
+        deduplicated: 1,
+      })
+      const result = (await store.query({ evalRunId: first.evalRunId })).items[0]!
+      expect(result.metadata).toEqual({ value: 'first' })
+      ;(result.metadata as Record<string, string>)['value'] = 'external'
+      expect((await store.query({ evalRunId: first.evalRunId })).items[0]?.metadata)
+        .toEqual({ value: 'first' })
+    })
+
+    it('supports every filter independently and in combination', async () => {
+      const store = createStore()
+      const first = evalRecord({
+        recordId: 'filter-a', evalRunId: 'eval-a', runId: 'run-a',
+        evalSetName: 'set-a', scorer: 'exact', source: 'offline',
+        status: 'scored', timestamp: 1_000,
+      })
+      const second = evalRecord({
+        recordId: 'filter-b', evalRunId: 'eval-b', runId: 'run-b',
+        evalSetName: 'set-b', scorer: 'judge', source: 'online',
+        status: 'scorer_error', timestamp: 2_000,
+      })
+      const third = evalRecord({
+        recordId: 'filter-c', evalRunId: 'eval-a', runId: 'run-c',
+        evalSetName: 'set-a', scorer: 'judge', source: 'offline',
+        status: 'skipped', timestamp: 3_000,
+      })
+      await store.append([first, second, third])
+
+      expect(ids((await store.query({ evalRunId: 'eval-a', order: 'time_asc' })).items))
+        .toEqual(['filter-a', 'filter-c'])
+      expect(ids((await store.query({ evalRunId: ['eval-b'] })).items)).toEqual(['filter-b'])
+      expect(ids((await store.query({ runId: 'run-b' })).items)).toEqual(['filter-b'])
+      expect(ids((await store.query({ runId: ['run-a', 'run-c'], order: 'time_asc' })).items))
+        .toEqual(['filter-a', 'filter-c'])
+      expect(ids((await store.query({ evalSetName: 'set-b' })).items)).toEqual(['filter-b'])
+      expect(ids((await store.query({ scorer: ['judge'], order: 'time_asc' })).items))
+        .toEqual(['filter-b', 'filter-c'])
+      expect(ids((await store.query({ source: 'online' })).items)).toEqual(['filter-b'])
+      expect(ids((await store.query({ status: ['skipped'] })).items)).toEqual(['filter-c'])
+      expect(ids((await store.query({ after: new Date(2_000).toISOString(), order: 'time_asc' })).items))
+        .toEqual(['filter-b', 'filter-c'])
+      expect(ids((await store.query({ before: new Date(3_000).toISOString(), order: 'time_asc' })).items))
+        .toEqual(['filter-a', 'filter-b'])
+      expect(ids((await store.query({
+        evalRunId: 'eval-a', runId: 'run-c', evalSetName: 'set-a',
+        scorer: ['judge'], source: 'offline', status: ['skipped'],
+        after: new Date(2_500).toISOString(), before: new Date(3_500).toISOString(),
+      })).items)).toEqual(['filter-c'])
+    })
+
+    it('uses a default limit of 100 and accepts limits through 1000', async () => {
+      const store = createStore()
+      await store.append(Array.from({ length: 101 }, (_, index) => evalRecord({
+        recordId: `limit-${index.toString().padStart(3, '0')}`,
+        timestamp: index,
+      })))
+      const defaultPage = await store.query({ order: 'time_asc' })
+      expect(defaultPage.items).toHaveLength(100)
+      expect(defaultPage.nextCursor).toBeTypeOf('string')
+      expect((await store.query({ limit: 1_000 })).items).toHaveLength(101)
+      await expect(store.query({ limit: 0 })).rejects.toMatchObject({
+        code: 'INVALID_ARGUMENT', field: 'limit',
+      })
+      await expect(store.query({ limit: 1_001 })).rejects.toMatchObject({
+        code: 'INVALID_ARGUMENT', field: 'limit',
+      })
+    })
+
+    it('orders both ways and paginates same-time ties over a stable append snapshot', async () => {
+      const store = createStore()
+      await store.append(['a', 'b', 'c', 'd', 'e'].map((recordId) =>
+        evalRecord({ recordId, timestamp: 5_000 })))
+      expect(ids((await store.query({ order: 'time_desc' })).items))
+        .toEqual(['e', 'd', 'c', 'b', 'a'])
+
+      const first = await store.query({ limit: 2, order: 'time_asc' })
+      expect(ids(first.items)).toEqual(['a', 'b'])
+      await store.append([evalRecord({ recordId: 'aa-new', timestamp: 5_000 })])
+      const second = await store.query({
+        limit: 2, order: 'time_asc', cursor: first.nextCursor,
+      })
+      const third = await store.query({
+        limit: 2, order: 'time_asc', cursor: second.nextCursor,
+      })
+      expect(ids([...first.items, ...second.items, ...third.items]))
+        .toEqual(['a', 'b', 'c', 'd', 'e'])
+      expect(ids((await store.query({ limit: 10, order: 'time_asc' })).items))
+        .toEqual(['a', 'aa-new', 'b', 'c', 'd', 'e'])
+    })
+
+    it('rejects invalid, tampered, mismatched, and delete-invalidated cursors', async () => {
+      const store = createStore()
+      await store.append([
+        evalRecord({ recordId: 'cursor-a', scorer: 'exact', timestamp: 1_000 }),
+        evalRecord({ recordId: 'cursor-b', scorer: 'exact', timestamp: 2_000 }),
+      ])
+      const page = await store.query({ limit: 1, scorer: ['exact'] })
+      await expect(store.query({ cursor: 'not-a-cursor' })).rejects.toBeInstanceOf(EvalStoreError)
+      await expect(store.query({ limit: 1, scorer: ['other'], cursor: page.nextCursor }))
+        .rejects.toMatchObject({ code: 'INVALID_CURSOR' })
+      await expect(store.query({ limit: 1, scorer: ['exact'], cursor: `${page.nextCursor}x` }))
+        .rejects.toMatchObject({ code: 'INVALID_CURSOR' })
+      await store.delete({ evalRunId: (page.items[0]!).evalRunId })
+      await expect(store.query({ limit: 1, scorer: ['exact'], cursor: page.nextCursor }))
+        .rejects.toMatchObject({ code: 'INVALID_CURSOR' })
+    })
+
+    it('preserves unknown minor fields and rejects a higher schema major', async () => {
+      const store = createStore()
+      const record = {
+        ...evalRecord({ recordId: 'minor-field' }),
+        futureMinorField: { preserved: true },
+      } as EvalRecord
+      await store.append([record])
+      expect((await store.query({ evalRunId: record.evalRunId })).items[0])
+        .toMatchObject({ futureMinorField: { preserved: true } })
+      await expect(store.append([{
+        ...evalRecord({ recordId: 'higher-major' }),
+        schemaVersion: 2,
+      } as unknown as EvalRecord])).rejects.toMatchObject({
+        code: 'UNSUPPORTED_SCHEMA_VERSION',
+      })
+    })
+
+    it('deletes by every delete dimension, reports affected eval runs, and is idempotent', async () => {
+      const store = createStore()
+      await store.append([
+        evalRecord({ recordId: 'delete-a', evalRunId: 'delete-run', evalSetName: 'set-a', timestamp: 1_000 }),
+        evalRecord({ recordId: 'delete-b', evalRunId: 'delete-run', evalSetName: 'set-b', timestamp: 2_000 }),
+        evalRecord({ recordId: 'delete-c', evalRunId: 'keep-run', evalSetName: 'set-a', timestamp: 3_000 }),
+      ])
+      const query = {
+        evalRunId: 'delete-run',
+        evalSetName: 'set-a',
+        before: new Date(1_500).toISOString(),
+      }
+      await expect(store.delete(query)).resolves.toEqual({
+        runsDeleted: 1,
+        recordsDeleted: 1,
+        runIds: ['delete-run'],
+      })
+      await expect(store.delete(query)).resolves.toEqual({
+        runsDeleted: 0, recordsDeleted: 0, runIds: [],
+      })
+      await expect(store.delete({ evalSetName: 'set-b' })).resolves.toMatchObject({
+        recordsDeleted: 1, runIds: ['delete-run'],
+      })
+      expect(ids((await store.query()).items)).toEqual(['delete-c'])
+    })
+
+    it('applies age, record-count, and source retention deterministically and idempotently', async () => {
+      const store = createStore({ now: () => 10_000 })
+      await store.append([
+        evalRecord({ recordId: 'old-offline', evalRunId: 'old', source: 'offline', timestamp: 1_000 }),
+        evalRecord({ recordId: 'mid-online', evalRunId: 'mid', source: 'online', timestamp: 6_000 }),
+        evalRecord({ recordId: 'new-offline', evalRunId: 'new', source: 'offline', timestamp: 9_000 }),
+      ])
+      await expect(store.applyRetention({ maxAgeMs: 5_000, sources: ['offline'] }))
+        .resolves.toMatchObject({ recordsDeleted: 1, runIds: ['old'] })
+      await expect(store.applyRetention({ maxRecords: 0, sources: ['online'] }))
+        .resolves.toMatchObject({ recordsDeleted: 1, runIds: ['mid'] })
+      await expect(store.applyRetention({ sources: ['offline'] }))
+        .resolves.toMatchObject({ recordsDeleted: 1, runIds: ['new'] })
+      await expect(store.applyRetention({ sources: ['offline'] })).resolves.toEqual({
+        runsDeleted: 0, recordsDeleted: 0, runIds: [],
+      })
+    })
+
+    it('returns structured errors for invalid query, retention, and record inputs', async () => {
+      const store = createStore()
+      await expect(store.query({ after: 'not-a-date' })).rejects.toMatchObject({
+        code: 'INVALID_ARGUMENT', field: 'after',
+      })
+      await expect(store.query({ status: ['not-a-status'] as never })).rejects.toMatchObject({
+        code: 'INVALID_ARGUMENT', field: 'status',
+      })
+      await expect(store.applyRetention({})).rejects.toMatchObject({
+        code: 'INVALID_ARGUMENT', field: 'policy',
+      })
+      await expect(store.append([{
+        ...evalRecord({ recordId: 'invalid-score' }),
+        score: 2,
+      }])).rejects.toMatchObject({ code: 'INVALID_ARGUMENT', field: 'records[0].score' })
+    })
+  })
+}

--- a/packages/core/tests/subpath-exports.test.ts
+++ b/packages/core/tests/subpath-exports.test.ts
@@ -29,6 +29,8 @@ describe('subpath export barrels', () => {
     expect(typeof mod.runEvalSet).toBe('function')
     expect(typeof mod.targetFromAgent).toBe('function')
     expect(typeof mod.evaluateGate).toBe('function')
+    expect(typeof mod.InMemoryEvalStore).toBe('function')
+    expect(mod).not.toHaveProperty('FileEvalStore')
   })
 
   it('/eval/file exposes Node-only EvalSet and report file helpers', async () => {
@@ -37,5 +39,6 @@ describe('subpath export barrels', () => {
     expect(typeof mod.loadEvalReport).toBe('function')
     expect(typeof mod.loadGatePolicy).toBe('function')
     expect(typeof mod.writeEvalReport).toBe('function')
+    expect(typeof mod.FileEvalStore).toBe('function')
   })
 })


### PR DESCRIPTION
## Summary

- add the `EvalStore` contract and `InMemoryEvalStore` with atomic batches, stable cursor pagination, filtering, deletion, and retention
- add the Node-only `FileEvalStore` with versioned NDJSON recovery, serialized writes, durability controls, and atomic compaction
- add optional evaluation persistence to `runEvalSet()`, returning the complete report with payload-free warnings when persistence fails
- add shared contract tests, file lifecycle and recovery coverage, subpath-boundary checks, and user documentation

## Motivation

Evaluation results need a storage-independent persistence contract so offline runs can accumulate quality history without coupling the public API to a particular file layout or database implementation.

## Scope and impact

- Affected areas: `@open-multi-agent/core/eval`, the Node-only `@open-multi-agent/core/eval/file` subpath, tests, and evaluation documentation
- Public API: adds `EvalStore`, `InMemoryEvalStore`, related query and retention types, and `FileEvalStore`; `runEvalSet()` accepts optional persistence without changing its default behavior
- Compatibility: additive and backward-compatible; existing evaluation calls remain in-memory unless a store is supplied
- Dependencies: no runtime dependencies added
- Security/privacy: persistence warnings identify the failed operation without echoing stored evaluation payloads
- Intentional non-goals: online evaluation, sampling, orchestration changes, and unrelated observability work

## Validation

- Node 18.20.8, 20.19.4, and 22.22.3: `npm run lint`, `npm test`, and `npm run build`
- shared store contract suite against both in-memory and file-backed implementations
- file recovery, compaction failure, lifecycle, and import-boundary tests
- `npm pack --dry-run --json` on Node 18/20/22; expected evaluation store artifacts included and source/tests excluded
- `npm run bench:observability:ci`
- `git diff --check`
- real-provider E2E was not run because no provider or network execution path changed

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING
