### PR TITLE
fix(core): restore CJK keyword-based agent selection

### DIFF
--- a/packages/core/src/utils/keywords.ts
+++ b/packages/core/src/utils/keywords.ts
@@ -10,20 +10,34 @@ export const STOP_WORDS: ReadonlySet<string> = new Set([
   'them', 'their', 'about', 'into', 'more', 'also', 'should', 'must',
 ])
 
+const WORD_SEGMENTER = new Intl.Segmenter('und', { granularity: 'word' })
+const CJK_CHARACTER = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u
+
 /**
  * Tokenise `text` into a deduplicated set of lower-cased keywords.
- * Words shorter than 4 characters and entries in {@link STOP_WORDS}
- * are filtered out.
+ * CJK words shorter than 2 characters, non-CJK words shorter than 4
+ * characters, and entries in {@link STOP_WORDS} are filtered out.
  */
 export function extractKeywords(text: string): string[] {
-  return [
-    ...new Set(
-      text
-        .toLowerCase()
-        .split(/\W+/)
-        .filter((w) => w.length > 3 && !STOP_WORDS.has(w)),
-    ),
-  ]
+  const keywords: string[] = []
+
+  for (const { segment, isWordLike } of WORD_SEGMENTER.segment(text.toLowerCase())) {
+    if (!isWordLike) continue
+
+    // Preserve the previous \W+ splitting semantics for Latin-script words
+    // while allowing Intl.Segmenter to surface CJK words instead of dropping them.
+    const words = CJK_CHARACTER.test(segment) ? [segment] : segment.split(/\W+/)
+    for (const word of words) {
+      const meetsLengthThreshold = CJK_CHARACTER.test(word)
+        ? [...word].length >= 2
+        : word.length > 3
+      if (meetsLengthThreshold && !STOP_WORDS.has(word)) {
+        keywords.push(word)
+      }
+    }
+  }
+
+  return [...new Set(keywords)]
 }
 
 /**

--- a/packages/core/tests/keywords.test.ts
+++ b/packages/core/tests/keywords.test.ts
@@ -47,6 +47,37 @@ describe('utils/keywords', () => {
     it('returns empty array for empty input', () => {
       expect(extractKeywords('')).toEqual([])
     })
+
+    it('extracts CJK words with at least two characters', () => {
+      expect(extractKeywords('分析代码质量并生成评审报告')).toEqual([
+        '分析',
+        '代码',
+        '质量',
+        '生成',
+        '评审',
+        '报告',
+      ])
+    })
+
+    it('extracts keywords from mixed Chinese and English text', () => {
+      expect(extractKeywords('Review这段TypeScript代码并生成API报告')).toEqual([
+        'review',
+        'typescript',
+        '代码',
+        '生成',
+        '报告',
+      ])
+    })
+
+    it('preserves pure-English punctuation and length behaviour', () => {
+      expect(extractKeywords("Writer's notes don't include tiny API words")).toEqual([
+        'writer',
+        'notes',
+        'include',
+        'tiny',
+        'words',
+      ])
+    })
   })
 
   describe('keywordScore', () => {

--- a/packages/core/tests/scheduler.test.ts
+++ b/packages/core/tests/scheduler.test.ts
@@ -140,6 +140,26 @@ describe('Scheduler: capability-match', () => {
     expect(assignments.get(tasks[1]!.id)).toBe('researcher')
   })
 
+  it('matches Chinese tasks to the corresponding Chinese agents', () => {
+    const s = new Scheduler('capability-match')
+    const agents = [
+      agent('营销专家', '制定品牌策略和市场推广方案'),
+      agent('代码评审员', '分析代码质量并生成评审报告'),
+      agent('数据分析师', '分析销售数据并生成趋势报告'),
+    ]
+    const tasks = [
+      pendingTask('分析代码质量并生成评审报告'),
+      pendingTask('分析销售数据并生成趋势报告'),
+      pendingTask('制定品牌策略和市场推广方案'),
+    ]
+
+    const assignments = s.schedule(tasks, agents)
+
+    expect(assignments.get(tasks[0]!.id)).toBe('代码评审员')
+    expect(assignments.get(tasks[1]!.id)).toBe('数据分析师')
+    expect(assignments.get(tasks[2]!.id)).toBe('营销专家')
+  })
+
   it('falls back to first agent when no keywords match', () => {
     const s = new Scheduler('capability-match')
     const agents = [agent('alpha'), agent('beta')]

--- a/packages/core/tests/short-circuit.test.ts
+++ b/packages/core/tests/short-circuit.test.ts
@@ -169,6 +169,20 @@ describe('selectBestAgent', () => {
     expect(selectBestAgent('Research the latest AI papers', agents)).toBe(agents[0])
   })
 
+  it.each([
+    ['分析代码质量并生成评审报告', 1],
+    ['分析销售数据并生成趋势报告', 2],
+    ['制定品牌策略和市场推广方案', 0],
+  ])('selects the semantically matching Chinese agent for "%s"', (goal, expectedIndex) => {
+    const agents: AgentConfig[] = [
+      { name: '营销专家', model: 'test', systemPrompt: '制定品牌策略和市场推广方案' },
+      { name: '代码评审员', model: 'test', systemPrompt: '分析代码质量并生成评审报告' },
+      { name: '数据分析师', model: 'test', systemPrompt: '分析销售数据并生成趋势报告' },
+    ]
+
+    expect(selectBestAgent(goal, agents)).toBe(agents[expectedIndex])
+  })
+
   it('falls back to first agent when no keywords match', () => {
     const agents: AgentConfig[] = [
       { name: 'alpha', model: 'test' },


### PR DESCRIPTION
## Summary

- tokenize word-like input with `Intl.Segmenter('und', { granularity: 'word' })`
- accept CJK keywords with at least two characters while preserving the existing English threshold and splitting behavior
- add regression coverage for Chinese agent selection, capability-match scheduling, mixed Chinese/English input, and pure English input

## Motivation

Chinese goals previously produced an empty keyword set because `\W+` treated CJK characters as separators. When a semantic match existed in a Chinese roster, short-circuit selection and capability-match scheduling therefore tied at zero and defaulted to the first agent.

This change restores keyword affinity for Chinese users without changing the scoring structure.

## Scope and impact

- Affected workspace: `@open-multi-agent/core`
- Public behavior: Chinese goals and task descriptions can now match Chinese agent names and prompts
- Compatibility: existing English token length, punctuation splitting, stop-word filtering, and scoring behavior remain unchanged
- Public API shape, configuration, dependencies, security, and privacy: unchanged
- Intentional non-goals: no changes to short-circuit or scheduler scoring, tie-breaking, or configuration
- Documentation and examples: not applicable; this fixes internal tokenization behavior without changing API usage

## Validation

- `npm run lint -w @open-multi-agent/core` — passed
- `npm run test -w @open-multi-agent/core` — 112 files, 1579 tests passed
- `npm run build -w @open-multi-agent/core` — passed
- focused keyword, short-circuit, and scheduler tests on Node 18, 20, and 22 — 79 tests passed on each version
- `git diff --check origin/main...HEAD` — passed

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING