### PR TITLE
fix(core): handle zero-score agent selection

### DIFF
--- a/packages/core/src/orchestrator/scheduler.ts
+++ b/packages/core/src/orchestrator/scheduler.ts
@@ -9,8 +9,9 @@
  * - `capability-match`   — Score agents by keyword overlap with the task description.
  * - `dependency-first`   — Prioritise tasks on the critical path (most blocked dependents).
  *
- * The scheduler is stateless between calls. All mutable task state lives in the
- * {@link TaskQueue} that is passed to {@link Scheduler.autoAssign}.
+ * The scheduler retains only a round-robin cursor between calls. All mutable
+ * task state lives in the {@link TaskQueue} passed to
+ * {@link Scheduler.autoAssign}.
  */
 
 import type { AgentConfig, Task } from '../types.js'
@@ -94,7 +95,7 @@ function countBlockedDependents(taskId: string, allTasks: Task[]): number {
  * ```
  */
 export class Scheduler {
-  /** Rolling cursor used by `round-robin` to distribute tasks sequentially. */
+  /** Rolling cursor used by round-robin strategies and fallbacks. */
   private roundRobinCursor = 0
 
   /**
@@ -115,9 +116,9 @@ export class Scheduler {
    * Only tasks without an existing `assignee` are considered. Tasks that are
    * already assigned are preserved unchanged.
    *
-   * The method is deterministic for all strategies except `round-robin`, which
-   * advances an internal cursor and therefore produces different results across
-   * successive calls with the same inputs.
+   * The method is deterministic except where a strategy uses the shared
+   * round-robin cursor: the `round-robin` strategy and zero-score fallback in
+   * `capability-match` advance it across successive calls.
    *
    * @param tasks  - Snapshot of all tasks in the current run (any status).
    * @param agents - Available agent configurations.
@@ -240,7 +241,9 @@ export class Scheduler {
    * between the task's title/description and the agent's `systemPrompt` and
    * `name`. The highest-scoring agent wins.
    *
-   * Falls back to round-robin when no agent has any positive score.
+   * The highest positive score wins; positive-score ties preserve agent roster
+   * order. When every agent scores zero for a task, that task consumes the
+   * shared round-robin cursor instead.
    */
   private scheduleCapabilityMatch(
     unassigned: Task[],
@@ -275,6 +278,11 @@ export class Scheduler {
           bestScore = score
           bestAgent = agent
         }
+      }
+
+      if (bestScore === 0) {
+        bestAgent = agents[this.roundRobinCursor % agents.length]!
+        this.roundRobinCursor = (this.roundRobinCursor + 1) % agents.length
       }
 
       result.set(task.id, bestAgent.name)

--- a/packages/core/src/orchestrator/short-circuit.ts
+++ b/packages/core/src/orchestrator/short-circuit.ts
@@ -89,6 +89,11 @@ export function isSimpleGoal(goal: string): boolean {
  * The two-direction sum (`scoreA + scoreB`) ensures both "agent describes
  * goal" and "goal mentions agent capability" contribute to the final score.
  *
+ * Score ties, including an all-zero result, are resolved by ascending agent
+ * name; duplicate names preserve roster order. Unlike Scheduler's stateful
+ * `capability-match` zero-score fallback, this helper cannot round-robin across
+ * calls because each invocation is stateless.
+ *
  * Exported for unit testing.
  */
 export function selectBestAgent(goal: string, agents: AgentConfig[]): AgentConfig {
@@ -108,7 +113,10 @@ export function selectBestAgent(goal: string, agents: AgentConfig[]): AgentConfi
     const scoreB = keywordScore(goal, agentKeywords)
     const score = scoreA + scoreB
 
-    if (score > bestScore) {
+    if (
+      score > bestScore
+      || (score === bestScore && agent.name < bestAgent.name)
+    ) {
       bestScore = score
       bestAgent = agent
     }

--- a/packages/core/tests/scheduler.test.ts
+++ b/packages/core/tests/scheduler.test.ts
@@ -160,15 +160,21 @@ describe('Scheduler: capability-match', () => {
     expect(assignments.get(tasks[2]!.id)).toBe('营销专家')
   })
 
-  it('falls back to first agent when no keywords match', () => {
+  it('round-robins zero-score tasks and advances the cursor across calls', () => {
     const s = new Scheduler('capability-match')
     const agents = [agent('alpha'), agent('beta')]
-    const tasks = [pendingTask('xyz')]
+    const tasks = [
+      pendingTask('x'),
+      pendingTask('y'),
+      pendingTask('z'),
+    ]
 
     const assignments = s.schedule(tasks, agents)
+    const nextTask = pendingTask('q')
+    const nextAssignments = s.schedule([nextTask], agents)
 
-    // When scores are tied (all 0), first agent wins
-    expect(assignments.size).toBe(1)
+    expect([...assignments.values()]).toEqual(['alpha', 'beta', 'alpha'])
+    expect(nextAssignments.get(nextTask.id)).toBe('beta')
   })
 })
 

--- a/packages/core/tests/short-circuit.test.ts
+++ b/packages/core/tests/short-circuit.test.ts
@@ -183,13 +183,23 @@ describe('selectBestAgent', () => {
     expect(selectBestAgent(goal, agents)).toBe(agents[expectedIndex])
   })
 
-  it('falls back to first agent when no keywords match', () => {
+  it('uses agent name as the stable tie-break when all scores are zero', () => {
     const agents: AgentConfig[] = [
-      { name: 'alpha', model: 'test' },
       { name: 'beta', model: 'test' },
+      { name: 'alpha', model: 'test' },
     ]
 
-    expect(selectBestAgent('xyzzy', agents)).toBe(agents[0])
+    expect(selectBestAgent('xyzzy', agents)).toBe(agents[1])
+    expect(selectBestAgent('xyzzy', [...agents].reverse())).toBe(agents[1])
+  })
+
+  it('uses agent name as the stable tie-break for equal positive scores', () => {
+    const agents: AgentConfig[] = [
+      { name: 'beta', model: 'test', systemPrompt: 'TypeScript specialist' },
+      { name: 'alpha', model: 'test', systemPrompt: 'TypeScript specialist' },
+    ]
+
+    expect(selectBestAgent('Write TypeScript', agents)).toBe(agents[1])
   })
 
   it('returns the only agent when team has one member', () => {


### PR DESCRIPTION
## Summary

- fall back to the scheduler's round-robin cursor when every agent receives a zero capability-match score
- make stateless short-circuit selection deterministic by breaking score ties by agent name
- document the intentional difference between scheduler and short-circuit zero-score behavior
- add regression coverage for cursor advancement and stable score ties

## Root cause and impact

The capability-match scheduler documented a round-robin fallback, but its score initialization allowed the first zero-scoring agent to win instead. The stateless short-circuit selector had the same implicit first-roster behavior. Tasks with no keyword affinity could therefore repeatedly select the first agent.

This change implements the scheduler's documented fallback. Because `selectBestAgent` has no cursor state across calls, it uses ascending agent name as a deterministic tie-break instead; duplicate names preserve roster order. The keyword extraction and scoring algorithms are unchanged.

## Testing

- `npm run test -w @open-multi-agent/core -- tests/scheduler.test.ts tests/short-circuit.test.ts`
- `npm run lint -w @open-multi-agent/core`
- `npm run test -w @open-multi-agent/core`
- `npm run build -w @open-multi-agent/core`
- `git diff --check`