### PR TITLE
fix(core): honor planOnly for governed team runs

### DIFF
--- a/docs/tool-configuration.md
+++ b/docs/tool-configuration.md
@@ -22,6 +22,12 @@ For both `required` and `preferred`, OMA skips coordinator decomposition and the
 
 The goal text is not inspected to choose this topology. The same declaration therefore produces the same roles and dependency order for English, Chinese, or any other language. Every `requiredRoles` name must exist in the team roster, and `requiredOrder`, when present, must be a permutation of those roles. Invalid declarations throw before any agent runs.
 
+When `planOnly: true` is combined with `governanceIntent: 'required'` or
+`'preferred'`, `planOnly` wins: OMA validates and returns the declared role DAG
+with every task pending, but runs neither the coordinator nor task agents. The
+result reports `governanceConclusion: 'not-applicable'` until that plan is
+executed, for example through `runFromPlan()`.
+
 Use `governanceIntent: 'none'` to opt into the existing automatic `runTeam()` route explicitly. Omitting `governanceIntent` also preserves the existing behavior, including simple-goal short circuit and coordinator-generated task planning.
 
 After execution, required declarations are checked against the execution

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -523,6 +523,17 @@ export class OpenMultiAgent {
     if (governanceTaskSpecs !== undefined) {
       const queue = new TaskQueue()
       loadSpecsIntoQueue(governanceTaskSpecs, agentConfigs, queue)
+      if (options?.planOnly) {
+        const { identity, metadata } = createRunFacts(identityOptionsForRun(options))
+        const traceRuntime = this.startTrace(identity, metadata)
+        const result = {
+          ...this.buildPlanOnlyTeamRunResult(new Map(), identity, goal, queue),
+          ...(metadata !== undefined ? { metadata } : {}),
+        }
+        traceRuntime?.close({ status: result.status ?? statusOnly('ok') })
+        this.completeOnlineEvaluation(pendingEvaluation, result)
+        return result
+      }
       return this.executeExplicitTaskQueue(
         team,
         queue,
@@ -952,29 +963,12 @@ export class OpenMultiAgent {
     }
 
     if (options?.planOnly) {
-      const planOnlyTasks: readonly TaskExecutionRecord[] = queue.list().map((task) => ({
-        id: task.id,
-        title: task.title,
-        assignee: task.assignee,
-        status: task.status,
-        dependsOn: task.dependsOn ?? [],
-        description: task.description,
-        memoryScope: task.memoryScope,
-        maxRetries: task.maxRetries,
-        retryDelayMs: task.retryDelayMs,
-        retryBackoff: task.retryBackoff,
-        verify: task.verify,
-        metrics: undefined,
-      }))
       this.config.onProgress?.({
         type: 'agent_complete',
         agent: 'coordinator',
         data: decompositionResult,
       })
-      return finish({
-        ...this.buildTeamRunResult(agentResults, identity, goal, planOnlyTasks),
-        planOnly: true,
-      })
+      return finish(this.buildPlanOnlyTeamRunResult(agentResults, identity, goal, queue))
     }
 
     await executeQueue(queue, ctx)
@@ -1918,6 +1912,32 @@ export class OpenMultiAgent {
       agentResults: collapsed,
       totalTokenUsage: totalUsage,
       metrics,
+    }
+  }
+
+  private buildPlanOnlyTeamRunResult(
+    agentResults: Map<string, AgentRunResult>,
+    identity: RunIdentity,
+    goal: string,
+    queue: TaskQueue,
+  ): TeamRunResult {
+    const tasks: readonly TaskExecutionRecord[] = queue.list().map((task) => ({
+      id: task.id,
+      title: task.title,
+      assignee: task.assignee,
+      status: 'pending',
+      dependsOn: task.dependsOn ?? [],
+      description: task.description,
+      memoryScope: task.memoryScope,
+      maxRetries: task.maxRetries,
+      retryDelayMs: task.retryDelayMs,
+      retryBackoff: task.retryBackoff,
+      verify: task.verify,
+      metrics: undefined,
+    }))
+    return {
+      ...this.buildTeamRunResult(agentResults, identity, goal, tasks),
+      planOnly: true,
     }
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1172,6 +1172,9 @@ export interface RunTeamOptions extends RunTasksOptions {
    * {@link requiredRoles} entry using the declared roster assignments.
    * `'none'` and an omitted value preserve the existing automatic routing
    * behavior.
+   *
+   * When combined with {@link planOnly}, the declared role topology is built
+   * and validated but not executed; `planOnly` wins.
    */
   readonly governanceIntent?: 'required' | 'preferred' | 'none'
   /**
@@ -1197,16 +1200,19 @@ export interface RunTeamOptions extends RunTasksOptions {
    */
   readonly preferredUnderBudget?: 'attempt' | 'degrade'
   /**
-   * When true, the coordinator decomposes the goal but no task agents run.
-   * The returned {@link TeamRunResult} has `planOnly: true`, `success: true`,
-   * `tasks` populated (all `pending`, no metrics), and `agentResults`
-   * containing only the coordinator's decomposition call. `totalTokenUsage`
-   * reflects the coordinator only.
+   * When true, returns a validated plan without running task agents. The
+   * returned {@link TeamRunResult} has `planOnly: true`, `success: true`, and
+   * `tasks` populated (all `pending`, no metrics).
    *
-   * Bypasses the simple-goal short-circuit so the coordinator always runs.
+   * With `governanceIntent: 'required' | 'preferred'`, no coordinator or task
+   * agent runs; the validated declared-role topology is returned instead, and
+   * `governanceConclusion` is `'not-applicable'`. Otherwise, `planOnly`
+   * bypasses the simple-goal short circuit and runs only the coordinator
+   * decomposition call, which is reflected in `agentResults` and token usage.
    *
-   * If {@link OrchestratorConfig.onPlanReady} is wired up and returns false,
-   * the rejection wins: result is `success: false` and `planOnly` is undefined.
+   * For coordinator-generated plans, if {@link OrchestratorConfig.onPlanReady}
+   * is wired up and returns false, the rejection wins: result is
+   * `success: false` and `planOnly` is undefined.
    */
   readonly planOnly?: boolean
   /**

--- a/packages/core/tests/governance-intent.test.ts
+++ b/packages/core/tests/governance-intent.test.ts
@@ -134,6 +134,80 @@ describe('runTeam declared governance intent', () => {
     ])
   })
 
+  it.each(['required', 'preferred'] as const)(
+    'returns the pending role DAG without executing agents for %s planOnly',
+    async (governanceIntent) => {
+      const result = await runGovernedGoal('Check this request.', {
+        ...requiredGovernance,
+        governanceIntent,
+        planOnly: true,
+      })
+
+      expect(result).toMatchObject({
+        success: true,
+        planOnly: true,
+        governanceConclusion: 'not-applicable',
+      })
+      expect(result.agentResults.size).toBe(0)
+      expect(result.totalTokenUsage).toEqual({ input_tokens: 0, output_tokens: 0 })
+      expect(result.tasks?.every((task) => (
+        task.status === 'pending' && task.metrics === undefined
+      ))).toBe(true)
+      expect(normalizeTopology(result.tasks)).toEqual([
+        { assignee: 'reviewer', dependsOn: [] },
+        { assignee: 'security', dependsOn: ['reviewer'] },
+      ])
+    },
+  )
+
+  it('replays a governed plan with the same role topology as direct execution', async () => {
+    const workerCalls: string[] = []
+    const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = orchestrator.createTeam('governance-team', {
+      name: 'governance-team',
+      agents: [
+        agent('reviewer', 'reviewer output', workerCalls),
+        agent('security', 'security output', workerCalls),
+      ],
+      sharedMemory: true,
+    })
+    const planned = await orchestrator.runTeam(team, 'Check this request.', {
+      ...requiredGovernance,
+      planOnly: true,
+    })
+    const replay = await orchestrator.runFromPlan(
+      team,
+      orchestrator.createPlanArtifact(planned),
+    )
+    const direct = await runGovernedGoal('Check this request.', requiredGovernance)
+
+    expect(replay.success).toBe(true)
+    expect(normalizeTopology(replay.tasks)).toEqual(normalizeTopology(direct.tasks))
+    expect(workerCalls).toHaveLength(2)
+  })
+
+  it.each([
+    ['omitted', {}],
+    ['none', { governanceIntent: 'none' as const }],
+  ])('preserves coordinator planning when governance intent is %s', async (_label, declaration) => {
+    const coordinatorCalls: string[] = []
+    const result = await runGovernedGoal('Plan this request.', {
+      ...declaration,
+      planOnly: true,
+      coordinator: {
+        adapter: responseAdapter(
+          '```json\n[{"title":"Coordinator plan","description":"Plan it","assignee":"reviewer"}]\n```',
+          coordinatorCalls,
+        ),
+      },
+    })
+
+    expect(result.planOnly).toBe(true)
+    expect(result.tasks?.map((task) => task.title)).toEqual(['Coordinator plan'])
+    expect(result.agentResults.has('coordinator')).toBe(true)
+    expect(coordinatorCalls).toHaveLength(1)
+  })
+
   it('leaves declared roles unordered when requiredOrder is omitted', async () => {
     const result = await runGovernedGoal('Check this request.', {
       governanceIntent: 'required',
@@ -164,6 +238,7 @@ describe('runTeam declared governance intent', () => {
     await expect(runGovernedGoal('Review this request.', {
       governanceIntent: 'required',
       requiredRoles: ['reviewer', 'auditor'],
+      planOnly: true,
     })).rejects.toThrow(
       'runTeam requiredRoles must exist in the team roster; unknown role(s): auditor.',
     )

--- a/packages/core/tests/mode-governance-resolution.test.ts
+++ b/packages/core/tests/mode-governance-resolution.test.ts
@@ -105,6 +105,37 @@ describe('runTeam explicit mode and budget/governance resolution', () => {
     })
   })
 
+  it("keeps mode 'single' incompatible with planOnly", async () => {
+    const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = createGovernanceTeam(orchestrator)
+
+    await expect(orchestrator.runTeam(team, 'Plan this request.', {
+      mode: 'single',
+      planOnly: true,
+    })).rejects.toThrow("runTeam mode 'single' cannot be combined with planOnly.")
+  })
+
+  it("keeps mode 'team' on the coordinator plan when governance is also declared", async () => {
+    const coordinatorCalls: string[] = []
+    const coordinator = scriptedAdapter([{
+      output: '```json\n[{"title":"Coordinator plan","description":"Plan it","assignee":"reviewer"}]\n```',
+    }], coordinatorCalls)
+    const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = createGovernanceTeam(orchestrator)
+
+    const result = await orchestrator.runTeam(team, 'Plan this request.', {
+      ...requiredGovernance,
+      mode: 'team',
+      planOnly: true,
+      coordinator: { model: 'mock-model', adapter: coordinator },
+    })
+
+    expect(result.tasks?.map((task) => task.title)).toEqual(['Coordinator plan'])
+    expect(result.agentResults.has('coordinator')).toBe(true)
+    expect(result.agentResults.has('reviewer')).toBe(false)
+    expect(coordinatorCalls).toHaveLength(1)
+  })
+
   it('executes a forced Single but discloses an overridden required floor', async () => {
     const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
     const team = createGovernanceTeam(orchestrator)

--- a/packages/core/tests/orchestrator.test.ts
+++ b/packages/core/tests/orchestrator.test.ts
@@ -1699,11 +1699,10 @@ describe('OpenMultiAgent', () => {
       expect(result.tasks).toBeDefined()
       expect(result.tasks!.length).toBe(2)
 
-      // Tasks should be in pre-execution states only. Independent tasks remain
-      // 'pending'; tasks with unmet dependencies are 'blocked' (set by the
-      // queue at insert time). Neither has executed.
+      // Plan artifacts expose every task as pending, including tasks whose
+      // dependencies will block them once execution begins.
       for (const task of result.tasks!) {
-        expect(['pending', 'blocked']).toContain(task.status)
+        expect(task.status).toBe('pending')
         expect(task.metrics).toBeUndefined()
       }
 


### PR DESCRIPTION
## Summary

- Make `planOnly` win when combined with `governanceIntent: 'required' | 'preferred'`.
- Validate and return the declared role DAG without executing the coordinator or task agents.
- Reuse one plan-only result builder for governed and coordinator-generated plans.
- Document the interaction in `RunTeamOptions` and the governance guide.

## Motivation

Governed `runTeam()` calls previously entered the explicit role execution path before checking `planOnly`. A caller combining the two options therefore received real task execution even though it requested a plan-only result.

This change makes the interaction explicit and preserves invalid-role validation before returning the plan.

## Scope and impact

- Affected area: `@open-multi-agent/core` orchestration, tests, and governance documentation.
- Public behavior: governed plan-only calls now return `success: true`, `planOnly: true`, `governanceConclusion: 'not-applicable'`, and pending tasks with assignees and dependency edges preserved.
- Compatibility: no API shape change or migration is required. Existing `governanceIntent: 'none'` and omitted-governance planning remain coordinator-generated.
- Security/privacy: no security or privacy boundary changes.
- Intentional non-goals: no changes to explicit mode semantics, simple-goal short circuit, budget resolution, or execution routing.
- Dependencies: none changed.

## Validation

- `npm run test -w @open-multi-agent/core -- governance-intent.test.ts mode-governance-resolution.test.ts orchestrator.test.ts` — 3 files, 86 tests passed.
- `npm run lint -w @open-multi-agent/core` — passed.
- `npm run test -w @open-multi-agent/core` — 113 files, 1611 tests passed.
- `npm run build -w @open-multi-agent/core` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Provider E2E was not run because this change does not affect provider integration and requires real credentials.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING