### PR TITLE
feat(core): make scheduling strategy configurable

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -52,7 +52,7 @@ The runtime schedules dependencies, runs independent work in parallel, shares co
 
 ## Contents
 
-[Quick Start](#quick-start) · [Execution Modes](#execution-modes) · [Capabilities](#capabilities) · [Architecture](#architecture) · [Examples](#examples) · [Providers](#providers) · [Production](#production) · [Documentation](#documentation)
+[Quick Start](#quick-start) · [Execution Modes](#execution-modes) · [Scheduling](#scheduling) · [Capabilities](#capabilities) · [Architecture](#architecture) · [Examples](#examples) · [Providers](#providers) · [Production](#production) · [Documentation](#documentation)
 
 ## Quick Start
 
@@ -120,6 +120,29 @@ const governed = await orchestrator.runTeam(team, 'Review the evidence and asses
 ```
 
 `required` and `preferred` both bypass automatic decomposition and the simple-goal short circuit. OMA creates one task per declared roster name, assigns it to that agent, and chains tasks in `requiredOrder`; dependency outputs are passed to downstream roles. The topology comes only from these structured fields, so equivalent goals in different languages use the same roles and order. `none` or an omitted `governanceIntent` preserves the existing automatic `runTeam()` behavior.
+
+## Scheduling
+
+Set `schedulingStrategy` on `OpenMultiAgent` to choose how unassigned tasks are
+mapped to agents. The setting applies to coordinator-generated `runTeam()`
+plans and explicit or restored task queues. Tasks with an explicit `assignee`
+keep that assignment.
+
+```typescript
+const orchestrator = new OpenMultiAgent({
+  schedulingStrategy: 'capability-match',
+})
+```
+
+| Strategy | Assignment behavior | Recommended when |
+|----------|---------------------|------------------|
+| `dependency-first` (default) | Assigns tasks that unblock the most downstream work first, rotating agents | The task graph has meaningful dependencies |
+| `round-robin` | Distributes tasks in queue order across the roster | Agents are interchangeable |
+| `least-busy` | Chooses the agent with the fewest active or newly assigned tasks | Task duration varies and load balance matters |
+| `capability-match` | Matches task text against agent names and system prompts | Agents have distinct, clearly described roles |
+
+These strategies select one scheduling dimension at a time; they are not
+combined or weighted.
 
 ## Capabilities
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -52,7 +52,7 @@
 
 ## 目录
 
-[快速开始](#快速开始) · [执行模式](#执行模式) · [核心能力](#核心能力) · [架构](#架构) · [示例](#示例) · [Provider](#provider) · [生产配置](#生产配置) · [文档](#文档)
+[快速开始](#快速开始) · [执行模式](#执行模式) · [调度](#调度) · [核心能力](#核心能力) · [架构](#架构) · [示例](#示例) · [Provider](#provider) · [生产配置](#生产配置) · [文档](#文档)
 
 ## 快速开始
 
@@ -108,6 +108,25 @@ console.log(result.agentResults.get('coordinator')?.output)
 | 显式任务管线 | `runTasks()` | 你自己定义任务图和分配 | [`basics/task-pipeline`](examples/basics/task-pipeline.ts) |
 
 用 `planOnly` 在执行前审查生成的任务图，再通过 `createPlanArtifact()` 和 `runFromPlan()` 回放。当一个答案需要额外把关时，`runConsensus()` 提供 proposer→judge 校验循环。
+
+## 调度
+
+在 `OpenMultiAgent` 上设置 `schedulingStrategy`，可以选择如何把未分配的任务映射给 Agent。该配置同时适用于 Coordinator 生成的 `runTeam()` 计划，以及显式或恢复的任务队列。已有显式 `assignee` 的任务会保留原分配。
+
+```typescript
+const orchestrator = new OpenMultiAgent({
+  schedulingStrategy: 'capability-match',
+})
+```
+
+| 策略 | 分配行为 | 适用场景 |
+|------|----------|----------|
+| `dependency-first`（默认） | 优先分配能解锁最多下游工作的任务，并轮转选择 Agent | 任务图存在明确依赖关系 |
+| `round-robin` | 按队列顺序在 Agent roster 中轮转分配 | Agent 能力可以互换 |
+| `least-busy` | 选择当前活跃任务或本批新分配任务最少的 Agent | 任务耗时差异较大，需要负载均衡 |
+| `capability-match` | 用任务文本匹配 Agent 名称和 system prompt | Agent 角色明确且差异清晰 |
+
+每种策略只负责一个调度维度，不会彼此组合或加权。
 
 ## 核心能力
 

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -202,6 +202,7 @@ export class OpenMultiAgent {
    * Sensible defaults:
    *   - `maxConcurrency`: 5
    *   - `maxDelegationDepth`: 3
+   *   - `schedulingStrategy`: `'dependency-first'`
    *   - `defaultModel`:   `'claude-opus-4-6'`
    *   - `defaultProvider`: `'anthropic'`
    */
@@ -228,6 +229,7 @@ export class OpenMultiAgent {
     this.config = {
       maxConcurrency: config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
       maxDelegationDepth: config.maxDelegationDepth ?? DEFAULT_MAX_DELEGATION_DEPTH,
+      schedulingStrategy: config.schedulingStrategy ?? 'dependency-first',
       defaultModel: config.defaultModel ?? DEFAULT_MODEL,
       defaultProvider: config.defaultProvider ?? 'anthropic',
       defaultBaseURL: config.defaultBaseURL,
@@ -747,7 +749,7 @@ export class OpenMultiAgent {
     const taskSpecs = parseTaskSpecs(decompositionResult.output)
 
     const queue = new TaskQueue()
-    const scheduler = new Scheduler('dependency-first')
+    const scheduler = new Scheduler(this.config.schedulingStrategy)
     const taskMetrics = new Map<string, TaskExecutionMetrics>()
 
     if (taskSpecs && taskSpecs.length > 0) {
@@ -1552,7 +1554,7 @@ export class OpenMultiAgent {
     const metadata = restoreMetadata?.metadata ?? newRunFacts?.metadata
     const traceRuntime = this.startTrace(runIdentity, metadata, restoreMetadata?.overridden)
     const agentConfigs = team.getAgents()
-    const scheduler = new Scheduler('dependency-first')
+    const scheduler = new Scheduler(this.config.schedulingStrategy)
     scheduler.autoAssign(queue, agentConfigs)
 
     const pool = this.buildPool(agentConfigs)

--- a/packages/core/src/orchestrator/scheduler.ts
+++ b/packages/core/src/orchestrator/scheduler.ts
@@ -29,6 +29,10 @@ import { extractKeywords, keywordScore } from '../utils/keywords.js'
  * - `least-busy`        — Prefers the agent with the fewest `in_progress` tasks.
  * - `capability-match`  — Keyword-based affinity between task text and agent role.
  * - `dependency-first`  — Prioritise tasks that unblock the most other tasks.
+ *
+ * `dependency-first` is the orchestrator default and suits dependency-heavy
+ * DAGs. Use `round-robin` for interchangeable agents, `least-busy` for uneven
+ * task durations, and `capability-match` for clearly differentiated roles.
  */
 export type SchedulingStrategy =
   | 'round-robin'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,6 +7,7 @@
 
 import type { ZodSchema } from 'zod'
 import type { SupportedProvider } from './llm/adapter.js'
+import type { SchedulingStrategy } from './orchestrator/scheduler.js'
 
 // ---------------------------------------------------------------------------
 // Content blocks
@@ -1421,6 +1422,22 @@ export interface OrchestratorEvent {
 /** Top-level configuration for the orchestrator. */
 export interface OrchestratorConfig {
   readonly maxConcurrency?: number
+  /**
+   * Strategy used to assign unassigned tasks to team agents:
+   *
+   * - `'round-robin'` distributes tasks evenly in roster order; use it when
+   *   agents are interchangeable.
+   * - `'least-busy'` prefers the agent with the fewest active tasks; use it to
+   *   balance work when task duration varies.
+   * - `'capability-match'` compares task text with agent names and system
+   *   prompts; use it when agents have distinct, clearly described roles.
+   * - `'dependency-first'` assigns tasks that unblock the most dependents
+   *   first; use it for dependency-heavy DAGs.
+   *
+   * Defaults to `'dependency-first'`. Explicit task assignees are preserved
+   * and are never replaced by this strategy.
+   */
+  readonly schedulingStrategy?: SchedulingStrategy
   /**
    * Maximum depth of `delegate_to_agent` chains from a task run (default `3`).
    * Depth is per nested delegated run, not per team.

--- a/packages/core/tests/orchestrator.test.ts
+++ b/packages/core/tests/orchestrator.test.ts
@@ -15,6 +15,7 @@ import type {
   TeamConfig,
   TraceEvent,
 } from '../src/types.js'
+import type { SchedulingStrategy } from '../src/orchestrator/scheduler.js'
 
 // ---------------------------------------------------------------------------
 // Mock LLM adapter
@@ -324,6 +325,110 @@ describe('OpenMultiAgent', () => {
       ])
 
       expect(result.success).toBe(true)
+    })
+
+    it.each<{
+      strategy: SchedulingStrategy
+      expected: Record<string, string>
+    }>([
+      {
+        strategy: 'round-robin',
+        expected: {
+          'Implement TypeScript service': 'researcher',
+          'Research market analysis': 'coder',
+          'Summarize findings': 'researcher',
+        },
+      },
+      {
+        strategy: 'least-busy',
+        expected: {
+          'Implement TypeScript service': 'researcher',
+          'Research market analysis': 'coder',
+          'Summarize findings': 'researcher',
+        },
+      },
+      {
+        strategy: 'capability-match',
+        expected: {
+          'Implement TypeScript service': 'coder',
+          'Research market analysis': 'researcher',
+          'Summarize findings': 'researcher',
+        },
+      },
+      {
+        strategy: 'dependency-first',
+        expected: {
+          'Implement TypeScript service': 'coder',
+          'Research market analysis': 'researcher',
+          'Summarize findings': 'researcher',
+        },
+      },
+    ])('applies the $strategy scheduling strategy from config', async ({ strategy, expected }) => {
+      mockAdapterResponses = ['first done', 'second done', 'third done']
+
+      const events: OrchestratorEvent[] = []
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        schedulingStrategy: strategy,
+        onProgress: (event) => events.push(event),
+      })
+      const team = oma.createTeam('t', teamCfg([
+        {
+          ...agentConfig('researcher'),
+          systemPrompt: 'Research markets and analyze evidence.',
+        },
+        {
+          ...agentConfig('coder'),
+          systemPrompt: 'Implement TypeScript software services.',
+        },
+      ]))
+
+      const result = await oma.runTasks(team, [
+        { title: 'Implement TypeScript service', description: 'Implement software code' },
+        { title: 'Research market analysis', description: 'Research and analyze market evidence' },
+        {
+          title: 'Summarize findings',
+          description: 'Summarize the research',
+          dependsOn: ['Research market analysis'],
+        },
+      ])
+
+      const assignments = Object.fromEntries(
+        events
+          .filter((event) => event.type === 'task_start')
+          .map((event) => [(event.data as { title: string }).title, event.agent]),
+      )
+      expect(result.success).toBe(true)
+      expect(assignments).toEqual(expected)
+    })
+
+    it('defaults to dependency-first scheduling', async () => {
+      mockAdapterResponses = ['first done', 'second done', 'third done']
+
+      const events: OrchestratorEvent[] = []
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onProgress: (event) => events.push(event),
+      })
+      const team = oma.createTeam('t', teamCfg())
+
+      const result = await oma.runTasks(team, [
+        { title: 'Independent', description: 'Independent work' },
+        { title: 'Critical root', description: 'Start the pipeline' },
+        { title: 'Dependent', description: 'Finish the pipeline', dependsOn: ['Critical root'] },
+      ])
+
+      const assignments = Object.fromEntries(
+        events
+          .filter((event) => event.type === 'task_start')
+          .map((event) => [(event.data as { title: string }).title, event.agent]),
+      )
+      expect(result.success).toBe(true)
+      expect(assignments).toEqual({
+        Independent: 'worker-b',
+        'Critical root': 'worker-a',
+        Dependent: 'worker-a',
+      })
     })
 
     it('uses a clean slate for tasks without dependencies', async () => {
@@ -868,6 +973,48 @@ describe('OpenMultiAgent', () => {
       const result = await oma.runTeam(team, 'First design the database schema, then implement the REST API endpoints')
 
       expect(result.success).toBe(true)
+    })
+
+    it('uses schedulingStrategy for unassigned coordinator tasks', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title":"Implement TypeScript service","description":"Implement software code"},{"title":"Research market analysis","description":"Research and analyze market evidence"}]\n```',
+        'worker result',
+        'worker result',
+        'synthesis',
+      ]
+
+      const events: OrchestratorEvent[] = []
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        schedulingStrategy: 'capability-match',
+        onProgress: (event) => events.push(event),
+      })
+      const team = oma.createTeam('t', teamCfg([
+        {
+          ...agentConfig('researcher'),
+          systemPrompt: 'Research markets and analyze evidence.',
+        },
+        {
+          ...agentConfig('coder'),
+          systemPrompt: 'Implement TypeScript software services.',
+        },
+      ]))
+
+      const result = await oma.runTeam(
+        team,
+        'First implement the service, then research the market and synthesize both results.',
+      )
+
+      const assignments = Object.fromEntries(
+        events
+          .filter((event) => event.type === 'task_start')
+          .map((event) => [(event.data as { title: string }).title, event.agent]),
+      )
+      expect(result.success).toBe(true)
+      expect(assignments).toEqual({
+        'Implement TypeScript service': 'coder',
+        'Research market analysis': 'researcher',
+      })
     })
 
     it('supports coordinator model override without affecting workers', async () => {


### PR DESCRIPTION
## Summary

- Add `OrchestratorConfig.schedulingStrategy` for the four existing scheduler strategies.
- Apply the configured strategy to coordinator-generated `runTeam()` plans and the explicit/restored task queue path.
- Preserve `dependency-first` as the default and preserve explicit task assignees.
- Document strategy semantics, defaults, and recommended use cases in the English and Chinese core READMEs.

## Motivation

`SchedulingStrategy` and all four scheduler implementations are public, but the orchestrator previously instantiated `Scheduler('dependency-first')` directly in both task-assignment paths. Applications therefore could not select an existing strategy through `OrchestratorConfig`.

This change connects the existing scheduler capability to the public configuration surface without changing strategy behavior.

## Scope and impact

- Affected workspace: `@open-multi-agent/core`
- Public API: adds the optional `schedulingStrategy?: SchedulingStrategy` field to `OrchestratorConfig`
- Compatibility: additive and backward-compatible; omitting the field keeps `dependency-first`
- Documentation: adds scheduling guidance to the English and Chinese core READMEs
- Security and privacy: no impact
- Intentional non-goals: no strategy implementation changes and no composite or weighted scheduling
- Dependencies: no changes

## Validation

- `npm run test -w @open-multi-agent/core -- orchestrator.test.ts` — 64 tests passed after rebasing onto current `main`
- `npm run lint -w @open-multi-agent/core` — passed
- `npm run test -w @open-multi-agent/core` — 112 files and 1,594 tests passed
- `npm run build -w @open-multi-agent/core` — passed
- `git diff --check origin/main...HEAD` — passed

Provider E2E was not run because this change does not affect provider integrations or require real credentials.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING