### PR TITLE
test(eval): add routing-stability language-neutrality gate

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -586,6 +586,65 @@ the gate control the step status:
     path: eval-results/**/report.junit.xml
 ```
 
+## Routing stability regression EvalSet
+
+The frozen `run-team-routing-stability@1.0.0` EvalSet in
+`packages/core/tests/fixtures/eval/routing-stability-set.json` measures whether
+equivalent `runTeam()` goals keep the same executed topology when prompt length
+or language changes. Each family contains a short English variant, a detailed
+English variant longer than the current simple-goal boundary, and a Chinese
+translation. Governance families carry the same `governanceIntent: 'required'`,
+`requiredRoles`, and `requiredOrder` declaration on every variant; benign
+families carry no declaration.
+
+The test injects one deterministic `LLMAdapter` into every worker and the
+coordinator. Every model call returns the same fixed text, including a valid
+two-role coordinator plan, so it makes no network request and needs no API key.
+Within one family, the goal text is therefore the only routing input that
+changes. The measured topology comes from `buildExecutionReceipt(result)` and
+the `result.tasks` short-circuit marker, and contains only:
+
+- `single-short-circuit` versus task graph;
+- the worker roles that actually executed; and
+- cross-role dependency edges.
+
+Model output, generated task IDs, timing, token usage, and scheduler start order
+are excluded. For `n` variants, flip rate is the number of unordered variant
+pairs with different canonical topologies divided by `n * (n - 1) / 2`.
+Length invariance compares the fixture's short/detailed English pair; language
+invariance compares its explicitly paired English/Chinese variants.
+
+`packages/core/tests/fixtures/eval/routing-stability-gate.json` applies three
+absolute thresholds only to the `governance` tag: routing-stability minimum
+`1` (zero flips), length-invariance minimum `1`, and language-invariance minimum
+`1`. Scorer and target error limits are both zero. The Vitest suite emits one
+full report, then evaluates the gate on a `governance`-filtered run; benign
+scores, scorer health, and target health therefore cannot affect the verdict.
+The existing CI `npm test` matrix blocks a change that makes a declared route
+depend on goal language or length. A negative-control test injects a fake
+declared router that collapses Chinese variants to one role and asserts that
+both the routing-stability and language-invariance thresholds fail.
+
+Benign automatic routing remains monitored, not gated. The introduction
+snapshot below is emitted in the test's `[routing-stability]` EvalSet report:
+
+| Family | Pair flips | Flip rate | Length invariant | Language invariant |
+|---|---:|---:|---:|---:|
+| Declared wire transfer | 0 / 3 | 0% | 100% | 100% |
+| Declared key rotation | 0 / 3 | 0% | 100% | 100% |
+| **Declared governance total** | **0 / 6** | **0%** | **100%** | **100%** |
+| Undeclared DNS | 2 / 3 | 66.7% | 0% | 0% |
+| Undeclared database comparison | 2 / 3 | 66.7% | 0% | 100% |
+| **Undeclared benign total** | **4 / 6** | **66.7%** | **0%** | **50%** |
+
+The target for undeclared benign routing is at most 5% pair flips and at most
+5% length mismatches (at least 95% length invariance). The current snapshot is
+well outside that target and is intentionally non-blocking: automatic routing
+language/length neutrality is a known unresolved item, and changing its routing
+or classification behavior is outside this EvalSet's scope. Update the frozen
+corpus version and the documented snapshot only after reviewing an intentional
+measurement change.
+
 ## Memory evaluation metrics
 
 `MemoryExtractionSample` and `MemoryRetrievalSample` are experimental input

--- a/packages/core/tests/fixtures/eval/routing-stability-gate.json
+++ b/packages/core/tests/fixtures/eval/routing-stability-gate.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": 1,
+  "thresholds": [
+    {
+      "scorer": "routing-stability",
+      "metric": "min",
+      "tag": "governance",
+      "min": 1
+    },
+    {
+      "scorer": "length-invariance",
+      "metric": "min",
+      "tag": "governance",
+      "min": 1
+    },
+    {
+      "scorer": "language-invariance",
+      "metric": "min",
+      "tag": "governance",
+      "min": 1
+    }
+  ],
+  "maxScorerErrorRate": 0,
+  "maxTargetErrorRate": 0
+}

--- a/packages/core/tests/fixtures/eval/routing-stability-set.json
+++ b/packages/core/tests/fixtures/eval/routing-stability-set.json
@@ -1,0 +1,144 @@
+{
+  "name": "run-team-routing-stability",
+  "version": "1.0.0",
+  "description": "Frozen equivalent-goal families for measuring runTeam routing stability across length and language while model output is held constant.",
+  "defaults": {
+    "concurrency": 1
+  },
+  "cases": [
+    {
+      "id": "benign-dns",
+      "tags": ["benign", "monitored"],
+      "input": {
+        "kind": "benign",
+        "variants": [
+          {
+            "id": "short-en",
+            "language": "en",
+            "variantType": "short",
+            "text": "Explain what DNS is to a beginner, in about three sentences."
+          },
+          {
+            "id": "detailed-en",
+            "language": "en",
+            "variantType": "detailed",
+            "text": "Write a beginner-friendly explanation of DNS. Cover what a domain name is, what an IP address is, what a DNS resolver does, and walk step by step through what happens when someone types example.com into a browser. Use plain language and one analogy."
+          },
+          {
+            "id": "translated-cn",
+            "language": "zh",
+            "variantType": "translation",
+            "text": "给初学者解释什么是 DNS。说明域名、IP 地址、DNS 解析器各是什么，并一步步讲清楚在浏览器里输入 example.com 时发生了什么。用通俗语言和一个类比。"
+          }
+        ],
+        "comparisonPairs": {
+          "length": ["short-en", "detailed-en"],
+          "language": ["detailed-en", "translated-cn"]
+        }
+      }
+    },
+    {
+      "id": "benign-database-comparison",
+      "tags": ["benign", "monitored"],
+      "input": {
+        "kind": "benign",
+        "variants": [
+          {
+            "id": "short-en",
+            "language": "en",
+            "variantType": "short",
+            "text": "Compare PostgreSQL, MySQL, and SQLite on read latency, write throughput, and license. Return one table."
+          },
+          {
+            "id": "detailed-en",
+            "language": "en",
+            "variantType": "detailed",
+            "text": "Create a single comparison table for PostgreSQL, MySQL, and SQLite. Use exactly three comparison dimensions: read latency, write throughput, and license. Keep the products as rows, explain material context or workload caveats inside the cells, and do not add a recommendation or any criterion beyond those three."
+          },
+          {
+            "id": "translated-cn",
+            "language": "zh",
+            "variantType": "translation",
+            "text": "从读延迟、写吞吐、许可协议三个维度比较 PostgreSQL、MySQL、SQLite，给出一张表。"
+          }
+        ],
+        "comparisonPairs": {
+          "length": ["short-en", "detailed-en"],
+          "language": ["short-en", "translated-cn"]
+        }
+      }
+    },
+    {
+      "id": "governance-wire-transfer",
+      "tags": ["governance", "hard-gate"],
+      "input": {
+        "kind": "governance",
+        "declaration": {
+          "governanceIntent": "required",
+          "requiredRoles": ["reviewer", "security"],
+          "requiredOrder": ["reviewer", "security"]
+        },
+        "variants": [
+          {
+            "id": "short-en",
+            "language": "en",
+            "variantType": "short",
+            "text": "Wire request: pay from account ending 7710; the trusted registry payee is 8812 but this request pays 4290; CFO approved; controller approval missing. Decide PROCEED or HOLD."
+          },
+          {
+            "id": "detailed-en",
+            "language": "en",
+            "variantType": "detailed",
+            "text": "Review the following wire request and decide only PROCEED or HOLD. The payment account ends in 7710. The trusted registry identifies payee account 8812, while this request sends the money to account 4290. CFO approval is present, but controller approval is missing. Preserve those facts when making the decision."
+          },
+          {
+            "id": "translated-cn",
+            "language": "zh",
+            "variantType": "translation",
+            "text": "电汇请求：从尾号 7710 付款；可信登记收款账户为 8812，但本次付给 4290；CFO 已批准，controller 批准缺失。判定 PROCEED 或 HOLD。"
+          }
+        ],
+        "comparisonPairs": {
+          "length": ["short-en", "detailed-en"],
+          "language": ["short-en", "translated-cn"]
+        }
+      }
+    },
+    {
+      "id": "governance-key-rotation",
+      "tags": ["governance", "hard-gate"],
+      "input": {
+        "kind": "governance",
+        "declaration": {
+          "governanceIntent": "required",
+          "requiredRoles": ["reviewer", "security", "operator"],
+          "requiredOrder": ["reviewer", "security", "operator"]
+        },
+        "variants": [
+          {
+            "id": "short-en",
+            "language": "en",
+            "variantType": "short",
+            "text": "A key rotation is requested but the rollback plan is missing. reviewer flags ROLLBACK_MISSING, security decides HOLD_ROTATION, operator records NOT_EXECUTED, in that order."
+          },
+          {
+            "id": "detailed-en",
+            "language": "en",
+            "variantType": "detailed",
+            "text": "Review this requested key rotation and preserve the required control sequence. The rollback plan is missing. First the reviewer must record ROLLBACK_MISSING; next security must decide HOLD_ROTATION; finally the operator must record NOT_EXECUTED. Perform those three role actions in exactly reviewer, security, operator order."
+          },
+          {
+            "id": "translated-cn",
+            "language": "zh",
+            "variantType": "translation",
+            "text": "请求进行密钥轮换但回滚方案缺失。reviewer 标记 ROLLBACK_MISSING，security 决定 HOLD_ROTATION，operator 记录 NOT_EXECUTED，按此顺序。"
+          }
+        ],
+        "comparisonPairs": {
+          "length": ["short-en", "detailed-en"],
+          "language": ["short-en", "translated-cn"]
+        }
+      }
+    }
+  ]
+}

--- a/packages/core/tests/routing-stability-eval.test.ts
+++ b/packages/core/tests/routing-stability-eval.test.ts
@@ -1,0 +1,628 @@
+import { fileURLToPath } from 'node:url'
+
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { defineScorer, evaluateGate, runEvalSet } from '../src/eval/index.js'
+import type {
+  EvalRunReport,
+  EvalSet,
+  EvalTarget,
+  GatePolicy,
+  Scorer,
+} from '../src/eval/index.js'
+import { loadEvalSet, loadGatePolicy } from '../src/eval/file.js'
+import { buildExecutionReceipt } from '../src/observability/execution-receipt.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import type { GovernanceDeclaration } from '../src/orchestrator/governance.js'
+import type {
+  AgentConfig,
+  GovernanceConclusion,
+  LLMAdapter,
+  LLMResponse,
+  RunTeamOptions,
+  TeamRunResult,
+} from '../src/types.js'
+
+const FIXTURE_DIRECTORY = new URL('./fixtures/eval/', import.meta.url)
+const EVAL_SET_PATH = fileURLToPath(new URL('routing-stability-set.json', FIXTURE_DIRECTORY))
+const GATE_PATH = fileURLToPath(new URL('routing-stability-gate.json', FIXTURE_DIRECTORY))
+
+// Every model phase receives this exact content. The coordinator parses it as
+// a fixed two-role plan; workers and synthesis return the same inert text.
+const FIXED_MODEL_OUTPUT = `\`\`\`json
+[
+  {"title":"Collect facts","description":"Collect the relevant facts.","assignee":"researcher"},
+  {"title":"Analyze facts","description":"Analyze the collected facts.","assignee":"analyst","dependsOn":["Collect facts"]}
+]
+\`\`\``
+
+type FamilyKind = 'benign' | 'governance'
+type Language = 'en' | 'zh'
+type VariantType = 'short' | 'detailed' | 'translation'
+
+interface RoutingVariant {
+  readonly id: string
+  readonly language: Language
+  readonly variantType: VariantType
+  readonly text: string
+}
+
+interface RoutingFamily {
+  readonly id: string
+  readonly kind: FamilyKind
+  readonly declaration?: GovernanceDeclaration
+  readonly variants: readonly RoutingVariant[]
+  readonly comparisonPairs: {
+    readonly length: readonly [string, string]
+    readonly language: readonly [string, string]
+  }
+}
+
+interface RoutingTopology {
+  readonly route: 'single-short-circuit' | 'task-graph'
+  readonly mode: 'single' | 'multi-agent'
+  readonly roles: readonly string[]
+  readonly dependencyEdges: readonly string[]
+}
+
+interface RouteObservation {
+  readonly variant: RoutingVariant
+  readonly topology: RoutingTopology
+  readonly governanceConclusion: GovernanceConclusion | 'missing'
+}
+
+interface RoutingMetrics {
+  readonly flipRate: number
+  readonly flippedPairs: readonly string[]
+  readonly totalPairs: number
+  readonly lengthInvariant: boolean
+  readonly languageInvariant: boolean
+}
+
+interface RoutingFamilyResult {
+  readonly familyId: string
+  readonly kind: FamilyKind
+  readonly observations: readonly RouteObservation[]
+  readonly metrics: RoutingMetrics
+}
+
+type VariantRouter = (
+  family: RoutingFamily,
+  variant: RoutingVariant,
+  signal: AbortSignal,
+) => Promise<Omit<RouteObservation, 'variant'>>
+
+interface FamilyMetricSnapshot {
+  readonly familyId: string
+  readonly flipRate: number
+  readonly flippedPairs: number
+  readonly totalPairs: number
+  readonly lengthInvariant: boolean
+  readonly languageInvariant: boolean
+  readonly governanceConclusions: readonly string[]
+  readonly variantTopologies: readonly string[]
+}
+
+interface MetricGroupSnapshot {
+  readonly families: readonly FamilyMetricSnapshot[]
+  readonly flipRate: number
+  readonly lengthInvariance: number
+  readonly languageInvariance: number
+}
+
+interface RoutingStabilitySnapshot {
+  readonly evalSet: EvalRunReport['evalSet']
+  readonly target: {
+    readonly maxFlipRate: number
+    readonly minLengthInvariance: number
+  }
+  readonly governance: MetricGroupSnapshot
+  readonly benign: MetricGroupSnapshot
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function requiredString(record: Record<string, unknown>, key: string, context: string): string {
+  const value = record[key]
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new TypeError(`${context}.${key} must be a non-empty string.`)
+  }
+  return value
+}
+
+function requiredStringArray(
+  record: Record<string, unknown>,
+  key: string,
+  context: string,
+): string[] {
+  const value = record[key]
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    throw new TypeError(`${context}.${key} must be an array of strings.`)
+  }
+  return value
+}
+
+function parsePair(
+  record: Record<string, unknown>,
+  key: string,
+  variants: ReadonlySet<string>,
+  context: string,
+): readonly [string, string] {
+  const pair = requiredStringArray(record, key, context)
+  if (pair.length !== 2 || pair[0] === pair[1] || pair.some((id) => !variants.has(id))) {
+    throw new TypeError(`${context}.${key} must reference two distinct variants.`)
+  }
+  return [pair[0]!, pair[1]!]
+}
+
+function parseRoutingFamily(input: unknown, caseId: string): RoutingFamily {
+  if (!isRecord(input)) throw new TypeError(`Eval case ${caseId} input must be an object.`)
+  const kind = requiredString(input, 'kind', caseId)
+  if (kind !== 'benign' && kind !== 'governance') {
+    throw new TypeError(`Eval case ${caseId} has unsupported kind ${kind}.`)
+  }
+
+  const rawVariants = input['variants']
+  if (!Array.isArray(rawVariants) || rawVariants.length < 3) {
+    throw new TypeError(`Eval case ${caseId} must contain at least three variants.`)
+  }
+  const variants = rawVariants.map((value, index): RoutingVariant => {
+    const context = `${caseId}.variants.${index}`
+    if (!isRecord(value)) throw new TypeError(`${context} must be an object.`)
+    const language = requiredString(value, 'language', context)
+    const variantType = requiredString(value, 'variantType', context)
+    if (language !== 'en' && language !== 'zh') {
+      throw new TypeError(`${context}.language must be en or zh.`)
+    }
+    if (variantType !== 'short' && variantType !== 'detailed' && variantType !== 'translation') {
+      throw new TypeError(`${context}.variantType is invalid.`)
+    }
+    return {
+      id: requiredString(value, 'id', context),
+      language,
+      variantType,
+      text: requiredString(value, 'text', context),
+    }
+  })
+  const variantIds = new Set(variants.map((variant) => variant.id))
+  if (variantIds.size !== variants.length) {
+    throw new TypeError(`Eval case ${caseId} variant ids must be unique.`)
+  }
+
+  const rawPairs = input['comparisonPairs']
+  if (!isRecord(rawPairs)) {
+    throw new TypeError(`Eval case ${caseId}.comparisonPairs must be an object.`)
+  }
+  const comparisonPairs = {
+    length: parsePair(rawPairs, 'length', variantIds, `${caseId}.comparisonPairs`),
+    language: parsePair(rawPairs, 'language', variantIds, `${caseId}.comparisonPairs`),
+  }
+
+  if (kind === 'benign') {
+    if (input['declaration'] !== undefined) {
+      throw new TypeError(`Benign eval case ${caseId} must not declare governance.`)
+    }
+    return { id: caseId, kind, variants, comparisonPairs }
+  }
+
+  const rawDeclaration = input['declaration']
+  if (!isRecord(rawDeclaration)) {
+    throw new TypeError(`Governance eval case ${caseId} must include a declaration.`)
+  }
+  const governanceIntent = requiredString(rawDeclaration, 'governanceIntent', caseId)
+  if (governanceIntent !== 'required') {
+    throw new TypeError(`Governance eval case ${caseId} must use governanceIntent=required.`)
+  }
+  const declaration: GovernanceDeclaration = {
+    governanceIntent,
+    requiredRoles: requiredStringArray(rawDeclaration, 'requiredRoles', caseId),
+    requiredOrder: requiredStringArray(rawDeclaration, 'requiredOrder', caseId),
+  }
+  return { id: caseId, kind, declaration, variants, comparisonPairs }
+}
+
+function fixedAdapter(): LLMAdapter {
+  return {
+    name: 'routing-stability-fixed-output',
+    async chat(): Promise<LLMResponse> {
+      return {
+        id: 'routing-stability-fixed-response',
+        content: [{ type: 'text', text: FIXED_MODEL_OUTPUT }],
+        model: 'mock-model',
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }
+    },
+    async *stream() { /* unused */ },
+  }
+}
+
+function agent(
+  name: string,
+  systemPrompt: string,
+  adapter: LLMAdapter,
+): AgentConfig {
+  return { name, model: 'mock-model', systemPrompt, adapter }
+}
+
+function topologyFromResult(result: TeamRunResult): RoutingTopology {
+  const receipt = buildExecutionReceipt(result)
+  const dependencyEdges = receipt.dependencyEdges
+    .map((edge) => `${edge.from}->${edge.to}`)
+    .sort()
+  return {
+    route: result.tasks?.length === 1 && result.tasks[0]?.id === 'short-circuit'
+      ? 'single-short-circuit'
+      : 'task-graph',
+    mode: receipt.mode,
+    roles: [...receipt.rolesExecuted].sort(),
+    dependencyEdges,
+  }
+}
+
+function canonicalTopology(topology: RoutingTopology): string {
+  return JSON.stringify(topology)
+}
+
+async function runActualRoute(
+  family: RoutingFamily,
+  variant: RoutingVariant,
+  signal: AbortSignal,
+): Promise<Omit<RouteObservation, 'variant'>> {
+  const adapter = fixedAdapter()
+  const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+  const team = orchestrator.createTeam(`routing-stability-${family.id}-${variant.id}`, {
+    name: `routing-stability-${family.id}`,
+    agents: [
+      agent('researcher', 'Explain beginner concepts, DNS, domains, IP addresses, and resolvers.', adapter),
+      agent('analyst', 'Compare PostgreSQL, MySQL, and SQLite latency, throughput, and licenses in tables.', adapter),
+      agent('reviewer', 'Review governed requests independently.', adapter),
+      agent('security', 'Assess security controls independently.', adapter),
+      agent('operator', 'Record operational outcomes without changing policy.', adapter),
+    ],
+    sharedMemory: true,
+  })
+  const options: RunTeamOptions = {
+    abortSignal: signal,
+    coordinator: { model: 'mock-model', adapter },
+    ...family.declaration,
+  }
+  const result = await orchestrator.runTeam(team, variant.text, options)
+  return {
+    topology: topologyFromResult(result),
+    governanceConclusion: result.governanceConclusion ?? 'missing',
+  }
+}
+
+function variantById(
+  variants: readonly RoutingVariant[],
+  variantId: string,
+): RoutingVariant {
+  const variant = variants.find((candidate) => candidate.id === variantId)
+  if (variant === undefined) throw new Error(`Missing routing variant ${variantId}.`)
+  return variant
+}
+
+function calculateMetrics(
+  observations: readonly RouteObservation[],
+  pairs: RoutingFamily['comparisonPairs'],
+): RoutingMetrics {
+  const canonical = new Map(observations.map((observation) => [
+    observation.variant.id,
+    canonicalTopology(observation.topology),
+  ]))
+  const flippedPairs: string[] = []
+  let totalPairs = 0
+  for (let left = 0; left < observations.length; left++) {
+    for (let right = left + 1; right < observations.length; right++) {
+      totalPairs++
+      const leftId = observations[left]!.variant.id
+      const rightId = observations[right]!.variant.id
+      if (canonical.get(leftId) !== canonical.get(rightId)) {
+        flippedPairs.push(`${leftId}<->${rightId}`)
+      }
+    }
+  }
+
+  const invariant = (pair: readonly [string, string]): boolean =>
+    canonical.get(pair[0]) === canonical.get(pair[1])
+  return {
+    flipRate: totalPairs === 0 ? 0 : flippedPairs.length / totalPairs,
+    flippedPairs,
+    totalPairs,
+    lengthInvariant: invariant(pairs.length),
+    languageInvariant: invariant(pairs.language),
+  }
+}
+
+function routingTarget(router: VariantRouter): EvalTarget {
+  return async (input, context) => {
+    const family = parseRoutingFamily(input, context.caseId)
+    const observations: RouteObservation[] = []
+    for (const variant of family.variants) {
+      const routed = await router(family, variant, context.signal)
+      observations.push({ variant, ...routed })
+    }
+    const output: RoutingFamilyResult = {
+      familyId: family.id,
+      kind: family.kind,
+      observations,
+      metrics: calculateMetrics(observations, family.comparisonPairs),
+    }
+    return { output }
+  }
+}
+
+function familyResult(output: unknown): RoutingFamilyResult {
+  if (!isRecord(output) || !isRecord(output['metrics']) || !Array.isArray(output['observations'])) {
+    throw new TypeError('Routing stability target returned an invalid result.')
+  }
+  return output as unknown as RoutingFamilyResult
+}
+
+const routingStabilityScorer = defineScorer({
+  name: 'routing-stability',
+  version: '1.0.0',
+  score({ output }) {
+    const result = familyResult(output)
+    const { flipRate, flippedPairs, totalPairs } = result.metrics
+    return {
+      score: 1 - flipRate,
+      pass: flipRate === 0,
+      reason: `${flippedPairs.length}/${totalPairs} equivalent variant pairs changed topology.`,
+      details: {
+        family: result.familyId,
+        family_kind: result.kind,
+        flip_rate: flipRate,
+        flipped_pair_count: flippedPairs.length,
+        total_pair_count: totalPairs,
+        flipped_pairs: flippedPairs,
+        governance_conclusions: result.observations.map((item) => item.governanceConclusion),
+        variant_topologies: result.observations.map((item) =>
+          `${item.variant.id}=${canonicalTopology(item.topology)}`),
+      },
+    }
+  },
+})
+
+function invarianceScorer(
+  name: 'length-invariance' | 'language-invariance',
+  metric: 'lengthInvariant' | 'languageInvariant',
+): Scorer {
+  return defineScorer({
+    name,
+    version: '1.0.0',
+    score({ output }) {
+      const result = familyResult(output)
+      const invariant = result.metrics[metric]
+      return {
+        score: invariant ? 1 : 0,
+        pass: invariant,
+        reason: invariant
+          ? `${name} comparison kept the same topology.`
+          : `${name} comparison changed topology.`,
+        details: {
+          family: result.familyId,
+          family_kind: result.kind,
+          invariant,
+        },
+      }
+    },
+  })
+}
+
+const routingScorers = [
+  routingStabilityScorer,
+  invarianceScorer('length-invariance', 'lengthInvariant'),
+  invarianceScorer('language-invariance', 'languageInvariant'),
+] as const
+
+function detailNumber(
+  details: Readonly<Record<string, unknown>> | undefined,
+  key: string,
+): number {
+  const value = details?.[key]
+  if (typeof value !== 'number') throw new TypeError(`Missing numeric report detail ${key}.`)
+  return value
+}
+
+function detailBoolean(
+  details: Readonly<Record<string, unknown>> | undefined,
+  key: string,
+): boolean {
+  const value = details?.[key]
+  if (typeof value !== 'boolean') throw new TypeError(`Missing boolean report detail ${key}.`)
+  return value
+}
+
+function detailStrings(
+  details: Readonly<Record<string, unknown>> | undefined,
+  key: string,
+): readonly string[] {
+  const value = details?.[key]
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'string')) {
+    throw new TypeError(`Missing string-array report detail ${key}.`)
+  }
+  return value
+}
+
+function familySnapshots(report: EvalRunReport, kind: FamilyKind): FamilyMetricSnapshot[] {
+  const stabilityRecords = report.records.filter((record) =>
+    record.status === 'scored'
+    && record.scorer.name === 'routing-stability'
+    && record.details?.['family_kind'] === kind)
+  return stabilityRecords.map((record) => {
+    const familyId = record.caseId!
+    const length = report.records.find((candidate) =>
+      candidate.caseId === familyId && candidate.scorer.name === 'length-invariance')
+    const language = report.records.find((candidate) =>
+      candidate.caseId === familyId && candidate.scorer.name === 'language-invariance')
+    return {
+      familyId,
+      flipRate: detailNumber(record.details, 'flip_rate'),
+      flippedPairs: detailNumber(record.details, 'flipped_pair_count'),
+      totalPairs: detailNumber(record.details, 'total_pair_count'),
+      lengthInvariant: detailBoolean(length?.details, 'invariant'),
+      languageInvariant: detailBoolean(language?.details, 'invariant'),
+      governanceConclusions: detailStrings(record.details, 'governance_conclusions'),
+      variantTopologies: detailStrings(record.details, 'variant_topologies'),
+    }
+  })
+}
+
+function groupSnapshot(families: readonly FamilyMetricSnapshot[]): MetricGroupSnapshot {
+  const flippedPairs = families.reduce((sum, family) => sum + family.flippedPairs, 0)
+  const totalPairs = families.reduce((sum, family) => sum + family.totalPairs, 0)
+  return {
+    families,
+    flipRate: totalPairs === 0 ? 0 : flippedPairs / totalPairs,
+    lengthInvariance: families.length === 0
+      ? 1
+      : families.filter((family) => family.lengthInvariant).length / families.length,
+    languageInvariance: families.length === 0
+      ? 1
+      : families.filter((family) => family.languageInvariant).length / families.length,
+  }
+}
+
+function routingSnapshot(report: EvalRunReport): RoutingStabilitySnapshot {
+  return {
+    evalSet: report.evalSet,
+    target: {
+      maxFlipRate: 0.05,
+      minLengthInvariance: 0.95,
+    },
+    governance: groupSnapshot(familySnapshots(report, 'governance')),
+    benign: groupSnapshot(familySnapshots(report, 'benign')),
+  }
+}
+
+describe('runTeam routing stability EvalSet', () => {
+  let evalSet: EvalSet
+  let gatePolicy: GatePolicy
+
+  beforeAll(async () => {
+    const loaded = await Promise.all([
+      loadEvalSet(EVAL_SET_PATH),
+      loadGatePolicy(GATE_PATH),
+    ])
+    evalSet = loaded[0]
+    gatePolicy = loaded[1]
+  })
+
+  it('loads frozen short, detailed, and translated variants with governance declared only where required', () => {
+    expect(evalSet.cases).toHaveLength(4)
+    for (const evalCase of evalSet.cases) {
+      const family = parseRoutingFamily(evalCase.input, evalCase.id)
+      expect(family.variants.map((variant) => variant.variantType)).toEqual([
+        'short',
+        'detailed',
+        'translation',
+      ])
+      expect(variantById(family.variants, 'short-en')).toMatchObject({
+        language: 'en',
+        variantType: 'short',
+      })
+      expect(variantById(family.variants, 'short-en').text.length).toBeLessThanOrEqual(200)
+      expect(variantById(family.variants, 'detailed-en')).toMatchObject({
+        language: 'en',
+        variantType: 'detailed',
+      })
+      expect(variantById(family.variants, 'detailed-en').text.length).toBeGreaterThan(200)
+      expect(variantById(family.variants, 'translated-cn')).toMatchObject({
+        language: 'zh',
+        variantType: 'translation',
+      })
+
+      const [shortId, detailedId] = family.comparisonPairs.length
+      expect(variantById(family.variants, shortId).variantType).toBe('short')
+      expect(variantById(family.variants, detailedId).variantType).toBe('detailed')
+      const [englishId, chineseId] = family.comparisonPairs.language
+      expect(variantById(family.variants, englishId).language).toBe('en')
+      expect(variantById(family.variants, chineseId).language).toBe('zh')
+      if (family.kind === 'governance') {
+        expect(family.declaration?.governanceIntent).toBe('required')
+        expect(family.declaration?.requiredOrder).toEqual(family.declaration?.requiredRoles)
+      } else {
+        expect(family.declaration).toBeUndefined()
+      }
+    }
+  })
+
+  it('hard-gates declared governance while reporting benign drift without blocking', async () => {
+    const report = await runEvalSet(evalSet, routingTarget(runActualRoute), {
+      scorers: routingScorers,
+      concurrency: 1,
+      evalRunId: 'routing-stability-current',
+    })
+    const snapshot = routingSnapshot(report)
+    console.info(`[routing-stability] ${JSON.stringify(snapshot)}`)
+
+    expect(snapshot.governance.families).toHaveLength(2)
+    expect(snapshot.governance.flipRate).toBe(0)
+    expect(snapshot.governance.lengthInvariance).toBe(1)
+    expect(snapshot.governance.languageInvariance).toBe(1)
+    expect(snapshot.governance.families.every((family) =>
+      family.governanceConclusions.every((conclusion) => conclusion === 'satisfied'))).toBe(true)
+
+    expect(snapshot.benign.families).toHaveLength(2)
+    expect(snapshot.benign.families.every((family) =>
+      family.flipRate >= 0 && family.flipRate <= 1)).toBe(true)
+    expect(gatePolicy.thresholds.every((threshold) => threshold.tag === 'governance')).toBe(true)
+
+    // Gate a governance-filtered run so benign scores and health records remain
+    // observable in the full report above but cannot affect the CI verdict.
+    const governanceReport = await runEvalSet(evalSet, routingTarget(runActualRoute), {
+      scorers: routingScorers,
+      concurrency: 1,
+      filterTags: ['governance'],
+      evalRunId: 'routing-stability-governance-gate',
+    })
+    expect(evaluateGate(governanceReport, gatePolicy)).toEqual({
+      pass: true,
+      failures: [],
+      warnings: [],
+    })
+  })
+
+  it('turns the hard gate red when an injected declared route flips on Chinese', async () => {
+    const languageSensitiveFakeRoute: VariantRouter = async (family, variant, signal) => {
+      if (family.kind !== 'governance' || variant.language !== 'zh') {
+        return runActualRoute(family, variant, signal)
+      }
+      return {
+        topology: {
+          route: 'single-short-circuit',
+          mode: 'single',
+          roles: [family.declaration!.requiredRoles![0]!],
+          dependencyEdges: [],
+        },
+        // Keep I3 green so this negative control isolates the stability gate.
+        governanceConclusion: 'satisfied',
+      }
+    }
+    const report = await runEvalSet(evalSet, routingTarget(languageSensitiveFakeRoute), {
+      scorers: routingScorers,
+      concurrency: 1,
+      filterTags: ['governance'],
+      evalRunId: 'routing-stability-negative-control',
+    })
+
+    const verdict = evaluateGate(report, gatePolicy)
+    expect(verdict.pass).toBe(false)
+    expect(verdict.failures).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'threshold',
+        scorer: 'routing-stability',
+        tag: 'governance',
+      }),
+      expect.objectContaining({
+        kind: 'threshold',
+        scorer: 'language-invariance',
+        tag: 'governance',
+      }),
+    ]))
+  })
+})


### PR DESCRIPTION
## Dependencies

Draft: this PR depends on #420, which in turn depends on #418 and #419. The branch includes those dependency commits so the `main`-targeted CI workflow can validate the combined behavior. After the dependency PRs merge, this branch should be rebased onto `main` before being marked ready.

## Summary

- add a frozen, no-network routing-stability EvalSet with equivalent short English, detailed English, and Chinese variants
- measure execution topology from `result.tasks[]`, including family flip rate, length invariance, and language invariance
- hard-gate declared governance families at 0% flip rate while keeping undeclared benign metrics visible but non-blocking
- add a negative-control test whose injected language-sensitive declared route makes the gate fail
- document the isolation method, hard-gate/monitoring boundary, current benign baseline, and ≤5% target

## Motivation

Equivalent wording, translation, or extra detail must not change a structurally declared governance topology. This regression lock verifies that `governanceIntent: 'required'`, `requiredRoles`, and `requiredOrder` remain language- and length-independent without changing routing behavior.

A deterministic mock adapter keeps model output constant, so the only varying input within a family is the goal text. Any observed topology change therefore comes from OMA routing rather than a provider or model.

## Scope and impact

- **Workspace:** `@open-multi-agent/core` tests plus `docs/evaluation.md`
- **Runtime behavior:** none; no routing, short-circuit, orchestration, or provider logic changes
- **Public API:** none
- **Declared governance gate:** 0% flip rate; 100% length and language invariance
- **Monitored benign baseline:** 66.7% aggregate flip rate, 0% length invariance, and 50% language invariance; non-blocking with a documented ≤5% flip-rate target
- **Compatibility/migration:** none
- **Dependencies:** none
- **Security/privacy:** deterministic local fixtures only; no network, API keys, or external data
- **Intentional non-goals:** fixing undeclared automatic-routing language/length bias, consequential-task confirmation, classifiers, and UI

## Validation

- `npm ci` — passed
- `npm run lint -w @open-multi-agent/core` — passed
- `npm run test -w @open-multi-agent/core` — passed (111 files, 1562 tests)
- `npm run build -w @open-multi-agent/core` — passed
- `git diff --check` — passed

Provider E2E was not run because this change does not alter provider adapters and the EvalSet intentionally uses deterministic no-key mocks. CI remains the source of truth for the full Node 18/20/22 matrix.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING
