### PR TITLE
fix: run oma through the installed npm bin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,19 @@ jobs:
             exit 1
           fi
 
+      - name: Smoke-test the installed core npm bin
+        working-directory: packages/core
+        run: |
+          pack_dir=$(mktemp -d)
+          consumer_dir=$(mktemp -d)
+          pack_json=$(npm pack --json --pack-destination "$pack_dir")
+          tarball=$(echo "$pack_json" | jq -r '.[0].filename')
+          npm install --prefix "$consumer_dir" "$pack_dir/$tarball"
+          help_output=$("$consumer_dir/node_modules/.bin/oma" help)
+          echo "$help_output" | grep -q "oma eval run"
+          echo "$help_output" | grep -q "oma eval gate"
+          echo "Installed CLI help runs OK"
+
       - name: Assert the create-oma-app tarball ships dist + template
         working-directory: packages/create-oma-app
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -6560,7 +6560,7 @@
     },
     "packages/core": {
       "name": "@open-multi-agent/core",
-      "version": "1.12.0",
+      "version": "1.12.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "TypeScript multi-agent framework: one runTeam() call from goal to result. Auto task decomposition and parallel execution for multi-step LLM jobs. Deploys anywhere Node.js runs.",
   "files": [
     "dist",

--- a/packages/core/src/cli/oma.ts
+++ b/packages/core/src/cli/oma.ts
@@ -12,7 +12,7 @@
  */
 
 import { mkdir, stat, writeFile } from 'node:fs/promises'
-import { readFileSync } from 'node:fs'
+import { readFileSync, realpathSync } from 'node:fs'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
@@ -1024,7 +1024,7 @@ const isMain = (() => {
   const argv1 = process.argv[1]
   if (!argv1) return false
   try {
-    return fileURLToPath(import.meta.url) === resolve(argv1)
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(resolve(argv1))
   } catch {
     return false
   }

--- a/packages/create-oma-app/template/package.json
+++ b/packages/create-oma-app/template/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.12.0"
+    "@open-multi-agent/core": "1.12.1"
   },
   "devDependencies": {
     "tsx": "^4.21.0"

--- a/packages/create-oma-app/templates/demo/package.json
+++ b/packages/create-oma-app/templates/demo/package.json
@@ -8,7 +8,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.12.0"
+    "@open-multi-agent/core": "1.12.1"
   },
   "devDependencies": {
     "tsx": "^4.21.0"

--- a/packages/create-oma-app/templates/pr-review/package.json
+++ b/packages/create-oma-app/templates/pr-review/package.json
@@ -8,7 +8,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.12.0",
+    "@open-multi-agent/core": "1.12.1",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/create-oma-app/templates/security/package.json
+++ b/packages/create-oma-app/templates/security/package.json
@@ -8,7 +8,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.12.0",
+    "@open-multi-agent/core": "1.12.1",
     "zod": "^3.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Motivation

The post-publish clean-consumer check for `@open-multi-agent/core@1.12.0` found that the installed npm bin exited successfully without running the CLI:

```text
./node_modules/.bin/oma help
# exit 0, empty output
```

Direct execution of `node dist/cli/oma.js help` worked, so the existing package CI did not cover the installed-bin path. The 1.12.0 package remains public; scaffolder publication, tag creation, and the GitHub Release are paused until this patch passes registry acceptance.

## Baseline

- Base commit: `3ffe7f9ec079e98d7b7a8a689b2c8d42bb93d390`
- `@open-multi-agent/core@1.12.0` is already published.
- `create-oma-app@0.5.0` and `@open-multi-agent/core@1.12.1` are not published.

## Root cause

The CLI main-module guard compared the real module path with the unresolved npm-bin symlink path. When npm invoked `node_modules/.bin/oma`, the paths differed and `main()` was skipped.

## Scope

- Resolve both paths through `realpathSync()` before deciding whether the CLI module is the executable entry point.
- Add package CI that creates the real core tarball, installs it into a clean consumer directory, and asserts the installed `oma help` output contains both evaluation commands.
- Bump core from `1.12.0` to `1.12.1` and synchronize the root lockfile.
- Pin the generic, demo, PR-review, and security starter manifests to core `1.12.1`.
- Keep `create-oma-app` at the unpublished `0.5.0` and OTel at `0.1.0`.

## Validation

- `git diff --check`
- `npm ci`
- `npm run test:example-catalog` — 9/9 tests; 58 entries validated
- `npm run lint`
- `npm test` — all workspaces passed; core 1530 tests
- `npm run build`
- `npm run typecheck:template -w create-oma-app` — demo, PR-review, and security passed
- `npm run test:eval-examples`
- `OMA_OBSERVABILITY_MIN_CORE_TARBALL=<core-1.11.0.tgz> npm run test:observability-pack` — core-only, core+OTel, and minimum-core passed
- `npm run test:scaffold`
- `npm audit --omit=dev --audit-level=high` — 0 production vulnerabilities
- Core 1.12.1 and create-oma-app 0.5.0 publish dry-runs passed
- Core 1.12.1 tarball clean-consumer smoke passed for root, `/eval`, `/eval/file`, installed `oma` bin, a no-network EvalSet, and OTel 0.1.0 compatibility

## Release handling after merge

Each external action still requires separate authorization. Publish and fully validate core 1.12.1 before publishing create-oma-app 0.5.0. The final milestone tag and GitHub Release will be `v1.12.1`; no tag or release is created by this PR.
