### PR TITLE
feat(observability): add execution receipt

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -81,6 +81,39 @@ This per-run channel is distinct from `ObservabilityResource`: use resource
 fields for instance-level facts such as service, release, and deployment
 environment; use run metadata for dimensions that may change on every call.
 
+## Execution receipts
+
+`buildExecutionReceipt(result, trace?)` derives a compact record of what the
+runtime actually executed. It accepts an `AgentRunResult` or `TeamRunResult`
+and optional legacy `TraceEvent[]` data, performs no I/O, and never throws when
+execution fields are missing:
+
+```typescript
+import { buildExecutionReceipt, OpenMultiAgent, type TraceEvent } from '@open-multi-agent/core'
+
+const trace: TraceEvent[] = []
+const tracedOrchestrator = new OpenMultiAgent({
+  onTrace: (event) => trace.push(event),
+})
+const result = await tracedOrchestrator.runTeam(team, goal)
+const receipt = buildExecutionReceipt(result, trace)
+```
+
+The receipt reports `mode`, distinct `rolesExecuted`, start-time-based
+`executionOrder`, cross-role `dependencyEdges`, `independentRolesCount`, token
+usage, duration, and whether the record is `partial`. `independentReviewOccurred`
+is true only when at least two different worker roles executed and at least one
+task dependency connects two different roles. Parallel roles with no dependency
+edge do not count as an independent review chain. Coordinator planning entries
+(`coordinator` and `coordinator:*`) are excluded.
+
+Governance decisions must use these execution facts, not labels, claims, or
+review markers in model answer text. The builder never inspects answer text.
+For a standalone `AgentRunResult`, the optional trace supplies the agent name
+and run duration because those facts are not fields on that result type. When
+the available result or trace cannot establish a fact, the builder returns an
+empty array or `null` for that field and sets `partial: true`.
+
 ## TraceRecord schema v2
 
 The core package exports the `TraceRecord` schema used by the internal

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -158,6 +158,7 @@ export {
   TRACE_STORE_SCHEMA_MAJOR,
   TraceStoreError,
   TraceStoreExporter,
+  buildExecutionReceipt,
   emptyTraceSinkStats,
   materializeRun,
 } from './observability/index.js'
