### PR TITLE
feat(tool): flag-and-confirm undeclared consequential runs

### DIFF
--- a/docs/tool-configuration.md
+++ b/docs/tool-configuration.md
@@ -38,6 +38,78 @@ The gate reads only the structured execution topology produced by
 or that an independent review occurred, even if it contains reviewer names,
 approval labels, or audit markers.
 
+## Consequential tools on undeclared runs
+
+Tool authors can declare that granting a tool permits real side effects:
+
+```typescript
+const rotateSecret = defineTool({
+  name: 'rotate_secret',
+  description: 'Rotate an application secret.',
+  inputSchema: z.object({ service: z.string() }),
+  consequential: true,
+  execute: async ({ service }) => rotateServiceSecret(service),
+})
+```
+
+`consequential` is optional and defaults to `false`. The built-in `bash`,
+`file_write`, and `file_edit` tools are marked consequential; read-only
+filesystem tools are not. Custom and MCP tools remain benign unless their
+registered `ToolDefinition` explicitly opts in.
+
+For `runAgent()` and an automatic `runTeam()` call that omits
+`governanceIntent`, OMA checks the final grant set after preset, allowlist,
+denylist, custom-tool, and default-preset resolution. If at least one granted
+tool is consequential, the result carries the additive machine-readable flag:
+
+```typescript
+if (result.flags?.includes('consequential-no-independence')) {
+  // The run had consequential capability without a governance declaration.
+}
+
+const receipt = buildExecutionReceipt(result)
+// The same flag is copied to receipt.flags.
+```
+
+This classification uses **tool grants only**. OMA never scans the goal,
+prompt, model output, tool arguments, or words such as `password`, `refund`,
+`security`, or `production` to infer consequences. A goal containing those
+words but exposing only benign tools is not flagged. Conversely, a granted
+consequential tool is flagged even when the goal sounds harmless.
+
+Declared `required`, `preferred`, and `none` `runTeam()` calls do not enter this
+fallback. Neither do explicit `runTasks()` DAGs or `runFromPlan()` replays;
+those calls already have application-supplied structure. The fallback never
+changes the execution topology or upgrades a run to independent governance.
+
+### Opt-in confirmation
+
+Confirmation is off by default. Set `requireConsequentialConfirmation: true`
+to guard consequential calls on the undeclared runs above:
+
+```typescript
+const orchestrator = new OpenMultiAgent({
+  requireConsequentialConfirmation: true,
+  onToolCall: async (context) => {
+    if (context.consequential !== true) return { action: 'allow' }
+    return (await app.confirm(context))
+      ? { action: 'allow' }
+      : { action: 'deny', reason: 'User rejected the action.' }
+  },
+})
+```
+
+The guard composes with the existing per-call `onToolCall` gateway, after input
+validation and before `execute`. An `allow` continues; a `deny` does not call
+the tool and returns a rejected run outcome. For a dynamically planned
+`runTeam()`, an approved `onPlanReady` callback can supply the approval when no
+per-call gate is configured. If neither approval path exists, the tool is not
+executed and the result returns `confirmationRequired: true` with
+`status.code === 'rejected'`. The application can then re-run with an
+`onToolCall` decision, or reject the action. The
+`consequential-no-independence` flag remains present whether confirmation is
+disabled, approved, pending, or rejected.
+
 ## Built-in tools are opt-in (default-deny)
 
 Built-in tools — `bash` and the filesystem tools (`file_read`, `file_write`, `file_edit`, `grep`, `glob`) — are **default-deny**. An agent receives a built-in tool only when it is granted explicitly via `tools` (an allowlist of names) or `toolPreset`. An agent that sets **neither** resolves to **zero** built-in tools:
@@ -127,7 +199,7 @@ import type { ToolCallContext, ToolCallDecision } from '@open-multi-agent/core'
 const orchestrator = new OpenMultiAgent({
   // Orchestrator-level default, inherited by any agent that sets no gate of its own.
   onToolCall: async (ctx: ToolCallContext): Promise<ToolCallDecision> => {
-    // ctx: { toolName, input (post-validation), agentName, runId?, taskId? }
+    // ctx: { toolName, input (post-validation), agentName, consequential?, runId?, taskId? }
     if (ctx.toolName !== 'bash') return { action: 'allow' }
     if (/^\s*rm\b/.test(String(ctx.input.command))) {
       return { action: 'deny', reason: 'rm is blocked' }

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -47,22 +47,17 @@ import { classifyRunFailure } from '../observability/status.js'
 import type { ToolRegistry } from '../tool/framework.js'
 import type { ToolExecutor } from '../tool/executor.js'
 import { defaultWorkspaceDir } from '../tool/built-in/path-safety.js'
+import {
+  AGENT_FRAMEWORK_DISALLOWED,
+  resolveGrantedToolDefinitions,
+  TOOL_PRESETS,
+} from '../tool/grants.js'
 
 // ---------------------------------------------------------------------------
 // Tool presets
 // ---------------------------------------------------------------------------
 
-/** Predefined tool sets for common agent use cases. */
-export const TOOL_PRESETS = {
-  readonly: ['file_read', 'grep', 'glob'],
-  readwrite: ['file_read', 'file_write', 'file_edit', 'grep', 'glob'],
-  full: ['file_read', 'file_write', 'file_edit', 'grep', 'glob', 'bash'],
-} as const satisfies Record<string, readonly string[]>
-
-/** Framework-level disallowed tools for safety rails. */
-export const AGENT_FRAMEWORK_DISALLOWED: readonly string[] = [
-  // Empty for now, infrastructure for future built-in tools
-]
+export { AGENT_FRAMEWORK_DISALLOWED, TOOL_PRESETS }
 
 // ---------------------------------------------------------------------------
 // Public interfaces
@@ -766,72 +761,15 @@ export class AgentRunner implements AgentBackend {
    * Returns LLMToolDef[] for direct use with LLM adapters.
    */
   private resolveTools(): LLMToolDef[] {
-    // Validate configuration for contradictions
-    if (this.options.toolPreset && this.options.allowedTools) {
-      console.warn(
-        'AgentRunner: both toolPreset and allowedTools are set. ' +
-        'Final tool access will be the intersection of both.'
-      )
-    }
-
-    if (this.options.allowedTools && this.options.disallowedTools) {
-      const overlap = this.options.allowedTools.filter(tool =>
-        this.options.disallowedTools!.includes(tool)
-      )
-      if (overlap.length > 0) {
-        console.warn(
-          `AgentRunner: tools [${overlap.map(name => `"${name}"`).join(', ')}] appear in both allowedTools and disallowedTools. ` +
-          'This is contradictory and may lead to unexpected behavior.'
-        )
-      }
-    }
-
-    const allTools = this.toolRegistry.toToolDefs()
-    const runtimeCustomTools = this.toolRegistry.toRuntimeToolDefs()
-    const runtimeCustomToolNames = new Set(runtimeCustomTools.map(t => t.name))
-    let filteredTools = allTools.filter(t => !runtimeCustomToolNames.has(t.name))
-
-    // Default-deny: built-in (non-runtime) tools require a positive grant via
-    // `toolPreset` or `allowedTools`. With neither set, an agent resolves to
-    // zero built-in tools — `bash` and the filesystem tools are opt-in, the
-    // same default-deny model #87 enforces for cross-agent context. Runtime /
-    // custom tools (registered via `addTool` / `customTools`) are exempt:
-    // registering them is the grant. All tools still respect the denylist and
-    // framework rails below.
-    const hasPositiveGrant =
-      this.options.toolPreset !== undefined || this.options.allowedTools !== undefined
-    if (!hasPositiveGrant) {
-      filteredTools = []
-    }
-
-    // 1. Apply preset filter if set
-    if (this.options.toolPreset) {
-      const presetTools = new Set(TOOL_PRESETS[this.options.toolPreset] as readonly string[])
-      filteredTools = filteredTools.filter(t => presetTools.has(t.name))
-    }
-
-    // 2. Apply allowlist filter if set
-    if (this.options.allowedTools) {
-      filteredTools = filteredTools.filter(t => this.options.allowedTools!.includes(t.name))
-    }
-
-    // 3. Apply denylist filter if set
-    const denied = this.options.disallowedTools
-      ? new Set(this.options.disallowedTools)
-      : undefined
-    if (denied) {
-      filteredTools = filteredTools.filter(t => !denied.has(t.name))
-    }
-
-    // 4. Apply framework-level safety rails
-    const frameworkDenied = new Set(AGENT_FRAMEWORK_DISALLOWED)
-    filteredTools = filteredTools.filter(t => !frameworkDenied.has(t.name))
-
-    // Runtime-added custom tools bypass preset / allowlist but respect denylist.
-    const finalRuntime = denied
-      ? runtimeCustomTools.filter(t => !denied.has(t.name))
-      : runtimeCustomTools
-    return [...filteredTools, ...finalRuntime]
+    const grantedTools = resolveGrantedToolDefinitions(this.toolRegistry, {
+      toolPreset: this.options.toolPreset,
+      allowedTools: this.options.allowedTools,
+      disallowedTools: this.options.disallowedTools,
+    })
+    const definitionsByName = new Map(
+      this.toolRegistry.toToolDefs().map((tool) => [tool.name, tool]),
+    )
+    return grantedTools.map((tool) => definitionsByName.get(tool.name)!)
   }
 
   // -------------------------------------------------------------------------

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@
 export { OpenMultiAgent, executeWithRetry, computeRetryDelay } from './orchestrator/orchestrator.js'
 export { evaluateGovernance } from './orchestrator/governance.js'
 export type { GovernanceDeclaration } from './orchestrator/governance.js'
+export { CONSEQUENTIAL_NO_INDEPENDENCE_FLAG } from './orchestrator/consequential.js'
 export { Scheduler } from './orchestrator/scheduler.js'
 export type { SchedulingStrategy } from './orchestrator/scheduler.js'
 
@@ -267,6 +268,7 @@ export type {
   RunIdentityOptions,
   RunStatus,
   RunStatusCode,
+  RunFlag,
   RunOutcomeFields,
   StructuredTraceError,
   TraceErrorKind,

--- a/packages/core/src/observability/execution-receipt.ts
+++ b/packages/core/src/observability/execution-receipt.ts
@@ -1,5 +1,6 @@
 import type {
   AgentRunResult,
+  RunFlag,
   TeamRunResult,
   TraceEvent,
 } from '../types.js'
@@ -15,6 +16,8 @@ export interface ExecutionReceiptDependencyEdge {
  * Agent output text is deliberately excluded as a source of evidence.
  */
 export interface ExecutionReceipt {
+  /** Machine-readable warnings copied from the run result, when present. */
+  readonly flags?: readonly RunFlag[]
   readonly mode: 'single' | 'multi-agent'
   readonly rolesExecuted: readonly string[]
   readonly executionOrder: readonly string[]
@@ -69,6 +72,13 @@ function readTokenUsage(value: unknown): ExecutionReceipt['totalTokens'] {
   const input = value['input_tokens']
   const output = value['output_tokens']
   return isFiniteNumber(input) && isFiniteNumber(output) ? { input, output } : null
+}
+
+function readFlags(value: unknown): readonly RunFlag[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const flags = value.filter((flag): flag is RunFlag =>
+    flag === 'consequential-no-independence')
+  return flags.length > 0 ? [...new Set(flags)] : undefined
 }
 
 function readTraceFacts(trace: readonly TraceEvent[] | undefined): TraceFacts {
@@ -159,6 +169,7 @@ function buildAgentReceipt(result: AgentRunResult, trace: TraceFacts): Execution
     ? Math.max(0, Math.max(...ends) - Math.min(...starts))
     : null
   const totalTokens = readTokenUsage(rawResult['tokenUsage'])
+  const flags = readFlags(rawResult['flags'])
   const partial = trace.partial
     || workerAgentEvents.length === 0
     || rolesExecuted.length === 0
@@ -167,6 +178,7 @@ function buildAgentReceipt(result: AgentRunResult, trace: TraceFacts): Execution
     || totalTokens === null
 
   return {
+    ...(flags ? { flags } : {}),
     mode: rolesExecuted.length > 1 ? 'multi-agent' : 'single',
     rolesExecuted,
     executionOrder,
@@ -261,6 +273,7 @@ function buildTeamReceipt(result: TeamRunResult, trace: TraceFacts): ExecutionRe
   }
 
   const totalTokens = readTokenUsage(rawResult['totalTokenUsage'])
+  const flags = readFlags(rawResult['flags'])
   const rawMetrics = rawResult['metrics']
   const durationMs = isRecord(rawMetrics) && isFiniteNumber(rawMetrics['totalDurationMs'])
     ? rawMetrics['totalDurationMs']
@@ -270,6 +283,7 @@ function buildTeamReceipt(result: TeamRunResult, trace: TraceFacts): ExecutionRe
   }
 
   return {
+    ...(flags ? { flags } : {}),
     mode: rolesExecuted.length > 1 ? 'multi-agent' : 'single',
     rolesExecuted,
     executionOrder,

--- a/packages/core/src/orchestrator/agent-config.ts
+++ b/packages/core/src/orchestrator/agent-config.ts
@@ -17,6 +17,7 @@ import { Agent } from '../agent/agent.js'
 import { ToolRegistry } from '../tool/framework.js'
 import { ToolExecutor } from '../tool/executor.js'
 import { registerBuiltInTools } from '../tool/built-in/index.js'
+import { resolveGrantedToolDefinitions } from '../tool/grants.js'
 
 export interface AgentDefaultsSource {
   readonly defaultModel?: OrchestratorConfig['defaultModel']
@@ -61,6 +62,26 @@ export function buildAgent(
       : {}),
   })
   return new Agent(config, registry, executor)
+}
+
+/** Resolve the same final grants that {@link AgentRunner} will expose. */
+export function resolveAgentToolDefinitions(
+  config: AgentConfig,
+  toolRegistration?: { readonly includeDelegateTool?: boolean },
+) {
+  if (config.backend !== undefined) return []
+  const registry = new ToolRegistry()
+  registerBuiltInTools(registry, toolRegistration)
+  if (config.customTools) {
+    for (const tool of config.customTools) {
+      registry.register(tool, { runtimeAdded: true })
+    }
+  }
+  return resolveGrantedToolDefinitions(registry, {
+    toolPreset: config.toolPreset,
+    allowedTools: config.tools,
+    disallowedTools: config.disallowedTools,
+  }, { warnOnConflict: false })
 }
 
 /**

--- a/packages/core/src/orchestrator/consequential.ts
+++ b/packages/core/src/orchestrator/consequential.ts
@@ -1,0 +1,112 @@
+import type {
+  AgentConfig,
+  RunFlag,
+  RunOutcomeFields,
+  ToolCallDecision,
+} from '../types.js'
+import { statusOnly } from '../observability/status.js'
+import { resolveAgentToolDefinitions } from './agent-config.js'
+
+export const CONSEQUENTIAL_NO_INDEPENDENCE_FLAG =
+  'consequential-no-independence' as const satisfies RunFlag
+
+const CONFIRMATION_REQUIRED_MESSAGE =
+  'Consequential tool confirmation required before execution.'
+const CONFIRMATION_REJECTED_MESSAGE =
+  'Consequential tool confirmation rejected.'
+
+/** Mutable state shared by every guarded agent participating in one run. */
+export interface ConsequentialConfirmationState {
+  planApproved: boolean
+  confirmationRequired: boolean
+  confirmationRejected: boolean
+}
+
+export function createConsequentialConfirmationState(): ConsequentialConfirmationState {
+  return {
+    planApproved: false,
+    confirmationRequired: false,
+    confirmationRejected: false,
+  }
+}
+
+/** True only when the agent's final grant set contains marked tool metadata. */
+export function hasGrantedConsequentialTool(
+  config: AgentConfig,
+  toolRegistration?: { readonly includeDelegateTool?: boolean },
+): boolean {
+  return resolveAgentToolDefinitions(config, toolRegistration)
+    .some((tool) => tool.consequential === true)
+}
+
+/**
+ * Compose the opt-in confirmation guard with the existing per-call gate.
+ * Tool metadata is the only classification input; prompt and argument text are
+ * deliberately unavailable to this decision.
+ */
+export function withConsequentialConfirmation(
+  config: AgentConfig,
+  state: ConsequentialConfirmationState,
+): AgentConfig {
+  const existingGate = config.onToolCall
+  return {
+    ...config,
+    onToolCall: async (context): Promise<ToolCallDecision> => {
+      if (context.consequential !== true) {
+        return existingGate ? existingGate(context) : { action: 'allow' }
+      }
+
+      if (existingGate) {
+        try {
+          const decision = await existingGate(context)
+          if (decision.action === 'deny') state.confirmationRejected = true
+          return decision
+        } catch (error) {
+          state.confirmationRejected = true
+          throw error
+        }
+      }
+
+      if (state.planApproved) return { action: 'allow' }
+
+      state.confirmationRequired = true
+      return { action: 'deny', reason: CONFIRMATION_REQUIRED_MESSAGE }
+    },
+  }
+}
+
+type FlaggedRunResult = RunOutcomeFields & { readonly success: boolean }
+
+/** Attach the fallback flag and normalise an unresolved/rejected confirmation. */
+export function finalizeConsequentialRun<T extends FlaggedRunResult>(
+  result: T,
+  flagged: boolean,
+  state: ConsequentialConfirmationState,
+): T {
+  if (!flagged) return result
+
+  const flags = [...new Set([
+    ...(result.flags ?? []),
+    CONSEQUENTIAL_NO_INDEPENDENCE_FLAG,
+  ])]
+  const flaggedResult = { ...result, flags }
+
+  if (state.confirmationRequired) {
+    return {
+      ...flaggedResult,
+      success: false,
+      confirmationRequired: true,
+      status: statusOnly('rejected', CONFIRMATION_REQUIRED_MESSAGE),
+    } as T
+  }
+
+  if (state.confirmationRejected) {
+    return {
+      ...flaggedResult,
+      success: false,
+      status: statusOnly('rejected', CONFIRMATION_REJECTED_MESSAGE),
+    } as T
+  }
+
+  return flaggedResult as T
+}

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -135,6 +135,13 @@ import {
   evaluateGovernance,
   type GovernanceDeclaration,
 } from './governance.js'
+import {
+  createConsequentialConfirmationState,
+  finalizeConsequentialRun,
+  hasGrantedConsequentialTool,
+  withConsequentialConfirmation,
+  type ConsequentialConfirmationState,
+} from './consequential.js'
 import { runConsensusCore, applyConsensusDefaults, type ConsensusAgentDefaults } from './consensus.js'
 import {
   createOnlineEvaluator,
@@ -242,6 +249,7 @@ export class OpenMultiAgent {
       observability: config.observability,
       onTrace: config.onTrace ?? (hasExplicitLegacyBridge ? LEGACY_TRACE_METADATA_ONLY : undefined),
       onToolCall: config.onToolCall,
+      requireConsequentialConfirmation: config.requireConsequentialConfirmation ?? false,
     }
   }
 
@@ -329,7 +337,12 @@ export class OpenMultiAgent {
       ...applyAgentDefaults(config, this.config),
       maxTokenBudget: effectiveBudget,
     }, this.config.defaultToolPreset)
-    const agent = buildAgent(effective)
+    const consequential = hasGrantedConsequentialTool(effective)
+    const confirmationState = createConsequentialConfirmationState()
+    const guardedEffective = consequential && this.config.requireConsequentialConfirmation
+      ? withConsequentialConfirmation(effective, confirmationState)
+      : effective
+    const agent = buildAgent(guardedEffective)
     this.config.onProgress?.({
       type: 'agent_start',
       agent: config.name,
@@ -406,19 +419,18 @@ export class OpenMultiAgent {
       }
     }
 
+    const completedResult = finalizeConsequentialRun<AgentRunResult>({
+      ...finalResult,
+      ...(metadata !== undefined ? { metadata } : {}),
+    }, consequential, confirmationState)
     this.config.onProgress?.({
       type: 'agent_complete',
       agent: config.name,
-      data: finalResult,
+      data: completedResult,
     })
 
-    if (finalResult.success) {
+    if (completedResult.success) {
       this.completedTaskCount++
-    }
-
-    const completedResult: AgentRunResult = {
-      ...finalResult,
-      ...(metadata !== undefined ? { metadata } : {}),
     }
     traceRuntime?.close({
       status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
@@ -482,13 +494,23 @@ export class OpenMultiAgent {
       )
     }
 
+    const undeclared = options?.governanceIntent === undefined
+    const confirmationState = createConsequentialConfirmationState()
+    let consequentialUndeclared = undeclared && agentConfigs.some((agentConfig) => {
+      const effective = applyDefaultToolPreset(
+        applyAgentDefaults(agentConfig, this.config),
+        this.config.defaultToolPreset,
+      )
+      return hasGrantedConsequentialTool(effective, { includeDelegateTool: true })
+    })
+
     const { identity, metadata } = createRunFacts(identityOptionsForRun(options))
     const traceRuntime = this.startTrace(identity, metadata)
     const finish = (result: TeamRunResult): TeamRunResult => {
-      const completedResult: TeamRunResult = {
+      const completedResult = finalizeConsequentialRun<TeamRunResult>({
         ...result,
         ...(metadata !== undefined ? { metadata } : {}),
-      }
+      }, consequentialUndeclared, confirmationState)
       traceRuntime?.close({
         status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
         ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
@@ -524,7 +546,13 @@ export class OpenMultiAgent {
         ...applyAgentDefaults(bestAgent, this.config),
         maxTokenBudget: effectiveBudget,
       }, this.config.defaultToolPreset), routeMatches(options?.modelRouting, { phase: 'short-circuit', agent: bestAgent.name }))
-      const agent = buildAgent(effective)
+      const selectedConsequential = undeclared
+        && hasGrantedConsequentialTool(effective)
+      const guardedEffective = selectedConsequential
+        && this.config.requireConsequentialConfirmation
+        ? withConsequentialConfirmation(effective, confirmationState)
+        : effective
+      const agent = buildAgent(guardedEffective)
 
       this.config.onProgress?.({
         type: 'agent_start',
@@ -599,6 +627,12 @@ export class OpenMultiAgent {
         }
       }
 
+      finalResult = finalizeConsequentialRun(
+        finalResult,
+        selectedConsequential,
+        confirmationState,
+      )
+
       this.config.onProgress?.({
         type: 'agent_complete',
         agent: bestAgent.name,
@@ -630,12 +664,19 @@ export class OpenMultiAgent {
     // ------------------------------------------------------------------
     // Step 1: Coordinator decomposes goal into tasks
     // ------------------------------------------------------------------
-    const coordinatorBaseConfig = buildCoordinatorBaseConfig(
+    const unguardedCoordinatorBaseConfig = buildCoordinatorBaseConfig(
       this.config,
       coordinatorOverrides,
       agentConfigs,
       (options?.verifyJudges?.length ?? 0) > 0,
     )
+    const coordinatorConsequential = undeclared
+      && hasGrantedConsequentialTool(unguardedCoordinatorBaseConfig)
+    if (coordinatorConsequential) consequentialUndeclared = true
+    const coordinatorBaseConfig = coordinatorConsequential
+      && this.config.requireConsequentialConfirmation
+      ? withConsequentialConfirmation(unguardedCoordinatorBaseConfig, confirmationState)
+      : unguardedCoordinatorBaseConfig
     const coordinatorConfig = withModelRoute(
       coordinatorBaseConfig,
       routeMatches(options?.modelRouting, { phase: 'coordinator', agent: 'coordinator' }),
@@ -734,7 +775,12 @@ export class OpenMultiAgent {
     // ------------------------------------------------------------------
     // Step 4: Build pool and execute
     // ------------------------------------------------------------------
-    const pool = this.buildPool(agentConfigs)
+    const pool = this.buildPool(
+      agentConfigs,
+      undeclared && this.config.requireConsequentialConfirmation
+        ? confirmationState
+        : undefined,
+    )
     const activeCheckpoint = this.createActiveCheckpoint(
       team,
       options?.checkpoint ?? this.config.checkpoint,
@@ -792,6 +838,14 @@ export class OpenMultiAgent {
         approved = false
         planApprovalError = error
       }
+    }
+    if (
+      approved
+      && this.config.onPlanReady
+      && consequentialUndeclared
+      && this.config.requireConsequentialConfirmation
+    ) {
+      confirmationState.planApproved = true
     }
     const planReadyEndMs = Date.now()
     const planLegacyEvent = this.config.onTrace ? {
@@ -1697,14 +1751,21 @@ export class OpenMultiAgent {
     return artifact['version'] === 1 && Array.isArray(artifact['tasks'])
   }
 
-  private buildPool(agentConfigs: AgentConfig[]): AgentPool {
+  private buildPool(
+    agentConfigs: AgentConfig[],
+    confirmationState?: ConsequentialConfirmationState,
+  ): AgentPool {
     const pool = new AgentPool(this.config.maxConcurrency)
     for (const config of agentConfigs) {
       const effective: AgentConfig = applyDefaultToolPreset(
         applyAgentDefaults(config, this.config),
         this.config.defaultToolPreset,
       )
-      pool.add(buildAgent(effective, { includeDelegateTool: true }))
+      const guardedEffective = confirmationState
+        && hasGrantedConsequentialTool(effective, { includeDelegateTool: true })
+        ? withConsequentialConfirmation(effective, confirmationState)
+        : effective
+      pool.add(buildAgent(guardedEffective, { includeDelegateTool: true }))
     }
     return pool
   }

--- a/packages/core/src/tool/built-in/bash.ts
+++ b/packages/core/src/tool/built-in/bash.ts
@@ -36,6 +36,7 @@ const SAFE_ENV_ALLOWLIST = new Set([
 
 export const bashTool = defineTool({
   name: 'bash',
+  consequential: true,
   description:
     'Execute a bash command and return its stdout and stderr. ' +
     'Use this for file system operations, running scripts, installing packages, ' +

--- a/packages/core/src/tool/built-in/file-edit.ts
+++ b/packages/core/src/tool/built-in/file-edit.ts
@@ -17,6 +17,7 @@ import { resolvePathWithinCwd } from './path-safety.js'
 
 export const fileEditTool = defineTool({
   name: 'file_edit',
+  consequential: true,
   description:
     'Edit a file by replacing a specific string with new content. ' +
     'The `old_string` must appear verbatim in the file. ' +

--- a/packages/core/src/tool/built-in/file-write.ts
+++ b/packages/core/src/tool/built-in/file-write.ts
@@ -17,6 +17,7 @@ import { resolvePathWithinCwd } from './path-safety.js'
 
 export const fileWriteTool = defineTool({
   name: 'file_write',
+  consequential: true,
   description:
     'Write content to a file, creating it (and any missing parent directories) if it ' +
     'does not already exist, or overwriting it if it does. ' +

--- a/packages/core/src/tool/executor.ts
+++ b/packages/core/src/tool/executor.ts
@@ -189,6 +189,7 @@ export class ToolExecutor {
           toolName: tool.name,
           input: inputParseResult.data as Record<string, unknown>,
           agentName: context.agent.name,
+          ...(tool.consequential === true ? { consequential: true } : {}),
           ...(context.runId !== undefined ? { runId: context.runId } : {}),
           ...(context.taskId !== undefined ? { taskId: context.taskId } : {}),
         })

--- a/packages/core/src/tool/framework.ts
+++ b/packages/core/src/tool/framework.ts
@@ -73,6 +73,10 @@ export function defineTool<TInput>(config: {
   description: string
   inputSchema: ZodSchema<TInput>
   /**
+   * Marks a tool whose grant permits real side effects. Defaults to false.
+   */
+  consequential?: boolean
+  /**
    * Optional runtime validator for `ToolResult.data`.
    * When omitted, output validation is skipped.
    *
@@ -97,6 +101,9 @@ export function defineTool<TInput>(config: {
     name: config.name,
     description: config.description,
     inputSchema: config.inputSchema,
+    ...(config.consequential !== undefined
+      ? { consequential: config.consequential }
+      : {}),
     ...(config.outputSchema !== undefined
       ? { outputSchema: config.outputSchema }
       : {}),

--- a/packages/core/src/tool/grants.ts
+++ b/packages/core/src/tool/grants.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared tool-grant resolution used by both the runner and orchestration
+ * preflight checks. Keeping one resolver prevents governance classification
+ * from drifting away from the tools the model can actually call.
+ */
+
+import type { ToolDefinition } from '../types.js'
+import type { ToolRegistry } from './framework.js'
+
+/** Predefined tool sets for common agent use cases. */
+export const TOOL_PRESETS = {
+  readonly: ['file_read', 'grep', 'glob'],
+  readwrite: ['file_read', 'file_write', 'file_edit', 'grep', 'glob'],
+  full: ['file_read', 'file_write', 'file_edit', 'grep', 'glob', 'bash'],
+} as const satisfies Record<string, readonly string[]>
+
+/** Framework-level disallowed tools for safety rails. */
+export const AGENT_FRAMEWORK_DISALLOWED: readonly string[] = [
+  // Empty for now, infrastructure for future built-in tools.
+]
+
+export interface ToolGrantOptions {
+  readonly toolPreset?: keyof typeof TOOL_PRESETS
+  readonly allowedTools?: readonly string[]
+  readonly disallowedTools?: readonly string[]
+}
+
+export interface ResolveToolGrantOptions {
+  /** Preserve the runner's existing contradictory-config warnings. */
+  readonly warnOnConflict?: boolean
+}
+
+/** Resolve the exact registered tool definitions granted to one agent. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function resolveGrantedToolDefinitions(
+  registry: ToolRegistry,
+  options: ToolGrantOptions,
+  resolveOptions: ResolveToolGrantOptions = {},
+): ToolDefinition<any>[] {
+  const warnOnConflict = resolveOptions.warnOnConflict ?? true
+  if (warnOnConflict && options.toolPreset && options.allowedTools) {
+    console.warn(
+      'AgentRunner: both toolPreset and allowedTools are set. ' +
+      'Final tool access will be the intersection of both.',
+    )
+  }
+
+  if (warnOnConflict && options.allowedTools && options.disallowedTools) {
+    const overlap = options.allowedTools.filter((tool) =>
+      options.disallowedTools!.includes(tool))
+    if (overlap.length > 0) {
+      console.warn(
+        `AgentRunner: tools [${overlap.map((name) => `"${name}"`).join(', ')}] appear in both allowedTools and disallowedTools. ` +
+        'This is contradictory and may lead to unexpected behavior.',
+      )
+    }
+  }
+
+  const allTools = registry.list()
+  const runtimeNames = new Set(registry.toRuntimeToolDefs().map((tool) => tool.name))
+  const runtimeTools = allTools.filter((tool) => runtimeNames.has(tool.name))
+  let filteredTools = allTools.filter((tool) => !runtimeNames.has(tool.name))
+
+  const hasPositiveGrant =
+    options.toolPreset !== undefined || options.allowedTools !== undefined
+  if (!hasPositiveGrant) filteredTools = []
+
+  if (options.toolPreset) {
+    const presetTools = new Set(TOOL_PRESETS[options.toolPreset] as readonly string[])
+    filteredTools = filteredTools.filter((tool) => presetTools.has(tool.name))
+  }
+
+  if (options.allowedTools) {
+    filteredTools = filteredTools.filter((tool) => options.allowedTools!.includes(tool.name))
+  }
+
+  const denied = options.disallowedTools
+    ? new Set(options.disallowedTools)
+    : undefined
+  if (denied) filteredTools = filteredTools.filter((tool) => !denied.has(tool.name))
+
+  const frameworkDenied = new Set(AGENT_FRAMEWORK_DISALLOWED)
+  filteredTools = filteredTools.filter((tool) => !frameworkDenied.has(tool.name))
+
+  const finalRuntime = denied
+    ? runtimeTools.filter((tool) => !denied.has(tool.name))
+    : runtimeTools
+  return [...filteredTools, ...finalRuntime]
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -265,7 +265,18 @@ export interface RunOutcomeFields {
   readonly errorInfo?: StructuredTraceError
   /** Echo of validated metadata; present at runtime whenever the caller provided it. */
   readonly metadata?: Readonly<Record<string, TraceAttributeValue>>
+  /** Additive, machine-readable execution warnings attached by the runtime. */
+  readonly flags?: readonly RunFlag[]
+  /**
+   * True when an opt-in consequential-tool guard stopped a tool call because
+   * no application approval gate was available. Re-run with an `onToolCall`
+   * gate that returns `allow` to approve the call, or `deny` to reject it.
+   */
+  readonly confirmationRequired?: boolean
 }
+
+/** Machine-readable warnings that describe how a run was governed. */
+export type RunFlag = 'consequential-no-independence'
 
 /** Context passed to user-supplied cost estimators. */
 export interface CostEstimateContext {
@@ -395,6 +406,8 @@ export interface ToolCallContext {
   readonly toolName: string
   readonly input: Record<string, unknown>
   readonly agentName: string
+  /** True when the registered tool definition declares real side effects. */
+  readonly consequential?: boolean
   readonly runId?: string
   readonly taskId?: string
 }
@@ -485,6 +498,12 @@ export interface ToolDefinition<TInput = Record<string, unknown>> {
   readonly name: string
   readonly description: string
   readonly inputSchema: ZodSchema<TInput>
+  /**
+   * Marks a tool whose grant permits real side effects. Omitted/false means
+   * benign for undeclared-run fallback classification. The runtime never
+   * infers this value from prompts, tool arguments, or keywords.
+   */
+  readonly consequential?: boolean
   /**
    * Optional runtime validator for `ToolResult.data` (always a string).
    *
@@ -1465,6 +1484,16 @@ export interface OrchestratorConfig {
    * or security boundary.
    */
   readonly onToolCall?: ToolCallGate
+  /**
+   * Opt in to confirmation for consequential tool calls in `runAgent()` and
+   * automatic `runTeam()` runs that omit `governanceIntent`.
+   *
+   * When enabled, an existing `onToolCall` gate decides each consequential
+   * invocation. A dynamically planned `runTeam()` may also inherit approval
+   * from `onPlanReady`. Without either approval path, the tool is not executed
+   * and the result carries `confirmationRequired: true`. Defaults to false.
+   */
+  readonly requireConsequentialConfirmation?: boolean
   /**
    * Optional approval gate called between task execution rounds.
    *

--- a/packages/core/tests/consequential-confirmation.test.ts
+++ b/packages/core/tests/consequential-confirmation.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import {
+  buildExecutionReceipt,
+  defineTool,
+  OpenMultiAgent,
+} from '../src/index.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMResponse,
+  OrchestratorConfig,
+} from '../src/index.js'
+
+function toolUse(name: string): LLMResponse {
+  return {
+    id: `tool-${name}`,
+    content: [{ type: 'tool_use', id: `call-${name}`, name, input: {} }],
+    model: 'mock-model',
+    stop_reason: 'tool_use',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function text(output = 'done'): LLMResponse {
+  return {
+    id: `text-${output}`,
+    content: [{ type: 'text', text: output }],
+    model: 'mock-model',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function scriptedAdapter(...responses: LLMResponse[]): LLMAdapter {
+  let index = 0
+  return {
+    name: 'consequential-confirmation-test',
+    async chat(): Promise<LLMResponse> {
+      return responses[Math.min(index++, responses.length - 1)]!
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: {} }
+    },
+  }
+}
+
+function mockTool(name: string, consequential: boolean) {
+  const execute = vi.fn(async () => ({ data: `${name}-executed`, isError: false }))
+  const tool = defineTool({
+    name,
+    description: `${name} test tool`,
+    inputSchema: z.object({}),
+    consequential,
+    execute,
+  })
+  return { tool, execute }
+}
+
+function agent(tool?: ReturnType<typeof mockTool>['tool']): AgentConfig {
+  return {
+    name: 'operator',
+    model: 'mock-model',
+    adapter: tool
+      ? scriptedAdapter(toolUse(tool.name), text())
+      : scriptedAdapter(text('unchanged benign output')),
+    ...(tool ? { customTools: [tool] } : {}),
+  }
+}
+
+async function runAutomaticTeam(
+  config: OrchestratorConfig,
+  agentConfig: AgentConfig,
+  goal = 'Rotate the password security secret.',
+) {
+  const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model', ...config })
+  const team = orchestrator.createTeam('consequential-test-team', {
+    name: 'consequential-test-team',
+    agents: [agentConfig],
+  })
+  return orchestrator.runTeam(team, goal)
+}
+
+describe('undeclared consequential run fallback', () => {
+  it('flags Probe-A and keeps confirmation off by default', async () => {
+    const { tool, execute } = mockTool('rotate_secret', true)
+
+    const result = await runAutomaticTeam({}, agent(tool))
+
+    expect(result.success).toBe(true)
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(result.flags).toEqual(['consequential-no-independence'])
+    expect(result.confirmationRequired).toBeUndefined()
+    expect(buildExecutionReceipt(result).flags)
+      .toEqual(['consequential-no-independence'])
+  })
+
+  it('returns confirmationRequired and does not execute Probe-A when confirmation is enabled', async () => {
+    const { tool, execute } = mockTool('rotate_secret', true)
+
+    const result = await runAutomaticTeam(
+      { requireConsequentialConfirmation: true },
+      agent(tool),
+    )
+
+    expect(execute).not.toHaveBeenCalled()
+    expect(result.success).toBe(false)
+    expect(result.status?.code).toBe('rejected')
+    expect(result.confirmationRequired).toBe(true)
+    expect(result.flags).toEqual(['consequential-no-independence'])
+  })
+
+  it('uses the existing onToolCall gate to approve a consequential action', async () => {
+    const { tool, execute } = mockTool('rotate_secret', true)
+    const onToolCall = vi.fn(async () => ({ action: 'allow' as const }))
+
+    const result = await runAutomaticTeam(
+      { requireConsequentialConfirmation: true, onToolCall },
+      agent(tool),
+    )
+
+    expect(onToolCall).toHaveBeenCalledWith(expect.objectContaining({
+      toolName: 'rotate_secret',
+      consequential: true,
+    }))
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(result.success).toBe(true)
+    expect(result.confirmationRequired).toBeUndefined()
+    expect(result.flags).toEqual(['consequential-no-independence'])
+  })
+
+  it('does not flag Probe-B when risky words appear but the granted tool is benign', async () => {
+    const { tool, execute } = mockTool('inspect_password_security', false)
+
+    const result = await runAutomaticTeam(
+      { requireConsequentialConfirmation: true },
+      agent(tool),
+      'Inspect password rotation security in production.',
+    )
+
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(result.success).toBe(true)
+    expect(result.flags).toBeUndefined()
+    expect(result.confirmationRequired).toBeUndefined()
+    expect(buildExecutionReceipt(result).flags).toBeUndefined()
+  })
+
+  it('checks the final grant set and ignores a disallowed consequential tool', async () => {
+    const { tool, execute } = mockTool('rotate_secret', true)
+    const config = agent(tool)
+
+    const result = await runAutomaticTeam(
+      { requireConsequentialConfirmation: true },
+      { ...config, disallowedTools: ['rotate_secret'] },
+    )
+
+    expect(execute).not.toHaveBeenCalled()
+    expect(result.success).toBe(true)
+    expect(result.flags).toBeUndefined()
+    expect(result.confirmationRequired).toBeUndefined()
+  })
+
+  it('leaves a pure benign run unchanged', async () => {
+    const result = await new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      requireConsequentialConfirmation: true,
+    }).runAgent(agent(), 'Summarize this paragraph.')
+
+    expect(result.success).toBe(true)
+    expect(result.output).toBe('unchanged benign output')
+    expect(result.flags).toBeUndefined()
+    expect(result.confirmationRequired).toBeUndefined()
+  })
+
+  it('leaves required governance to I3 even when a consequential tool executes', async () => {
+    const { tool, execute } = mockTool('rotate_secret', true)
+    const orchestrator = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      requireConsequentialConfirmation: true,
+    })
+    const team = orchestrator.createTeam('required-governance-team', {
+      name: 'required-governance-team',
+      agents: [agent(tool)],
+    })
+
+    const result = await orchestrator.runTeam(team, 'Rotate the secret.', {
+      governanceIntent: 'required',
+      requiredRoles: ['operator'],
+    })
+
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(result.success).toBe(true)
+    expect(result.governanceConclusion).toBe('satisfied')
+    expect(result.flags).toBeUndefined()
+    expect(result.confirmationRequired).toBeUndefined()
+  })
+
+  it('treats governanceIntent none as an explicit declaration, not an omission', async () => {
+    const { tool, execute } = mockTool('rotate_secret', true)
+    const orchestrator = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      requireConsequentialConfirmation: true,
+    })
+    const team = orchestrator.createTeam('declared-none-team', {
+      name: 'declared-none-team',
+      agents: [agent(tool)],
+    })
+
+    const result = await orchestrator.runTeam(team, 'Rotate the secret.', {
+      governanceIntent: 'none',
+    })
+
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(result.success).toBe(true)
+    expect(result.flags).toBeUndefined()
+    expect(result.confirmationRequired).toBeUndefined()
+  })
+
+  it('reuses an approved runTeam plan gate when no per-call gate is configured', async () => {
+    const { tool, execute } = mockTool('rotate_secret', true)
+    const onPlanReady = vi.fn(async () => true)
+    const orchestrator = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      requireConsequentialConfirmation: true,
+      onPlanReady,
+    })
+    const team = orchestrator.createTeam('plan-approved-team', {
+      name: 'plan-approved-team',
+      agents: [agent(tool)],
+    })
+    const plan = '```json\n[{"title":"Rotate","description":"Rotate it","assignee":"operator"}]\n```'
+
+    const result = await orchestrator.runTeam(
+      team,
+      'First prepare the rotation plan, then perform the rotation.',
+      { coordinator: { adapter: scriptedAdapter(text(plan), text('synthesized')) } },
+    )
+
+    expect(onPlanReady).toHaveBeenCalledTimes(1)
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(result.success).toBe(true)
+    expect(result.flags).toEqual(['consequential-no-independence'])
+    expect(result.confirmationRequired).toBeUndefined()
+  })
+
+  it('does not apply the fallback to an explicit runTasks DAG', async () => {
+    const { tool, execute } = mockTool('rotate_secret', true)
+    const orchestrator = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      requireConsequentialConfirmation: true,
+    })
+    const team = orchestrator.createTeam('explicit-dag-team', {
+      name: 'explicit-dag-team',
+      agents: [agent(tool)],
+    })
+
+    const result = await orchestrator.runTasks(team, [{
+      title: 'Rotate',
+      description: 'Rotate the secret.',
+      assignee: 'operator',
+    }])
+
+    expect(execute).toHaveBeenCalledTimes(1)
+    expect(result.success).toBe(true)
+    expect(result.flags).toBeUndefined()
+    expect(result.confirmationRequired).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Dependencies

#418, #420, and #421 are now merged. This branch has been rebased onto main and contains only the consequential-tool change.

## Summary

- add optional ToolDefinition.consequential metadata and mark the side-effecting bash, file_write, and file_edit built-ins
- attach consequential-no-independence to undeclared runAgent and automatic runTeam results and execution receipts, based only on final tool grants
- add opt-in requireConsequentialConfirmation, composing with onToolCall and approved plans without changing topology
- preserve declared governance and explicit structured run behavior
- document the contract and add deterministic provider-mock regressions

## Semantics

- no prompt, task-text, output-text, or tool-argument keyword scanning
- no autonomous governance-topology upgrade
- confirmation is off by default
- when confirmation is enabled without approval, consequential execution is blocked and the result reports confirmationRequired with rejected status

## Validation

- focused consequential confirmation tests: passed, 1 file and 10 tests
- npm run lint -w @open-multi-agent/core: passed
- npm run test -w @open-multi-agent/core: passed, 112 files and 1572 tests
- npm run build -w @open-multi-agent/core: passed
- git diff --check against the rebased main: passed
- DeepSeek provider E2E previously passed on the original stacked head, 1 file and 3 tests; it was not rerun after the behavior-preserving rebase because provider adapters are unchanged

CI remains the source of truth for the complete Node 18, 20, and 22 matrix.