### PR TITLE
feat(orchestrator): honor declared governance intent in runTeam

### DIFF
--- a/docs/tool-configuration.md
+++ b/docs/tool-configuration.md
@@ -2,6 +2,24 @@
 
 Agents can be configured with fine-grained tool access control using presets, allowlists, and denylists.
 
+## Declared governance roles in `runTeam()`
+
+Tool and credential boundaries are often tied to named agents. When a goal must actually pass through specific roster roles, declare the topology structurally on the `runTeam()` call:
+
+```typescript
+const result = await orchestrator.runTeam(team, 'Review this change before release.', {
+  governanceIntent: 'required',
+  requiredRoles: ['reviewer', 'security'],
+  requiredOrder: ['reviewer', 'security'],
+})
+```
+
+For both `required` and `preferred`, OMA skips coordinator decomposition and the simple-goal single-agent short circuit. It creates one task for every `requiredRoles` entry, keeps each task assigned to that roster agent, and uses `requiredOrder` to create dependency edges. Each task receives the original goal unchanged; the agent's `systemPrompt`, tools, and credentials define the role. Downstream tasks receive prerequisite outputs through dependency-scoped memory.
+
+The goal text is not inspected to choose this topology. The same declaration therefore produces the same roles and dependency order for English, Chinese, or any other language. Every `requiredRoles` name must exist in the team roster, and `requiredOrder`, when present, must be a permutation of those roles. Invalid declarations throw before any agent runs.
+
+Use `governanceIntent: 'none'` to opt into the existing automatic `runTeam()` route explicitly. Omitting `governanceIntent` also preserves the existing behavior, including simple-goal short circuit and coordinator-generated task planning.
+
 ## Built-in tools are opt-in (default-deny)
 
 Built-in tools — `bash` and the filesystem tools (`file_read`, `file_write`, `file_edit`, `grep`, `glob`) — are **default-deny**. An agent receives a built-in tool only when it is granted explicitly via `tools` (an allowlist of names) or `toolPreset`. An agent that sets **neither** resolves to **zero** built-in tools:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -109,6 +109,18 @@ Set `OPENAI_API_KEY` for this example. For other hosted or local models, see [Pr
 
 Use `planOnly` to inspect a generated task graph before execution, then `createPlanArtifact()` and `runFromPlan()` to replay it. `runConsensus()` adds a proposer→judge verification loop when one answer needs extra scrutiny.
 
+When an application must enforce named independent roles, declare that governance intent instead of relying on wording in the goal:
+
+```typescript
+const governed = await orchestrator.runTeam(team, 'Review the evidence and assess the risk.', {
+  governanceIntent: 'required',
+  requiredRoles: ['researcher', 'analyst'],
+  requiredOrder: ['researcher', 'analyst'],
+})
+```
+
+`required` and `preferred` both bypass automatic decomposition and the simple-goal short circuit. OMA creates one task per declared roster name, assigns it to that agent, and chains tasks in `requiredOrder`; dependency outputs are passed to downstream roles. The topology comes only from these structured fields, so equivalent goals in different languages use the same roles and order. `none` or an omitted `governanceIntent` preserves the existing automatic `runTeam()` behavior.
+
 ## Capabilities
 
 | Capability | What you get |

--- a/packages/core/src/orchestrator/governance.ts
+++ b/packages/core/src/orchestrator/governance.ts
@@ -1,0 +1,90 @@
+import type { AgentConfig, RunTaskSpec, RunTeamOptions } from '../types.js'
+
+/**
+ * Build the explicit role topology requested by a structured governance
+ * declaration. `undefined` means the caller selected the legacy automatic
+ * `runTeam()` route.
+ */
+export function buildGovernanceTaskSpecs(
+  goal: string,
+  agentConfigs: readonly AgentConfig[],
+  options?: RunTeamOptions,
+): readonly RunTaskSpec[] | undefined {
+  const intent = options?.governanceIntent
+  if (intent !== 'required' && intent !== 'preferred') return undefined
+
+  const requiredRoles = options?.requiredRoles ?? []
+  if (requiredRoles.length === 0) {
+    throw new Error(
+      `runTeam governanceIntent '${intent}' requires at least one role in requiredRoles.`,
+    )
+  }
+
+  const duplicateRoles = findDuplicates(requiredRoles)
+  if (duplicateRoles.length > 0) {
+    throw new Error(
+      `runTeam requiredRoles must contain unique team agent names; duplicate role(s): ${duplicateRoles.join(', ')}.`,
+    )
+  }
+
+  const rosterNames = new Set(agentConfigs.map((agent) => agent.name))
+  const unknownRoles = requiredRoles.filter((role) => !rosterNames.has(role))
+  if (unknownRoles.length > 0) {
+    throw new Error(
+      `runTeam requiredRoles must exist in the team roster; unknown role(s): ${unknownRoles.join(', ')}.`,
+    )
+  }
+
+  const requiredOrder = options?.requiredOrder
+  if (requiredOrder !== undefined) {
+    const declaredRoles = new Set(requiredRoles)
+    const unknownOrderRoles = requiredOrder.filter((role) => !declaredRoles.has(role))
+    if (unknownOrderRoles.length > 0) {
+      throw new Error(
+        `runTeam requiredOrder may reference only requiredRoles; invalid role(s): ${unknownOrderRoles.join(', ')}.`,
+      )
+    }
+
+    const duplicateOrderRoles = findDuplicates(requiredOrder)
+    if (duplicateOrderRoles.length > 0) {
+      throw new Error(
+        `runTeam requiredOrder must contain each required role once; duplicate role(s): ${duplicateOrderRoles.join(', ')}.`,
+      )
+    }
+
+    if (requiredOrder.length !== requiredRoles.length) {
+      const orderedRoles = new Set(requiredOrder)
+      const missingRoles = requiredRoles.filter((role) => !orderedRoles.has(role))
+      throw new Error(
+        `runTeam requiredOrder must be a permutation of requiredRoles; missing role(s): ${missingRoles.join(', ')}.`,
+      )
+    }
+  }
+
+  const executionOrder = requiredOrder ?? requiredRoles
+  // Keep task text role-neutral: assignment selects the roster agent, whose
+  // systemPrompt owns the role semantics. Titles exist only for dependency IDs.
+  const titleByRole = new Map(
+    executionOrder.map((role, index) => [role, `Governance task ${index + 1}`]),
+  )
+
+  return executionOrder.map((role, index) => ({
+    title: titleByRole.get(role)!,
+    description: goal,
+    assignee: role,
+    ...(index > 0 && requiredOrder !== undefined
+      ? { dependsOn: [titleByRole.get(executionOrder[index - 1]!)!] }
+      : {}),
+    memoryScope: 'dependencies',
+  }))
+}
+
+function findDuplicates(values: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const duplicates = new Set<string>()
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value)
+    seen.add(value)
+  }
+  return [...duplicates]
+}

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -129,6 +129,7 @@ import {
 } from './agent-config.js'
 import { isSimpleGoal, selectBestAgent } from './short-circuit.js'
 import { executeQueue, saveRunCheckpoint } from './task-execution.js'
+import { buildGovernanceTaskSpecs } from './governance.js'
 import { runConsensusCore, applyConsensusDefaults, type ConsensusAgentDefaults } from './consensus.js'
 import {
   createOnlineEvaluator,
@@ -453,6 +454,25 @@ export class OpenMultiAgent {
     options?: RunTeamOptions,
   ): Promise<TeamRunResult> {
     const pendingEvaluation = this.beginOnlineEvaluation(goal)
+    const agentConfigs = team.getAgents()
+    const governanceTaskSpecs = buildGovernanceTaskSpecs(goal, agentConfigs, options)
+    if (governanceTaskSpecs !== undefined) {
+      const queue = new TaskQueue()
+      loadSpecsIntoQueue(governanceTaskSpecs, agentConfigs, queue)
+      return this.executeExplicitTaskQueue(
+        team,
+        queue,
+        options,
+        goal,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        pendingEvaluation,
+      )
+    }
+
     const { identity, metadata } = createRunFacts(identityOptionsForRun(options))
     const traceRuntime = this.startTrace(identity, metadata)
     const finish = (result: TeamRunResult): TeamRunResult => {
@@ -467,7 +487,6 @@ export class OpenMultiAgent {
       this.completeOnlineEvaluation(pendingEvaluation, completedResult)
       return completedResult
     }
-    const agentConfigs = team.getAgents()
     const coordinatorOverrides = options?.coordinator
 
     // ------------------------------------------------------------------

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1102,6 +1102,28 @@ export interface RunTasksOptions extends RunIdentityOptions {
 export interface RunTeamOptions extends RunTasksOptions {
   readonly coordinator?: CoordinatorConfig
   /**
+   * Optional structured governance signal for this goal.
+   *
+   * `'required'` and `'preferred'` both bypass coordinator decomposition and
+   * the simple-goal short circuit. Instead, `runTeam()` executes one task per
+   * {@link requiredRoles} entry using the declared roster assignments.
+   * `'none'` and an omitted value preserve the existing automatic routing
+   * behavior.
+   */
+  readonly governanceIntent?: 'required' | 'preferred' | 'none'
+  /**
+   * Agent names from the team roster that must execute independent tasks when
+   * {@link governanceIntent} is `'required'` or `'preferred'`.
+   */
+  readonly requiredRoles?: readonly string[]
+  /**
+   * Optional execution order for {@link requiredRoles}. When provided, it must
+   * be a permutation of `requiredRoles`; each role depends on the previous one.
+   * When omitted, the declared role tasks have no dependencies and may run in
+   * parallel.
+   */
+  readonly requiredOrder?: readonly string[]
+  /**
    * When true, the coordinator decomposes the goal but no task agents run.
    * The returned {@link TeamRunResult} has `planOnly: true`, `success: true`,
    * `tasks` populated (all `pending`, no metrics), and `agentResults`

--- a/packages/core/tests/governance-intent.test.ts
+++ b/packages/core/tests/governance-intent.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMMessage,
+  LLMResponse,
+  RunTeamOptions,
+  TaskExecutionRecord,
+} from '../src/types.js'
+
+function userPrompt(messages: LLMMessage[]): string {
+  const message = [...messages].reverse().find((candidate) => candidate.role === 'user')
+  return (message?.content ?? [])
+    .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n')
+}
+
+function responseAdapter(reply: string, captures: string[] = []): LLMAdapter {
+  return {
+    name: 'governance-test',
+    async chat(messages): Promise<LLMResponse> {
+      captures.push(userPrompt(messages))
+      return {
+        id: `response-${captures.length}`,
+        content: [{ type: 'text', text: reply }],
+        model: 'mock-model',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: {} }
+    },
+  }
+}
+
+function agent(name: string, reply: string, captures?: string[]): AgentConfig {
+  return {
+    name,
+    model: 'mock-model',
+    systemPrompt: `You are the ${name}.`,
+    adapter: responseAdapter(reply, captures),
+  }
+}
+
+function normalizeTopology(tasks: readonly TaskExecutionRecord[] | undefined) {
+  const records = tasks ?? []
+  const assigneeById = new Map(records.map((task) => [task.id, task.assignee]))
+  return records.map((task) => ({
+    assignee: task.assignee,
+    dependsOn: task.dependsOn.map((dependencyId) => assigneeById.get(dependencyId)),
+  }))
+}
+
+async function runGovernedGoal(goal: string, options: RunTeamOptions) {
+  const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+  const team = orchestrator.createTeam('governance-team', {
+    name: 'governance-team',
+    agents: [
+      agent('reviewer', 'reviewer output'),
+      agent('security', 'security output'),
+    ],
+    sharedMemory: true,
+  })
+  return orchestrator.runTeam(team, goal, options)
+}
+
+describe('runTeam declared governance intent', () => {
+  const requiredGovernance = {
+    governanceIntent: 'required',
+    requiredRoles: ['reviewer', 'security'],
+    requiredOrder: ['reviewer', 'security'],
+  } as const satisfies RunTeamOptions
+
+  it('executes every required role in the declared dependency order', async () => {
+    const reviewerPrompts: string[] = []
+    const securityPrompts: string[] = []
+    const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = orchestrator.createTeam('governance-team', {
+      name: 'governance-team',
+      agents: [
+        agent('reviewer', 'reviewer output', reviewerPrompts),
+        agent('security', 'security output', securityPrompts),
+      ],
+      sharedMemory: true,
+    })
+    const goal = 'Review this transfer request.'
+
+    const result = await orchestrator.runTeam(team, goal, requiredGovernance)
+
+    expect(result.success).toBe(true)
+    expect(result.agentResults.has('coordinator')).toBe(false)
+    expect(result.agentResults.has('reviewer')).toBe(true)
+    expect(result.agentResults.has('security')).toBe(true)
+    expect(normalizeTopology(result.tasks)).toEqual([
+      { assignee: 'reviewer', dependsOn: [] },
+      { assignee: 'security', dependsOn: ['reviewer'] },
+    ])
+    expect(result.tasks?.every((task) => task.description === goal)).toBe(true)
+    expect(result.tasks?.every((task) => task.memoryScope === 'dependencies')).toBe(true)
+    expect(reviewerPrompts).toHaveLength(1)
+    expect(securityPrompts[0]).toContain('## Context from prerequisite tasks')
+    expect(securityPrompts[0]).toContain('reviewer output')
+  })
+
+  it('builds the same role topology for equivalent English and Chinese goals', async () => {
+    const english = await runGovernedGoal(
+      'Review the key rotation and verify that it is safe.',
+      requiredGovernance,
+    )
+    const chinese = await runGovernedGoal(
+      '审核密钥轮换并确认其安全性。',
+      requiredGovernance,
+    )
+
+    expect(normalizeTopology(english.tasks)).toEqual(normalizeTopology(chinese.tasks))
+    expect(normalizeTopology(chinese.tasks)).toEqual([
+      { assignee: 'reviewer', dependsOn: [] },
+      { assignee: 'security', dependsOn: ['reviewer'] },
+    ])
+  })
+
+  it('treats preferred as the same satisfying topology in this release', async () => {
+    const result = await runGovernedGoal('Check this request.', {
+      ...requiredGovernance,
+      governanceIntent: 'preferred',
+    })
+
+    expect(normalizeTopology(result.tasks)).toEqual([
+      { assignee: 'reviewer', dependsOn: [] },
+      { assignee: 'security', dependsOn: ['reviewer'] },
+    ])
+  })
+
+  it('leaves declared roles unordered when requiredOrder is omitted', async () => {
+    const result = await runGovernedGoal('Check this request.', {
+      governanceIntent: 'required',
+      requiredRoles: ['reviewer', 'security'],
+    })
+
+    expect(normalizeTopology(result.tasks)).toEqual([
+      { assignee: 'reviewer', dependsOn: [] },
+      { assignee: 'security', dependsOn: [] },
+    ])
+  })
+
+  it('preserves the existing simple-goal route for none and an omitted intent', async () => {
+    const withoutIntent = await runGovernedGoal('Say hello.', {
+      requiredRoles: ['reviewer', 'security'],
+      requiredOrder: ['reviewer', 'security'],
+    })
+    const withNone = await runGovernedGoal('Say hello.', { governanceIntent: 'none' })
+
+    expect(normalizeTopology(withNone.tasks)).toEqual(normalizeTopology(withoutIntent.tasks))
+    expect(withNone.tasks?.map((task) => task.id)).toEqual(['short-circuit'])
+    expect(withNone.agentResults.has('coordinator')).toBe(false)
+    expect(withoutIntent.tasks?.map((task) => task.id)).toEqual(['short-circuit'])
+    expect(withoutIntent.agentResults.has('coordinator')).toBe(false)
+  })
+
+  it('rejects required roles that are absent from the team roster', async () => {
+    await expect(runGovernedGoal('Review this request.', {
+      governanceIntent: 'required',
+      requiredRoles: ['reviewer', 'auditor'],
+    })).rejects.toThrow(
+      'runTeam requiredRoles must exist in the team roster; unknown role(s): auditor.',
+    )
+  })
+
+  it('rejects requiredOrder entries that are not declared in requiredRoles', async () => {
+    await expect(runGovernedGoal('Review this request.', {
+      governanceIntent: 'required',
+      requiredRoles: ['reviewer'],
+      requiredOrder: ['security'],
+    })).rejects.toThrow(
+      'runTeam requiredOrder may reference only requiredRoles; invalid role(s): security.',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- add optional `governanceIntent`, `requiredRoles`, and `requiredOrder` fields to `RunTeamOptions`
- route `required` and `preferred` declarations through an explicit role DAG, bypassing coordinator decomposition and the simple-goal short circuit
- preserve the existing `none` and omitted-intent behavior unchanged
- document the language-independent topology contract and add no-network regression coverage

## Motivation

`runTeam()` currently chooses between the simple-goal path and coordinator decomposition using goal-text heuristics. Equivalent governance goals can therefore select different topologies when their wording or language changes, and a required independent reviewer can be skipped while the run still succeeds.

This change lets applications declare required roster roles and their dependency order structurally. The declared topology no longer depends on goal length, keywords, or language.

## Scope and impact

- **Workspace:** `@open-multi-agent/core`, plus core README and tool-configuration documentation
- **Public API:** additive optional fields only; existing calls require no migration
- **Behavior:** `required` and `preferred` create one task per declared role, preserve the original goal as each task description, assign tasks to the named roster agents, and pass prerequisite outputs through dependency-scoped memory
- **Validation:** unknown roster roles and invalid role ordering throw descriptive errors before agent execution
- **Compatibility:** `governanceIntent: 'none'` and omitted `governanceIntent` retain the existing short-circuit/coordinator routing behavior
- **Intentional non-goals:** governance-unsatisfied result states, budget downgrade behavior, default-signal fallback, language-flip EvalSet gates, and UI
- **Security/privacy:** no new permissions, credentials, dependencies, or external data flow

## Validation

- `npm run lint -w @open-multi-agent/core` — passed
- `npm run test -w @open-multi-agent/core` — passed (108 files, 1537 tests)
- `npm run build -w @open-multi-agent/core` — passed
- `git diff --check` — passed
- Provider E2E was not run because this change does not alter provider adapters and those suites require real credentials.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING (no dependency changes)
