### PR TITLE
feat(core): trace execution routing decisions

### DIFF
--- a/docs/execution-routing.md
+++ b/docs/execution-routing.md
@@ -69,7 +69,12 @@ result.routingDecision
 // }
 ```
 
-Automatic routes expose `TeamRunResult.routingDecision`. Explicit `mode`, declared role governance, `preferredUnderBudget: 'degrade'`, and `planOnly` paths omit it because no router chose their topology.
+Every `runTeam()` topology choice exposes `TeamRunResult.routingDecision`.
+Its `source` distinguishes caller `override`, governance `declared`, framework
+`policy`, and automatic `router` decisions; only `router` records carry the
+actual `routerVersion`. See the
+[five routing trace source classifications](./observability.md#trace-spans),
+including the compatibility-only `legacy-deterministic` label.
 
 ## Built-in deterministic policy
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -107,6 +107,14 @@ task dependency connects two different roles. Parallel roles with no dependency
 edge do not count as an independent review chain. Coordinator planning entries
 (`coordinator` and `coordinator:*`) are excluded.
 
+For `runTeam()`, the receipt also carries its stable `id` plus
+`routingDecisionId` and, when tracing is enabled, `routingDecisionSpanId`.
+These fields link the post-execution topology back to
+`TeamRunResult.routingDecision`, which in turn carries the receipt's `receiptId`.
+The routing span records the same receipt ID. `ExecutionReceipt` remains the
+only structured record of the topology that actually ran; the routing record
+describes only the pre-execution choice and its reasons.
+
 Governance decisions must use these execution facts, not labels, claims, or
 review markers in model answer text. The builder never inspects answer text.
 For a standalone `AgentRunResult`, the optional trace supplies the agent name
@@ -617,7 +625,26 @@ const orchestrator = new OpenMultiAgent({
 
 Forward trace spans to OpenTelemetry, Datadog, Honeycomb, Langfuse, or your own run database only after deciding what data is safe for that sink. See [`integrations/trace-observability`](../packages/core/examples/integrations/trace-observability.ts) for a runnable example.
 
-The seven-member `TraceEvent` union and completion/event timing are unchanged.
+Every `runTeam()` topology choice emits a `routing_decision` legacy event and
+a v2 span with kind `routing` named `decide_execution_route`. The
+record includes the decision-time `mode`, `reasons`, optional `confidence`,
+and the actual `routerVersion` when a router ran. Its `source` distinguishes
+the priority-chain path without pretending every choice came from a router:
+
+- `override` — the caller supplied `mode`;
+- `declared` — structured governance roles selected the team topology;
+- `policy` — framework policy selected the topology, including
+  `preferredUnderBudget: 'degrade'` and `planOnly`;
+- `router` — automatic routing ran; `routerVersion` identifies that router;
+- `legacy-deterministic` — reserved for serialized or compatibility paths that
+  bypass an `ExecutionRouter`. Current `runTeam()` auto routing passes through
+  `ExecutionRouter`, so new runs do not use this label.
+
+The event/span's `receiptId` points to the eventual `ExecutionReceipt`; the
+receipt points back with `routingDecisionId` and `routingDecisionSpanId`.
+Neither record duplicates task roles, order, or dependency edges.
+
+The `TraceEvent` union now has eight members, including `routing_decision`.
 Internally, `LegacyCallbackTraceSink` maps v2 records back to the exact legacy
 event object. Synchronous callback throws and asynchronous rejections remain
 isolated and cannot become unhandled rejections. `onTrace` is not marked
@@ -676,6 +703,13 @@ tokens, costs, agents, models, and providers when recorded. DAG and Waterfall
 selection are synchronized by task ID; search and kind/status/agent/task
 filters preserve ancestor context. Cyclic or missing hierarchy/dependency data
 degrades to visible warnings instead of being silently treated as success.
+When routing data is present, a summary above both views shows what mode was
+selected, the source and reasons for that choice, and the actual
+`ExecutionReceipt` mode/roles/dependency evidence. Result-only and combined
+views use `buildExecutionReceipt(result)` for the actual topology rather than
+maintaining a dashboard-specific topology model. Trace-only views summarize
+the already-materialized Viewer tasks and label that evidence trace-derived
+because an `ExecutionReceipt` was not provided.
 
 The generated HTML contains its CSS, JavaScript, and allowlisted data and loads
 no remote scripts, stylesheets, fonts, images, telemetry, or runtime API. It

--- a/packages/core/src/dashboard/render-run-viewer.ts
+++ b/packages/core/src/dashboard/render-run-viewer.ts
@@ -65,7 +65,7 @@ export function renderRunViewer(input: RunViewerInput, options: RunViewerOptions
     button:focus-visible, input:focus-visible, select:focus-visible {
       outline: 2px solid var(--cyan); outline-offset: 2px;
     }
-    .shell { height: 100vh; display: grid; grid-template-rows: auto auto auto minmax(0,1fr); }
+    .shell { height: 100vh; display: grid; grid-template-rows: auto auto auto auto minmax(0,1fr); }
     .masthead {
       min-width: 0; display: grid; border-bottom: 1px solid var(--line); background: rgba(7,10,14,.93);
     }
@@ -105,6 +105,15 @@ export function renderRunViewer(input: RunViewerInput, options: RunViewerOptions
     .icon-btn:hover, .fit-btn:hover, .load-more:hover { border-color: var(--cyan); color: var(--cyan); }
     .warning-strip { display: none; padding: 9px 22px; gap: 8px; align-items: center; background: #251f12; border-bottom: 1px solid #5a4820; color: #ffd989; font: 12px/1.3 var(--mono); }
     .warning-strip.visible { display: flex; }
+    .routing-summary {
+      display: none; grid-template-columns: minmax(180px,.75fr) minmax(240px,1.25fr) minmax(260px,1.5fr);
+      border-bottom: 1px solid var(--line); background: rgba(18,24,35,.96);
+    }
+    .routing-summary.visible { display: grid; }
+    .routing-card { min-width: 0; padding: 11px 18px; border-right: 1px solid var(--line); }
+    .routing-card:last-child { border-right: 0; }
+    .routing-value { margin-top: 6px; font: 700 13px/1.35 var(--mono); color: var(--ink); overflow-wrap: anywhere; }
+    .routing-meta { margin-top: 5px; font: 10px/1.35 var(--mono); color: var(--muted); overflow-wrap: anywhere; }
     .toolbar {
       padding: 10px 18px; display: flex; align-items: end; gap: 9px; border-bottom: 1px solid var(--line);
       background: rgba(13,17,24,.96); overflow-x: auto;
@@ -123,7 +132,7 @@ export function renderRunViewer(input: RunViewerInput, options: RunViewerOptions
       border-radius: var(--radius); padding: 0 10px; color: var(--ink); font: 12px/1 var(--mono);
     }
     .result-count { margin-left: auto; padding-bottom: 8px; white-space: nowrap; font: 11px/1 var(--mono); color: var(--muted); }
-    .workspace { grid-row: 4; min-height: 0; display: grid; grid-template-columns: minmax(0,1fr) 360px; }
+    .workspace { grid-row: 5; min-height: 0; display: grid; grid-template-columns: minmax(0,1fr) 360px; }
     .stage { min-width: 0; min-height: 0; position: relative; background: rgba(7,10,14,.58); }
     .view { position: absolute; inset: 0; min-height: 0; }
     .view[hidden] { display: none; }
@@ -182,6 +191,7 @@ export function renderRunViewer(input: RunViewerInput, options: RunViewerOptions
     .kind-dot.tool { background: var(--amber); }
     .kind-dot.task { background: var(--mint); }
     .kind-dot.agent { background: var(--cyan); }
+    .kind-dot.routing { background: var(--coral); }
     .wf-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font: 700 11px/1.2 var(--mono); }
     .wf-kind { color: var(--faint); font-size: 9px; text-transform: uppercase; }
     .wf-track {
@@ -192,6 +202,7 @@ export function renderRunViewer(input: RunViewerInput, options: RunViewerOptions
     .wf-bar.kind-llm { background: var(--violet); }
     .wf-bar.kind-tool { background: var(--amber); }
     .wf-bar.kind-task { background: var(--mint); }
+    .wf-bar.kind-routing { background: var(--coral); }
     .wf-bar.failed { background: var(--coral); }
     .wf-bar.incomplete { background: repeating-linear-gradient(90deg, var(--amber), var(--amber) 5px, transparent 5px, transparent 8px); border: 1px solid var(--amber); }
     .wf-unknown { position: absolute; left: 3px; top: 4px; color: var(--faint); font: 9px/1 var(--mono); }
@@ -235,6 +246,9 @@ export function renderRunViewer(input: RunViewerInput, options: RunViewerOptions
       .brand h1 { font-size: 20px; }
       .run-context { min-width: 0; max-width: none; width: 100%; margin-left: 0; grid-template-columns: 1fr; gap: 6px; }
       .toolbar { padding: 8px 10px; }
+      .routing-summary.visible { grid-template-columns: 1fr; max-height: 220px; overflow: auto; }
+      .routing-card { border-right: 0; border-bottom: 1px solid var(--line); }
+      .routing-card:last-child { border-bottom: 0; }
       .tab { min-width: 0; flex: 1; }
       .workspace { grid-template-rows: 520px auto; }
       .detail-grid { grid-template-columns: 1fr; }
@@ -259,6 +273,7 @@ export function renderRunViewer(input: RunViewerInput, options: RunViewerOptions
       <div id="summaryGrid" class="summary-grid" aria-label="Run summary"></div>
     </header>
     <div id="warningStrip" class="warning-strip" role="status"></div>
+    <section id="routingSummary" class="routing-summary" aria-label="Routing decision and actual execution"></section>
     <div class="toolbar">
       <div class="tabs" role="tablist" aria-label="Run views">
         <button id="dagTab" class="tab" type="button" role="tab" aria-controls="dagView">DAG</button>
@@ -294,7 +309,7 @@ export function renderRunViewer(input: RunViewerInput, options: RunViewerOptions
       var tasksById = new Map((payload.tasks || []).map(function (task) { return [task.id, task]; }));
       var state = { view: payload.defaultView || 'dag', selectedKey: null, selectedTaskId: null, collapsed: new Set(), waterfallLimit: 500, scale: 1, tx: 0, ty: 0, lastFocus: null };
       var els = {};
-      ['viewerTitle','summaryGrid','runId','copyRunId','copyStatus','warningStrip','dagTab','waterfallTab','dagView','waterfallView','searchInput','kindFilter','statusFilter','agentFilter','taskFilter','resetFilters','resultCount','dagViewport','dagCanvas','dagEdges','dagNodes','fitDag','resetDag','waterfallBody','details'].forEach(function (id) { els[id] = document.getElementById(id); });
+      ['viewerTitle','summaryGrid','runId','copyRunId','copyStatus','warningStrip','routingSummary','dagTab','waterfallTab','dagView','waterfallView','searchInput','kindFilter','statusFilter','agentFilter','taskFilter','resetFilters','resultCount','dagViewport','dagCanvas','dagEdges','dagNodes','fitDag','resetDag','waterfallBody','details'].forEach(function (id) { els[id] = document.getElementById(id); });
 
       function text(tag, value, className) { var node = document.createElement(tag); if (className) node.className = className; node.textContent = value == null ? '' : String(value); return node; }
       function fmtDuration(ms) { if (typeof ms !== 'number') return 'Unknown'; if (ms < 1) return ms.toFixed(2) + ' ms'; if (ms < 1000) return Math.round(ms) + ' ms'; if (ms < 60000) return (ms / 1000).toFixed(ms < 10000 ? 2 : 1) + ' s'; return (ms / 60000).toFixed(1) + ' min'; }
@@ -329,6 +344,25 @@ export function renderRunViewer(input: RunViewerInput, options: RunViewerOptions
       }
       function populateSelect(select, values) { (values || []).forEach(function (value) { var option = document.createElement('option'); option.value = value; option.textContent = value; select.appendChild(option); }); }
       function metric(label, value, cls) { var box = document.createElement('div'); box.className = 'metric'; var display = text('strong', value, 'metric-value ' + (cls || '')); display.title = String(value); box.appendChild(text('span', label, 'metric-label')); box.appendChild(display); return box; }
+      function routingCard(label, value, meta) { var card = document.createElement('div'); card.className = 'routing-card'; card.appendChild(text('span',label,'metric-label')); card.appendChild(text('div',value,'routing-value')); if (meta) card.appendChild(text('div',meta,'routing-meta')); return card; }
+      function renderRoutingSummary() {
+        var routing = payload.routing; els.routingSummary.replaceChildren();
+        if (!routing || !routing.decision) { els.routingSummary.classList.remove('visible'); return; }
+        var decision = routing.decision; var receipt = routing.receipt;
+        var decisionMeta = [decision.routerVersion ? 'router ' + decision.routerVersion : null, decision.confidence != null ? 'confidence ' + decision.confidence : null].filter(Boolean).join(' · ');
+        var traceRoles = Array.from(new Set((payload.tasks || []).map(function (task) { return task.assignee; }).filter(Boolean)));
+        var traceDependencyCount = (payload.tasks || []).reduce(function (count, task) { return count + (task.dependsOn || []).length; },0);
+        var actual = receipt
+          ? receipt.mode + (receipt.rolesExecuted && receipt.rolesExecuted.length ? ' · ' + receipt.rolesExecuted.join(' → ') : ' · no executed roles')
+          : (traceRoles.length > 1 ? 'multi-agent' : 'single') + (traceRoles.length ? ' · ' + traceRoles.join(' → ') : ' · no executed roles');
+        var actualMeta = receipt
+          ? (receipt.dependencyEdges || []).length + ' dependency edge(s)' + (receipt.partial ? ' · partial evidence' : ' · complete evidence')
+          : traceDependencyCount + ' task dependency edge(s) · trace-derived evidence; ExecutionReceipt unavailable';
+        els.routingSummary.appendChild(routingCard('Decided',decision.mode + ' · ' + decision.source,decisionMeta));
+        els.routingSummary.appendChild(routingCard('Why',(decision.reasons || []).join(' · ') || 'No reason recorded','decision ' + decision.decisionId));
+        els.routingSummary.appendChild(routingCard('Actually ran',actual,actualMeta + (receipt && receipt.routingDecisionSpanId ? ' · span ' + receipt.routingDecisionSpanId : '')));
+        els.routingSummary.classList.add('visible');
+      }
       function renderSummary() {
         var summary = payload.summary || {};
         els.viewerTitle.textContent = payload.title || 'OMA Run Viewer';
@@ -429,6 +463,7 @@ export function renderRunViewer(input: RunViewerInput, options: RunViewerOptions
       var dragging = false, lastX = 0, lastY = 0; els.dagViewport.addEventListener('pointerdown',function (event) { if (event.target.closest('.dag-node')) return; dragging = true; lastX = event.clientX; lastY = event.clientY; els.dagViewport.classList.add('dragging'); els.dagViewport.setPointerCapture(event.pointerId); }); els.dagViewport.addEventListener('pointermove',function (event) { if (!dragging) return; state.tx += event.clientX - lastX; state.ty += event.clientY - lastY; lastX = event.clientX; lastY = event.clientY; applyDagTransform(); }); els.dagViewport.addEventListener('pointerup',function () { dragging = false; els.dagViewport.classList.remove('dragging'); });
       document.addEventListener('keydown',function (event) { if (event.key === 'Escape') { var returnFocus = state.lastFocus; state.selectedKey = null; state.selectedTaskId = null; renderDetails(null); if (state.view === 'dag') renderDag(); else renderWaterfall(); if (returnFocus && returnFocus.isConnected && typeof returnFocus.focus === 'function') returnFocus.focus(); } });
       renderSummary();
+      renderRoutingSummary();
       var initialSpan = (payload.spans || []).find(function (span) { return ['error','failed','timeout','budget_exhausted','rejected'].indexOf(span.status) !== -1; }) || (payload.spans || []).find(function (span) { return span.kind === 'run'; });
       if (initialSpan) selectSpan(initialSpan.key); else if ((payload.tasks || [])[0]) selectTask(payload.tasks[0].id);
       setView(state.view);

--- a/packages/core/src/dashboard/run-viewer-model.ts
+++ b/packages/core/src/dashboard/run-viewer-model.ts
@@ -1,4 +1,5 @@
 import type {
+  ExecutionRoutingDecisionRecord,
   RunStatusCode,
   StructuredTraceError,
   TaskStatus,
@@ -6,6 +7,10 @@ import type {
   TokenUsage,
   TraceAttributeValue,
 } from '../types.js'
+import {
+  buildExecutionReceipt,
+  type ExecutionReceipt,
+} from '../observability/execution-receipt.js'
 import type { MaterializedSpan, StoredRun } from '../observability/store.js'
 import type { SpanEndRecord } from '../observability/records.js'
 import { TRACE_STORE_SCHEMA_MAJOR } from '../observability/store.js'
@@ -140,6 +145,11 @@ export interface RunViewerSummary {
   readonly providers: readonly string[]
 }
 
+export interface RunViewerRoutingSummary {
+  readonly decision: ExecutionRoutingDecisionRecord
+  readonly receipt?: ExecutionReceipt
+}
+
 export interface RunViewerModel {
   readonly schemaVersion: 1
   readonly generatedAt: string
@@ -147,6 +157,7 @@ export interface RunViewerModel {
   readonly defaultView: 'dag' | 'waterfall'
   readonly sourceMode: RunViewerSourceMode
   readonly summary: RunViewerSummary
+  readonly routing?: RunViewerRoutingSummary
   readonly tasks: readonly RunViewerTask[]
   readonly spans: readonly RunViewerSpan[]
   readonly dag: RunViewerDagLayout
@@ -178,6 +189,13 @@ const SAFE_FACT_KEYS: Readonly<Record<string, string>> = {
   'oma.retry.attempt': 'Retry attempt',
   'oma.retry.delay_ms': 'Retry delay (ms)',
   'oma.retry.max_attempts': 'Retry max attempts',
+  'oma.routing.confidence': 'Routing confidence',
+  'oma.routing.decision_id': 'Routing decision ID',
+  'oma.routing.mode': 'Routing mode',
+  'oma.routing.receipt_id': 'Execution receipt ID',
+  'oma.routing.reasons': 'Routing reasons',
+  'oma.routing.router_version': 'Router version',
+  'oma.routing.source': 'Routing source',
   'oma.stream.type': 'Stream type',
   'oma.task.retries': 'Task retries',
   'oma.tool.is_error': 'Tool error',
@@ -217,9 +235,45 @@ function numberAttr(
 }
 
 function safeScalar(value: TraceAttributeValue | undefined): string | number | boolean | undefined {
+  if (Array.isArray(value)) return value.join('; ')
   return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
     ? value
     : undefined
+}
+
+function traceRoutingDecision(run: StoredRun | undefined): ExecutionRoutingDecisionRecord | undefined {
+  const span = run?.spans.find((candidate) =>
+    candidate.kind === 'routing' && candidate.name === 'decide_execution_route')
+  if (!span) return undefined
+  const attributes = span.attributes
+  const decisionId = stringAttr(attributes, 'oma.routing.decision_id')
+  const receiptId = stringAttr(attributes, 'oma.routing.receipt_id')
+  const source = stringAttr(attributes, 'oma.routing.source')
+  const mode = stringAttr(attributes, 'oma.routing.mode')
+  if (
+    !decisionId
+    || !receiptId
+    || !['override', 'declared', 'policy', 'router', 'legacy-deterministic'].includes(source ?? '')
+    || (mode !== 'single' && mode !== 'team')
+  ) return undefined
+  const rawReasons = attributes['oma.routing.reasons']
+  const reasons = Array.isArray(rawReasons)
+    ? rawReasons.filter((reason): reason is string => typeof reason === 'string')
+    : []
+  return {
+    decisionId,
+    receiptId,
+    traceSpanId: span.spanId,
+    source: source as ExecutionRoutingDecisionRecord['source'],
+    mode,
+    reasons,
+    ...(stringAttr(attributes, 'oma.routing.router_version')
+      ? { routerVersion: stringAttr(attributes, 'oma.routing.router_version') }
+      : {}),
+    ...(numberAttr(attributes, 'oma.routing.confidence') !== undefined
+      ? { confidence: numberAttr(attributes, 'oma.routing.confidence') }
+      : {}),
+  }
 }
 
 function safeFacts(attributes: Readonly<Record<string, TraceAttributeValue>>): RunViewerFact[] {
@@ -554,6 +608,13 @@ export function buildRunViewerModel(
     message: 'No task graph was recorded for this run.',
   })
   const sourceMode: RunViewerSourceMode = result && run ? 'combined' : result ? 'result' : 'trace'
+  const routingDecision = result?.routingDecision ?? traceRoutingDecision(run)
+  const routing = routingDecision
+    ? {
+        decision: routingDecision,
+        ...(result ? { receipt: buildExecutionReceipt(result) } : {}),
+      }
+    : undefined
   const availableKinds = uniqueSorted(spans.map((span) => span.kind))
   const availableStatuses = uniqueSorted([
     ...spans.map((span) => span.status),
@@ -566,6 +627,7 @@ export function buildRunViewerModel(
     defaultView: options.defaultView ?? (tasks.length > 0 ? 'dag' : 'waterfall'),
     sourceMode,
     summary: summary(result, run),
+    ...(routing ? { routing } : {}),
     tasks,
     spans,
     dag: dagLayout(tasks, warnings),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,8 @@ export {
 } from './orchestrator/orchestrator.js'
 export type {
   ExecutionRouter,
+  ExecutionRoutingDecisionRecord,
+  ExecutionRoutingDecisionSource,
   RoutingBudget,
   RoutingContext,
   RoutingDecision,
@@ -88,6 +90,7 @@ export type {
   RunViewerInputErrorCode,
   RunViewerLink,
   RunViewerModel,
+  RunViewerRoutingSummary,
   RunViewerOptions,
   RunViewerSourceMode,
   RunViewerSpan,
@@ -353,6 +356,7 @@ export type {
   PlanReadyTrace,
   AgentStreamTrace,
   ConsensusTrace,
+  RoutingDecisionTrace,
 
   // Memory
   MemoryEntry,

--- a/packages/core/src/observability/execution-receipt.ts
+++ b/packages/core/src/observability/execution-receipt.ts
@@ -16,6 +16,12 @@ export interface ExecutionReceiptDependencyEdge {
  * Agent output text is deliberately excluded as a source of evidence.
  */
 export interface ExecutionReceipt {
+  /** Stable ID referenced by the corresponding routing-decision record. */
+  readonly id?: string
+  /** Stable decision ID referenced by this receipt. */
+  readonly routingDecisionId?: string
+  /** Trace span containing the decision-time explanation, when traced. */
+  readonly routingDecisionSpanId?: string
   /** Machine-readable warnings copied from the run result, when present. */
   readonly flags?: readonly RunFlag[]
   readonly mode: 'single' | 'multi-agent'
@@ -195,6 +201,12 @@ function buildAgentReceipt(result: AgentRunResult, trace: TraceFacts): Execution
 
 function buildTeamReceipt(result: TeamRunResult, trace: TraceFacts): ExecutionReceipt {
   const rawResult = result as unknown as UnknownRecord
+  const routingDecision = isRecord(rawResult['routingDecision'])
+    ? rawResult['routingDecision']
+    : undefined
+  const receiptId = readString(routingDecision?.['receiptId'])
+  const routingDecisionId = readString(routingDecision?.['decisionId'])
+  const routingDecisionSpanId = readString(routingDecision?.['traceSpanId'])
   const rawTasks = rawResult['tasks']
   const tasks = Array.isArray(rawTasks) ? rawTasks : []
   const traceTasks = readTraceTaskFacts(trace)
@@ -285,6 +297,9 @@ function buildTeamReceipt(result: TeamRunResult, trace: TraceFacts): ExecutionRe
   }
 
   return {
+    ...(receiptId ? { id: receiptId } : {}),
+    ...(routingDecisionId ? { routingDecisionId } : {}),
+    ...(routingDecisionSpanId ? { routingDecisionSpanId } : {}),
     ...(flags ? { flags } : {}),
     mode: rolesExecuted.length > 1 ? 'multi-agent' : 'single',
     rolesExecuted,

--- a/packages/core/src/observability/records.ts
+++ b/packages/core/src/observability/records.ts
@@ -8,6 +8,7 @@ import type {
 /** Stable operation categories used by TraceRecord schema v2. */
 export type SpanKind =
   | 'run'
+  | 'routing'
   | 'agent'
   | 'task'
   | 'llm'

--- a/packages/core/src/observability/routing-decision.ts
+++ b/packages/core/src/observability/routing-decision.ts
@@ -1,0 +1,79 @@
+import type {
+  ExecutionRoutingDecisionRecord,
+  ExecutionRoutingDecisionSource,
+  RoutingDecision,
+  RunIdentity,
+  RoutingDecisionTrace,
+} from '../types.js'
+import type { TraceRuntime } from './runtime.js'
+
+export interface RoutingDecisionRecordInput {
+  readonly source: ExecutionRoutingDecisionSource
+  readonly mode: RoutingDecision['mode']
+  readonly confidence?: number
+  readonly reasons: readonly string[]
+  readonly routerVersion?: string
+}
+
+/**
+ * Records one execution-routing decision through the existing trace runtime.
+ * The returned result field and its future ExecutionReceipt share stable IDs.
+ */
+export function recordRoutingDecision(
+  identity: RunIdentity,
+  traceRuntime: TraceRuntime | undefined,
+  input: RoutingDecisionRecordInput,
+): ExecutionRoutingDecisionRecord {
+  const decisionId = `${identity.traceId}:routing-decision`
+  const receiptId = `${identity.traceId}:execution-receipt`
+  const span = traceRuntime?.startSpan({
+    kind: 'routing',
+    name: 'decide_execution_route',
+    parent: traceRuntime.root,
+    attributes: {
+      'oma.routing.decision_id': decisionId,
+      'oma.routing.receipt_id': receiptId,
+      'oma.routing.source': input.source,
+      'oma.routing.mode': input.mode,
+      'oma.routing.reasons': input.reasons,
+      ...(input.routerVersion !== undefined
+        ? { 'oma.routing.router_version': input.routerVersion }
+        : {}),
+      ...(input.confidence !== undefined
+        ? { 'oma.routing.confidence': input.confidence }
+        : {}),
+    },
+  })
+  const record: ExecutionRoutingDecisionRecord = {
+    decisionId,
+    receiptId,
+    ...(span ? { traceSpanId: span.spanId } : {}),
+    source: input.source,
+    mode: input.mode,
+    reasons: input.reasons,
+    ...(input.routerVersion !== undefined ? { routerVersion: input.routerVersion } : {}),
+    ...(input.confidence !== undefined ? { confidence: input.confidence } : {}),
+  }
+  if (span) {
+    const endMs = Date.now()
+    const legacyEvent: RoutingDecisionTrace = {
+      type: 'routing_decision',
+      runId: identity.runId,
+      spanId: span.spanId,
+      parentId: identity.rootSpanId,
+      agent: 'orchestrator',
+      decisionId,
+      receiptId,
+      source: input.source,
+      mode: input.mode,
+      reasons: input.reasons,
+      ...(input.routerVersion !== undefined ? { routerVersion: input.routerVersion } : {}),
+      ...(input.confidence !== undefined ? { confidence: input.confidence } : {}),
+      startMs: span.startUnixMs,
+      endMs,
+      durationMs: Math.max(0, endMs - span.startUnixMs),
+    }
+    span.end({ status: { code: 'ok' }, legacyEvent })
+  }
+  return record
+}

--- a/packages/core/src/orchestrator/execution-router.ts
+++ b/packages/core/src/orchestrator/execution-router.ts
@@ -17,6 +17,8 @@ import { isSimpleGoal } from './short-circuit.js'
 
 export type {
   ExecutionRouter,
+  ExecutionRoutingDecisionRecord,
+  ExecutionRoutingDecisionSource,
   RoutingBudget,
   RoutingContext,
   RoutingDecision,

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -91,6 +91,10 @@ import {
 import { classifyRunFailure, statusOnly } from '../observability/status.js'
 import { buildExecutionReceipt } from '../observability/execution-receipt.js'
 import {
+  recordRoutingDecision,
+  type RoutingDecisionRecordInput,
+} from '../observability/routing-decision.js'
+import {
   createTraceRuntime,
   LEGACY_TRACE_METADATA_ONLY,
   traceRecordObserverFrom,
@@ -541,8 +545,14 @@ export class OpenMultiAgent {
       if (options?.planOnly) {
         const { identity, metadata } = createRunFacts(identityOptionsForRun(options))
         const traceRuntime = this.startTrace(identity, metadata)
+        const routingDecision = recordRoutingDecision(identity, traceRuntime, {
+          source: 'declared',
+          mode: 'team',
+          reasons: ['Structured governance roles declared the execution topology.'],
+        })
         const result = {
           ...this.buildPlanOnlyTeamRunResult(new Map(), identity, goal, queue),
+          routingDecision,
           ...(metadata !== undefined ? { metadata } : {}),
         }
         traceRuntime?.close({ status: result.status ?? statusOnly('ok') })
@@ -561,10 +571,17 @@ export class OpenMultiAgent {
         undefined,
         pendingEvaluation,
         options,
+        {
+          source: 'declared',
+          mode: 'team',
+          reasons: ['Structured governance roles declared the execution topology.'],
+        },
       )
     }
 
-    const routingDecision: ExecutionRoutingDecision | undefined = explicitMode === undefined
+    const { identity, metadata } = createRunFacts(identityOptionsForRun(options))
+    const traceRuntime = this.startTrace(identity, metadata)
+    const routerDecision: ExecutionRoutingDecision | undefined = explicitMode === undefined
       && !options?.planOnly
       && !preferredBudgetDegraded
       ? await resolveExecutionRouting(
@@ -573,6 +590,38 @@ export class OpenMultiAgent {
           new DeterministicRouter(),
         )
       : undefined
+    const routingDecisionInput: RoutingDecisionRecordInput = explicitMode !== undefined
+      ? {
+          source: 'override',
+          mode: explicitMode,
+          reasons: [
+            options?.governanceIntent !== undefined
+              ? `Caller mode '${explicitMode}' overrode the declared governance topology.`
+              : `Caller explicitly selected mode '${explicitMode}'.`,
+          ],
+        }
+      : preferredBudgetDegraded
+        ? {
+            source: 'policy',
+            mode: 'single',
+            reasons: ['preferredUnderBudget policy degraded the preferred governance topology under a configured budget.'],
+          }
+        : options?.planOnly
+          ? {
+              source: 'policy',
+              mode: 'team',
+              reasons: ['planOnly policy requires coordinator planning without task execution.'],
+            }
+          : {
+              source: 'router',
+              mode: routerDecision!.mode,
+              reasons: routerDecision!.reasons,
+              routerVersion: routerDecision!.routerVersion,
+              ...(routerDecision!.confidence !== undefined
+                ? { confidence: routerDecision!.confidence }
+                : {}),
+            }
+    const routingDecision = recordRoutingDecision(identity, traceRuntime, routingDecisionInput)
     const undeclared = options?.governanceIntent === undefined
     const confirmationState = createConsequentialConfirmationState()
     let consequentialUndeclared = undeclared && agentConfigs.some((agentConfig) => {
@@ -583,17 +632,16 @@ export class OpenMultiAgent {
       return hasGrantedConsequentialTool(effective, { includeDelegateTool: true })
     })
 
-    const { identity, metadata } = createRunFacts(identityOptionsForRun(options))
-    const traceRuntime = this.startTrace(identity, metadata)
     const finish = (result: TeamRunResult): TeamRunResult => {
+      const resultWithRouting = {
+        ...result,
+        routingDecision,
+        ...(metadata !== undefined ? { metadata } : {}),
+      }
       const governedResult = finalizeGovernanceRun(
-        {
-          ...result,
-          ...(routingDecision !== undefined ? { routingDecision } : {}),
-          ...(metadata !== undefined ? { metadata } : {}),
-        },
+        resultWithRouting,
         options,
-        buildExecutionReceipt(result),
+        buildExecutionReceipt(resultWithRouting),
         {
           modeOverride: explicitMode !== undefined,
           preferredBudgetDegraded,
@@ -628,7 +676,7 @@ export class OpenMultiAgent {
       && (
         explicitMode === 'single'
         || preferredBudgetDegraded
-        || routingDecision?.mode === 'single'
+        || routingDecision.mode === 'single'
       )
     ) {
       const bestAgent = selectBestAgent(goal, agentConfigs)
@@ -1624,6 +1672,7 @@ export class OpenMultiAgent {
     restoreMetadata?: RestoreMetadataResolution,
     pendingEvaluation?: PendingOnlineEvaluation,
     governanceDeclaration?: GovernanceDeclaration,
+    routingDecisionInput?: RoutingDecisionRecordInput,
   ): Promise<TeamRunResult> {
     const newRunFacts = identity === undefined
       ? createRunFacts(identityOptionsForRun(options))
@@ -1631,6 +1680,9 @@ export class OpenMultiAgent {
     const runIdentity = identity ?? newRunFacts!.identity
     const metadata = restoreMetadata?.metadata ?? newRunFacts?.metadata
     const traceRuntime = this.startTrace(runIdentity, metadata, restoreMetadata?.overridden)
+    const routingDecision = routingDecisionInput
+      ? recordRoutingDecision(runIdentity, traceRuntime, routingDecisionInput)
+      : undefined
     const agentConfigs = team.getAgents()
     const scheduler = new Scheduler(this.config.schedulingStrategy)
     scheduler.autoAssign(queue, agentConfigs)
@@ -1753,13 +1805,15 @@ export class OpenMultiAgent {
       ctx.outcomeStatus,
       ctx.outcomeErrorInfo,
     )
+    const resultWithRouting = {
+      ...result,
+      ...(routingDecision !== undefined ? { routingDecision } : {}),
+      ...(metadata !== undefined ? { metadata } : {}),
+    }
     const completedResult = finalizeGovernanceRun(
-      {
-        ...result,
-        ...(metadata !== undefined ? { metadata } : {}),
-      },
+      resultWithRouting,
       governanceDeclaration,
-      buildExecutionReceipt(result),
+      buildExecutionReceipt(resultWithRouting),
     )
     traceRuntime?.close({
       status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1178,6 +1178,32 @@ export interface RoutingDecision {
   readonly routerVersion: string
 }
 
+/** Why a `runTeam()` execution topology was selected. */
+export type ExecutionRoutingDecisionSource =
+  | 'override'
+  | 'declared'
+  | 'policy'
+  | 'router'
+  | 'legacy-deterministic'
+
+/**
+ * Observable routing fact attached to a `runTeam()` result.
+ *
+ * `routerVersion` is present only when `source` is `router` (or when reading a
+ * serialized legacy-deterministic record). Non-router paths remain explicit
+ * rather than impersonating a router decision.
+ */
+export interface ExecutionRoutingDecisionRecord {
+  readonly decisionId: string
+  readonly receiptId: string
+  readonly traceSpanId?: string
+  readonly source: ExecutionRoutingDecisionSource
+  readonly mode: RoutingDecision['mode']
+  readonly confidence?: number
+  readonly reasons: readonly string[]
+  readonly routerVersion?: string
+}
+
 /** Pluggable execution-topology policy for automatic `runTeam()` calls. */
 export interface ExecutionRouter {
   readonly version: string
@@ -1323,13 +1349,13 @@ export interface RunMetrics {
 export interface TeamRunResult extends RunOutcomeFields {
   readonly success: boolean
   /**
-   * Explainable topology decision for automatic execution routing.
+   * Explainable topology decision for this `runTeam()` invocation.
    *
-   * Present on auto `runTeam()` paths. Omitted when the caller selected
-   * `mode`, declared a role topology, chose governance budget degradation, or
-   * requested `planOnly`.
+   * Runtime results set this on routed, overridden, declared, and policy
+   * paths. It remains optional so older serialized results and caller-created
+   * fixtures continue to type-check.
    */
-  readonly routingDecision?: RoutingDecision
+  readonly routingDecision?: ExecutionRoutingDecisionRecord
   /**
    * Post-execution governance verdict for this run.
    *
@@ -1926,6 +1952,7 @@ export type TraceEventType =
   | 'plan_ready'
   | 'agent_stream'
   | 'consensus'
+  | 'routing_decision'
 
 /** Shared fields present on every trace event. */
 export interface TraceEventBase {
@@ -2017,6 +2044,18 @@ export interface ConsensusTrace extends TraceEventBase {
   readonly dissent?: string
 }
 
+/** Emitted when `runTeam()` selects its execution topology. */
+export interface RoutingDecisionTrace extends TraceEventBase {
+  readonly type: 'routing_decision'
+  readonly decisionId: string
+  readonly receiptId: string
+  readonly source: ExecutionRoutingDecisionSource
+  readonly mode: RoutingDecision['mode']
+  readonly confidence?: number
+  readonly reasons: readonly string[]
+  readonly routerVersion?: string
+}
+
 /** Discriminated union of all trace event types. */
 export type TraceEvent =
   | LLMCallTrace
@@ -2026,6 +2065,7 @@ export type TraceEvent =
   | PlanReadyTrace
   | AgentStreamTrace
   | ConsensusTrace
+  | RoutingDecisionTrace
 
 // ---------------------------------------------------------------------------
 // Memory

--- a/packages/core/tests/dashboard-render.test.ts
+++ b/packages/core/tests/dashboard-render.test.ts
@@ -151,4 +151,68 @@ describe('renderTeamRunDashboard', () => {
     expect(html).toContain('class="masthead-primary"')
     expect(html).toContain('class="run-context"')
   })
+
+  it('renders one linked routing summary from the decision and execution receipt', () => {
+    const html = renderTeamRunDashboard({
+      success: true,
+      tasks: [{
+        id: 'short-circuit',
+        title: 'Short-circuit: alpha',
+        assignee: 'alpha',
+        status: 'completed',
+        dependsOn: [],
+        metrics: {
+          startMs: 1,
+          endMs: 2,
+          durationMs: 1,
+          tokenUsage: { input_tokens: 1, output_tokens: 1 },
+          toolCalls: [],
+          retries: 0,
+        },
+      }],
+      agentResults: new Map(),
+      totalTokenUsage: { input_tokens: 1, output_tokens: 1 },
+      routingDecision: {
+        decisionId: 'decision-1',
+        receiptId: 'receipt-1',
+        traceSpanId: 'routing-span-1',
+        source: 'router',
+        mode: 'single',
+        reasons: ['The goal is a single action.'],
+        routerVersion: 'deterministic-v1',
+      },
+    })
+
+    const start = html.indexOf('id="oma-data">') + 'id="oma-data">'.length
+    const end = html.indexOf('</script>', start)
+    const parsed = JSON.parse(html.slice(start, end)) as {
+      routing: {
+        decision: { source: string; routerVersion?: string }
+        receipt: {
+          id?: string
+          routingDecisionId?: string
+          routingDecisionSpanId?: string
+          rolesExecuted: string[]
+        }
+      }
+    }
+
+    expect(parsed.routing.decision).toMatchObject({
+      source: 'router',
+      routerVersion: 'deterministic-v1',
+    })
+    expect(parsed.routing.receipt).toMatchObject({
+      id: 'receipt-1',
+      routingDecisionId: 'decision-1',
+      routingDecisionSpanId: 'routing-span-1',
+      rolesExecuted: ['alpha'],
+    })
+    expect(html).toContain('id="routingSummary" class="routing-summary"')
+    expect(html).toContain('.routing-summary.visible')
+    expect(html).toContain('.kind-dot.routing')
+    expect(html).toContain('.wf-bar.kind-routing')
+    expect(html).toContain("routingCard('Decided'")
+    expect(html).toContain("routingCard('Why'")
+    expect(html).toContain("routingCard('Actually ran'")
+  })
 })

--- a/packages/core/tests/execution-receipt.test.ts
+++ b/packages/core/tests/execution-receipt.test.ts
@@ -109,10 +109,25 @@ describe('buildExecutionReceipt', () => {
   })
 
   it('reports a short-circuited team result as one executed role', () => {
-    const receipt = buildExecutionReceipt(teamResult([
+    const result = {
+      ...teamResult([
       task('short-circuit', 'security', [], 100),
-    ]))
+      ]),
+      routingDecision: {
+        decisionId: 'decision-1',
+        receiptId: 'receipt-1',
+        traceSpanId: 'span-routing',
+        source: 'router',
+        mode: 'single',
+        reasons: ['simple goal'],
+        routerVersion: 'deterministic-v1',
+      },
+    } satisfies TeamRunResult
+    const receipt = buildExecutionReceipt(result)
 
+    expect(receipt.id).toBe('receipt-1')
+    expect(receipt.routingDecisionId).toBe('decision-1')
+    expect(receipt.routingDecisionSpanId).toBe('span-routing')
     expect(receipt.mode).toBe('single')
     expect(receipt.rolesExecuted).toEqual(['security'])
     expect(receipt.independentReviewOccurred).toBe(false)

--- a/packages/core/tests/execution-router.test.ts
+++ b/packages/core/tests/execution-router.test.ts
@@ -4,15 +4,20 @@ import {
   DETERMINISTIC_ROUTER_VERSION,
   DeterministicRouter,
 } from '../src/orchestrator/execution-router.js'
+import { buildExecutionReceipt } from '../src/observability/execution-receipt.js'
+import { TRACE_RECORD_OBSERVER } from '../src/observability/runtime.js'
+import type { TraceRecord } from '../src/observability/records.js'
 import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
 import type {
   AgentConfig,
   ExecutionRouter,
   LLMAdapter,
   LLMResponse,
+  OrchestratorConfig,
   RoutingContext,
   RoutingDecision,
   RunTeamOptions,
+  TraceEvent,
 } from '../src/types.js'
 
 const PLAN = `\`\`\`json
@@ -63,9 +68,11 @@ async function run(
   options?: RunTeamOptions,
   configRouter?: ExecutionRouter,
   roster = agents(),
+  extraConfig: OrchestratorConfig = {},
 ) {
   const orchestrator = new OpenMultiAgent({
     defaultModel: 'mock-model',
+    ...extraConfig,
     ...(configRouter ? { executionRouter: configRouter } : {}),
   })
   const team = orchestrator.createTeam('routing-team', {
@@ -113,6 +120,7 @@ describe('runTeam execution routing', () => {
 
     expect(result.routingDecision).toMatchObject({
       mode: 'single',
+      source: 'router',
       routerVersion: DETERMINISTIC_ROUTER_VERSION,
     })
     expect(result.tasks?.[0]?.id).toBe('short-circuit')
@@ -146,6 +154,65 @@ describe('runTeam execution routing', () => {
     expect(JSON.stringify(observed)).not.toContain('systemPrompt')
   })
 
+  it('records the routing decision in legacy and v2 traces and links its receipt', async () => {
+    const traces: TraceEvent[] = []
+    const records: TraceRecord[] = []
+    const tracedRouter = {
+      version: 'trace-router-v1',
+      decide: () => ({
+        mode: 'single' as const,
+        confidence: 0.85,
+        reasons: ['Single route chosen for trace coverage.'],
+        routerVersion: 'trace-router-v1',
+      }),
+    } satisfies ExecutionRouter
+    const result = await run(
+      'Say hello',
+      undefined,
+      tracedRouter,
+      agents(),
+      {
+        onTrace: (event) => { traces.push(event) },
+        [TRACE_RECORD_OBSERVER]: (record: TraceRecord) => { records.push(record) },
+      } as OrchestratorConfig & {
+        [TRACE_RECORD_OBSERVER]: (record: TraceRecord) => void
+      },
+    )
+
+    const routingTrace = traces.find(
+      (event): event is Extract<TraceEvent, { type: 'routing_decision' }> =>
+        event.type === 'routing_decision',
+    )
+    expect(routingTrace).toMatchObject({
+      source: 'router',
+      mode: 'single',
+      routerVersion: 'trace-router-v1',
+      confidence: 0.85,
+      reasons: ['Single route chosen for trace coverage.'],
+      receiptId: result.routingDecision?.receiptId,
+      decisionId: result.routingDecision?.decisionId,
+    })
+
+    const routingSpan = records.find((record) =>
+      record.recordType === 'span_end'
+      && record.kind === 'routing'
+      && record.name === 'decide_execution_route')
+    expect(routingSpan?.attributes).toMatchObject({
+      'oma.routing.mode': 'single',
+      'oma.routing.source': 'router',
+      'oma.routing.router_version': 'trace-router-v1',
+      'oma.routing.confidence': 0.85,
+      'oma.routing.reasons': ['Single route chosen for trace coverage.'],
+      'oma.routing.receipt_id': result.routingDecision?.receiptId,
+    })
+
+    const receipt = buildExecutionReceipt(result)
+    expect(result.routingDecision?.traceSpanId).toBe(routingSpan?.spanId)
+    expect(result.routingDecision?.receiptId).toBe(receipt.id)
+    expect(receipt.routingDecisionId).toBe(result.routingDecision?.decisionId)
+    expect(receipt.routingDecisionSpanId).toBe(result.routingDecision?.traceSpanId)
+  })
+
   it('lets a per-run router override the orchestrator router', async () => {
     const configured = {
       version: 'configured-v1',
@@ -171,7 +238,10 @@ describe('runTeam execution routing', () => {
 
     const result = await run('Say hello', { executionRouter: router })
 
-    expect(result.routingDecision).toEqual(decision('team-first-v1', 'team'))
+    expect(result.routingDecision).toMatchObject({
+      ...decision('team-first-v1', 'team'),
+      source: 'router',
+    })
     expect(result.agentResults.has('coordinator')).toBe(true)
     expect(result.tasks?.[0]?.id).not.toBe('short-circuit')
   })
@@ -218,7 +288,7 @@ describe('runTeam execution routing', () => {
     expect(result.routingDecision?.reasons.join(' ')).toContain(reason)
   })
 
-  it('bypasses routers for explicit mode and omits the decision', async () => {
+  it('bypasses routers and marks an explicit mode as an override', async () => {
     const router = {
       version: 'unused-v1',
       decide: vi.fn(() => decision('unused-v1', 'team')),
@@ -230,11 +300,15 @@ describe('runTeam execution routing', () => {
     })
 
     expect(router.decide).not.toHaveBeenCalled()
-    expect(result.routingDecision).toBeUndefined()
+    expect(result.routingDecision).toMatchObject({
+      source: 'override',
+      mode: 'single',
+    })
+    expect(result.routingDecision?.routerVersion).toBeUndefined()
     expect(result.tasks?.[0]?.id).toBe('short-circuit')
   })
 
-  it('bypasses routers for declared role governance and omits the decision', async () => {
+  it('bypasses routers and marks a declared role topology', async () => {
     const router = {
       version: 'unused-v1',
       decide: vi.fn(() => decision('unused-v1', 'single')),
@@ -247,11 +321,15 @@ describe('runTeam execution routing', () => {
     })
 
     expect(router.decide).not.toHaveBeenCalled()
-    expect(result.routingDecision).toBeUndefined()
+    expect(result.routingDecision).toMatchObject({
+      source: 'declared',
+      mode: 'team',
+    })
+    expect(result.routingDecision?.routerVersion).toBeUndefined()
     expect(result.tasks?.map((task) => task.assignee)).toEqual(['alpha', 'beta'])
   })
 
-  it('bypasses routers for planOnly and omits the decision', async () => {
+  it('bypasses routers and marks planOnly as a topology policy', async () => {
     const router = {
       version: 'unused-v1',
       decide: vi.fn(() => decision('unused-v1', 'single')),
@@ -263,7 +341,10 @@ describe('runTeam execution routing', () => {
     })
 
     expect(router.decide).not.toHaveBeenCalled()
-    expect(result.routingDecision).toBeUndefined()
+    expect(result.routingDecision).toMatchObject({
+      source: 'policy',
+      mode: 'team',
+    })
     expect(result.planOnly).toBe(true)
   })
 })

--- a/packages/core/tests/mode-governance-resolution.test.ts
+++ b/packages/core/tests/mode-governance-resolution.test.ts
@@ -98,6 +98,8 @@ describe('runTeam explicit mode and budget/governance resolution', () => {
     expect(result.tasks?.some((task) => task.id === 'short-circuit')).toBe(false)
     expect(result.agentResults.get('coordinator')?.output).toContain('coordinator synthesis')
     expect(coordinatorCalls).toHaveLength(2)
+    expect(result.routingDecision).toMatchObject({ source: 'override', mode: 'team' })
+    expect(result.routingDecision?.routerVersion).toBeUndefined()
     expect(receipt).toMatchObject({
       mode: 'multi-agent',
       rolesExecuted: ['reviewer', 'security'],
@@ -134,6 +136,7 @@ describe('runTeam explicit mode and budget/governance resolution', () => {
     expect(result.agentResults.has('coordinator')).toBe(true)
     expect(result.agentResults.has('reviewer')).toBe(false)
     expect(coordinatorCalls).toHaveLength(1)
+    expect(result.routingDecision).toMatchObject({ source: 'override', mode: 'team' })
   })
 
   it('executes a forced Single but discloses an overridden required floor', async () => {
@@ -152,6 +155,7 @@ describe('runTeam explicit mode and budget/governance resolution', () => {
     expect(result.governanceConclusion).toBe('unsatisfied')
     expect(result.governanceReason).toBe('overridden')
     expect(result.flags).toContain(GOVERNANCE_OVERRIDDEN_FLAG)
+    expect(result.routingDecision).toMatchObject({ source: 'override', mode: 'single' })
   })
 
   it('marks required governance unsatisfied with a budget reason when roles cannot finish', async () => {
@@ -195,6 +199,8 @@ describe('runTeam explicit mode and budget/governance resolution', () => {
     expect(result.governanceConclusion).toBe('not-applicable')
     expect(result.governanceReason).toBeUndefined()
     expect(result.flags).toContain(REVIEW_SKIPPED_DUE_TO_BUDGET_FLAG)
+    expect(result.routingDecision).toMatchObject({ source: 'policy', mode: 'single' })
+    expect(result.routingDecision?.routerVersion).toBeUndefined()
   })
 
   it('preserves the required topology when no override occurs and budget is sufficient', async () => {
@@ -215,6 +221,7 @@ describe('runTeam explicit mode and budget/governance resolution', () => {
       rolesExecuted: ['reviewer', 'security'],
       dependencyEdges: [{ from: 'reviewer', to: 'security' }],
     })
+    expect(result.routingDecision).toMatchObject({ source: 'declared', mode: 'team' })
   })
 
   it('keeps the existing preferred-role attempt when no degrade policy is selected', async () => {
@@ -231,6 +238,7 @@ describe('runTeam explicit mode and budget/governance resolution', () => {
     expect(result.governanceConclusion).toBe('not-applicable')
     expect(result.flags).toBeUndefined()
     expect(buildExecutionReceipt(result).rolesExecuted).toEqual(['reviewer', 'security'])
+    expect(result.routingDecision).toMatchObject({ source: 'declared', mode: 'team' })
   })
 
   it('applies a per-run cost ceiling through the existing estimator', async () => {


### PR DESCRIPTION
## Summary

- Record every `runTeam()` topology choice through the existing trace runtime as a `routing` span and `routing_decision` legacy trace event.
- Distinguish automatic router decisions from caller overrides, declared governance topology, and framework policy without inventing a parallel execution record.
- Link decision-time evidence to the post-execution `ExecutionReceipt` with stable decision, receipt, and span identifiers.
- Add a Run Viewer summary that shows what was selected, why it was selected, and what topology actually ran.
- Document the routing trace contract and receipt linkage.

## Motivation

Execution routing already determines whether `runTeam()` takes a single-agent short circuit or a coordinator-generated team topology, but that decision and its reasons were not represented in the observability system. Operators could inspect the resulting tasks without seeing why the topology was selected or whether it came from a router, an explicit override, a governance declaration, or a budget policy.

This change makes the decision explainable while keeping `ExecutionReceipt` as the sole structured record of the topology that actually executed.

## Scope and impact

- **Affected areas:** `@open-multi-agent/core` orchestration, trace types/runtime integration, execution receipts, Run Viewer, tests, and `docs/observability.md`.
- **Public API and behavior:** adds `ExecutionRoutingDecisionRecord`, `ExecutionRoutingDecisionSource`, `RoutingDecisionTrace`, the `routing` span kind, and the `routing_decision` `TraceEvent` member. `TeamRunResult.routingDecision` is now populated for router, override, declared, and policy paths; `routerVersion` is present only when a router actually ran.
- **Compatibility:** existing serialized results remain readable because the result field and receipt linkage fields remain optional. Consumers with exhaustive `TraceEvent` or span-kind handling must accept the new members. Consumers that assumed every result-level routing decision has a `routerVersion` should branch on `source === 'router'`.
- **Privacy:** routing spans contain mode, source, router-provided reasons, optional confidence/version, and linkage IDs. They do not add goal text, prompts, outputs, task topology, tool I/O, or reasoning content, and use the existing observability processing path.
- **Intentional non-goals:** no second topology record, no change to routing priority or execution behavior, and no new telemetry transport.
- **Dependencies:** none.

## Validation

- `npm run lint -w @open-multi-agent/core` — passed
- `npm run test -w @open-multi-agent/core` — passed (114 test files, 1,638 tests)
- `npm run build -w @open-multi-agent/core` — passed
- Focused routing, receipt, governance, and dashboard tests — passed (4 files, 36 tests)
- `git diff --check` — passed

Provider E2E was not run because this change does not alter provider behavior or require real credentials.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING