### PR TITLE
feat(core): add online evaluation sampling

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -84,6 +84,149 @@ Each case/repeat target runs once, then that sample's scorers run serially. Diff
 
 Report percentiles use the nearest-rank method. For two sorted scores, p50 is the lower score and p95 is the higher score. `passRate` only includes scored records that explicitly contain `pass`; scorer errors are excluded from every score denominator. `byTag` repeats the same aggregation for each case tag. Target token usage is counted once per sample, even when multiple scorers run, and costs are summed only within the same currency.
 
+## Sample production runs online
+
+Online evaluation is opt-in on `OpenMultiAgent`. A settled top-level run only
+performs a synchronous sampling decision and bounded queue admission; scorers
+and store writes run later and never change the business result.
+
+```ts
+import { OpenMultiAgent } from '@open-multi-agent/core'
+import {
+  InMemoryEvalStore,
+  defineScorer,
+} from '@open-multi-agent/core/eval'
+
+const onlineStore = new InMemoryEvalStore()
+const lengthScorer = defineScorer({
+  name: 'length',
+  version: '1',
+  score({ output }) {
+    const length = String(output).length
+    return { score: Math.min(1, length / 200), pass: length >= 40 }
+  },
+})
+
+const orchestrator = new OpenMultiAgent({
+  evaluation: {
+    scorers: [lengthScorer],
+    sample: 0.05,
+    maxConcurrent: 1,
+    maxQueueLength: 100,
+    budget: { maxEvaluationsPerMinute: 30 },
+    store: onlineStore,
+  },
+})
+
+const run = await orchestrator.runAgent(agent, prompt)
+// The business result does not wait for lengthScorer or onlineStore.
+console.log(run.success)
+
+await orchestrator.evaluation.forceFlush({ timeoutMs: 1_000 })
+const page = await onlineStore.query({ runId: [run.identity!.runId] })
+console.log(page.items[0]?.source) // online
+```
+
+`runAgent`, `runTeam`, `runTasks`, `runFromPlan`, `runConsensus`, and `restore`
+all use the same evaluator owned by the `OpenMultiAgent` instance. Its
+`evalRunId` therefore remains stable for that instance lifetime. Each sampled
+run produces one `EvalRecord` per scorer with `source: 'online'`, no EvalSet or
+case ID, and a `runRef` containing the exact logical run and attempt.
+
+Numeric sampling uses `Math.random() < sample`. A rule can select by normalized
+status and validated run metadata without implementing tail sampling:
+
+```ts
+const failuresOnly = new OpenMultiAgent({
+  evaluation: {
+    scorers: [lengthScorer],
+    sample: (context) =>
+      context.status.code !== 'ok'
+      && context.metadata['deployment'] === 'canary',
+    store: onlineStore,
+  },
+})
+```
+
+A throwing sampling rule is treated as `false` and diagnosed. A scorer throw,
+rejection, or timeout produces a `scorer_error` record. A rejected store append
+drops that sample's record batch. Queue overflow, exhausted budgets, callbacks,
+and all evaluation failures are isolated from the original run result.
+
+Online defaults are deliberately conservative: evaluation is off when the
+configuration is omitted or `sample` is `0`; `maxConcurrent` is `1`,
+`maxQueueLength` is `100`, payload persistence is `none`, diagnostics warn at
+most once per code per 60 seconds, and there is no implicit rate or cost cap.
+`diagnostics: 'silent'` must be explicit. `getStats()` returns cumulative
+`sampled`, `enqueued`, `completed`, `dropped`, `failed`, and `storeFailed`
+counts.
+
+`maxEvaluationsPerMinute` counts scorer evaluations, so one sampled run with
+three scorers consumes three units. `maxCostPerHour` uses the caller's existing
+`OrchestratorConfig.estimateCost` function and the model usage surfaced by
+framework-backed scorers such as `createJudgeScorer`. The cap uses the same
+caller-defined unit returned by `estimateCost`, can overshoot by currently
+running scorer work, and resumes as the rolling hour advances. Rule scorers
+without model usage cost zero. Custom model-backed scorers cannot be costed
+unless they use a framework scorer that reports its internal usage. Configuring
+`maxCostPerHour` without `estimateCost` leaves the cap inactive and emits one
+payload-free warning; it never silently blocks runs.
+
+`storePayloads: 'none'` gives scorers a content-free run-input description and
+does not persist input or output. `'redacted'` gives scorers and the record a
+bounded, redacted input string and persists a bounded, redacted output;
+`'full'` does the same without redaction and must be an explicit privacy
+decision. Scorers always receive the candidate output in memory so they can
+score it. In particular, a judge scorer sends that output to its configured
+model provider; do not enable an external judge for data that may not leave its
+trust boundary.
+
+### Lifecycle ownership
+
+The application owns evaluator lifecycle. OMA installs no signal handlers and
+does not call `process.exit()`. All evaluator timers are unreferenced, so they
+do not keep a CLI or serverless process alive. This also means a process crash
+or natural exit can lose queued work: the first implementation is in-process,
+best-effort, and intentionally not durable. A durable or cross-process scoring
+queue is a separate future integration, not an `EvalStore` guarantee.
+
+```ts
+// Serverless/FaaS: flush this invocation; keep a shared singleton usable.
+const result = await orchestrator.runAgent(agent, prompt)
+const evaluation = await orchestrator.evaluation.forceFlush({ timeoutMs: 1_500 })
+return { result, evaluation: evaluation.status }
+
+// Short-lived CLI: settle accepted samples before natural process exit.
+try {
+  await main()
+} finally {
+  await orchestrator.evaluation.forceFlush({ timeoutMs: 5_000 })
+  await orchestrator.evaluation.shutdown({ timeoutMs: 5_000 })
+}
+
+// Long-lived server: stop traffic, then drain and close on graceful shutdown.
+async function stopServer() {
+  await stopAcceptingAndWaitForInflight(server)
+  await orchestrator.evaluation.forceFlush({ timeoutMs: 10_000 })
+  await orchestrator.evaluation.shutdown({ timeoutMs: 10_000 })
+  await provider?.shutdown()
+}
+// Register stopServer with your server/process framework if desired.
+```
+
+`forceFlush()` waits for the samples accepted before its watermark and returns
+`ok`, `partial`, `timeout`, or `error` plus cumulative counts. `shutdown()`
+atomically rejects new samples, flushes its cutoff, and is idempotent: repeated
+or concurrent calls share the first result. `OpenMultiAgent.shutdown()` remains
+the existing team-registry reset; evaluator shutdown is explicit through
+`orchestrator.evaluation`.
+
+On the online-evaluation maintainer benchmark (Node 22, 50,000 same-process direct
+admissions), sampling plus bounded enqueue measured approximately `0.42 µs`
+p95 (`0.30 µs` mean) on the implementation host. Absolute microseconds vary by
+host; CI additionally retains the existing observability same-host regression
+gate for the unconfigured path.
+
 ## Persist evaluation records
 
 Use `InMemoryEvalStore` for short-lived local runs, tests, or an adapter