@@ -168,6 +169,8 @@ export type {
   DiagnosticMode,
   DiagnosticOptions,
   ExportResult,
+  ExecutionReceipt,
+  ExecutionReceiptDependencyEdge,
   FlushOptions,
   FlushResult,
   GetRunOptions,

--- a/packages/core/src/observability/execution-receipt.ts
+++ b/packages/core/src/observability/execution-receipt.ts
@@ -1,0 +1,301 @@
+import type {
+  AgentRunResult,
+  TeamRunResult,
+  TraceEvent,
+} from '../types.js'
+
+/** A dependency observed between tasks assigned to different worker roles. */
+export interface ExecutionReceiptDependencyEdge {
+  readonly from: string
+  readonly to: string
+}
+
+/**
+ * Structured execution facts derived from run records and optional trace events.
+ * Agent output text is deliberately excluded as a source of evidence.
+ */
+export interface ExecutionReceipt {
+  readonly mode: 'single' | 'multi-agent'
+  readonly rolesExecuted: readonly string[]
+  readonly executionOrder: readonly string[]
+  readonly dependencyEdges: readonly ExecutionReceiptDependencyEdge[]
+  readonly independentRolesCount: number
+  readonly independentReviewOccurred: boolean
+  readonly totalTokens: {
+    readonly input: number
+    readonly output: number
+  } | null
+  readonly durationMs: number | null
+  readonly partial: boolean
+}
+
+type UnknownRecord = Readonly<Record<string, unknown>>
+
+interface TraceFacts {
+  readonly events: readonly UnknownRecord[]
+  readonly partial: boolean
+}
+
+interface TaskFact {
+  readonly id?: string
+  readonly role?: string
+  readonly dependsOn: readonly string[]
+  readonly startMs?: number
+}
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function isCoordinator(role: string): boolean {
+  return role === 'coordinator' || role.startsWith('coordinator:')
+}
+
+function readWorkerRole(value: unknown): string | undefined {
+  const role = readString(value)
+  return role && role !== 'unknown' && !isCoordinator(role) ? role : undefined
+}
+
+function readTokenUsage(value: unknown): ExecutionReceipt['totalTokens'] {
+  if (!isRecord(value)) return null
+  const input = value['input_tokens']
+  const output = value['output_tokens']
+  return isFiniteNumber(input) && isFiniteNumber(output) ? { input, output } : null
+}
+
+function readTraceFacts(trace: readonly TraceEvent[] | undefined): TraceFacts {
+  if (trace === undefined) return { events: [], partial: false }
+  if (!Array.isArray(trace)) return { events: [], partial: true }
+
+  const events: UnknownRecord[] = []
+  let partial = false
+  for (const event of trace) {
+    if (isRecord(event)) events.push(event)
+    else partial = true
+  }
+  return { events, partial }
+}
+
+function readTraceTaskFacts(trace: TraceFacts): Map<string, TaskFact> {
+  const facts = new Map<string, TaskFact>()
+  for (const event of trace.events) {
+    if (event['type'] !== 'task') continue
+    const id = readString(event['taskId'])
+    if (!id) continue
+
+    const candidate: TaskFact = {
+      id,
+      role: readWorkerRole(event['agent']),
+      dependsOn: [],
+      startMs: isFiniteNumber(event['startMs']) ? event['startMs'] : undefined,
+    }
+    const existing = facts.get(id)
+    if (!existing || (candidate.startMs !== undefined
+      && (existing.startMs === undefined || candidate.startMs < existing.startMs))) {
+      facts.set(id, candidate)
+    }
+  }
+  return facts
+}
+
+function emptyReceipt(): ExecutionReceipt {
+  return {
+    mode: 'single',
+    rolesExecuted: [],
+    executionOrder: [],
+    dependencyEdges: [],
+    independentRolesCount: 0,
+    independentReviewOccurred: false,
+    totalTokens: null,
+    durationMs: null,
+    partial: true,
+  }
+}
+
+function isTeamRunResult(result: unknown): result is TeamRunResult {
+  if (!isRecord(result)) return false
+  return Array.isArray(result['tasks'])
+    || result['agentResults'] instanceof Map
+    || 'totalTokenUsage' in result
+}
+
+function buildAgentReceipt(result: AgentRunResult, trace: TraceFacts): ExecutionReceipt {
+  const rawResult = result as unknown as UnknownRecord
+  const agentEvents = trace.events.filter((event) => event['type'] === 'agent')
+  const workerAgentEvents = agentEvents.filter((event) => readWorkerRole(event['agent']) !== undefined)
+  const earliestByRole = new Map<string, number>()
+  let missingRoleOrStart = false
+
+  for (const event of workerAgentEvents) {
+    const role = readWorkerRole(event['agent'])
+    const startMs = event['startMs']
+    if (!role || !isFiniteNumber(startMs)) {
+      missingRoleOrStart = true
+      continue
+    }
+    const previous = earliestByRole.get(role)
+    if (previous === undefined || startMs < previous) earliestByRole.set(role, startMs)
+  }
+
+  const rolesExecuted = [...earliestByRole.keys()]
+  const executionOrder = [...rolesExecuted].sort((left, right) =>
+    earliestByRole.get(left)! - earliestByRole.get(right)!)
+
+  const starts = workerAgentEvents
+    .map((event) => event['startMs'])
+    .filter(isFiniteNumber)
+  const ends = workerAgentEvents
+    .map((event) => event['endMs'])
+    .filter(isFiniteNumber)
+  const durationMs = starts.length > 0 && ends.length > 0
+    ? Math.max(0, Math.max(...ends) - Math.min(...starts))
+    : null
+  const totalTokens = readTokenUsage(rawResult['tokenUsage'])
+  const partial = trace.partial
+    || workerAgentEvents.length === 0
+    || rolesExecuted.length === 0
+    || missingRoleOrStart
+    || durationMs === null
+    || totalTokens === null
+
+  return {
+    mode: rolesExecuted.length > 1 ? 'multi-agent' : 'single',
+    rolesExecuted,
+    executionOrder,
+    dependencyEdges: [],
+    independentRolesCount: rolesExecuted.length,
+    independentReviewOccurred: false,
+    totalTokens,
+    durationMs,
+    partial,
+  }
+}
+
+function buildTeamReceipt(result: TeamRunResult, trace: TraceFacts): ExecutionReceipt {
+  const rawResult = result as unknown as UnknownRecord
+  const rawTasks = rawResult['tasks']
+  const tasks = Array.isArray(rawTasks) ? rawTasks : []
+  const traceTasks = readTraceTaskFacts(trace)
+  const taskFacts: TaskFact[] = []
+  let partial = trace.partial || !Array.isArray(rawTasks)
+
+  for (const value of tasks) {
+    if (!isRecord(value)) {
+      partial = true
+      continue
+    }
+
+    const id = readString(value['id'])
+    const traced = id ? traceTasks.get(id) : undefined
+    const metrics = isRecord(value['metrics']) ? value['metrics'] : undefined
+    const hasExecutionEvidence = metrics !== undefined || traced !== undefined
+    const status = readString(value['status'])
+    if (!hasExecutionEvidence && (status === 'pending' || status === 'blocked' || status === 'skipped')) {
+      continue
+    }
+
+    const rawRole = readString(value['assignee'])
+    const role = readWorkerRole(rawRole) ?? traced?.role
+    const rawDependsOn = value['dependsOn']
+    const dependsOn = Array.isArray(rawDependsOn)
+      ? rawDependsOn.filter((dependency): dependency is string => typeof dependency === 'string')
+      : []
+    const startMs = metrics && isFiniteNumber(metrics['startMs'])
+      ? metrics['startMs']
+      : traced?.startMs
+
+    if (!id || (!rawRole && !traced?.role) || !Array.isArray(rawDependsOn)) partial = true
+    if (Array.isArray(rawDependsOn) && dependsOn.length !== rawDependsOn.length) partial = true
+    if (role && startMs === undefined) partial = true
+    taskFacts.push({ id, role, dependsOn, startMs })
+  }
+
+  const rolesExecuted: string[] = []
+  const knownRoles = new Set<string>()
+  const earliestByRole = new Map<string, number>()
+  let orderComplete = true
+
+  for (const task of taskFacts) {
+    if (!task.role) continue
+    if (!knownRoles.has(task.role)) {
+      knownRoles.add(task.role)
+      rolesExecuted.push(task.role)
+    }
+    if (task.startMs === undefined) {
+      orderComplete = false
+      continue
+    }
+    const previous = earliestByRole.get(task.role)
+    if (previous === undefined || task.startMs < previous) earliestByRole.set(task.role, task.startMs)
+  }
+
+  const executionOrder = orderComplete && earliestByRole.size === rolesExecuted.length
+    ? [...rolesExecuted].sort((left, right) => earliestByRole.get(left)! - earliestByRole.get(right)!)
+    : []
+
+  const roleByTaskId = new Map<string, string>()
+  for (const task of taskFacts) {
+    if (task.id && task.role) roleByTaskId.set(task.id, task.role)
+  }
+
+  const dependencyEdges: ExecutionReceiptDependencyEdge[] = []
+  for (const task of taskFacts) {
+    if (!task.role) continue
+    for (const dependencyId of task.dependsOn) {
+      const predecessor = roleByTaskId.get(dependencyId)
+      if (!predecessor) {
+        const dependency = taskFacts.find((candidate) => candidate.id === dependencyId)
+        if (!dependency || dependency.role !== undefined) partial = true
+        continue
+      }
+      if (predecessor !== task.role) dependencyEdges.push({ from: predecessor, to: task.role })
+    }
+  }
+
+  const totalTokens = readTokenUsage(rawResult['totalTokenUsage'])
+  const rawMetrics = rawResult['metrics']
+  const durationMs = isRecord(rawMetrics) && isFiniteNumber(rawMetrics['totalDurationMs'])
+    ? rawMetrics['totalDurationMs']
+    : null
+  if (rolesExecuted.length === 0 || !orderComplete || totalTokens === null || durationMs === null) {
+    partial = true
+  }
+
+  return {
+    mode: rolesExecuted.length > 1 ? 'multi-agent' : 'single',
+    rolesExecuted,
+    executionOrder,
+    dependencyEdges,
+    independentRolesCount: rolesExecuted.length,
+    independentReviewOccurred: rolesExecuted.length >= 2 && dependencyEdges.length > 0,
+    totalTokens,
+    durationMs,
+    partial,
+  }
+}
+
+/**
+ * Builds a non-throwing execution receipt without inspecting model output text.
+ */
+export function buildExecutionReceipt(
+  result: AgentRunResult | TeamRunResult,
+  trace?: readonly TraceEvent[],
+): ExecutionReceipt {
+  try {
+    const traceFacts = readTraceFacts(trace)
+    if (!isRecord(result)) return emptyReceipt()
+    return isTeamRunResult(result)
+      ? buildTeamReceipt(result, traceFacts)
+      : buildAgentReceipt(result, traceFacts)
+  } catch {
+    return emptyReceipt()
+  }
+}

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -36,6 +36,11 @@ export type {
 } from './processors.js'
 export { LegacyCallbackTraceSink } from './legacy-callback.js'
 export { materializeRun } from './materialize.js'
+export { buildExecutionReceipt } from './execution-receipt.js'
+export type {
+  ExecutionReceipt,
+  ExecutionReceiptDependencyEdge,
+} from './execution-receipt.js'
 export { InMemoryTraceStore } from './in-memory-store.js'
 export type { InMemoryTraceStoreOptions } from './in-memory-store.js'
 export { TraceStoreExporter } from './store-exporter.js'

--- a/packages/core/tests/execution-receipt.test.ts
+++ b/packages/core/tests/execution-receipt.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+import { buildExecutionReceipt } from '../src/index.js'
+import type {
+  AgentRunResult,
+  AgentTrace,
+  TaskExecutionRecord,
+  TeamRunResult,
+} from '../src/types.js'
+
+function agentResult(output: string): AgentRunResult {
+  return {
+    success: true,
+    output,
+    messages: [],
+    tokenUsage: { input_tokens: 7, output_tokens: 3 },
+    toolCalls: [],
+  }
+}
+
+function agentTrace(agent: string): AgentTrace {
+  return {
+    type: 'agent',
+    runId: 'run-1',
+    spanId: 'span-1',
+    agent,
+    startMs: 100,
+    endMs: 125,
+    durationMs: 25,
+    turns: 1,
+    tokens: { input_tokens: 7, output_tokens: 3 },
+    toolCalls: 0,
+  }
+}
+
+function task(
+  id: string,
+  assignee: string,
+  dependsOn: readonly string[],
+  startMs: number,
+): TaskExecutionRecord {
+  return {
+    id,
+    title: id,
+    assignee,
+    status: 'completed',
+    dependsOn,
+    metrics: {
+      startMs,
+      endMs: startMs + 10,
+      durationMs: 10,
+      tokenUsage: { input_tokens: 1, output_tokens: 1 },
+      toolCalls: [],
+      retries: 0,
+    },
+  }
+}
+
+function teamResult(tasks: readonly TaskExecutionRecord[]): TeamRunResult {
+  return {
+    success: true,
+    tasks,
+    agentResults: new Map(),
+    totalTokenUsage: { input_tokens: 20, output_tokens: 10 },
+    metrics: {
+      totalTokens: { input_tokens: 20, output_tokens: 10 },
+      totalRetries: 0,
+      errorCount: 0,
+      failureCount: 0,
+      completedCount: tasks.length,
+      totalDurationMs: 40,
+    },
+  }
+}
+
+describe('buildExecutionReceipt', () => {
+  it('does not treat multi-role answer text as independent execution', () => {
+    const receipt = buildExecutionReceipt(
+      agentResult('ROLLBACK_MISSING HOLD_ROTATION NOT_EXECUTED'),
+      [agentTrace('security')],
+    )
+
+    expect(receipt).toMatchObject({
+      mode: 'single',
+      rolesExecuted: ['security'],
+      executionOrder: ['security'],
+      independentRolesCount: 1,
+      independentReviewOccurred: false,
+      totalTokens: { input: 7, output: 3 },
+      durationMs: 25,
+      partial: false,
+    })
+  })
+
+  it('derives an ordered cross-role dependency chain from a DAG result', () => {
+    const receipt = buildExecutionReceipt(teamResult([
+      task('review', 'reviewer', [], 100),
+      task('secure', 'security', ['review'], 200),
+      task('operate', 'operator', ['secure'], 300),
+    ]))
+
+    expect(receipt.rolesExecuted).toEqual(['reviewer', 'security', 'operator'])
+    expect(receipt.executionOrder).toEqual(['reviewer', 'security', 'operator'])
+    expect(receipt.dependencyEdges).toEqual([
+      { from: 'reviewer', to: 'security' },
+      { from: 'security', to: 'operator' },
+    ])
+    expect(receipt.independentReviewOccurred).toBe(true)
+    expect(receipt.partial).toBe(false)
+  })
+
+  it('reports a short-circuited team result as one executed role', () => {
+    const receipt = buildExecutionReceipt(teamResult([
+      task('short-circuit', 'security', [], 100),
+    ]))
+
+    expect(receipt.mode).toBe('single')
+    expect(receipt.rolesExecuted).toEqual(['security'])
+    expect(receipt.independentReviewOccurred).toBe(false)
+  })
+
+  it('does not report independent review for parallel roles without dependency edges', () => {
+    const roles = ['reviewer', 'security', 'operator', 'legal', 'finance', 'auditor']
+    const receipt = buildExecutionReceipt(teamResult(
+      roles.map((role, index) => task(`task-${index}`, role, [], 100 + index)),
+    ))
+
+    expect(receipt.rolesExecuted).toEqual(roles)
+    expect(receipt.independentRolesCount).toBe(6)
+    expect(receipt.dependencyEdges).toEqual([])
+    expect(receipt.independentReviewOccurred).toBe(false)
+  })
+
+  it('excludes coordinator planning records from executed worker roles', () => {
+    const receipt = buildExecutionReceipt(teamResult([
+      task('plan', 'coordinator', [], 50),
+      task('decompose', 'coordinator:decompose', [], 60),
+      task('work', 'security', ['plan'], 100),
+    ]))
+
+    expect(receipt.rolesExecuted).toEqual(['security'])
+    expect(receipt.executionOrder).toEqual(['security'])
+    expect(receipt.dependencyEdges).toEqual([])
+    expect(receipt.independentReviewOccurred).toBe(false)
+  })
+
+  it('returns a partial receipt instead of throwing when execution fields are missing', () => {
+    const incomplete = {
+      success: true,
+      tasks: [{
+        id: 'review',
+        title: 'review',
+        assignee: 'reviewer',
+        status: 'completed',
+        dependsOn: [],
+      }],
+      agentResults: new Map(),
+      totalTokenUsage: { input_tokens: 1, output_tokens: 1 },
+    } as TeamRunResult
+
+    expect(() => buildExecutionReceipt(incomplete)).not.toThrow()
+    expect(buildExecutionReceipt(incomplete)).toMatchObject({
+      rolesExecuted: ['reviewer'],
+      executionOrder: [],
+      durationMs: null,
+      partial: true,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add the public `buildExecutionReceipt(result, trace?)` pure function and `ExecutionReceipt` types
- derive executed worker roles, task order, cross-role dependency edges, token usage, duration, and partial-data status from execution records and optional trace events
- exclude coordinator planning entries and never inspect model answer text as execution evidence
- export the API from both the package root and the observability subpath
- document the governance boundary and partial receipt semantics

## Why

Answer text can claim that several roles reviewed or approved work even when only one agent actually ran. Execution receipts provide a structured, non-throwing data-plane record of the worker topology that really executed, so later governance checks can rely on execution facts instead of self-reported labels.

This change is additive and does not modify routing, short-circuiting, orchestration, task execution, approval flows, or UI behavior.

## Validation

- `npm run lint -w @open-multi-agent/core`
- `npm run test -w @open-multi-agent/core` (108 files, 1536 tests)
- `npm run build -w @open-multi-agent/core`
- `git diff --check`

All tests use constructed fixtures and require no network, API key, or LLM call.
