### PR TITLE
feat(core): add retryable route fallback

### DIFF
--- a/docs/model-routing.md
+++ b/docs/model-routing.md
@@ -52,6 +52,45 @@ The `route` is the override applied when the rule matches. Only `model` is requi
 | `baseURL` | Base URL for OpenAI-compatible or self-hosted endpoints. |
 | `apiKey` | API key for the matched call. |
 | `region` | AWS region, for Bedrock routes. |
+| `fallback` | Ordered backup routes for retryable worker-provider failures. |
+
+## Retryable provider fallback
+
+Worker routes can declare an ordered `fallback` list. The initial attempt uses
+the route itself. When a confirmed provider error is retryable, the next task
+retry moves to the next entry in the list. Once the list is exhausted, later
+retries keep using its final entry.
+
+```ts
+const modelRouting: ModelRoutingPolicy = {
+  rules: [{
+    match: { phase: 'worker' },
+    route: {
+      model: 'claude-sonnet-4-5',
+      provider: 'anthropic',
+      fallback: [{
+        model: 'gpt-5',
+        provider: 'openai',
+      }],
+    },
+  }],
+}
+
+await orchestrator.runTasks(team, [{
+  title: 'Write report',
+  description: 'Summarize the findings.',
+  assignee: 'writer',
+  maxRetries: 1,
+}], { modelRouting })
+```
+
+Fallback is opt-in and reuses each task's existing retry settings, so set
+`maxRetries` high enough to reach the backup entries you configure. Authentication,
+validation, hook, and other non-provider errors never advance the fallback chain.
+A failed task without a structured provider error continues to use its current
+route. Each fallback entry is applied to the worker's effective configuration like
+any other route. When a backup uses a different provider or endpoint, include its
+`provider`, `baseURL`, `apiKey`, and `region` overrides as appropriate.
 
 ## Which calls are routed
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -741,21 +741,26 @@ export class Agent {
     })
     let agentTraceEmitted = false
     let effectiveTraceOptions: Partial<RunOptions> | undefined = callerOptions
+    let timeoutSignal: AbortSignal | undefined
+    let callerAbort: AbortSignal | undefined
+    let failureKind: TraceErrorKind | undefined
 
     try {
       // --- beforeRun hook ---
       if (this.config.beforeRun) {
+        failureKind = 'callback'
         const hookCtx = this.buildBeforeRunHookContext(messages)
         const modified = await this.config.beforeRun(hookCtx)
         this.applyHookContext(messages, modified, hookCtx.prompt)
+        failureKind = undefined
       }
 
       const backend = await this.getBackend()
       // Fresh timeout per stream call, same as executeRun.
-      const timeoutSignal = this.config.timeoutMs !== undefined && this.config.timeoutMs > 0
+      timeoutSignal = this.config.timeoutMs !== undefined && this.config.timeoutMs > 0
         ? AbortSignal.timeout(this.config.timeoutMs)
         : undefined
-      const callerAbort = callerOptions?.abortSignal
+      callerAbort = callerOptions?.abortSignal
       const effectiveAbort = timeoutSignal && callerAbort
         ? mergeAbortSignals(timeoutSignal, callerAbort)
         : timeoutSignal ?? callerAbort
@@ -791,7 +796,9 @@ export class Agent {
             result, !result.budgetExceeded, undefined, identity, status,
           )
           if (this.config.afterRun) {
+            failureKind = 'callback'
             agentResult = await this.config.afterRun(agentResult)
+            failureKind = undefined
           }
           agentResult = this.ensureAgentOutcome(agentResult, identity)
           this.transitionTo('completed')
@@ -803,12 +810,16 @@ export class Agent {
           const error = event.data instanceof Error
             ? event.data
             : new Error(String(event.data))
+          // Backend stream errors originate from the configured provider. Keep
+          // the source classification on the event so task retry can make an
+          // explicit failover decision without reclassifying a raw Error.
+          const classified = classifyRunFailure(error, { provider: this.config.provider })
           this.transitionToError(error)
           this.emitAgentTrace(runOptions, agentStartMs, {
             success: false,
             identity,
-            status: classifyRunFailure(error).status,
-            errorInfo: classifyRunFailure(error).errorInfo,
+            status: classified.status,
+            errorInfo: classified.errorInfo,
             output: error.message,
             messages: [],
             tokenUsage: ZERO_USAGE,
@@ -817,6 +828,8 @@ export class Agent {
             error,
           })
           agentTraceEmitted = true
+          yield { ...event, errorInfo: classified.errorInfo } satisfies StreamEvent
+          continue
         }
 
         yield event
@@ -824,12 +837,20 @@ export class Agent {
     } catch (err) {
       const error = err instanceof Error ? err : new Error(String(err))
       this.transitionToError(error)
+      const classified = timeoutSignal?.aborted
+        ? classifyRunFailure(error, { kind: 'timeout', statusCode: 'timeout' })
+        : callerAbort?.aborted
+          ? classifyRunFailure(error, { kind: 'cancellation', statusCode: 'cancelled' })
+          : classifyRunFailure(error, {
+              ...(failureKind !== undefined ? { kind: failureKind } : {}),
+              provider: this.config.provider,
+            })
       if (!agentTraceEmitted) {
         this.emitAgentTrace(effectiveTraceOptions, agentStartMs, {
           success: false,
           identity,
-          status: classifyRunFailure(error).status,
-          errorInfo: classifyRunFailure(error).errorInfo,
+          status: classified.status,
+          errorInfo: classified.errorInfo,
           output: error.message,
           messages: [],
           tokenUsage: ZERO_USAGE,
@@ -838,7 +859,7 @@ export class Agent {
           error,
         })
       }
-      yield { type: 'error', data: error } satisfies StreamEvent
+      yield { type: 'error', data: error, errorInfo: classified.errorInfo } satisfies StreamEvent
     }
   }
 

--- a/packages/core/src/orchestrator/agent-config.ts
+++ b/packages/core/src/orchestrator/agent-config.ts
@@ -145,6 +145,11 @@ export function withModelRoute(config: AgentConfig, route: ModelRouteConfig | un
   }
 }
 
+/** Return a route followed by its ordered fallback entries. */
+export function routeChain(route: ModelRouteConfig | undefined): readonly ModelRouteConfig[] {
+  return route ? [route, ...(route.fallback ?? [])] : []
+}
+
 export function isLeafTask(task: Task, tasks: readonly Task[]): boolean {
   for (const candidate of tasks) {
     if (candidate.dependsOn?.includes(task.id)) return false

--- a/packages/core/src/orchestrator/task-execution.ts
+++ b/packages/core/src/orchestrator/task-execution.ts
@@ -419,9 +419,11 @@ export async function executeQueue(
         )
         let routeIndex = 0
         let lastFailureWasRetryableProviderError = false
+        let streamedErrorInfo: AgentRunResult['errorInfo']
         const attemptUsages: Array<{ readonly usage: TokenUsage; readonly config: AgentConfig }> = []
         const streamCallback = config.onAgentStream
           ? (event: StreamEvent) => {
+              if (event.type === 'error') streamedErrorInfo = event.errorInfo
               const streamMs = Date.now()
               const legacyEvent = config.onTrace ? {
                   type: 'agent_stream',
@@ -457,6 +459,7 @@ export async function executeQueue(
               ? routedConfigs[activeRouteIndex]!
               : workerBaseConfig
             try {
+              streamedErrorInfo = undefined
               const attemptResult = routedAgent
                 ? await pool.runEphemeral(
                     routedAgent,
@@ -477,10 +480,12 @@ export async function executeQueue(
                 && attemptResult.errorInfo.retryable === true
               return attemptResult
             } catch (error) {
-              // A thrown value has no result-level source classification. Keep
-              // the current route rather than failing over on an unconfirmed
-              // error such as a hook or framework callback failure.
-              lastFailureWasRetryableProviderError = false
+              // Streaming errors are thrown by AgentPool after they have been
+              // forwarded through onAgentStream. Use the source classification
+              // attached by Agent rather than inferring it from the raw Error.
+              lastFailureWasRetryableProviderError =
+                streamedErrorInfo?.kind === 'provider'
+                && streamedErrorInfo.retryable === true
               throw error
             }
           },

--- a/packages/core/src/orchestrator/task-execution.ts
+++ b/packages/core/src/orchestrator/task-execution.ts
@@ -41,6 +41,7 @@ import { recordRunUsage, buildCostEstimateContext } from './budget.js'
 import {
   routeMatches,
   withModelRoute,
+  routeChain,
   applyAgentDefaults,
   applyDefaultToolPreset,
   buildAgent,
@@ -405,13 +406,20 @@ export async function executeQueue(
           task,
           leaf: ctx.taskLeafById.get(task.id),
         })
-        const workerEffectiveConfig = withModelRoute(applyDefaultToolPreset(
+        const workerBaseConfig = applyDefaultToolPreset(
           applyAgentDefaults(agentConfig, config),
           config.defaultToolPreset,
-        ), workerRoute)
-        const routedAgent = workerRoute
-          ? buildAgent(workerEffectiveConfig, { includeDelegateTool: true })
-          : undefined
+        )
+        const routedConfigs = routeChain(workerRoute).map(route =>
+          withModelRoute(workerBaseConfig, route),
+        )
+        const workerEffectiveConfig = routedConfigs[0] ?? workerBaseConfig
+        const routedAgents = routedConfigs.map(route =>
+          buildAgent(route, { includeDelegateTool: true }),
+        )
+        let routeIndex = 0
+        let lastFailureWasRetryableProviderError = false
+        const attemptUsages: Array<{ readonly usage: TokenUsage; readonly config: AgentConfig }> = []
         const streamCallback = config.onAgentStream
           ? (event: StreamEvent) => {
               const streamMs = Date.now()
@@ -440,21 +448,50 @@ export async function executeQueue(
         let retryCount = 0
 
         const result = await executeWithRetry(
-          (attempt) => routedAgent
-            ? pool.runEphemeral(
-                routedAgent,
-                prompt,
-                { ...runOptions, traceAgentAttempt: attempt },
-                streamCallback,
-              )
-            : pool.run(
-                assignee,
-                prompt,
-                { ...runOptions, traceAgentAttempt: attempt },
-                streamCallback,
-              ),
+          async (attempt) => {
+            const activeRouteIndex = Math.min(routeIndex, routedAgents.length - 1)
+            const routedAgent = routedAgents.length > 0
+              ? routedAgents[activeRouteIndex]
+              : undefined
+            const activeConfig = routedConfigs.length > 0
+              ? routedConfigs[activeRouteIndex]!
+              : workerBaseConfig
+            try {
+              const attemptResult = routedAgent
+                ? await pool.runEphemeral(
+                    routedAgent,
+                    prompt,
+                    { ...runOptions, traceAgentAttempt: attempt },
+                    streamCallback,
+                  )
+                : await pool.run(
+                    assignee,
+                    prompt,
+                    { ...runOptions, traceAgentAttempt: attempt },
+                    streamCallback,
+                  )
+              attemptUsages.push({ usage: attemptResult.tokenUsage, config: activeConfig })
+              lastFailureWasRetryableProviderError =
+                !attemptResult.success
+                && attemptResult.errorInfo?.kind === 'provider'
+                && attemptResult.errorInfo.retryable === true
+              return attemptResult
+            } catch (error) {
+              // A thrown value has no result-level source classification. Keep
+              // the current route rather than failing over on an unconfirmed
+              // error such as a hook or framework callback failure.
+              lastFailureWasRetryableProviderError = false
+              throw error
+            }
+          },
           task,
           (retryData) => {
+            if (
+              lastFailureWasRetryableProviderError
+              && routeIndex < routedAgents.length - 1
+            ) {
+              routeIndex++
+            }
             retryCount++
             taskSpan?.event('retry_scheduled', {
               'oma.retry.attempt': retryData.attempt,
@@ -499,15 +536,22 @@ export async function executeQueue(
           retries: retryCount,
         })
         try {
-          const budgetError = recordRunUsage(ctx, result.tokenUsage, buildCostEstimateContext({
-            agentName: assignee,
-            model: workerEffectiveConfig.model ?? config.defaultModel ?? DEFAULT_MODEL,
-            provider: workerEffectiveConfig.provider,
-            phase: 'worker',
-            taskId: task.id,
-          }), assignee, task.id)
-          if (budgetError) {
-            taskSpan?.event('budget_exhausted', {})
+          // Keep the existing aggregate estimate for a single route. A fallback
+          // chain needs per-attempt contexts so each provider is priced correctly.
+          const costAttempts = routedConfigs.length > 1
+            ? attemptUsages
+            : [{ usage: result.tokenUsage, config: workerEffectiveConfig }]
+          for (const attemptUsage of costAttempts) {
+            const budgetError = recordRunUsage(ctx, attemptUsage.usage, buildCostEstimateContext({
+              agentName: assignee,
+              model: attemptUsage.config.model ?? config.defaultModel ?? DEFAULT_MODEL,
+              provider: attemptUsage.config.provider,
+              phase: 'worker',
+              taskId: task.id,
+            }), assignee, task.id)
+            if (budgetError) {
+              taskSpan?.event('budget_exhausted', {})
+            }
           }
         } catch (error) {
           const message = errorMessage(error)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1050,6 +1050,13 @@ export interface ModelRouteConfig {
   readonly apiKey?: string
   /** AWS region selected for Bedrock routes. */
   readonly region?: string
+  /**
+   * Ordered fallback routes to try on retryable provider errors.
+   *
+   * The first entry becomes active on the next retry after the primary route
+   * fails; later retries advance through the list in order. Empty by default.
+   */
+  readonly fallback?: readonly ModelRouteConfig[]
 }
 
 /** Deterministic, predicate-free route selector for a model routing rule. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -319,6 +319,12 @@ export interface LLMResponse {
 export interface StreamEvent {
   readonly type: 'text' | 'reasoning' | 'tool_use' | 'tool_result' | 'loop_detected' | 'budget_exceeded' | 'done' | 'error'
   readonly data: unknown
+  /**
+   * Normalized failure metadata for an `error` event when its source is known.
+   * This lets orchestrators distinguish a provider failure from a callback or
+   * framework failure without inferring the source from the error text.
+   */
+  readonly errorInfo?: StructuredTraceError
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/tests/orchestrator.test.ts
+++ b/packages/core/tests/orchestrator.test.ts
@@ -6,6 +6,7 @@ import { ToolExecutor } from '../src/tool/executor.js'
 import type {
   AgentConfig,
   AgentRunResult,
+  CostEstimateContext,
   LLMAdapter,
   LLMChatOptions,
   LLMMessage,
@@ -81,9 +82,12 @@ function extractUserPrompt(messages: LLMMessage[]): string {
 let mockAdapterResponses: string[] = []
 let capturedChatOptions: LLMChatOptions[] = []
 let capturedPrompts: string[] = []
+let capturedAdapterProviders: string[] = []
+let mockAdapterHandler: ((options: LLMChatOptions) => string | Error) | undefined
 
 vi.mock('../src/llm/adapter.js', () => ({
-  createAdapter: async () => {
+  createAdapter: async (provider: string) => {
+    capturedAdapterProviders.push(provider)
     let callIndex = 0
     return {
       name: 'mock',
@@ -95,7 +99,9 @@ vi.mock('../src/llm/adapter.js', () => ({
           .map((b) => b.text)
           .join('\n')
         capturedPrompts.push(prompt)
-        const text = mockAdapterResponses[callIndex] ?? 'default mock response'
+        const configuredResponse = mockAdapterHandler?.(options)
+        if (configuredResponse instanceof Error) throw configuredResponse
+        const text = configuredResponse ?? mockAdapterResponses[callIndex] ?? 'default mock response'
         callIndex++
         return {
           id: `resp-${callIndex}`,
@@ -142,6 +148,8 @@ describe('OpenMultiAgent', () => {
     mockAdapterResponses = []
     capturedChatOptions = []
     capturedPrompts = []
+    capturedAdapterProviders = []
+    mockAdapterHandler = undefined
   })
 
   describe('createTeam', () => {
@@ -427,6 +435,312 @@ describe('OpenMultiAgent', () => {
 
       expect(capturedChatOptions[0]?.model).toBe('default-worker-model')
       expect(capturedChatOptions[1]?.model).toBe('premium-review-model')
+    })
+
+    it('fails over to the next route after a retryable provider error', async () => {
+      mockAdapterHandler = (options) => {
+        if (options.model === 'primary-model') {
+          return Object.assign(new Error('rate limited'), { status: 429 })
+        }
+        return 'backup output'
+      }
+
+      const oma = new OpenMultiAgent({ defaultModel: 'default-model' })
+      const team = oma.createTeam('t', teamCfg([
+        { ...agentConfig('worker-a'), model: 'default-worker-model' },
+      ]))
+
+      const result = await oma.runTasks(team, [
+        {
+          title: 'Fallback',
+          description: 'Recover from a provider outage',
+          assignee: 'worker-a',
+          maxRetries: 1,
+          retryDelayMs: 0,
+        },
+      ], {
+        modelRouting: {
+          rules: [{
+            match: { phase: 'worker' },
+            route: {
+              model: 'primary-model',
+              provider: 'anthropic',
+              fallback: [{ model: 'backup-model', provider: 'openai' }],
+            },
+          }],
+        },
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.agentResults.get('worker-a')?.output).toBe('backup output')
+      expect(capturedChatOptions.map(options => options.model)).toEqual([
+        'primary-model',
+        'backup-model',
+      ])
+      expect(capturedAdapterProviders).toEqual(['anthropic', 'openai'])
+    })
+
+    it('prices each fallback attempt with the route that handled it', async () => {
+      const costContexts: CostEstimateContext[] = []
+      mockAdapterHandler = (options) => {
+        if (options.model === 'primary-model') {
+          return Object.assign(new Error('rate limited'), { status: 429 })
+        }
+        return 'backup output'
+      }
+
+      const oma = new OpenMultiAgent({
+        defaultModel: 'default-model',
+        maxCostBudget: 100,
+        estimateCost: (_usage, context) => {
+          costContexts.push(context)
+          return 1
+        },
+      })
+      const team = oma.createTeam('t', teamCfg([
+        agentConfig('worker-a'),
+      ]))
+
+      const result = await oma.runTasks(team, [
+        {
+          title: 'Fallback cost accounting',
+          description: 'Price each attempt with its active route',
+          assignee: 'worker-a',
+          maxRetries: 1,
+          retryDelayMs: 0,
+        },
+      ], {
+        modelRouting: {
+          rules: [{
+            match: { phase: 'worker' },
+            route: {
+              model: 'primary-model',
+              provider: 'anthropic',
+              fallback: [{ model: 'backup-model', provider: 'openai' }],
+            },
+          }],
+        },
+      })
+
+      expect(result.success).toBe(true)
+      expect(costContexts.map(context => context.model)).toEqual([
+        'primary-model',
+        'backup-model',
+      ])
+      expect(costContexts.map(context => context.provider)).toEqual([
+        'anthropic',
+        'openai',
+      ])
+    })
+
+    it('advances through ordered fallbacks and retries the final route after exhaustion', async () => {
+      let finalRouteAttempts = 0
+      mockAdapterHandler = (options) => {
+        if (options.model === 'primary-model' || options.model === 'first-backup-model') {
+          return Object.assign(new Error('provider unavailable'), { status: 503 })
+        }
+        finalRouteAttempts++
+        return finalRouteAttempts === 1
+          ? Object.assign(new Error('rate limited'), { status: 429 })
+          : 'final backup output'
+      }
+
+      const oma = new OpenMultiAgent({ defaultModel: 'default-model' })
+      const team = oma.createTeam('t', teamCfg([
+        { ...agentConfig('worker-a'), model: 'default-worker-model' },
+      ]))
+
+      const result = await oma.runTasks(team, [
+        {
+          title: 'Multi-hop fallback',
+          description: 'Use each backup route in order',
+          assignee: 'worker-a',
+          maxRetries: 3,
+          retryDelayMs: 0,
+        },
+      ], {
+        modelRouting: {
+          rules: [{
+            match: { phase: 'worker' },
+            route: {
+              model: 'primary-model',
+              fallback: [
+                { model: 'first-backup-model' },
+                { model: 'final-backup-model' },
+              ],
+            },
+          }],
+        },
+      })
+
+      expect(result.success).toBe(true)
+      expect(capturedChatOptions.map(options => options.model)).toEqual([
+        'primary-model',
+        'first-backup-model',
+        'final-backup-model',
+        'final-backup-model',
+      ])
+    })
+
+    it('does not fail over after a terminal provider error', async () => {
+      mockAdapterHandler = (options) => {
+        if (options.model === 'primary-model') {
+          return Object.assign(new Error('unauthorized'), { status: 401 })
+        }
+        return 'backup output'
+      }
+
+      const oma = new OpenMultiAgent({ defaultModel: 'default-model' })
+      const team = oma.createTeam('t', teamCfg([
+        { ...agentConfig('worker-a'), model: 'default-worker-model' },
+      ]))
+
+      const result = await oma.runTasks(team, [
+        {
+          title: 'Terminal error',
+          description: 'Do not retry invalid credentials',
+          assignee: 'worker-a',
+          maxRetries: 1,
+          retryDelayMs: 0,
+        },
+      ], {
+        modelRouting: {
+          rules: [{
+            match: { phase: 'worker' },
+            route: {
+              model: 'primary-model',
+              fallback: [{ model: 'backup-model' }],
+            },
+          }],
+        },
+      })
+
+      expect(result.success).toBe(false)
+      expect(capturedChatOptions.map(options => options.model)).toEqual(['primary-model'])
+    })
+
+    it('retries the current route when a task failure has no provider error', async () => {
+      let afterRunCalls = 0
+      const oma = new OpenMultiAgent({ defaultModel: 'default-model' })
+      const team = oma.createTeam('t', teamCfg([
+        {
+          ...agentConfig('worker-a'),
+          afterRun: (result) => {
+            afterRunCalls++
+            return afterRunCalls === 1 ? { ...result, success: false } : result
+          },
+        },
+      ]))
+
+      const result = await oma.runTasks(team, [
+        {
+          title: 'Unclassified failure',
+          description: 'Retry without changing the active route',
+          assignee: 'worker-a',
+          maxRetries: 1,
+          retryDelayMs: 0,
+        },
+      ], {
+        modelRouting: {
+          rules: [{
+            match: { phase: 'worker' },
+            route: {
+              model: 'primary-model',
+              fallback: [{ model: 'backup-model' }],
+            },
+          }],
+        },
+      })
+
+      expect(result.success).toBe(true)
+      expect(capturedChatOptions.map(options => options.model)).toEqual([
+        'primary-model',
+        'primary-model',
+      ])
+    })
+
+    it('does not fail over after a retryable-looking beforeRun hook error', async () => {
+      const hookModels: string[] = []
+      let beforeRunCalls = 0
+      const hookError = Object.assign(new Error('hook rate limited'), { status: 429 })
+      const oma = new OpenMultiAgent({ defaultModel: 'default-model' })
+      const team = oma.createTeam('t', teamCfg([
+        {
+          ...agentConfig('worker-a'),
+          beforeRun: (context) => {
+            hookModels.push(context.agent.model ?? '')
+            beforeRunCalls++
+            if (beforeRunCalls === 1) throw hookError
+            return context
+          },
+        },
+      ]))
+
+      const result = await oma.runTasks(team, [
+        {
+          title: 'beforeRun hook error',
+          description: 'Retry without changing the active route',
+          assignee: 'worker-a',
+          maxRetries: 1,
+          retryDelayMs: 0,
+        },
+      ], {
+        modelRouting: {
+          rules: [{
+            match: { phase: 'worker' },
+            route: {
+              model: 'primary-model',
+              fallback: [{ model: 'backup-model' }],
+            },
+          }],
+        },
+      })
+
+      expect(result.success).toBe(true)
+      expect(hookModels).toEqual(['primary-model', 'primary-model'])
+      expect(capturedChatOptions.map(options => options.model)).toEqual(['primary-model'])
+    })
+
+    it('does not fail over after a retryable-looking afterRun hook error', async () => {
+      let afterRunCalls = 0
+      const hookError = Object.assign(new Error('hook rate limited'), { status: 429 })
+      const oma = new OpenMultiAgent({ defaultModel: 'default-model' })
+      const team = oma.createTeam('t', teamCfg([
+        {
+          ...agentConfig('worker-a'),
+          afterRun: (result) => {
+            afterRunCalls++
+            if (afterRunCalls === 1) throw hookError
+            return result
+          },
+        },
+      ]))
+
+      const result = await oma.runTasks(team, [
+        {
+          title: 'afterRun hook error',
+          description: 'Retry without changing the active route',
+          assignee: 'worker-a',
+          maxRetries: 1,
+          retryDelayMs: 0,
+        },
+      ], {
+        modelRouting: {
+          rules: [{
+            match: { phase: 'worker' },
+            route: {
+              model: 'primary-model',
+              fallback: [{ model: 'backup-model' }],
+            },
+          }],
+        },
+      })
+
+      expect(result.success).toBe(true)
+      expect(capturedChatOptions.map(options => options.model)).toEqual([
+        'primary-model',
+        'primary-model',
+      ])
     })
   })
 

--- a/packages/core/tests/orchestrator.test.ts
+++ b/packages/core/tests/orchestrator.test.ts
@@ -480,6 +480,60 @@ describe('OpenMultiAgent', () => {
       expect(capturedAdapterProviders).toEqual(['anthropic', 'openai'])
     })
 
+    it('fails over after a retryable provider error while onAgentStream is enabled', async () => {
+      const streamedErrorKinds: Array<{ kind: string | undefined; retryable: boolean | undefined }> = []
+      let defaultModelCalls = 0
+      mockAdapterHandler = (options) => {
+        if (options.model === 'primary-model') {
+          return Object.assign(new Error('provider unavailable'), { status: 503 })
+        }
+        if (options.model === 'backup-model') return 'backup output'
+        defaultModelCalls++
+        return defaultModelCalls === 1
+          ? '```json\n[{"title":"Fallback","description":"Recover from a provider outage","assignee":"worker-a","maxRetries":1,"retryDelayMs":0}]\n```'
+          : 'final synthesis'
+      }
+
+      const oma = new OpenMultiAgent({
+        defaultModel: 'default-model',
+        onAgentStream: (_agentName, event) => {
+          if (event.type === 'error') {
+            streamedErrorKinds.push({
+              kind: event.errorInfo?.kind,
+              retryable: event.errorInfo?.retryable,
+            })
+          }
+        },
+      })
+      const team = oma.createTeam('t', teamCfg([
+        { ...agentConfig('worker-a'), model: 'default-worker-model' },
+      ]))
+
+      const result = await oma.runTeam(
+        team,
+        'First recover from the provider outage, then write a summary of the result',
+        {
+          modelRouting: {
+            rules: [{
+              match: { phase: 'worker' },
+              route: {
+                model: 'primary-model',
+                provider: 'anthropic',
+                fallback: [{ model: 'backup-model', provider: 'openai' }],
+              },
+            }],
+          },
+        },
+      )
+
+      expect(result.success).toBe(true)
+      expect(capturedChatOptions
+        .map(options => options.model)
+        .filter(model => model === 'primary-model' || model === 'backup-model'))
+        .toEqual(['primary-model', 'backup-model'])
+      expect(streamedErrorKinds).toEqual([{ kind: 'provider', retryable: true }])
+    })
+
     it('prices each fallback attempt with the route that handled it', async () => {
       const costContexts: CostEstimateContext[] = []
       mockAdapterHandler = (options) => {


### PR DESCRIPTION
## Summary

- Add an ordered `fallback` chain to worker `modelRouting` routes.
- Advance the next task retry to the next configured route only for retryable provider errors.
- Price fallback attempts with the model/provider that actually handled them, while retaining aggregate cost estimation for single-route tasks.

## Motivation

Closes #350. Task retry already classifies retryable errors, but previously retried the same provider for every attempt. This lets callers configure a backup route for outages and persistent rate limits without mutating their Team or swapping adapters manually.

## Scope and impact

- Affected: `@open-multi-agent/core` and `docs/model-routing.md`.
- Public API: optional `ModelRouteConfig.fallback`; the behavior is opt-in and applies only to worker tasks, which already have task-level retry settings.
- Terminal errors such as 401 do not retry or fail over. When fallbacks are exhausted, later retries remain on the final route.
- Security and privacy: none. Each fallback uses only its own route overrides combined with the original worker configuration.
- Non-goals: coordinator, synthesis, short-circuit, and delegated phases do not gain a separate retry policy.

## Validation

- [x] `npm test --workspace @open-multi-agent/core -- orchestrator.test.ts` (55 tests)
- [x] `npm run lint --workspace @open-multi-agent/core`
- [x] `npm run build --workspace @open-multi-agent/core`
- [x] Added tests for retryable failover, ordered fallback exhaustion, terminal and unclassified errors, and per-route cost contexts.
- [x] No new runtime dependencies.

`npm test --workspace @open-multi-agent/core` was also run. Its local Windows-only failures are in independent file-store `fsync` permission and POSIX CLI subprocess suites; routing and retry coverage passes.
```