--- a/packages/core/src/eval/index.ts
+++ b/packages/core/src/eval/index.ts
@@ -27,6 +27,13 @@ export type {
 export { runEvalSet } from './runner.js'
 export type { EvalProgressEvent, RunEvalOptions } from './runner.js'
 export type { EvalRunReport, ScorerAggregate } from './report.js'
+export type {
+  EvalDiagnostic,
+  OnlineEvaluationConfig,
+  OnlineEvaluationLifecycle,
+  OnlineEvaluationStats,
+  OnlineSampleContext,
+} from './online.js'
 export { evaluateGate } from './gate.js'
 export type {
   GateFailure,

--- a/packages/core/src/eval/judge.ts
+++ b/packages/core/src/eval/judge.ts
@@ -1,11 +1,18 @@
 import { z, type ZodSchema } from 'zod'
-import type { AgentConfig } from '../types.js'
+import type { AgentConfig, CostEstimateContext, TokenUsage } from '../types.js'
 import {
   buildStructuredOutputInstruction,
   extractJSON,
   validateOutput,
 } from '../agent/structured-output.js'
-import { defineScorer, type Scorer, type ScorerContext } from './scorer.js'
+import {
+  attachScoreCostInputs,
+  defineScorer,
+  scoreCostInputs,
+  type ScoreCostInput,
+  type Scorer,
+  type ScorerContext,
+} from './scorer.js'
 
 export interface JudgeScorerOptions {
   readonly name: string
@@ -115,6 +122,7 @@ function createDeadline(
     error.name = 'TimeoutError'
     controller.abort(error)
   }, timeoutMs)
+  timer?.unref?.()
 
   return {
     signal: controller.signal,
@@ -146,16 +154,43 @@ async function runJudge(
   prompt: string,
   schema: ZodSchema,
   signal: AbortSignal,
-): Promise<JudgeVerdict> {
+): Promise<{
+  readonly verdict: JudgeVerdict
+  readonly usage: TokenUsage
+  readonly costContext: CostEstimateContext
+}> {
   // Keep the eval barrel browser-safe to import. The Node-capable Agent path is
   // loaded only when a judge scorer actually executes.
   const { buildAgent } = await import('../orchestrator/agent-config.js')
   const result = await buildAgent(judge).run(prompt, { abortSignal: signal })
-  if (!result.success) {
-    if (result.error instanceof Error) throw result.error
-    throw new Error(result.errorInfo?.message ?? `Judge "${judge.name}" failed.`)
+  const model = judge.model ?? (judge.backend ? `${judge.backend.kind}-backend` : 'unknown')
+  const costInput: ScoreCostInput = {
+    usage: result.tokenUsage,
+    context: {
+      agentName: judge.name,
+      model,
+      phase: 'agent',
+      ...(judge.provider !== undefined ? { provider: judge.provider } : {}),
+    },
   }
-  return parseVerdict(result.output, schema, judge)
+  if (!result.success) {
+    const error = result.error instanceof Error
+      ? result.error
+      : new Error(result.errorInfo?.message ?? `Judge "${judge.name}" failed.`)
+    throw attachScoreCostInputs(error, [costInput])
+  }
+  let verdict: JudgeVerdict
+  try {
+    verdict = parseVerdict(result.output, schema, judge)
+  } catch (error) {
+    if (error instanceof Error) attachScoreCostInputs(error, [costInput])
+    throw error
+  }
+  return {
+    verdict,
+    usage: result.tokenUsage,
+    costContext: costInput.context,
+  }
 }
 
 /** Create an OMA-agent-backed scorer with mean-score and quorum aggregation. */
@@ -191,11 +226,21 @@ export function createJudgeScorer(options: JudgeScorerOptions): Scorer {
 
       try {
         const verdicts: JudgeVerdict[] = []
-        for (const judge of judges) {
-          verdicts.push(await raceWithAbort(
-            runJudge(judge, prompt, schema, deadline.signal),
-            deadline.signal,
-          ))
+        const costInputs: ScoreCostInput[] = []
+        try {
+          for (const judge of judges) {
+            const judged = await raceWithAbort(
+              runJudge(judge, prompt, schema, deadline.signal),
+              deadline.signal,
+            )
+            verdicts.push(judged.verdict)
+            costInputs.push({ usage: judged.usage, context: judged.costContext })
+          }
+        } catch (error) {
+          if (error instanceof Error) {
+            attachScoreCostInputs(error, [...costInputs, ...scoreCostInputs(error)])
+          }
+          throw error
         }
 
         const score = verdicts.reduce((sum, verdict) => sum + verdict.score, 0) / verdicts.length
@@ -205,7 +250,7 @@ export function createJudgeScorer(options: JudgeScorerOptions): Scorer {
           .filter((verdict) => verdict.reason)
           .map((verdict) => `${verdict.judge}: ${verdict.reason}`)
 
-        return {
+        return attachScoreCostInputs({
           score,
           ...(hasPass ? { pass: passVotes >= quorum } : {}),
           ...(reasons.length > 0 ? { reason: reasons.join('\n') } : {}),
@@ -216,7 +261,7 @@ export function createJudgeScorer(options: JudgeScorerOptions): Scorer {
             models: verdicts.map((verdict) => verdict.model),
             scores: verdicts.map((verdict) => verdict.score),
           },
-        }
+        }, costInputs)
       } finally {
         deadline.dispose()
       }

--- a/packages/core/src/eval/online.ts
+++ b/packages/core/src/eval/online.ts
@@ -1,0 +1,790 @@
+import { classifyRunFailure } from '../observability/status.js'
+import type { FlushOptions, FlushResult } from '../observability/sink.js'
+import type {
+  AgentRunResult,
+  ConsensusResult,
+  CostEstimateContext,
+  RunIdentity,
+  RunStatus,
+  TeamRunResult,
+  TokenUsage,
+  TraceAttributeValue,
+} from '../types.js'
+import { redactSensitiveText } from '../utils/redaction.js'
+import type { EvalCase } from './evalcase.js'
+import type { EvalRecord } from './record.js'
+import {
+  scoreCostInputs,
+  type ScoreResult,
+  type Scorer,
+  type ScorerContext,
+} from './scorer.js'
+import type { EvalStore } from './store.js'
+
+const DEFAULT_MAX_CONCURRENT = 1
+const DEFAULT_MAX_QUEUE_LENGTH = 100
+const DEFAULT_FLUSH_TIMEOUT_MS = 30_000
+const DIAGNOSTIC_INTERVAL_MS = 60_000
+const PAYLOAD_MAX_CHARS = 8 * 1024
+const REASON_MAX_CHARS = 1_024
+
+type OnlineRunResult = AgentRunResult | TeamRunResult | ConsensusResult
+
+export interface OnlineSampleContext {
+  readonly identity: RunIdentity
+  readonly status: RunStatus
+  readonly metadata: Readonly<Record<string, TraceAttributeValue>>
+  readonly durationMs: number
+}
+
+export interface EvalDiagnostic {
+  readonly code:
+    | 'queue_full'
+    | 'budget_exhausted'
+    | 'scorer_failed'
+    | 'store_append_failed'
+    | 'flush_timeout'
+    | 'enqueue_after_shutdown'
+  readonly severity: 'warning' | 'error'
+  /** Number of occurrences aggregated since the previous emitted diagnostic. */
+  readonly count: number
+  readonly scorerName?: string
+  /** Fixed, payload-free message. Never contains run content or credentials. */
+  readonly message: string
+}
+
+export interface OnlineEvaluationConfig {
+  readonly scorers: readonly Scorer[]
+  /** Number in [0,1], or a rule evaluated after a top-level run settles. */
+  readonly sample: number | ((context: OnlineSampleContext) => boolean)
+  readonly maxConcurrent?: number
+  readonly maxQueueLength?: number
+  readonly budget?: {
+    readonly maxEvaluationsPerMinute?: number
+    readonly maxCostPerHour?: number
+  }
+  readonly store?: EvalStore
+  readonly storePayloads?: 'none' | 'redacted' | 'full'
+  readonly onResult?: (record: EvalRecord) => void
+  readonly onDiagnostic?: (diagnostic: EvalDiagnostic) => void
+  readonly diagnostics?: 'warn' | 'silent'
+}
+
+export interface OnlineEvaluationStats {
+  readonly sampled: number
+  readonly enqueued: number
+  readonly completed: number
+  readonly dropped: number
+  readonly failed: number
+  readonly storeFailed: number
+}
+
+export interface OnlineEvaluationLifecycle {
+  forceFlush(options?: FlushOptions): Promise<FlushResult>
+  shutdown(options?: FlushOptions): Promise<FlushResult>
+  getStats(): OnlineEvaluationStats
+}
+
+/** Internal hand-off from a top-level OMA entry point to the async evaluator. */
+export interface OnlineEvaluationInput {
+  readonly input: unknown
+  readonly result: OnlineRunResult
+  readonly durationMs: number
+}
+
+interface MutableStats {
+  sampled: number
+  enqueued: number
+  completed: number
+  dropped: number
+  failed: number
+  storeFailed: number
+}
+
+interface QueueEntry {
+  readonly id: number
+  readonly sample: OnlineEvaluationInput
+  readonly context: OnlineSampleContext
+}
+
+interface EvaluationReservation {
+  readonly entryId: number
+  readonly at: number
+  readonly count: number
+}
+
+interface CostEntry {
+  readonly at: number
+  readonly amount: number
+}
+
+interface OnlineEvaluatorRuntime {
+  readonly now?: () => number
+  readonly random?: () => number
+  readonly estimateCost?: (usage: TokenUsage, context: CostEstimateContext) => number
+}
+
+class ScorerTimeoutError extends Error {
+  constructor(scorerName: string, timeoutMs: number) {
+    super(`Scorer "${scorerName}" timed out after ${timeoutMs}ms.`)
+    this.name = 'TimeoutError'
+  }
+}
+
+function positiveInteger(value: number | undefined, fallback: number, name: string): number {
+  if (value === undefined) return fallback
+  if (!Number.isInteger(value) || value < 1) {
+    throw new RangeError(`${name} must be a positive integer.`)
+  }
+  return value
+}
+
+function optionalPositiveInteger(value: number | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined
+  return positiveInteger(value, value, name)
+}
+
+function positiveFinite(value: number | undefined, name: string): number | undefined {
+  if (value === undefined) return undefined
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RangeError(`${name} must be a positive finite number.`)
+  }
+  return value
+}
+
+function createId(prefix: string): string {
+  const uuid = globalThis.crypto?.randomUUID?.()
+  return uuid === undefined
+    ? `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`
+    : `${prefix}_${uuid}`
+}
+
+function unrefTimer(callback: () => void, delayMs: number): ReturnType<typeof setTimeout> {
+  const timer = setTimeout(callback, delayMs)
+  timer.unref?.()
+  return timer
+}
+
+function stringifyPayload(value: unknown): string {
+  if (typeof value === 'string') return value
+  try {
+    const serialized = JSON.stringify(value)
+    return serialized === undefined ? String(value) : serialized
+  } catch {
+    return String(value)
+  }
+}
+
+function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value
+  const marker = `\n[truncated at ${maxChars} characters]`
+  return `${value.slice(0, Math.max(0, maxChars - marker.length))}${marker}`
+}
+
+function sanitizeText(value: string, maxChars: number): string {
+  return truncate(redactSensitiveText(value), maxChars)
+}
+
+function inputDescription(value: unknown): string {
+  if (typeof value === 'string') return `[string input omitted; ${value.length} characters]`
+  if (Array.isArray(value)) return `[array input omitted; ${value.length} items]`
+  if (value === null) return '[null input]'
+  if (value === undefined) return '[undefined input]'
+  return `[${typeof value} input omitted]`
+}
+
+function storedPayload(
+  mode: NonNullable<OnlineEvaluationConfig['storePayloads']>,
+  input: unknown,
+  output: unknown,
+): EvalRecord['payload'] {
+  if (mode === 'none') return undefined
+  const serialize = (value: unknown): string => {
+    const bounded = truncate(stringifyPayload(value), PAYLOAD_MAX_CHARS)
+    return mode === 'redacted' ? sanitizeText(bounded, PAYLOAD_MAX_CHARS) : bounded
+  }
+  return {
+    ...(input !== undefined ? { input: serialize(input) } : {}),
+    ...(output !== undefined ? { output: serialize(output) } : {}),
+  }
+}
+
+function scorerInput(
+  mode: NonNullable<OnlineEvaluationConfig['storePayloads']>,
+  input: unknown,
+): unknown {
+  if (mode === 'none') return inputDescription(input)
+  const bounded = truncate(stringifyPayload(input), PAYLOAD_MAX_CHARS)
+  return mode === 'redacted' ? sanitizeText(bounded, PAYLOAD_MAX_CHARS) : bounded
+}
+
+function resultOutput(result: OnlineRunResult): unknown {
+  if ('output' in result) return result.output
+  if ('answer' in result) return result.answer
+  const coordinator = result.agentResults.get('coordinator')?.output
+  if (coordinator !== undefined) return coordinator
+  return [...result.agentResults.values()]
+    .map((agentResult) => agentResult.output)
+    .filter(Boolean)
+    .join('\n\n---\n\n')
+}
+
+function resultTokens(result: OnlineRunResult): TokenUsage {
+  return 'totalTokenUsage' in result ? result.totalTokenUsage : result.tokenUsage
+}
+
+function runRef(identity: RunIdentity): NonNullable<EvalRecord['runRef']> {
+  return {
+    runId: identity.runId,
+    attempt: identity.attempt,
+    traceId: identity.traceId,
+    rootSpanId: identity.rootSpanId,
+  }
+}
+
+function sanitizeDetails(
+  details: Readonly<Record<string, TraceAttributeValue>> | undefined,
+): Readonly<Record<string, TraceAttributeValue>> | undefined {
+  if (details === undefined) return undefined
+  const sanitized: Record<string, TraceAttributeValue> = {}
+  for (const [key, value] of Object.entries(details)) {
+    if (typeof value === 'string') sanitized[key] = sanitizeText(value, REASON_MAX_CHARS)
+    else if (Array.isArray(value) && value.every((item) => typeof item === 'string')) {
+      sanitized[key] = value.map((item) => sanitizeText(item, REASON_MAX_CHARS))
+    } else sanitized[key] = value
+  }
+  return Object.freeze(sanitized)
+}
+
+async function scoreWithTimeout(
+  scorer: Scorer,
+  context: ScorerContext,
+): Promise<ScoreResult> {
+  if (scorer.timeoutMs === undefined) {
+    return Promise.resolve().then(() => scorer.score(context))
+  }
+
+  const timeoutMs = Math.max(0, scorer.timeoutMs)
+  const controller = new AbortController()
+  const onAbort = (): void => controller.abort(context.signal.reason)
+  if (context.signal.aborted) onAbort()
+  else context.signal.addEventListener('abort', onAbort, { once: true })
+
+  return new Promise<ScoreResult>((resolve, reject) => {
+    const timer = unrefTimer(() => {
+      const error = new ScorerTimeoutError(scorer.name, timeoutMs)
+      controller.abort(error)
+      context.signal.removeEventListener('abort', onAbort)
+      reject(error)
+    }, timeoutMs)
+
+    Promise.resolve().then(() => scorer.score({ ...context, signal: controller.signal })).then(
+      (value) => {
+        clearTimeout(timer)
+        context.signal.removeEventListener('abort', onAbort)
+        resolve(value)
+      },
+      (error: unknown) => {
+        clearTimeout(timer)
+        context.signal.removeEventListener('abort', onAbort)
+        reject(error)
+      },
+    )
+  })
+}
+
+const EMPTY_STATS: OnlineEvaluationStats = Object.freeze({
+  sampled: 0,
+  enqueued: 0,
+  completed: 0,
+  dropped: 0,
+  failed: 0,
+  storeFailed: 0,
+})
+
+const EMPTY_FLUSH: FlushResult = Object.freeze({
+  status: 'ok',
+  accepted: 0,
+  exported: 0,
+  dropped: 0,
+  failed: 0,
+})
+
+/** Shared lifecycle facade used when online evaluation is disabled. */
+export const NOOP_ONLINE_EVALUATION: OnlineEvaluationLifecycle = Object.freeze({
+  async forceFlush() { return EMPTY_FLUSH },
+  async shutdown() { return EMPTY_FLUSH },
+  getStats() { return EMPTY_STATS },
+})
+
+/** Bounded, best-effort online evaluator used by one OpenMultiAgent instance. */
+export class OnlineEvaluator implements OnlineEvaluationLifecycle {
+  private readonly scorers: readonly Scorer[]
+  private readonly sample: OnlineEvaluationConfig['sample']
+  private readonly maxConcurrent: number
+  private readonly maxQueueLength: number
+  private readonly maxEvaluationsPerMinute?: number
+  private readonly maxCostPerHour?: number
+  private readonly store?: EvalStore
+  private readonly storePayloads: NonNullable<OnlineEvaluationConfig['storePayloads']>
+  private readonly onResult?: OnlineEvaluationConfig['onResult']
+  private readonly onDiagnostic?: OnlineEvaluationConfig['onDiagnostic']
+  private readonly diagnosticMode: NonNullable<OnlineEvaluationConfig['diagnostics']>
+  private readonly now: () => number
+  private readonly random: () => number
+  private readonly estimateCost?: OnlineEvaluatorRuntime['estimateCost']
+  private readonly queue: QueueEntry[] = []
+  private readonly reservations: EvaluationReservation[] = []
+  private readonly costs: CostEntry[] = []
+  private readonly diagnosticCounts = new Map<EvalDiagnostic['code'], number>()
+  private readonly diagnosticLastEmitted = new Map<EvalDiagnostic['code'], number>()
+  private readonly settledOutOfOrder = new Set<number>()
+  private readonly waiters = new Set<() => void>()
+  private readonly mutable: MutableStats = {
+    sampled: 0,
+    enqueued: 0,
+    completed: 0,
+    dropped: 0,
+    failed: 0,
+    storeFailed: 0,
+  }
+  private readonly evalRunId = createId('online_eval')
+  private nextId = 0
+  private settledThrough = 0
+  private active = 0
+  private scheduled?: ReturnType<typeof setTimeout>
+  private closing = false
+  private shutdownPromise?: Promise<FlushResult>
+
+  constructor(config: OnlineEvaluationConfig, runtime: OnlineEvaluatorRuntime = {}) {
+    if (!Array.isArray(config.scorers) || config.scorers.length === 0) {
+      throw new TypeError('OnlineEvaluationConfig.scorers must contain at least one scorer.')
+    }
+    if (
+      typeof config.sample !== 'function'
+      && (typeof config.sample !== 'number'
+        || !Number.isFinite(config.sample)
+        || config.sample < 0
+        || config.sample > 1)
+    ) {
+      throw new RangeError('OnlineEvaluationConfig.sample must be a number in [0, 1] or a function.')
+    }
+    if (
+      config.storePayloads !== undefined
+      && config.storePayloads !== 'none'
+      && config.storePayloads !== 'redacted'
+      && config.storePayloads !== 'full'
+    ) {
+      throw new TypeError('OnlineEvaluationConfig.storePayloads must be none, redacted, or full.')
+    }
+
+    this.scorers = Object.freeze([...config.scorers])
+    this.sample = config.sample
+    this.maxConcurrent = positiveInteger(config.maxConcurrent, DEFAULT_MAX_CONCURRENT, 'maxConcurrent')
+    this.maxQueueLength = positiveInteger(config.maxQueueLength, DEFAULT_MAX_QUEUE_LENGTH, 'maxQueueLength')
+    this.maxEvaluationsPerMinute = optionalPositiveInteger(
+      config.budget?.maxEvaluationsPerMinute,
+      'budget.maxEvaluationsPerMinute',
+    )
+    this.maxCostPerHour = positiveFinite(config.budget?.maxCostPerHour, 'budget.maxCostPerHour')
+    this.store = config.store
+    this.storePayloads = config.storePayloads ?? 'none'
+    this.onResult = config.onResult
+    this.onDiagnostic = config.onDiagnostic
+    this.diagnosticMode = config.diagnostics ?? 'warn'
+    this.now = runtime.now ?? Date.now
+    this.random = runtime.random ?? Math.random
+    this.estimateCost = runtime.estimateCost
+
+    if (this.maxCostPerHour !== undefined && this.estimateCost === undefined) {
+      this.report(
+        'budget_exhausted',
+        'Cost budget is inactive because no estimateCost function was configured.',
+      )
+    }
+  }
+
+  /** Synchronously decide, budget, and enqueue one settled top-level run. */
+  enqueue(sample: OnlineEvaluationInput): boolean {
+    if (this.closing) {
+      this.mutable.dropped++
+      this.report('enqueue_after_shutdown', 'Online evaluation rejected after shutdown began.')
+      return false
+    }
+
+    const identity = sample.result.identity
+    if (identity === undefined) {
+      this.mutable.failed++
+      this.report('scorer_failed', 'Online evaluation skipped a run without runtime identity.', 'error')
+      return false
+    }
+    const status: RunStatus = sample.result.status ?? {
+      code: 'error',
+      message: 'Run settled without a normalized status.',
+    }
+    const context: OnlineSampleContext = Object.freeze({
+      identity,
+      status,
+      metadata: Object.freeze({ ...sample.result.metadata }),
+      durationMs: Math.max(0, sample.durationMs),
+    })
+
+    if (!this.shouldSample(context)) return false
+    this.mutable.sampled++
+
+    if (this.queue.length >= this.maxQueueLength) {
+      this.mutable.dropped++
+      this.report('queue_full', 'Online evaluation sample dropped because the bounded queue is full.')
+      return false
+    }
+
+    const now = this.now()
+    this.pruneBudgets(now)
+    if (this.costBudgetExhausted()) {
+      this.mutable.dropped++
+      this.report('budget_exhausted', 'Online evaluation cost budget is exhausted.')
+      return false
+    }
+    const evaluationCount = this.scorers.length
+    if (!this.reserveEvaluations(this.nextId + 1, evaluationCount, now)) {
+      this.mutable.dropped++
+      this.report('budget_exhausted', 'Online evaluation rate budget is exhausted.')
+      return false
+    }
+
+    const entry: QueueEntry = {
+      id: ++this.nextId,
+      sample,
+      context,
+    }
+    this.mutable.enqueued++
+    this.queue.push(entry)
+    this.schedule()
+    return true
+  }
+
+  async forceFlush(options: FlushOptions = {}): Promise<FlushResult> {
+    const target = this.nextId
+    if (target <= this.settledThrough) return this.flushResult(this.resultStatus())
+    this.clearSchedule()
+    this.startWorkers()
+    const completed = await this.waitForWatermark(
+      target,
+      options.timeoutMs ?? DEFAULT_FLUSH_TIMEOUT_MS,
+    )
+    if (!completed) {
+      this.report('flush_timeout', 'Online evaluation flush timed out before queued samples settled.')
+      return this.flushResult('timeout')
+    }
+    return this.flushResult(this.resultStatus())
+  }
+
+  shutdown(options: FlushOptions = {}): Promise<FlushResult> {
+    if (this.shutdownPromise) return this.shutdownPromise
+    this.closing = true
+    this.clearSchedule()
+    this.shutdownPromise = this.forceFlush(options)
+    return this.shutdownPromise
+  }
+
+  getStats(): OnlineEvaluationStats {
+    return { ...this.mutable }
+  }
+
+  private shouldSample(context: OnlineSampleContext): boolean {
+    if (typeof this.sample === 'number') return this.random() < this.sample
+    try {
+      return this.sample(context) === true
+    } catch {
+      this.report('scorer_failed', 'Online sampling rule failed; the run was not sampled.', 'error')
+      return false
+    }
+  }
+
+  private schedule(): void {
+    if (this.scheduled !== undefined || this.active > 0) return
+    this.scheduled = unrefTimer(() => {
+      this.scheduled = undefined
+      this.startWorkers()
+    }, 0)
+  }
+
+  private clearSchedule(): void {
+    if (this.scheduled !== undefined) clearTimeout(this.scheduled)
+    this.scheduled = undefined
+  }
+
+  private startWorkers(): void {
+    while (this.active < this.maxConcurrent) {
+      const entry = this.queue.shift()
+      if (entry === undefined) break
+      this.active++
+      void this.process(entry).catch(() => {
+        this.mutable.failed++
+        this.report('scorer_failed', 'Online evaluation worker failed unexpectedly.', 'error')
+      }).finally(() => {
+        this.active--
+        this.settle(entry.id)
+        this.startWorkers()
+      })
+    }
+  }
+
+  private async process(entry: QueueEntry): Promise<void> {
+    const now = this.now()
+    this.pruneBudgets(now)
+    if (this.costBudgetExhausted()) {
+      this.releaseReservation(entry.id)
+      this.mutable.dropped++
+      this.report('budget_exhausted', 'Online evaluation cost budget is exhausted.')
+      return
+    }
+
+    const output = resultOutput(entry.sample.result)
+    const evalCase: EvalCase = Object.freeze({
+      id: entry.context.identity.runId,
+      input: scorerInput(this.storePayloads, entry.sample.input),
+      metadata: entry.context.metadata,
+    })
+    const payload = storedPayload(this.storePayloads, entry.sample.input, output)
+    const signal = new AbortController().signal
+    const records: EvalRecord[] = []
+
+    for (const scorer of this.scorers) {
+      try {
+        const scored = await scoreWithTimeout(scorer, {
+          evalCase,
+          output,
+          result: entry.sample.result,
+          metadata: entry.context.metadata,
+          signal,
+        })
+        this.mutable.completed++
+        this.recordCost(scored)
+        const details = sanitizeDetails(scored.details)
+        records.push({
+          ...this.baseRecord(entry.context, scorer),
+          status: 'scored',
+          score: scored.score,
+          ...(scored.pass !== undefined ? { pass: scored.pass } : {}),
+          ...(scored.reason !== undefined
+            ? { reason: sanitizeText(scored.reason, REASON_MAX_CHARS) }
+            : {}),
+          ...(details !== undefined ? { details } : {}),
+          usage: {
+            tokens: resultTokens(entry.sample.result),
+            durationMs: entry.context.durationMs,
+          },
+          ...(payload !== undefined ? { payload } : {}),
+        })
+      } catch (error) {
+        this.mutable.failed++
+        this.recordCost(error)
+        const timeout = error instanceof ScorerTimeoutError
+        records.push({
+          ...this.baseRecord(entry.context, scorer),
+          status: 'scorer_error',
+          usage: {
+            tokens: resultTokens(entry.sample.result),
+            durationMs: entry.context.durationMs,
+          },
+          error: classifyRunFailure(error, timeout
+            ? { kind: 'timeout', statusCode: 'timeout' }
+            : {}).errorInfo,
+          ...(payload !== undefined ? { payload } : {}),
+        })
+        this.report(
+          'scorer_failed',
+          'Online evaluation scorer failed; a scorer_error record was produced.',
+          'error',
+          scorer.name,
+        )
+      }
+    }
+
+    if (this.store !== undefined) {
+      try {
+        await this.store.append(records)
+      } catch {
+        this.mutable.storeFailed += records.length
+        this.report(
+          'store_append_failed',
+          'Online evaluation records were discarded because EvalStore append failed.',
+          'error',
+        )
+        return
+      }
+    }
+
+    for (const record of records) {
+      try {
+        this.onResult?.(record)
+      } catch {
+        this.mutable.failed++
+      }
+    }
+  }
+
+  private baseRecord(
+    context: OnlineSampleContext,
+    scorer: Scorer,
+  ): Pick<EvalRecord,
+    'schemaVersion' | 'recordId' | 'evalRunId' | 'source' | 'timestampUnixMs'
+    | 'scorer' | 'runRef' | 'metadata'> {
+    return {
+      schemaVersion: 1,
+      recordId: createId('eval_record'),
+      evalRunId: this.evalRunId,
+      source: 'online',
+      timestampUnixMs: this.now(),
+      scorer: {
+        name: scorer.name,
+        ...(scorer.version !== undefined ? { version: scorer.version } : {}),
+      },
+      runRef: runRef(context.identity),
+      metadata: context.metadata,
+    }
+  }
+
+  private recordCost(scored: unknown): void {
+    if (this.maxCostPerHour === undefined || this.estimateCost === undefined) return
+    let amount = 0
+    try {
+      for (const input of scoreCostInputs(scored)) {
+        const estimated = this.estimateCost(input.usage, input.context)
+        if (!Number.isFinite(estimated) || estimated < 0) {
+          throw new Error('estimateCost returned an invalid amount.')
+        }
+        amount += estimated
+      }
+    } catch {
+      this.mutable.failed++
+      this.report(
+        'budget_exhausted',
+        'Online evaluation cost could not be estimated; the cost budget remains best-effort.',
+      )
+      return
+    }
+    if (amount > 0) this.costs.push({ at: this.now(), amount })
+  }
+
+  private pruneBudgets(now: number): void {
+    while (this.reservations[0] && this.reservations[0].at <= now - 60_000) {
+      this.reservations.shift()
+    }
+    while (this.costs[0] && this.costs[0].at <= now - 3_600_000) {
+      this.costs.shift()
+    }
+  }
+
+  private reserveEvaluations(entryId: number, count: number, now: number): boolean {
+    if (this.maxEvaluationsPerMinute === undefined) return true
+    const used = this.reservations.reduce((sum, reservation) => sum + reservation.count, 0)
+    if (used + count > this.maxEvaluationsPerMinute) return false
+    this.reservations.push({ entryId, at: now, count })
+    return true
+  }
+
+  private releaseReservation(entryId: number): void {
+    const index = this.reservations.findIndex((reservation) => reservation.entryId === entryId)
+    if (index >= 0) this.reservations.splice(index, 1)
+  }
+
+  private costBudgetExhausted(): boolean {
+    if (this.maxCostPerHour === undefined || this.estimateCost === undefined) return false
+    return this.costs.reduce((sum, entry) => sum + entry.amount, 0) >= this.maxCostPerHour
+  }
+
+  private report(
+    code: EvalDiagnostic['code'],
+    message: string,
+    severity: EvalDiagnostic['severity'] = 'warning',
+    scorerName?: string,
+  ): void {
+    const count = (this.diagnosticCounts.get(code) ?? 0) + 1
+    this.diagnosticCounts.set(code, count)
+    const now = this.now()
+    if (now - (this.diagnosticLastEmitted.get(code) ?? -Infinity) < DIAGNOSTIC_INTERVAL_MS) return
+    this.diagnosticCounts.set(code, 0)
+    this.diagnosticLastEmitted.set(code, now)
+    const diagnostic: EvalDiagnostic = {
+      code,
+      severity,
+      count,
+      ...(scorerName !== undefined ? { scorerName } : {}),
+      message,
+    }
+    try {
+      if (this.onDiagnostic !== undefined) this.onDiagnostic(diagnostic)
+      else if (this.diagnosticMode !== 'silent') {
+        console.warn(`[open-multi-agent evaluation] ${code}: ${message}`)
+      }
+    } catch {
+      this.mutable.failed++
+    }
+  }
+
+  private settle(id: number): void {
+    if (id === this.settledThrough + 1) {
+      this.settledThrough = id
+      while (this.settledOutOfOrder.delete(this.settledThrough + 1)) this.settledThrough++
+    } else if (id > this.settledThrough) {
+      this.settledOutOfOrder.add(id)
+    }
+    for (const wake of this.waiters) wake()
+  }
+
+  private waitForWatermark(target: number, timeoutMs: number): Promise<boolean> {
+    if (target <= this.settledThrough) return Promise.resolve(true)
+    return new Promise((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const check = () => {
+        if (target > this.settledThrough) return
+        cleanup()
+        resolve(true)
+      }
+      const cleanup = () => {
+        this.waiters.delete(check)
+        if (timer !== undefined) clearTimeout(timer)
+      }
+      this.waiters.add(check)
+      timer = unrefTimer(() => {
+        cleanup()
+        resolve(false)
+      }, Math.max(0, timeoutMs))
+      check()
+    })
+  }
+
+  private resultStatus(): FlushResult['status'] {
+    if (this.mutable.failed === 0 && this.mutable.storeFailed === 0 && this.mutable.dropped === 0) {
+      return 'ok'
+    }
+    return this.mutable.completed > 0 ? 'partial' : 'error'
+  }
+
+  private flushResult(status: FlushResult['status']): FlushResult {
+    return {
+      status,
+      accepted: this.mutable.enqueued,
+      exported: this.mutable.completed,
+      dropped: this.mutable.dropped,
+      failed: this.mutable.failed + this.mutable.storeFailed,
+    }
+  }
+}
+
+/** Avoid constructing an evaluator for omitted or numeric-zero sampling. */
+export function createOnlineEvaluator(
+  config: OnlineEvaluationConfig | undefined,
+  estimateCost?: OnlineEvaluatorRuntime['estimateCost'],
+): OnlineEvaluator | undefined {
+  if (config === undefined) return undefined
+  if (typeof config.sample === 'number') {
+    if (!Number.isFinite(config.sample) || config.sample < 0 || config.sample > 1) {
+      throw new RangeError('OnlineEvaluationConfig.sample must be a number in [0, 1] or a function.')
+    }
+    if (config.sample === 0) return undefined
+  }
+  return new OnlineEvaluator(config, { estimateCost })
+}

--- a/packages/core/src/eval/scorer.ts
+++ b/packages/core/src/eval/scorer.ts
@@ -1,7 +1,9 @@
 import type {
   AgentRunResult,
   ConsensusResult,
+  CostEstimateContext,
   TeamRunResult,
+  TokenUsage,
   TraceAttributeValue,
 } from '../types.js'
 import type { StoredRun } from '../observability/store.js'
@@ -32,6 +34,41 @@ export interface Scorer {
   readonly version?: string
   readonly timeoutMs?: number
   score(context: ScorerContext): Promise<ScoreResult> | ScoreResult
+}
+
+const SCORE_COST_INPUTS = Symbol('oma.eval.score_cost_inputs')
+
+/** Internal usage detail attached non-enumerably by framework-backed scorers. */
+export interface ScoreCostInput {
+  readonly usage: TokenUsage
+  readonly context: CostEstimateContext
+}
+
+type ValueWithCost = {
+  readonly [SCORE_COST_INPUTS]?: readonly ScoreCostInput[]
+}
+
+/** Attach scorer-side model usage without expanding the serialized ScoreResult contract. */
+export function attachScoreCostInputs<T extends object>(
+  result: T,
+  inputs: readonly ScoreCostInput[],
+): T {
+  if (inputs.length === 0) return result
+  Object.defineProperty(result, SCORE_COST_INPUTS, {
+    value: Object.freeze(inputs.map((input) => Object.freeze({
+      usage: Object.freeze({ ...input.usage }),
+      context: Object.freeze({ ...input.context }),
+    }))),
+    enumerable: false,
+    configurable: true,
+  })
+  return result
+}
+
+/** Read framework-owned scorer usage for online cost budgeting. */
+export function scoreCostInputs(value: unknown): readonly ScoreCostInput[] {
+  if ((typeof value !== 'object' || value === null) && typeof value !== 'function') return []
+  return (value as ValueWithCost)[SCORE_COST_INPUTS] ?? []
 }
 
 function isTraceAttributeValue(value: unknown): value is TraceAttributeValue {

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -130,6 +130,13 @@ import {
 import { isSimpleGoal, selectBestAgent } from './short-circuit.js'
 import { executeQueue, saveRunCheckpoint } from './task-execution.js'
 import { runConsensusCore, applyConsensusDefaults, type ConsensusAgentDefaults } from './consensus.js'
+import {
+  createOnlineEvaluator,
+  NOOP_ONLINE_EVALUATION,
+  type OnlineEvaluationInput,
+  type OnlineEvaluationLifecycle,
+  type OnlineEvaluator,
+} from '../eval/online.js'
 
 import {
   parseTaskSpecs,
@@ -151,6 +158,11 @@ export { computeRetryDelay, executeWithRetry } from './retry.js'
 // OpenMultiAgent
 // ---------------------------------------------------------------------------
 
+interface PendingOnlineEvaluation {
+  readonly input: unknown
+  readonly startedAtMs: number
+}
+
 /**
  * Top-level orchestrator for the open-multi-agent framework.
  *
@@ -159,14 +171,17 @@ export { computeRetryDelay, executeWithRetry } from './retry.js'
  */
 export class OpenMultiAgent {
   private readonly config: Required<
-    Omit<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
-  > & Pick<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
+    Omit<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'evaluation' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
+  > & Pick<OrchestratorConfig, 'onApproval' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'evaluation' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
 
   private readonly teams: Map<string, Team> = new Map()
   private readonly fallbackCheckpointStore = new InMemoryStore()
   private completedTaskCount = 0
   private readonly traceRecordObserver?: TraceRecordObserver
   private readonly traceSink?: TraceSink
+  private readonly onlineEvaluator?: OnlineEvaluator
+  /** Online evaluation lifecycle. A shared no-op facade is returned when disabled. */
+  readonly evaluation: OnlineEvaluationLifecycle
 
   /**
    * @param config - Optional top-level configuration.
@@ -183,6 +198,8 @@ export class OpenMultiAgent {
     }
 
     this.traceRecordObserver = traceRecordObserverFrom(config)
+    this.onlineEvaluator = createOnlineEvaluator(config.evaluation, config.estimateCost)
+    this.evaluation = this.onlineEvaluator ?? NOOP_ONLINE_EVALUATION
     const hasExplicitLegacyBridge = config.observability?.sinks.some(
       (sink) => sink instanceof LegacyCallbackTraceSink,
     ) ?? false
@@ -215,10 +232,28 @@ export class OpenMultiAgent {
       onPlanReady: config.onPlanReady,
       onAgentStream: config.onAgentStream,
       onProgress: config.onProgress,
+      evaluation: config.evaluation,
       observability: config.observability,
       onTrace: config.onTrace ?? (hasExplicitLegacyBridge ? LEGACY_TRACE_METADATA_ONLY : undefined),
       onToolCall: config.onToolCall,
     }
+  }
+
+  private beginOnlineEvaluation(input: unknown): PendingOnlineEvaluation | undefined {
+    if (this.onlineEvaluator === undefined) return undefined
+    return { input, startedAtMs: Date.now() }
+  }
+
+  private completeOnlineEvaluation(
+    pending: PendingOnlineEvaluation | undefined,
+    result: OnlineEvaluationInput['result'],
+  ): void {
+    if (pending === undefined || this.onlineEvaluator === undefined) return
+    this.onlineEvaluator.enqueue({
+      input: pending.input,
+      result,
+      durationMs: Date.now() - pending.startedAtMs,
+    })
   }
 
   private startTrace(
@@ -280,6 +315,7 @@ export class OpenMultiAgent {
     prompt: string,
     options?: RunAgentOptions,
   ): Promise<AgentRunResult> {
+    const pendingEvaluation = this.beginOnlineEvaluation(prompt)
     const { identity, metadata } = createRunFacts(options)
     const traceRuntime = this.startTrace(identity, metadata)
     const effectiveBudget = resolveTokenBudget(config.maxTokenBudget, this.config.maxTokenBudget)
@@ -382,6 +418,7 @@ export class OpenMultiAgent {
       status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
       ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
     })
+    this.completeOnlineEvaluation(pendingEvaluation, completedResult)
     return completedResult
   }
 
@@ -415,6 +452,7 @@ export class OpenMultiAgent {
     goal: string,
     options?: RunTeamOptions,
   ): Promise<TeamRunResult> {
+    const pendingEvaluation = this.beginOnlineEvaluation(goal)
     const { identity, metadata } = createRunFacts(identityOptionsForRun(options))
     const traceRuntime = this.startTrace(identity, metadata)
     const finish = (result: TeamRunResult): TeamRunResult => {
@@ -426,6 +464,7 @@ export class OpenMultiAgent {
         status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
         ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
       })
+      this.completeOnlineEvaluation(pendingEvaluation, completedResult)
       return completedResult
     }
     const agentConfigs = team.getAgents()
@@ -902,6 +941,7 @@ export class OpenMultiAgent {
     plan: PlanArtifact,
     options?: RunTasksOptions,
   ): Promise<TeamRunResult> {
+    const pendingEvaluation = this.beginOnlineEvaluation(plan)
     if (plan.version !== 1) {
       throw new Error(`Unsupported plan artifact version: ${String(plan.version)}`)
     }
@@ -914,7 +954,18 @@ export class OpenMultiAgent {
     }
     queue.addBatch(tasks)
 
-    return this.executeExplicitTaskQueue(team, queue, options, plan.goal)
+    return this.executeExplicitTaskQueue(
+      team,
+      queue,
+      options,
+      plan.goal,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      pendingEvaluation,
+    )
   }
 
   /**
@@ -953,6 +1004,7 @@ export class OpenMultiAgent {
     tasksOrOptions?: ReadonlyArray<RunTaskSpec> | PlanArtifact | RestoreOptions,
     maybeOptions?: RestoreOptions,
   ): Promise<TeamRunResult> {
+    const evaluationStartedAtMs = this.onlineEvaluator === undefined ? undefined : Date.now()
     const hasTaskSource = Array.isArray(tasksOrOptions) || this.isPlanArtifact(tasksOrOptions)
     const options = hasTaskSource ? maybeOptions : tasksOrOptions as RestoreOptions | undefined
     validateRunMetadata(options?.metadata)
@@ -991,6 +1043,13 @@ export class OpenMultiAgent {
           options?.goal,
           undefined,
           activeCheckpoint,
+          undefined,
+          undefined,
+          undefined,
+          evaluationStartedAtMs === undefined ? undefined : {
+            input: tasksOrOptions,
+            startedAtMs: evaluationStartedAtMs,
+          },
         )
       }
       if (this.isPlanArtifact(tasksOrOptions)) {
@@ -1008,6 +1067,13 @@ export class OpenMultiAgent {
           tasksOrOptions.goal ?? options?.goal,
           undefined,
           activeCheckpoint,
+          undefined,
+          undefined,
+          undefined,
+          evaluationStartedAtMs === undefined ? undefined : {
+            input: tasksOrOptions,
+            startedAtMs: evaluationStartedAtMs,
+          },
         )
       }
 
@@ -1019,6 +1085,13 @@ export class OpenMultiAgent {
         options?.goal,
         undefined,
         activeCheckpoint,
+        undefined,
+        undefined,
+        undefined,
+        evaluationStartedAtMs === undefined ? undefined : {
+          input: { kind: 'restore', goal: options?.goal },
+          startedAtMs: evaluationStartedAtMs,
+        },
       )
     }
 
@@ -1059,6 +1132,10 @@ export class OpenMultiAgent {
       options?.coordinator,
       identity,
       restoreMetadata,
+      evaluationStartedAtMs === undefined ? undefined : {
+        input: { kind: 'restore', goal: snapshot.goal ?? options?.goal },
+        startedAtMs: evaluationStartedAtMs,
+      },
     )
   }
 
@@ -1077,6 +1154,7 @@ export class OpenMultiAgent {
     tasks: ReadonlyArray<RunTaskSpec>,
     options?: RunTasksOptions,
   ): Promise<TeamRunResult> {
+    const pendingEvaluation = this.beginOnlineEvaluation(tasks)
     const agentConfigs = team.getAgents()
     const queue = new TaskQueue()
 
@@ -1098,7 +1176,18 @@ export class OpenMultiAgent {
       queue,
     )
 
-    return this.executeExplicitTaskQueue(team, queue, options)
+    return this.executeExplicitTaskQueue(
+      team,
+      queue,
+      options,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      pendingEvaluation,
+    )
   }
 
   // -------------------------------------------------------------------------
@@ -1118,6 +1207,7 @@ export class OpenMultiAgent {
     prompt: string,
     options: ConsensusOptions,
   ): Promise<ConsensusResult> {
+    const pendingEvaluation = this.beginOnlineEvaluation(prompt)
     const { identity, metadata } = createRunFacts(options)
     const proposers = Array.isArray(options.proposer) ? options.proposer : [options.proposer]
     if (proposers.length === 0) {
@@ -1152,6 +1242,7 @@ export class OpenMultiAgent {
         status,
         ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
       })
+      this.completeOnlineEvaluation(pendingEvaluation, completedResult)
       return completedResult
     }
 
@@ -1364,6 +1455,7 @@ export class OpenMultiAgent {
     coordinatorForSynthesis?: CoordinatorConfig,
     identity?: RunIdentity,
     restoreMetadata?: RestoreMetadataResolution,
+    pendingEvaluation?: PendingOnlineEvaluation,
   ): Promise<TeamRunResult> {
     const newRunFacts = identity === undefined
       ? createRunFacts(identityOptionsForRun(options))
@@ -1500,6 +1592,7 @@ export class OpenMultiAgent {
       status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
       ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
     })
+    this.completeOnlineEvaluation(pendingEvaluation, completedResult)
     return completedResult
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1421,6 +1421,8 @@ export interface OrchestratorConfig {
    */
   readonly defaultCwd?: string | null
   readonly onProgress?: (event: OrchestratorEvent) => void
+  /** Best-effort online scoring of settled top-level runs. Disabled unless configured. */
+  readonly evaluation?: import('./eval/online.js').OnlineEvaluationConfig
   /** Observability v2 sinks. User code owns forceFlush/shutdown lifecycle. */
   readonly observability?: import('./observability/sink.js').ObservabilityConfig
   readonly onTrace?: (event: TraceEvent) => void | Promise<void>

--- a/packages/core/tests/eval-online-lifecycle.test.ts
+++ b/packages/core/tests/eval-online-lifecycle.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import { InMemoryEvalStore, type EvalStore } from '../src/eval/store.js'
+import type { Scorer } from '../src/eval/scorer.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { Team } from '../src/team/team.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMChatOptions,
+  LLMMessage,
+  LLMResponse,
+  RunOutcomeFields,
+} from '../src/types.js'
+
+function response(text: string): LLMResponse {
+  return {
+    id: `response-${text}`,
+    content: [{ type: 'text', text }],
+    model: 'test-model',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function adapter(
+  chat: (messages: LLMMessage[], options: LLMChatOptions) => Promise<LLMResponse>,
+): LLMAdapter {
+  return { name: 'online-eval-test', chat, async *stream() { /* unused */ } }
+}
+
+function staticAdapter(text = 'ok'): LLMAdapter {
+  return adapter(async () => response(text))
+}
+
+function agentConfig(name = 'worker', llm: LLMAdapter = staticAdapter()): AgentConfig {
+  return { name, model: 'test-model', adapter: llm }
+}
+
+function teamWith(llm: LLMAdapter = staticAdapter()): Team {
+  return new Team({ name: 'team', agents: [agentConfig('worker', llm)] })
+}
+
+function deferred(): { readonly promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => { resolve = done })
+  return { promise, resolve }
+}
+
+const passScorer: Scorer = {
+  name: 'length',
+  version: '1',
+  score({ output }) {
+    return { score: String(output).length > 0 ? 1 : 0, pass: String(output).length > 0 }
+  },
+}
+
+describe('OpenMultiAgent online evaluation lifecycle', () => {
+  it('uses one shared no-op lifecycle when evaluation is absent or sample is zero', () => {
+    const absent = new OpenMultiAgent()
+    const zero = new OpenMultiAgent({
+      evaluation: { scorers: [], sample: 0 },
+    })
+
+    expect(absent.evaluation).toBe(zero.evaluation)
+    expect(absent.evaluation.getStats()).toEqual({
+      sampled: 0,
+      enqueued: 0,
+      completed: 0,
+      dropped: 0,
+      failed: 0,
+      storeFailed: 0,
+    })
+  })
+
+  it('returns the business result without waiting for a slow scorer', async () => {
+    const started = deferred()
+    const release = deferred()
+    const store = new InMemoryEvalStore()
+    const slowScorer: Scorer = {
+      name: 'slow',
+      async score() {
+        started.resolve()
+        await release.promise
+        return { score: 1 }
+      },
+    }
+    const oma = new OpenMultiAgent({
+      defaultModel: 'test-model',
+      evaluation: { scorers: [slowScorer], sample: 1, store },
+    })
+
+    const run = await oma.runAgent(agentConfig(), 'hello')
+    expect(run.success).toBe(true)
+    expect(oma.evaluation.getStats().completed).toBe(0)
+
+    await started.promise
+    expect(oma.evaluation.getStats().completed).toBe(0)
+    release.resolve()
+    await oma.evaluation.forceFlush({ timeoutMs: 1_000 })
+    expect((await store.query({ runId: [run.identity!.runId] })).items).toHaveLength(1)
+  })
+
+  it('samples all six top-level entries and preserves restore attempt identity', async () => {
+    const store = new InMemoryEvalStore()
+    const oma = new OpenMultiAgent({
+      defaultModel: 'test-model',
+      evaluation: { scorers: [passScorer], sample: 1, store },
+    })
+    const metadata = { deployment: 'canary' } as const
+
+    const runAgent = await oma.runAgent(agentConfig(), 'hello', { metadata })
+    const runTeam = await oma.runTeam(teamWith(), 'Say hello', { metadata })
+    const runTasks = await oma.runTasks(teamWith(), [
+      { title: 'task', description: 'work', assignee: 'worker' },
+    ], { metadata })
+    const runFromPlan = await oma.runFromPlan(teamWith(), {
+      version: 1,
+      tasks: [{ id: 'planned', title: 'planned', description: 'work', assignee: 'worker' }],
+    }, { metadata })
+
+    let consensusCall = 0
+    const consensusAdapter = adapter(async () => response(
+      consensusCall++ === 0 ? 'answer' : '{"accept":true,"critique":""}',
+    ))
+    const runConsensus = await oma.runConsensus(teamWith(), 'question', {
+      proposer: agentConfig('proposer', consensusAdapter),
+      judges: [agentConfig('judge', consensusAdapter)],
+      maxRounds: 1,
+      metadata,
+    })
+
+    const checkpointStore = new InMemoryStore()
+    const checkpointRunId = 'online-restore'
+    await new OpenMultiAgent({ defaultModel: 'test-model' }).runTasks(teamWith(), [
+      { title: 'checkpointed', description: 'work', assignee: 'worker' },
+    ], { checkpoint: { store: checkpointStore, runId: checkpointRunId }, metadata })
+    const restore = await oma.restore(teamWith(), {
+      checkpoint: { store: checkpointStore, runId: checkpointRunId },
+    })
+
+    const results: RunOutcomeFields[] = [
+      runAgent,
+      runTeam,
+      runTasks,
+      runFromPlan,
+      runConsensus,
+      restore,
+    ]
+    await oma.evaluation.forceFlush({ timeoutMs: 2_000 })
+    const records = (await store.query({ source: 'online', order: 'time_asc' })).items
+
+    expect(records).toHaveLength(6)
+    expect(new Set(records.map((record) => record.evalRunId)).size).toBe(1)
+    for (const outcome of results) {
+      const record = records.find((candidate) => candidate.runRef?.runId === outcome.identity?.runId)
+      expect(record).toMatchObject({
+        source: 'online',
+        scorer: { name: 'length', version: '1' },
+        status: 'scored',
+      })
+    }
+    const restoredRecord = records.find((record) => record.runRef?.runId === checkpointRunId)
+    expect(restoredRecord?.runRef?.attempt).toBe(2)
+    expect(restoredRecord?.metadata).toEqual(metadata)
+  })
+
+  it('never changes the business result when scoring or storage fails', async () => {
+    const rejectingStore: EvalStore = {
+      async append() { throw new Error('store rejected') },
+      async query() { return { items: [] } },
+      async delete() { return { runsDeleted: 0, recordsDeleted: 0, runIds: [] } },
+      async applyRetention() { return { runsDeleted: 0, recordsDeleted: 0, runIds: [] } },
+    }
+    const throwingScorer: Scorer = {
+      name: 'throws',
+      score() { throw new Error('scorer rejected') },
+    }
+    const oma = new OpenMultiAgent({
+      defaultModel: 'test-model',
+      evaluation: {
+        scorers: [throwingScorer],
+        sample: 1,
+        store: rejectingStore,
+        diagnostics: 'silent',
+      },
+    })
+
+    const business = await oma.runAgent(agentConfig(), 'business prompt')
+    expect(business).toMatchObject({ success: true, output: 'ok', status: { code: 'ok' } })
+    await oma.evaluation.forceFlush({ timeoutMs: 1_000 })
+    expect(business).toMatchObject({ success: true, output: 'ok', status: { code: 'ok' } })
+    expect(oma.evaluation.getStats()).toMatchObject({ failed: 1, storeFailed: 1 })
+  })
+})

--- a/packages/core/tests/eval-online.test.ts
+++ b/packages/core/tests/eval-online.test.ts
@@ -1,0 +1,444 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  OnlineEvaluator,
+  type EvalDiagnostic,
+  type OnlineEvaluationInput,
+} from '../src/eval/online.js'
+import { attachScoreCostInputs, type Scorer } from '../src/eval/scorer.js'
+import { InMemoryEvalStore, type EvalStore } from '../src/eval/store.js'
+import { createRunIdentity } from '../src/observability/identity.js'
+import type { AgentRunResult, CostEstimateContext } from '../src/types.js'
+
+function deferred(): { readonly promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => { resolve = done })
+  return { promise, resolve }
+}
+
+function result(
+  runId: string,
+  options: {
+    readonly attempt?: number
+    readonly success?: boolean
+    readonly metadata?: Readonly<Record<string, string | number | boolean>>
+  } = {},
+): AgentRunResult {
+  const success = options.success ?? true
+  return {
+    success,
+    output: `output-${runId}`,
+    messages: [],
+    tokenUsage: { input_tokens: 2, output_tokens: 3 },
+    toolCalls: [],
+    identity: createRunIdentity({ runId, attempt: options.attempt }),
+    status: { code: success ? 'ok' : 'error' },
+    ...(options.metadata !== undefined ? { metadata: options.metadata } : {}),
+  }
+}
+
+function sample(runId: string, options: Parameters<typeof result>[1] = {}): OnlineEvaluationInput {
+  return { input: `prompt-${runId}`, result: result(runId, options), durationMs: 12 }
+}
+
+const passScorer: Scorer = {
+  name: 'pass',
+  score() { return { score: 1, pass: true, reason: 'ok' } },
+}
+
+describe('OnlineEvaluator sampling and records', () => {
+  it('supports zero, full, ratio, and rule sampling with stable evaluator IDs', async () => {
+    const decisions = [0.1, 0.9, 0.1]
+    const store = new InMemoryEvalStore()
+    const evaluator = new OnlineEvaluator({ scorers: [passScorer], sample: 0.5, store }, {
+      random: () => decisions.shift() ?? 1,
+    })
+
+    expect(evaluator.enqueue(sample('ratio-hit'))).toBe(true)
+    expect(evaluator.enqueue(sample('ratio-miss'))).toBe(false)
+    await evaluator.forceFlush()
+
+    const page = await store.query({ source: 'online' })
+    expect(page.items).toHaveLength(1)
+    expect(page.items[0]).toMatchObject({
+      source: 'online',
+      scorer: { name: 'pass' },
+      status: 'scored',
+      runRef: { runId: 'ratio-hit', attempt: 1 },
+      usage: { tokens: { input_tokens: 2, output_tokens: 3 }, durationMs: 12 },
+    })
+    expect(page.items[0]?.caseId).toBeUndefined()
+    expect(page.items[0]?.evalSet).toBeUndefined()
+
+    evaluator.enqueue(sample('same-evaluator'))
+    await evaluator.forceFlush()
+    const all = await store.query({ order: 'time_asc' })
+    expect(new Set(all.items.map((record) => record.evalRunId)).size).toBe(1)
+
+    const disabled = new OnlineEvaluator({ scorers: [passScorer], sample: 0, diagnostics: 'silent' })
+    expect(disabled.enqueue(sample('disabled'))).toBe(false)
+    expect(disabled.getStats()).toEqual({
+      sampled: 0,
+      enqueued: 0,
+      completed: 0,
+      dropped: 0,
+      failed: 0,
+      storeFailed: 0,
+    })
+  })
+
+  it('passes status and metadata to rules, and isolates a throwing rule', () => {
+    const diagnostics: EvalDiagnostic[] = []
+    const seen: unknown[] = []
+    const evaluator = new OnlineEvaluator({
+      scorers: [passScorer],
+      sample(context) {
+        seen.push(context)
+        if (context.metadata['throw']) throw new Error('private payload')
+        return context.status.code !== 'ok' && context.metadata['tier'] === 'canary'
+      },
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    })
+
+    expect(evaluator.enqueue(sample('ok', { metadata: { tier: 'canary' } }))).toBe(false)
+    expect(evaluator.enqueue(sample('failed', {
+      success: false,
+      metadata: { tier: 'canary' },
+    }))).toBe(true)
+    expect(evaluator.enqueue(sample('throws', { metadata: { throw: true } }))).toBe(false)
+
+    expect(seen).toHaveLength(3)
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]).toMatchObject({ code: 'scorer_failed', severity: 'error' })
+    expect(diagnostics[0]?.message).not.toContain('private payload')
+  })
+
+  it('keeps payloads out by default and redacts explicit redacted payload storage', async () => {
+    const contexts: unknown[] = []
+    const scorer: Scorer = {
+      name: 'inspect',
+      score(context) {
+        contexts.push(context.evalCase.input)
+        return { score: 1 }
+      },
+    }
+    const noneStore = new InMemoryEvalStore()
+    const none = new OnlineEvaluator({ scorers: [scorer], sample: 1, store: noneStore })
+    none.enqueue({
+      input: 'token sk-abcdefghijklmnop',
+      result: result('private-none'),
+      durationMs: 1,
+    })
+    await none.forceFlush()
+    expect(contexts[0]).toBe('[string input omitted; 25 characters]')
+    expect((await noneStore.query()).items[0]?.payload).toBeUndefined()
+
+    const redactedStore = new InMemoryEvalStore()
+    const redacted = new OnlineEvaluator({
+      scorers: [scorer],
+      sample: 1,
+      store: redactedStore,
+      storePayloads: 'redacted',
+    })
+    redacted.enqueue({
+      input: 'token sk-abcdefghijklmnop',
+      result: { ...result('private-redacted'), output: 'password="hunter2"' },
+      durationMs: 1,
+    })
+    await redacted.forceFlush()
+    const record = (await redactedStore.query()).items[0]
+    expect(record?.payload?.input).not.toContain('sk-abcdefghijklmnop')
+    expect(record?.payload?.output).not.toContain('hunter2')
+  })
+})
+
+describe('OnlineEvaluator bounds and budgets', () => {
+  it('drops when the bounded queue is full and reports the drop', () => {
+    const diagnostics: EvalDiagnostic[] = []
+    const evaluator = new OnlineEvaluator({
+      scorers: [passScorer],
+      sample: 1,
+      maxQueueLength: 1,
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    })
+
+    expect(evaluator.enqueue(sample('queued'))).toBe(true)
+    expect(evaluator.enqueue(sample('dropped'))).toBe(false)
+    expect(evaluator.getStats()).toMatchObject({ sampled: 2, enqueued: 1, dropped: 1 })
+    expect(diagnostics).toEqual([expect.objectContaining({ code: 'queue_full', count: 1 })])
+  })
+
+  it('never exceeds maxConcurrent workers', async () => {
+    const release = deferred()
+    const twoStarted = deferred()
+    let active = 0
+    let maxActive = 0
+    let started = 0
+    const scorer: Scorer = {
+      name: 'slow',
+      async score() {
+        active++
+        started++
+        maxActive = Math.max(maxActive, active)
+        if (started === 2) twoStarted.resolve()
+        await release.promise
+        active--
+        return { score: 1 }
+      },
+    }
+    const evaluator = new OnlineEvaluator({
+      scorers: [scorer],
+      sample: 1,
+      maxConcurrent: 2,
+      maxQueueLength: 3,
+    })
+    evaluator.enqueue(sample('concurrent-1'))
+    evaluator.enqueue(sample('concurrent-2'))
+    evaluator.enqueue(sample('concurrent-3'))
+
+    const flush = evaluator.forceFlush()
+    await twoStarted.promise
+    expect(maxActive).toBe(2)
+    release.resolve()
+    await flush
+    expect(evaluator.getStats().completed).toBe(3)
+  })
+
+  it('enforces and recovers the per-minute evaluation budget', async () => {
+    let now = 1_000
+    const diagnostics: EvalDiagnostic[] = []
+    const evaluator = new OnlineEvaluator({
+      scorers: [passScorer],
+      sample: 1,
+      budget: { maxEvaluationsPerMinute: 1 },
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    }, { now: () => now })
+
+    expect(evaluator.enqueue(sample('minute-1'))).toBe(true)
+    expect(evaluator.enqueue(sample('minute-blocked'))).toBe(false)
+    await evaluator.forceFlush()
+    now += 60_001
+    expect(evaluator.enqueue(sample('minute-recovered'))).toBe(true)
+    await evaluator.forceFlush()
+
+    expect(evaluator.getStats()).toMatchObject({ enqueued: 2, completed: 2, dropped: 1 })
+    expect(diagnostics[0]).toMatchObject({ code: 'budget_exhausted' })
+  })
+
+  it('warns once and stays uncapped when a cost budget has no estimator', async () => {
+    const diagnostics: EvalDiagnostic[] = []
+    const evaluator = new OnlineEvaluator({
+      scorers: [passScorer],
+      sample: 1,
+      budget: { maxCostPerHour: 1 },
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    })
+    evaluator.enqueue(sample('cost-unavailable-1'))
+    evaluator.enqueue(sample('cost-unavailable-2'))
+    await evaluator.forceFlush()
+
+    expect(evaluator.getStats()).toMatchObject({ enqueued: 2, completed: 2, dropped: 0 })
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]).toMatchObject({ code: 'budget_exhausted', count: 1 })
+  })
+
+  it('caps framework-reported scorer cost and recovers after the hourly window', async () => {
+    let now = 10_000
+    const costContext: CostEstimateContext = {
+      agentName: 'judge',
+      model: 'judge-model',
+      phase: 'agent',
+    }
+    const scorer: Scorer = {
+      name: 'costed',
+      score() {
+        return attachScoreCostInputs({ score: 1 }, [{
+          usage: { input_tokens: 4, output_tokens: 1 },
+          context: costContext,
+        }])
+      },
+    }
+    const evaluator = new OnlineEvaluator({
+      scorers: [scorer],
+      sample: 1,
+      budget: { maxCostPerHour: 5 },
+      diagnostics: 'silent',
+    }, {
+      now: () => now,
+      estimateCost: (usage) => usage.input_tokens + usage.output_tokens,
+    })
+
+    evaluator.enqueue(sample('costed-1'))
+    await evaluator.forceFlush()
+    expect(evaluator.enqueue(sample('costed-blocked'))).toBe(false)
+    now += 3_600_001
+    expect(evaluator.enqueue(sample('costed-recovered'))).toBe(true)
+    await evaluator.forceFlush()
+  })
+
+  it('accounts for framework-reported model cost even when the scorer fails', async () => {
+    const costContext: CostEstimateContext = {
+      agentName: 'judge',
+      model: 'judge-model',
+      phase: 'agent',
+    }
+    const scorer: Scorer = {
+      name: 'failing-costed',
+      score() {
+        throw attachScoreCostInputs(new Error('invalid judge verdict'), [{
+          usage: { input_tokens: 4, output_tokens: 1 },
+          context: costContext,
+        }])
+      },
+    }
+    const evaluator = new OnlineEvaluator({
+      scorers: [scorer],
+      sample: 1,
+      budget: { maxCostPerHour: 5 },
+      diagnostics: 'silent',
+    }, {
+      estimateCost: (usage) => usage.input_tokens + usage.output_tokens,
+    })
+
+    evaluator.enqueue(sample('failing-costed-1'))
+    await evaluator.forceFlush()
+    expect(evaluator.enqueue(sample('failing-costed-blocked'))).toBe(false)
+  })
+})
+
+describe('OnlineEvaluator failure isolation and lifecycle', () => {
+  it('records sync throws, async rejects, and timeouts as scorer_error', async () => {
+    const scorers: Scorer[] = [
+      { name: 'sync', score() { throw new Error('sync secret') } },
+      { name: 'async', async score() { throw new Error('async secret') } },
+      { name: 'timeout', timeoutMs: 5, async score() { await new Promise(() => {}) } },
+    ]
+    const diagnostics: EvalDiagnostic[] = []
+    const store = new InMemoryEvalStore()
+    const evaluator = new OnlineEvaluator({
+      scorers,
+      sample: 1,
+      store,
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    })
+    evaluator.enqueue(sample('scorer-failures'))
+    const flushed = await evaluator.forceFlush({ timeoutMs: 1_000 })
+
+    expect(flushed.status).toBe('error')
+    const records = (await store.query({ status: ['scorer_error'] })).items
+    expect(records).toHaveLength(3)
+    expect(records.map((record) => record.scorer.name).sort()).toEqual(['async', 'sync', 'timeout'])
+    expect(records.find((record) => record.scorer.name === 'timeout')?.error?.kind).toBe('timeout')
+    expect(evaluator.getStats()).toMatchObject({ failed: 3, storeFailed: 0 })
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]).toMatchObject({ code: 'scorer_failed', count: 1 })
+  })
+
+  it('isolates store, result, and diagnostic callback failures', async () => {
+    const rejectingStore: EvalStore = {
+      async append() { throw new Error('store down') },
+      async query() { return { items: [] } },
+      async delete() { return { runsDeleted: 0, recordsDeleted: 0, runIds: [] } },
+      async applyRetention() { return { runsDeleted: 0, recordsDeleted: 0, runIds: [] } },
+    }
+    const storeEvaluator = new OnlineEvaluator({
+      scorers: [passScorer],
+      sample: 1,
+      store: rejectingStore,
+      onDiagnostic() { throw new Error('diagnostic callback') },
+    })
+    storeEvaluator.enqueue(sample('store-failure'))
+    await storeEvaluator.forceFlush()
+    expect(storeEvaluator.getStats()).toMatchObject({
+      completed: 1,
+      failed: 1,
+      storeFailed: 1,
+    })
+
+    const resultEvaluator = new OnlineEvaluator({
+      scorers: [passScorer],
+      sample: 1,
+      onResult() { throw new Error('result callback') },
+      diagnostics: 'silent',
+    })
+    resultEvaluator.enqueue(sample('result-callback'))
+    await resultEvaluator.forceFlush()
+    expect(resultEvaluator.getStats()).toMatchObject({ completed: 1, failed: 1 })
+  })
+
+  it('times out flush, makes shutdown idempotent, and rejects post-shutdown enqueue', async () => {
+    const diagnostics: EvalDiagnostic[] = []
+    const never: Scorer = { name: 'never', async score() { await new Promise(() => {}) } }
+    const timed = new OnlineEvaluator({
+      scorers: [never],
+      sample: 1,
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    })
+    timed.enqueue(sample('never'))
+    expect((await timed.forceFlush({ timeoutMs: 5 })).status).toBe('timeout')
+    expect(diagnostics[0]).toMatchObject({ code: 'flush_timeout' })
+
+    const evaluator = new OnlineEvaluator({
+      scorers: [passScorer],
+      sample: 1,
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    })
+    evaluator.enqueue(sample('shutdown'))
+    const first = evaluator.shutdown({ timeoutMs: 1_000 })
+    const second = evaluator.shutdown({ timeoutMs: 1 })
+    expect(second).toBe(first)
+    await Promise.all([first, evaluator.forceFlush({ timeoutMs: 1_000 })])
+    expect(evaluator.enqueue(sample('after-shutdown'))).toBe(false)
+    expect(diagnostics.some((diagnostic) => diagnostic.code === 'enqueue_after_shutdown')).toBe(true)
+  })
+
+  it('rate-limits console warnings, honors silent mode, and unrefs scheduling timers', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const timers = vi.spyOn(globalThis, 'setTimeout')
+    const evaluator = new OnlineEvaluator({
+      scorers: [passScorer],
+      sample: 1,
+      maxQueueLength: 1,
+    })
+    evaluator.enqueue(sample('warn-queued'))
+    evaluator.enqueue(sample('warn-1'))
+    evaluator.enqueue(sample('warn-2'))
+    expect(warn).toHaveBeenCalledTimes(1)
+    const scheduled = timers.mock.results
+      .map((entry) => entry.value as { hasRef?: () => boolean } | undefined)
+      .find((timer) => typeof timer?.hasRef === 'function')
+    expect(scheduled?.hasRef?.()).toBe(false)
+
+    const silent = new OnlineEvaluator({
+      scorers: [passScorer],
+      sample: 1,
+      maxQueueLength: 1,
+      diagnostics: 'silent',
+    })
+    silent.enqueue(sample('silent-queued'))
+    silent.enqueue(sample('silent-drop'))
+    expect(warn).toHaveBeenCalledTimes(1)
+    warn.mockRestore()
+    timers.mockRestore()
+  })
+
+  it('aggregates suppressed diagnostic counts into the next rate-limit window', () => {
+    let now = 1_000
+    const diagnostics: EvalDiagnostic[] = []
+    const evaluator = new OnlineEvaluator({
+      scorers: [passScorer],
+      sample: 1,
+      maxQueueLength: 1,
+      onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+    }, { now: () => now })
+
+    evaluator.enqueue(sample('diagnostic-queued'))
+    evaluator.enqueue(sample('diagnostic-drop-1'))
+    evaluator.enqueue(sample('diagnostic-drop-2'))
+    evaluator.enqueue(sample('diagnostic-drop-3'))
+    expect(diagnostics).toEqual([expect.objectContaining({ code: 'queue_full', count: 1 })])
+
+    now += 60_001
+    evaluator.enqueue(sample('diagnostic-drop-4'))
+    expect(diagnostics[1]).toMatchObject({ code: 'queue_full', count: 3 })
+  })
+})


### PR DESCRIPTION
## Summary

- add configurable best-effort online evaluation for settled top-level runs, including ratio/rule sampling
- bound background work with queue, concurrency, rolling rate, and scorer-cost budgets
- wire evaluation into runAgent, runTeam, runTasks, runFromPlan, runConsensus, and restore
- add input privacy controls, failure-isolated diagnostics, lifecycle APIs, documentation, and focused tests

## Developer impact

Online evaluation is disabled unless configured. Disabled and zero-sample configurations use a shared no-op lifecycle, while enabled evaluation runs asynchronously so scorer, store, or callback failures do not change the business result.

## Validation

- `npm run lint` on Node 18, 20, and 22
- `npm test` on Node 18, 20, and 22
- `npm run build` on Node 18, 20, and 22
- Node 22 full suite: 112 files / 1,560 tests
- `npm run bench:observability:ci`
- `npm pack --dry-run -w @open-multi-agent/core --silent`
- root and `@open-multi-agent/core/eval` package-boundary import smoke
- `git diff --check`

Measured synchronous online-evaluation admission overhead in-process at approximately 0.42 µs p95.