### PR TITLE
feat(orchestrator): resolve mode and governance budget conflicts

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -56,6 +56,47 @@ No bundled shortcut is needed when a server speaks OpenAI Chat Completions. Use 
 
 Other services can be connected the same way if they implement the OpenAI Chat Completions API, but they are not listed as verified providers here. For services where the key is not `OPENAI_API_KEY`, pass it explicitly via `apiKey`; otherwise the `openai` adapter falls back to `OPENAI_API_KEY`.
 
+## Budget ceilings and governed runs
+
+Token accounting is provider-independent. Cost accounting remains
+application-owned because provider prices, cached-token rules, regions, and
+contract rates vary. Configure `estimateCost` once, then place a ceiling on the
+orchestrator or on an individual team run:
+
+```typescript
+const orchestrator = new OpenMultiAgent({
+  maxCostBudget: 1,
+  estimateCost: (usage, context) => priceTable[context.model](usage),
+})
+
+const result = await orchestrator.runTeam(team, goal, {
+  governanceIntent: 'required',
+  requiredRoles: ['reviewer', 'security'],
+  maxCostBudget: 0.25,
+})
+```
+
+When both scopes set a ceiling, the lower value wins. The same applies to
+`maxTokenBudget`. A required run that exhausts the effective ceiling before its
+required execution facts are complete reports
+`governanceConclusion: 'unsatisfied'` and `governanceReason: 'budget'`; it is
+not presented as a clean governance success. An application `mode`
+wins over the required topology, but an unmet floor is disclosed as
+`unsatisfied` / `overridden` with the `governance-overridden` flag. Automatic
+routing has the lowest priority.
+
+For `governanceIntent: 'preferred'`, set
+`preferredUnderBudget: 'degrade'` to choose Single whenever an effective
+ceiling applies. The result carries `review-skipped-due-to-budget`, while the
+soft preference remains `not-applicable` to the required-governance verdict.
+The default is `attempt`, preserving existing behavior.
+
+These controls do **not** run a preflight price or latency estimator.
+`estimateCost` converts usage after each provider response, and Token/cost
+checks still happen at existing turn/task boundaries, so a run can overshoot by
+one model turn. `preferredUnderBudget: 'degrade'` is an application-declared
+policy choice, not a prediction that a particular plan would exceed budget.
+
 ## Vercel AI SDK (optional)
 
 The AI SDK bridge routes an agent through [any AI SDK provider](https://ai-sdk.dev/providers) instead of the built-in `provider` factory. Install the optional peers with `npm i ai @ai-sdk/<provider>`; the peer range accepts AI SDK 5, 6, and 7, and AI SDK 7 requires Node.js >= 22.

--- a/docs/tool-configuration.md
+++ b/docs/tool-configuration.md
@@ -38,6 +38,85 @@ The gate reads only the structured execution topology produced by
 or that an independent review occurred, even if it contains reviewer names,
 approval labels, or audit markers.
 
+### Explicit modes and budget conflicts
+
+`runTeam()` resolves execution policy in this order:
+
+1. An application `mode` (`single` or `team`).
+2. A declared `governanceIntent: 'required'` topology.
+3. The existing automatic route, including the simple-goal Single short circuit.
+
+`single` always uses the existing best-agent path. `team` forces the
+coordinator-generated team path and bypasses the simple-goal short circuit.
+`runAgent()` and `runTasks()` remain explicit choices in their own right.
+Selecting `mode` declares a topology preference, not governance intent, so it
+does not bypass consequential confirmation when `governanceIntent` is omitted.
+
+An application may select a mode that overrides a required floor, but that
+decision is never reported as a clean governance success:
+
+```typescript
+const result = await orchestrator.runTeam(team, goal, {
+  mode: 'single',
+  governanceIntent: 'required',
+  requiredRoles: ['reviewer', 'security'],
+  requiredOrder: ['reviewer', 'security'],
+})
+
+// The Single result is still returned, and runtime success keeps its existing meaning.
+result.governanceConclusion // 'unsatisfied'
+result.governanceReason     // 'overridden'
+result.flags                // includes 'governance-overridden'
+```
+
+This is the "floor may be explicitly overridden, but never silently" rule.
+The structured declaration is still validated before execution, even when an
+explicit mode displaces its topology.
+
+Token and cost ceilings can be set on the orchestrator or on one `runTeam()` /
+`runTasks()` call. A per-run value cannot widen the orchestrator ceiling; the
+lower value wins. This lets an application declare the governance floor and
+budget ceiling together without introducing another budget subsystem:
+
+```typescript
+const result = await orchestrator.runTeam(team, goal, {
+  governanceIntent: 'required',
+  requiredRoles: ['reviewer', 'security'],
+  requiredOrder: ['reviewer', 'security'],
+  maxTokenBudget: 12_000,
+  maxCostBudget: 0.25, // requires orchestrator estimateCost
+})
+```
+
+If a required run exhausts that ceiling before every required role/order fact
+is observed, the existing budget stop remains in force and the result reports
+`governanceConclusion: 'unsatisfied'` with `governanceReason: 'budget'`.
+`result.success` is not repurposed as a governance field; budget exhaustion
+continues to use the existing `budget_exhausted` runtime status.
+
+For a soft preference, the application can predeclare that a ceiling should
+win without turning the missed review into a governance violation:
+
+```typescript
+const result = await orchestrator.runTeam(team, goal, {
+  governanceIntent: 'preferred',
+  requiredRoles: ['reviewer', 'security'],
+  preferredUnderBudget: 'degrade',
+  maxTokenBudget: 4_000,
+})
+
+// Executes the Single path and discloses why independent review was skipped.
+result.governanceConclusion // 'not-applicable'
+result.flags                // includes 'review-skipped-due-to-budget'
+```
+
+`preferredUnderBudget` defaults to `attempt`, which preserves the pre-existing
+preferred-role behavior. `degrade` applies only when an effective token or cost
+ceiling exists and no explicit `mode` already won. It is an application policy,
+not a model-cost prediction: OMA intentionally does not estimate whether a plan
+will fit before it runs. Normal ceiling enforcement remains reactive at model
+turn and task boundaries.
+
 ## Consequential tools on undeclared runs
 
 Tool authors can declare that granting a tool permits real side effects:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,7 +55,11 @@
 // ---------------------------------------------------------------------------
 
 export { OpenMultiAgent, executeWithRetry, computeRetryDelay } from './orchestrator/orchestrator.js'
-export { evaluateGovernance } from './orchestrator/governance.js'
+export {
+  evaluateGovernance,
+  GOVERNANCE_OVERRIDDEN_FLAG,
+  REVIEW_SKIPPED_DUE_TO_BUDGET_FLAG,
+} from './orchestrator/governance.js'
 export type { GovernanceDeclaration } from './orchestrator/governance.js'
 export { CONSEQUENTIAL_NO_INDEPENDENCE_FLAG } from './orchestrator/consequential.js'
 export { Scheduler } from './orchestrator/scheduler.js'
@@ -287,6 +291,7 @@ export type {
   TeamConfig,
   TeamRunResult,
   GovernanceConclusion,
+  GovernanceUnsatisfiedReason,
   RunMetrics,
   RunTeamOptions,
   RunTasksOptions,

--- a/packages/core/src/observability/execution-receipt.ts
+++ b/packages/core/src/observability/execution-receipt.ts
@@ -77,7 +77,9 @@ function readTokenUsage(value: unknown): ExecutionReceipt['totalTokens'] {
 function readFlags(value: unknown): readonly RunFlag[] | undefined {
   if (!Array.isArray(value)) return undefined
   const flags = value.filter((flag): flag is RunFlag =>
-    flag === 'consequential-no-independence')
+    flag === 'consequential-no-independence'
+    || flag === 'governance-overridden'
+    || flag === 'review-skipped-due-to-budget')
   return flags.length > 0 ? [...new Set(flags)] : undefined
 }
 

--- a/packages/core/src/orchestrator/budget.ts
+++ b/packages/core/src/orchestrator/budget.ts
@@ -76,7 +76,8 @@ export function computeRunMetrics(
   }
 }
 
-export function resolveTokenBudget(primary?: number, fallback?: number): number | undefined {
+/** Resolve nested ceilings without allowing a per-run/agent override to widen its parent. */
+export function resolveBudgetCeiling(primary?: number, fallback?: number): number | undefined {
   if (primary === undefined) return fallback
   if (fallback === undefined) return primary
   return Math.min(primary, fallback)

--- a/packages/core/src/orchestrator/governance.ts
+++ b/packages/core/src/orchestrator/governance.ts
@@ -1,16 +1,31 @@
 import type {
   AgentConfig,
   GovernanceConclusion,
+  GovernanceUnsatisfiedReason,
+  RunFlag,
   RunTaskSpec,
   RunTeamOptions,
+  TeamRunResult,
 } from '../types.js'
 import type { ExecutionReceipt } from '../observability/execution-receipt.js'
+
+export const GOVERNANCE_OVERRIDDEN_FLAG =
+  'governance-overridden' as const satisfies RunFlag
+export const REVIEW_SKIPPED_DUE_TO_BUDGET_FLAG =
+  'review-skipped-due-to-budget' as const satisfies RunFlag
 
 /** The structured governance fields accepted by {@link RunTeamOptions}. */
 export type GovernanceDeclaration = Pick<
   RunTeamOptions,
   'governanceIntent' | 'requiredRoles' | 'requiredOrder'
 >
+
+export interface GovernanceRunResolution {
+  /** True when an explicit `mode` displaced the declared governance topology. */
+  readonly modeOverride?: boolean
+  /** True when the application selected the preferred-under-budget Single path. */
+  readonly preferredBudgetDegraded?: boolean
+}
 
 /**
  * Compare required governance with an execution receipt.
@@ -44,6 +59,45 @@ export function evaluateGovernance(
   }
 
   return 'satisfied'
+}
+
+/**
+ * Attach the I3 conclusion plus additive I5-style conflict disclosures.
+ * Runtime success remains untouched; callers must continue to read the
+ * governance fields independently.
+ */
+export function finalizeGovernanceRun(
+  result: TeamRunResult,
+  declaration: GovernanceDeclaration | undefined,
+  receipt: ExecutionReceipt,
+  resolution: GovernanceRunResolution = {},
+): TeamRunResult {
+  const governanceConclusion = evaluateGovernance(declaration, receipt)
+  let governanceReason: GovernanceUnsatisfiedReason | undefined
+  const flags = new Set(result.flags ?? [])
+
+  if (
+    declaration?.governanceIntent === 'required'
+    && governanceConclusion === 'unsatisfied'
+  ) {
+    if (resolution.modeOverride) {
+      governanceReason = 'overridden'
+      flags.add(GOVERNANCE_OVERRIDDEN_FLAG)
+    } else if (result.status?.code === 'budget_exhausted') {
+      governanceReason = 'budget'
+    }
+  }
+
+  if (resolution.preferredBudgetDegraded) {
+    flags.add(REVIEW_SKIPPED_DUE_TO_BUDGET_FLAG)
+  }
+
+  return {
+    ...result,
+    governanceConclusion,
+    ...(governanceReason !== undefined ? { governanceReason } : {}),
+    ...(flags.size > 0 ? { flags: [...flags] } : {}),
+  }
 }
 
 /**

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -115,7 +115,7 @@ import {
 } from './run-context.js'
 import {
   computeRunMetrics,
-  resolveTokenBudget,
+  resolveBudgetCeiling,
   buildCostEstimateContext,
   applyBudgetAccounting,
   emitBudgetExceeded,
@@ -132,7 +132,7 @@ import { isSimpleGoal, selectBestAgent } from './short-circuit.js'
 import { executeQueue, saveRunCheckpoint } from './task-execution.js'
 import {
   buildGovernanceTaskSpecs,
-  evaluateGovernance,
+  finalizeGovernanceRun,
   type GovernanceDeclaration,
 } from './governance.js'
 import {
@@ -174,6 +174,29 @@ export { computeRetryDelay, executeWithRetry } from './retry.js'
 interface PendingOnlineEvaluation {
   readonly input: unknown
   readonly startedAtMs: number
+}
+
+interface EffectiveRunBudgets {
+  readonly maxTokenBudget?: number
+  readonly maxCostBudget?: number
+}
+
+function resolveRunBudgets(
+  config: Pick<OrchestratorConfig, 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost'>,
+  options?: Pick<RunTasksOptions, 'maxTokenBudget' | 'maxCostBudget'>,
+): EffectiveRunBudgets {
+  const maxTokenBudget = resolveBudgetCeiling(
+    options?.maxTokenBudget,
+    config.maxTokenBudget,
+  )
+  const maxCostBudget = resolveBudgetCeiling(
+    options?.maxCostBudget,
+    config.maxCostBudget,
+  )
+  if (maxCostBudget !== undefined && config.estimateCost === undefined) {
+    throw new Error('maxCostBudget requires estimateCost so cost caps cannot be silently ignored.')
+  }
+  return { maxTokenBudget, maxCostBudget }
 }
 
 /**
@@ -332,7 +355,7 @@ export class OpenMultiAgent {
     const pendingEvaluation = this.beginOnlineEvaluation(prompt)
     const { identity, metadata } = createRunFacts(options)
     const traceRuntime = this.startTrace(identity, metadata)
-    const effectiveBudget = resolveTokenBudget(config.maxTokenBudget, this.config.maxTokenBudget)
+    const effectiveBudget = resolveBudgetCeiling(config.maxTokenBudget, this.config.maxTokenBudget)
     const effective: AgentConfig = applyDefaultToolPreset({
       ...applyAgentDefaults(config, this.config),
       maxTokenBudget: effectiveBudget,
@@ -472,8 +495,27 @@ export class OpenMultiAgent {
   ): Promise<TeamRunResult> {
     const pendingEvaluation = this.beginOnlineEvaluation(goal)
     const agentConfigs = team.getAgents()
-    const governanceTaskSpecs = buildGovernanceTaskSpecs(goal, agentConfigs, options)
-    if (options?.governanceIntent === 'required' && governanceTaskSpecs === undefined) {
+    const budgets = resolveRunBudgets(this.config, options)
+    const explicitMode = options?.mode
+    if (explicitMode === 'single' && options?.planOnly) {
+      throw new Error("runTeam mode 'single' cannot be combined with planOnly.")
+    }
+    const preferredBudgetDegraded = explicitMode === undefined
+      && !options?.planOnly
+      && options?.governanceIntent === 'preferred'
+      && options.preferredUnderBudget === 'degrade'
+      && (budgets.maxTokenBudget !== undefined || budgets.maxCostBudget !== undefined)
+    // Always validate declared role names/order, even when an explicit mode
+    // selects a different execution topology.
+    const declaredGovernanceTaskSpecs = buildGovernanceTaskSpecs(goal, agentConfigs, options)
+    const governanceTaskSpecs = explicitMode === undefined && !preferredBudgetDegraded
+      ? declaredGovernanceTaskSpecs
+      : undefined
+    if (
+      explicitMode === undefined
+      && options?.governanceIntent === 'required'
+      && declaredGovernanceTaskSpecs === undefined
+    ) {
       throw new Error('Invariant violation: required runTeam governance must use an explicit task topology.')
     }
     if (governanceTaskSpecs !== undefined) {
@@ -507,10 +549,23 @@ export class OpenMultiAgent {
     const { identity, metadata } = createRunFacts(identityOptionsForRun(options))
     const traceRuntime = this.startTrace(identity, metadata)
     const finish = (result: TeamRunResult): TeamRunResult => {
-      const completedResult = finalizeConsequentialRun<TeamRunResult>({
-        ...result,
-        ...(metadata !== undefined ? { metadata } : {}),
-      }, consequentialUndeclared, confirmationState)
+      const governedResult = finalizeGovernanceRun(
+        {
+          ...result,
+          ...(metadata !== undefined ? { metadata } : {}),
+        },
+        options,
+        buildExecutionReceipt(result),
+        {
+          modeOverride: explicitMode !== undefined,
+          preferredBudgetDegraded,
+        },
+      )
+      const completedResult = finalizeConsequentialRun<TeamRunResult>(
+        governedResult,
+        consequentialUndeclared,
+        confirmationState,
+      )
       traceRuntime?.close({
         status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
         ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
@@ -531,17 +586,23 @@ export class OpenMultiAgent {
     // (same algorithm as the `capability-match` scheduler strategy).
     // ------------------------------------------------------------------
     if (
-      options?.governanceIntent !== 'required'
-      && !options?.planOnly
+      !options?.planOnly
       && agentConfigs.length > 0
-      && isSimpleGoal(goal)
+      && (
+        explicitMode === 'single'
+        || preferredBudgetDegraded
+        || (explicitMode === undefined && isSimpleGoal(goal))
+      )
     ) {
       const bestAgent = selectBestAgent(goal, agentConfigs)
 
       // Use buildAgent() + agent.run() directly instead of this.runAgent()
       // to avoid duplicate progress events and double completedTaskCount.
       // Events are emitted here; counting is handled by buildTeamRunResult().
-      const effectiveBudget = resolveTokenBudget(bestAgent.maxTokenBudget, this.config.maxTokenBudget)
+      const effectiveBudget = resolveBudgetCeiling(
+        bestAgent.maxTokenBudget,
+        budgets.maxTokenBudget,
+      )
       const effective: AgentConfig = withModelRoute(applyDefaultToolPreset({
         ...applyAgentDefaults(bestAgent, this.config),
         maxTokenBudget: effectiveBudget,
@@ -603,7 +664,7 @@ export class OpenMultiAgent {
           currentUsage: ZERO_USAGE,
           currentCost: 0,
           usage: result.tokenUsage,
-          maxCostBudget: this.config.maxCostBudget,
+          maxCostBudget: budgets.maxCostBudget,
           estimateCost: this.config.estimateCost,
           costContext: buildCostEstimateContext({
             agentName: bestAgent.name,
@@ -714,8 +775,7 @@ export class OpenMultiAgent {
     const decompositionResult = await coordinatorAgent.run(decompositionPrompt, decompTraceOptions)
     const agentResults = new Map<string, AgentRunResult>()
     agentResults.set('coordinator:decompose', decompositionResult)
-    const maxTokenBudget = this.config.maxTokenBudget
-    const maxCostBudget = this.config.maxCostBudget
+    const { maxTokenBudget, maxCostBudget } = budgets
     const decompositionBudget = applyBudgetAccounting({
       currentUsage: ZERO_USAGE,
       currentCost: 0,
@@ -1554,6 +1614,7 @@ export class OpenMultiAgent {
     const agentConfigs = team.getAgents()
     const scheduler = new Scheduler('dependency-first')
     scheduler.autoAssign(queue, agentConfigs)
+    const budgets = resolveRunBudgets(this.config, options)
 
     const pool = this.buildPool(agentConfigs)
     const agentResults = initialAgentResults ?? new Map<string, AgentRunResult>()
@@ -1578,8 +1639,8 @@ export class OpenMultiAgent {
       abortSignal: options?.abortSignal,
       cumulativeUsage: ZERO_USAGE,
       cumulativeCost: 0,
-      maxTokenBudget: this.config.maxTokenBudget,
-      maxCostBudget: this.config.maxCostBudget,
+      maxTokenBudget: budgets.maxTokenBudget,
+      maxCostBudget: budgets.maxCostBudget,
       estimateCost: this.config.estimateCost,
       budgetExceededTriggered: false,
       budgetExceededReason: undefined,
@@ -1672,14 +1733,14 @@ export class OpenMultiAgent {
       ctx.outcomeStatus,
       ctx.outcomeErrorInfo,
     )
-    const completedResult: TeamRunResult = {
-      ...result,
-      governanceConclusion: evaluateGovernance(
-        governanceDeclaration,
-        buildExecutionReceipt(result),
-      ),
-      ...(metadata !== undefined ? { metadata } : {}),
-    }
+    const completedResult = finalizeGovernanceRun(
+      {
+        ...result,
+        ...(metadata !== undefined ? { metadata } : {}),
+      },
+      governanceDeclaration,
+      buildExecutionReceipt(result),
+    )
     traceRuntime?.close({
       status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
       ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -276,7 +276,10 @@ export interface RunOutcomeFields {
 }
 
 /** Machine-readable warnings that describe how a run was governed. */
-export type RunFlag = 'consequential-no-independence'
+export type RunFlag =
+  | 'consequential-no-independence'
+  | 'governance-overridden'
+  | 'review-skipped-due-to-budget'
 
 /** Context passed to user-supplied cost estimators. */
 export interface CostEstimateContext {
@@ -1098,6 +1101,18 @@ export interface RunTaskSpec {
 export interface RunTasksOptions extends RunIdentityOptions {
   readonly abortSignal?: AbortSignal
   /**
+   * Optional per-run token ceiling. When an orchestrator-level
+   * {@link OrchestratorConfig.maxTokenBudget} is also set, the lower ceiling
+   * wins. Enforcement reuses the existing turn/task-boundary accounting.
+   */
+  readonly maxTokenBudget?: number
+  /**
+   * Optional per-run cost ceiling in the application-defined cost unit. When
+   * an orchestrator-level {@link OrchestratorConfig.maxCostBudget} is also set,
+   * the lower ceiling wins. Requires {@link OrchestratorConfig.estimateCost}.
+   */
+  readonly maxCostBudget?: number
+  /**
    * Opt-in durable task checkpointing. When enabled, the orchestrator writes a
    * checkpoint after each successfully completed task using the configured
    * {@link MemoryStore}. Defaults to off.
@@ -1121,6 +1136,21 @@ export interface RunTasksOptions extends RunIdentityOptions {
 export interface RunTeamOptions extends RunTasksOptions {
   readonly coordinator?: CoordinatorConfig
   /**
+   * Application-selected execution mode for this invocation.
+   *
+   * `'single'` always uses the existing best-agent path. `'team'` forces the
+   * existing coordinator-generated team path and bypasses the simple-goal
+   * short circuit.
+   *
+   * This application choice takes precedence over {@link governanceIntent}.
+   * If the selected mode fails a declared `required` floor, execution is kept
+   * but the result is disclosed as governance `unsatisfied` / `overridden`.
+   * Selecting a mode does not count as declaring governance intent, so
+   * consequential confirmation still applies when `governanceIntent` is
+   * omitted.
+   */
+  readonly mode?: 'single' | 'team'
+  /**
    * Optional structured governance signal for this goal.
    *
    * `'required'` and `'preferred'` both bypass coordinator decomposition and
@@ -1142,6 +1172,16 @@ export interface RunTeamOptions extends RunTasksOptions {
    * parallel.
    */
   readonly requiredOrder?: readonly string[]
+  /**
+   * Application policy for a `preferred` declaration when a token or cost
+   * ceiling applies to the run.
+   *
+   * `'attempt'` (the default) preserves the existing declared-role topology.
+   * `'degrade'` chooses the Single path up front and attaches the
+   * `review-skipped-due-to-budget` disclosure flag. It does not predict model
+   * cost or attempt a pre-run fit estimate.
+   */
+  readonly preferredUnderBudget?: 'attempt' | 'degrade'
   /**
    * When true, the coordinator decomposes the goal but no task agents run.
    * The returned {@link TeamRunResult} has `planOnly: true`, `success: true`,
@@ -1192,6 +1232,9 @@ export interface RunTeamOptions extends RunTasksOptions {
 /** Post-execution result of comparing required governance with execution facts. */
 export type GovernanceConclusion = 'satisfied' | 'unsatisfied' | 'not-applicable'
 
+/** Known application/budget causes for an unsatisfied governance conclusion. */
+export type GovernanceUnsatisfiedReason = 'overridden' | 'budget'
+
 /** Run-level aggregated metrics summary. */
 export interface RunMetrics {
   readonly totalTokens: TokenUsage
@@ -1216,6 +1259,12 @@ export interface TeamRunResult extends RunOutcomeFields {
    * to type-check. `success` retains its existing runtime-error semantics.
    */
   readonly governanceConclusion?: GovernanceConclusion
+  /**
+   * Machine-readable cause when a required governance floor is unsatisfied by
+   * an explicit application override or by budget exhaustion. Omitted for a
+   * satisfied/not-applicable conclusion and for other execution failures.
+   */
+  readonly governanceReason?: GovernanceUnsatisfiedReason
   readonly goal?: string
   readonly tasks?: readonly TaskExecutionRecord[]
   /**

--- a/packages/core/tests/consequential-confirmation.test.ts
+++ b/packages/core/tests/consequential-confirmation.test.ts
@@ -216,6 +216,52 @@ describe('undeclared consequential run fallback', () => {
     expect(result.confirmationRequired).toBeUndefined()
   })
 
+  it("keeps consequential confirmation enabled for mode 'single'", async () => {
+    const { tool, execute } = mockTool('rotate_secret', true)
+    const orchestrator = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      requireConsequentialConfirmation: true,
+    })
+    const team = orchestrator.createTeam('explicit-single-mode-team', {
+      name: 'explicit-single-mode-team',
+      agents: [agent(tool)],
+    })
+
+    const result = await orchestrator.runTeam(team, 'Rotate the secret.', {
+      mode: 'single',
+    })
+
+    expect(execute).not.toHaveBeenCalled()
+    expect(result.success).toBe(false)
+    expect(result.confirmationRequired).toBe(true)
+    expect(result.flags).toEqual(['consequential-no-independence'])
+  })
+
+  it("keeps consequential confirmation enabled for mode 'team'", async () => {
+    const { tool, execute } = mockTool('rotate_secret', true)
+    const orchestrator = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      requireConsequentialConfirmation: true,
+    })
+    const team = orchestrator.createTeam('explicit-team-mode-team', {
+      name: 'explicit-team-mode-team',
+      agents: [agent(tool)],
+    })
+    const plan = '```json\n[{"title":"Rotate","description":"Rotate it","assignee":"operator"}]\n```'
+
+    const result = await orchestrator.runTeam(team, 'Rotate the secret.', {
+      mode: 'team',
+      coordinator: {
+        adapter: scriptedAdapter(text(plan), text('synthesized')),
+      },
+    })
+
+    expect(execute).not.toHaveBeenCalled()
+    expect(result.success).toBe(false)
+    expect(result.confirmationRequired).toBe(true)
+    expect(result.flags).toEqual(['consequential-no-independence'])
+  })
+
   it('reuses an approved runTeam plan gate when no per-call gate is configured', async () => {
     const { tool, execute } = mockTool('rotate_secret', true)
     const onPlanReady = vi.fn(async () => true)

--- a/packages/core/tests/mode-governance-resolution.test.ts
+++ b/packages/core/tests/mode-governance-resolution.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildExecutionReceipt,
+  GOVERNANCE_OVERRIDDEN_FLAG,
+  OpenMultiAgent,
+  REVIEW_SKIPPED_DUE_TO_BUDGET_FLAG,
+} from '../src/index.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMResponse,
+  RunTeamOptions,
+} from '../src/index.js'
+
+interface ScriptedReply {
+  readonly output: string
+  readonly inputTokens?: number
+  readonly outputTokens?: number
+}
+
+function scriptedAdapter(
+  replies: readonly ScriptedReply[],
+  calls: string[] = [],
+): LLMAdapter {
+  let index = 0
+  return {
+    name: 'mode-governance-test',
+    async chat(): Promise<LLMResponse> {
+      const reply = replies[index] ?? replies.at(-1)
+      if (!reply) throw new Error('No scripted reply configured.')
+      index++
+      calls.push(reply.output)
+      return {
+        id: `response-${index}`,
+        content: [{ type: 'text', text: reply.output }],
+        model: 'mock-model',
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: reply.inputTokens ?? 1,
+          output_tokens: reply.outputTokens ?? 1,
+        },
+      }
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: {} }
+    },
+  }
+}
+
+function agent(name: string, output: string): AgentConfig {
+  return {
+    name,
+    model: 'mock-model',
+    systemPrompt: `You are the ${name}.`,
+    adapter: scriptedAdapter([{ output }]),
+  }
+}
+
+function createGovernanceTeam(orchestrator: OpenMultiAgent) {
+  return orchestrator.createTeam('mode-governance-team', {
+    name: 'mode-governance-team',
+    agents: [
+      agent('reviewer', 'reviewer output'),
+      agent('security', 'security output'),
+    ],
+    sharedMemory: true,
+  })
+}
+
+const requiredGovernance = {
+  governanceIntent: 'required',
+  requiredRoles: ['reviewer', 'security'],
+  requiredOrder: ['reviewer', 'security'],
+} as const satisfies RunTeamOptions
+
+describe('runTeam explicit mode and budget/governance resolution', () => {
+  it('forces the coordinator-generated DAG over the automatic simple-goal route', async () => {
+    const coordinatorCalls: string[] = []
+    const coordinator = scriptedAdapter([
+      {
+        output: '```json\n['
+          + '{"title":"Review","description":"Review the request.","assignee":"reviewer"},'
+          + '{"title":"Security","description":"Check the review.","assignee":"security","dependsOn":["Review"]}'
+          + ']\n```',
+      },
+      { output: 'coordinator synthesis' },
+    ], coordinatorCalls)
+    const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = createGovernanceTeam(orchestrator)
+
+    const result = await orchestrator.runTeam(team, 'Say hello.', {
+      mode: 'team',
+      coordinator: { model: 'mock-model', adapter: coordinator },
+    })
+    const receipt = buildExecutionReceipt(result)
+
+    expect(result.success).toBe(true)
+    expect(result.tasks?.some((task) => task.id === 'short-circuit')).toBe(false)
+    expect(result.agentResults.get('coordinator')?.output).toContain('coordinator synthesis')
+    expect(coordinatorCalls).toHaveLength(2)
+    expect(receipt).toMatchObject({
+      mode: 'multi-agent',
+      rolesExecuted: ['reviewer', 'security'],
+      dependencyEdges: [{ from: 'reviewer', to: 'security' }],
+    })
+  })
+
+  it('executes a forced Single but discloses an overridden required floor', async () => {
+    const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = createGovernanceTeam(orchestrator)
+
+    const result = await orchestrator.runTeam(
+      team,
+      'First review the request, then assess its security.',
+      { ...requiredGovernance, mode: 'single' },
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.tasks?.map((task) => task.id)).toEqual(['short-circuit'])
+    expect(buildExecutionReceipt(result).mode).toBe('single')
+    expect(result.governanceConclusion).toBe('unsatisfied')
+    expect(result.governanceReason).toBe('overridden')
+    expect(result.flags).toContain(GOVERNANCE_OVERRIDDEN_FLAG)
+  })
+
+  it('marks required governance unsatisfied with a budget reason when roles cannot finish', async () => {
+    const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = createGovernanceTeam(orchestrator)
+
+    const result = await orchestrator.runTeam(team, 'Review this request.', {
+      ...requiredGovernance,
+      maxTokenBudget: 1,
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.status?.code).toBe('budget_exhausted')
+    expect(result.governanceConclusion).toBe('unsatisfied')
+    expect(result.governanceReason).toBe('budget')
+    expect(buildExecutionReceipt(result).rolesExecuted).toEqual(['reviewer'])
+    expect(result.tasks?.map((task) => task.status)).toEqual(['completed', 'skipped'])
+  })
+
+  it('degrades preferred governance to Single under a declared ceiling and discloses it', async () => {
+    const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = createGovernanceTeam(orchestrator)
+
+    const result = await orchestrator.runTeam(
+      team,
+      'First review the request, then assess its security.',
+      {
+        ...requiredGovernance,
+        governanceIntent: 'preferred',
+        preferredUnderBudget: 'degrade',
+        maxTokenBudget: 3,
+      },
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.tasks?.map((task) => task.id)).toEqual(['short-circuit'])
+    expect(buildExecutionReceipt(result)).toMatchObject({
+      mode: 'single',
+      flags: [REVIEW_SKIPPED_DUE_TO_BUDGET_FLAG],
+    })
+    expect(result.governanceConclusion).toBe('not-applicable')
+    expect(result.governanceReason).toBeUndefined()
+    expect(result.flags).toContain(REVIEW_SKIPPED_DUE_TO_BUDGET_FLAG)
+  })
+
+  it('preserves the required topology when no override occurs and budget is sufficient', async () => {
+    const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = createGovernanceTeam(orchestrator)
+
+    const result = await orchestrator.runTeam(team, 'Review this request.', {
+      ...requiredGovernance,
+      maxTokenBudget: 10,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.governanceConclusion).toBe('satisfied')
+    expect(result.governanceReason).toBeUndefined()
+    expect(result.flags).toBeUndefined()
+    expect(buildExecutionReceipt(result)).toMatchObject({
+      mode: 'multi-agent',
+      rolesExecuted: ['reviewer', 'security'],
+      dependencyEdges: [{ from: 'reviewer', to: 'security' }],
+    })
+  })
+
+  it('keeps the existing preferred-role attempt when no degrade policy is selected', async () => {
+    const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = createGovernanceTeam(orchestrator)
+
+    const result = await orchestrator.runTeam(team, 'Review this request.', {
+      ...requiredGovernance,
+      governanceIntent: 'preferred',
+      maxTokenBudget: 10,
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.governanceConclusion).toBe('not-applicable')
+    expect(result.flags).toBeUndefined()
+    expect(buildExecutionReceipt(result).rolesExecuted).toEqual(['reviewer', 'security'])
+  })
+
+  it('applies a per-run cost ceiling through the existing estimator', async () => {
+    const orchestrator = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      estimateCost: (usage) => usage.input_tokens + usage.output_tokens,
+    })
+    const team = createGovernanceTeam(orchestrator)
+
+    const result = await orchestrator.runTeam(team, 'Review this request.', {
+      ...requiredGovernance,
+      maxCostBudget: 1,
+    })
+
+    expect(result.status?.code).toBe('budget_exhausted')
+    expect(result.governanceConclusion).toBe('unsatisfied')
+    expect(result.governanceReason).toBe('budget')
+  })
+
+  it('rejects a per-run cost ceiling when no estimator is configured', async () => {
+    const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = createGovernanceTeam(orchestrator)
+
+    await expect(orchestrator.runTeam(team, 'Review this request.', {
+      ...requiredGovernance,
+      maxCostBudget: 1,
+    })).rejects.toThrow(/maxCostBudget requires estimateCost/)
+  })
+})


### PR DESCRIPTION
## Summary

- Add optional `runTeam.mode: 'single' | 'team'` so applications can select the best-agent or coordinator-generated team path explicitly.
- Preserve governance disclosures when an explicit mode overrides a required floor, without changing runtime `success` semantics.
- Add optional per-run token/cost ceilings and retain `preferredUnderBudget: 'degrade'` with an explicit skipped-review flag.
- Keep consequential confirmation tied to omitted `governanceIntent`; selecting an execution mode does not declare governance intent.
- Document the finalized API terminology, precedence, budget behavior, and compatibility contract.

## Motivation

Applications need a deterministic, user-facing execution-mode control without exposing task-DAG implementation terminology. The finalized API uses `single` and `team`, while automatic routing remains the behavior when `mode` is omitted.

Budget exhaustion and application-selected degradation must remain visible. Likewise, choosing an execution topology must not imply acceptance of consequential side effects.

## Decision basis

This implements the finalized API decisions for #423:

- use `mode: 'single' | 'team'`;
- retain per-run `maxTokenBudget` / `maxCostBudget`;
- retain opt-in `preferredUnderBudget: 'degrade'`;
- do not exempt explicit modes from consequential confirmation when `governanceIntent` is omitted.

## Scope and impact

- Workspace: `@open-multi-agent/core`, plus provider and tool-configuration documentation.
- Public API: optional `mode`, `preferredUnderBudget`, per-run `maxTokenBudget` / `maxCostBudget`, `governanceReason`, and two additive run flags.
- Compatibility: all fields are additive relative to `main`. Runs without `mode` or a budget-conflict policy preserve existing routing behavior.
- Governance: a mode that displaces a required topology is reported as `unsatisfied` / `overridden`; runtime success remains independent.
- Security: `mode` does not count as a governance declaration, so `requireConsequentialConfirmation` continues to protect undeclared runs.
- Dependencies: unchanged.
- Intentional non-goals: pre-run cost/latency prediction, autonomous governance upgrades, and UI work.

## Validation

- `npm run test -w @open-multi-agent/core -- mode-governance-resolution.test.ts consequential-confirmation.test.ts` — passed (2 files, 20 tests)
- `npm run lint -w @open-multi-agent/core` — passed
- `npm run test -w @open-multi-agent/core` — passed (113 files, 1582 tests)
- `npm run build -w @open-multi-agent/core` — passed
- `git diff --check origin/main...HEAD` — passed
- Provider E2E was not run because provider adapters are unchanged and the policy behavior is covered by deterministic tests.

## Checklist

- [x] Tests were added or updated for changed behavior
- [x] User-facing documentation was updated
- [x] Compatibility and governance semantics are documented
- [x] Dependency ownership remains unchanged
