### PR TITLE
feat(core): add composite scheduling and strict assignees

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -132,7 +132,8 @@ keep that assignment.
 
 ```typescript
 const orchestrator = new OpenMultiAgent({
-  schedulingStrategy: 'capability-match',
+  schedulingStrategy: 'composite',
+  schedulingWeights: { fit: 0.7, load: 0.3 },
 })
 ```
 
@@ -142,9 +143,21 @@ const orchestrator = new OpenMultiAgent({
 | `round-robin` | Distributes tasks in queue order across the roster | Agents are interchangeable |
 | `least-busy` | Chooses the agent with the fewest active or newly assigned tasks | Task duration varies and load balance matters |
 | `capability-match` | Filters explicit task requirements, then prefers declared capability tags before legacy keyword affinity | Tasks or agents declare differentiated requirements/capabilities |
+| `composite` | Ranks tasks by blocked dependents, hard-filters with `AgentSelector`, then maximizes `fitWeight * fit + loadWeight * (1 - normalizedCurrentLoad)` | Criticality, capability fit, and current load should influence one decision |
 
-These strategies select one scheduling dimension at a time; they are not
-combined or weighted.
+The four original strategies remain compatibility paths with unchanged
+behavior. `composite` uses `schedulingWeights.fit` and
+`schedulingWeights.load`, which default to `0.7` and `0.3`. Current load is the
+agent's `in_progress` task count normalized within the roster at scheduling
+time; assignments made earlier in the same call do not alter that snapshot.
+If hard filtering finds no eligible agent, OMA emits a structured `warning`
+event and explicitly falls back to zero fit plus current load instead of
+silently ignoring the requirements.
+
+Coordinator plans that name an agent outside the roster emit an
+`INVALID_ASSIGNEE` warning, clear that assignment, and use the configured
+scheduler by default. Set `strictAssignees: true` to stop before task execution
+with a structured validation error instead.
 
 Agents may declare `description`, `capabilities`, `costTier`, and
 `latencyClass`; none is inferred when omitted. Explicit `runTasks()` specs and

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -117,7 +117,8 @@ console.log(result.agentResults.get('coordinator')?.output)
 
 ```typescript
 const orchestrator = new OpenMultiAgent({
-  schedulingStrategy: 'capability-match',
+  schedulingStrategy: 'composite',
+  schedulingWeights: { fit: 0.7, load: 0.3 },
 })
 ```
 
@@ -127,8 +128,18 @@ const orchestrator = new OpenMultiAgent({
 | `round-robin` | 按队列顺序在 Agent roster 中轮转分配 | Agent 能力可以互换 |
 | `least-busy` | 选择当前活跃任务或本批新分配任务最少的 Agent | 任务耗时差异较大，需要负载均衡 |
 | `capability-match` | 先过滤显式任务要求，再优先匹配声明的能力标签，最后使用兼容的关键词亲和度 | 任务或 Agent 声明了有区分度的要求/能力 |
+| `composite` | 按阻塞的下游任务数排列任务，经 `AgentSelector` 硬过滤后，最大化 `fitWeight * fit + loadWeight * (1 - normalizedCurrentLoad)` | 需要在一次决策中同时考虑关键度、能力匹配与当前负载 |
 
-每种策略只负责一个调度维度，不会彼此组合或加权。
+原有四种策略作为兼容路径保留，行为不变。`composite` 使用
+`schedulingWeights.fit` 与 `schedulingWeights.load`，缺省分别为 `0.7` 和
+`0.3`。当前负载是在调度时按 roster 归一化的 `in_progress` 任务数；同一次
+调用中先前完成的分配不会改变该快照。若硬过滤后没有合格 Agent，OMA 会发出
+结构化 `warning` 事件，并显式回退到 fit 为零、只结合当前负载的路径，不会
+静默忽略任务要求。
+
+Coordinator 计划若引用 roster 之外的 Agent，缺省会发出
+`INVALID_ASSIGNEE` warning、清空该分配，再交由所选调度策略处理。设置
+`strictAssignees: true` 后，会在任何计划任务执行前以结构化校验错误终止。
 
 Agent 可显式声明 `description`、`capabilities`、`costTier` 和
 `latencyClass`；字段缺省时框架不会推断。显式 `runTasks()` 任务和

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,8 +76,16 @@ export {
 } from './orchestrator/governance.js'
 export type { GovernanceDeclaration } from './orchestrator/governance.js'
 export { CONSEQUENTIAL_NO_INDEPENDENCE_FLAG } from './orchestrator/consequential.js'
-export { Scheduler } from './orchestrator/scheduler.js'
-export type { SchedulingStrategy } from './orchestrator/scheduler.js'
+export {
+  Scheduler,
+  DEFAULT_SCHEDULING_WEIGHTS,
+} from './orchestrator/scheduler.js'
+export type {
+  SchedulingStrategy,
+  SchedulingWeights,
+  SchedulerOptions,
+  SchedulerWarning,
+} from './orchestrator/scheduler.js'
 export { AgentSelector } from './orchestrator/agent-selector.js'
 export type {
   AgentSelectionFailure,

--- a/packages/core/src/orchestrator/coordinator.ts
+++ b/packages/core/src/orchestrator/coordinator.ts
@@ -69,6 +69,23 @@ export interface ParsedTaskSpec {
   verify?: ConsensusVerifyOptions | CoordinatorVerifySpec | true
 }
 
+export interface InvalidAssigneeIssue {
+  readonly taskTitle: string
+  readonly assignee: string
+}
+
+/** Find coordinator-authored assignees that are not present in the team roster. */
+export function findInvalidAssignees(
+  specs: readonly ParsedTaskSpec[],
+  agents: readonly AgentConfig[],
+): readonly InvalidAssigneeIssue[] {
+  const agentNames = new Set(agents.map((agent) => agent.name))
+  return specs.flatMap((spec) =>
+    spec.assignee !== undefined && !agentNames.has(spec.assignee)
+      ? [{ taskTitle: spec.title, assignee: spec.assignee }]
+      : [])
+}
+
 /**
  * Resolve a parsed task spec's `verify` field into a full
  * {@link ConsensusVerifyOptions} (or `undefined` when no verify should run).
@@ -341,7 +358,9 @@ export function buildCoordinatorOutputFormatSection(hasVerifyJudges?: boolean): 
     'Each task must have:',
     '  - "title":       Short descriptive title (string)',
     '  - "description": Full task description with context and expected output (string)',
-    '  - "assignee":    One of the agent names listed in the roster (string)',
+    '  - "assignee":    One of the agent names listed in the roster (string).',
+    '                   Prefer an agent whose manifest `capabilities` best match the task;',
+    '                   use `roleSummary` and `tools` only as secondary assignment signals.',
     '  - "dependsOn":   Array of titles of tasks this task depends on (string[], may be empty).',
     '  - "requires":    (optional) Explicit hard requirements with optional "requiredTools" (string[]),',
     '                   "requiredCapabilities" (string[]), "requiredBackend" ("llm"|"process"|"acp"),',

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -167,6 +167,7 @@ import {
   buildDecompositionPrompt,
   runCoordinatorSynthesis,
   loadSpecsIntoQueue,
+  findInvalidAssignees,
 } from './coordinator.js'
 
 // ---------------------------------------------------------------------------
@@ -244,6 +245,8 @@ export class OpenMultiAgent {
    *   - `maxConcurrency`: 5
    *   - `maxDelegationDepth`: 3
    *   - `schedulingStrategy`: `'dependency-first'`
+   *   - `schedulingWeights`: `{ fit: 0.7, load: 0.3 }`
+   *   - `strictAssignees`: `false`
    *   - `defaultModel`:   `'claude-opus-4-6'`
    *   - `defaultProvider`: `'anthropic'`
    */
@@ -271,6 +274,8 @@ export class OpenMultiAgent {
       maxConcurrency: config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
       maxDelegationDepth: config.maxDelegationDepth ?? DEFAULT_MAX_DELEGATION_DEPTH,
       schedulingStrategy: config.schedulingStrategy ?? 'dependency-first',
+      schedulingWeights: config.schedulingWeights ?? {},
+      strictAssignees: config.strictAssignees ?? false,
       executionRouter: config.executionRouter ?? new DeterministicRouter(),
       defaultModel: config.defaultModel ?? DEFAULT_MODEL,
       defaultProvider: config.defaultProvider ?? 'anthropic',
@@ -295,6 +300,27 @@ export class OpenMultiAgent {
       onToolCall: config.onToolCall,
       requireConsequentialConfirmation: config.requireConsequentialConfirmation ?? false,
     }
+  }
+
+  private createScheduler(): Scheduler {
+    return new Scheduler(
+      this.config.schedulingStrategy,
+      {
+        defaultProvider: this.config.defaultProvider,
+        defaultToolPreset: this.config.defaultToolPreset,
+        includeDelegateTool: true,
+      },
+      {
+        weights: this.config.schedulingWeights,
+        onWarning: (warning) => {
+          this.config.onProgress?.({
+            type: 'warning',
+            task: warning.taskId,
+            data: warning,
+          })
+        },
+      },
+    )
   }
 
   private beginOnlineEvaluation(input: unknown): PendingOnlineEvaluation | undefined {
@@ -892,14 +918,55 @@ export class OpenMultiAgent {
     const taskSpecs = parseTaskSpecs(decompositionResult.output)
 
     const queue = new TaskQueue()
-    const scheduler = new Scheduler(this.config.schedulingStrategy, {
-      defaultProvider: this.config.defaultProvider,
-      defaultToolPreset: this.config.defaultToolPreset,
-      includeDelegateTool: true,
-    })
+    const scheduler = this.createScheduler()
     const taskMetrics = new Map<string, TaskExecutionMetrics>()
 
     if (taskSpecs && taskSpecs.length > 0) {
+      const invalidAssignees = findInvalidAssignees(taskSpecs, agentConfigs)
+      if (invalidAssignees.length > 0 && this.config.strictAssignees) {
+        const error = Object.assign(
+          new Error(
+            `Coordinator plan contains invalid assignees: ${invalidAssignees
+              .map((issue) => `"${issue.assignee}" for "${issue.taskTitle}"`)
+              .join(', ')}.`,
+          ),
+          { code: 'INVALID_ASSIGNEE' },
+        )
+        const classified = classifyRunFailure(error, { kind: 'validation' })
+        this.config.onProgress?.({
+          type: 'agent_complete',
+          agent: 'coordinator',
+          data: decompositionResult,
+        })
+        this.config.onProgress?.({
+          type: 'error',
+          data: {
+            code: 'INVALID_ASSIGNEE',
+            issues: invalidAssignees,
+            error: classified.errorInfo,
+          },
+        })
+        return finish(this.buildTeamRunResult(
+          agentResults,
+          identity,
+          goal,
+          [],
+          classified.status,
+          classified.errorInfo,
+        ))
+      }
+      for (const issue of invalidAssignees) {
+        this.config.onProgress?.({
+          type: 'warning',
+          task: issue.taskTitle,
+          data: {
+            code: 'INVALID_ASSIGNEE',
+            assignee: issue.assignee,
+            taskTitle: issue.taskTitle,
+            fallback: 'clear-and-schedule',
+          },
+        })
+      }
       // Map title-based dependsOn references to real task IDs so we can
       // build the dependency graph before adding tasks to the queue.
       loadSpecsIntoQueue(taskSpecs, agentConfigs, queue, options?.verifyJudges)
@@ -1692,11 +1759,7 @@ export class OpenMultiAgent {
       ? recordRoutingDecision(runIdentity, traceRuntime, routingDecisionInput)
       : undefined
     const agentConfigs = team.getAgents()
-    const scheduler = new Scheduler(this.config.schedulingStrategy, {
-      defaultProvider: this.config.defaultProvider,
-      defaultToolPreset: this.config.defaultToolPreset,
-      includeDelegateTool: true,
-    })
+    const scheduler = this.createScheduler()
     scheduler.autoAssign(queue, agentConfigs)
     const budgets = resolveRunBudgets(this.config, options)
 

--- a/packages/core/src/orchestrator/scheduler.ts
+++ b/packages/core/src/orchestrator/scheduler.ts
@@ -1,13 +1,14 @@
 /**
  * @fileoverview Task scheduling strategies for the open-multi-agent orchestrator.
  *
- * The {@link Scheduler} class encapsulates four distinct strategies for
+ * The {@link Scheduler} class encapsulates five distinct strategies for
  * mapping a set of pending {@link Task}s onto a pool of available agents:
  *
  * - `round-robin`        — Distribute tasks evenly across agents by index.
  * - `least-busy`         — Assign to whichever agent has the fewest active tasks.
  * - `capability-match`   — Filter explicit requirements, then score capability/keyword affinity.
  * - `dependency-first`   — Prioritise tasks on the critical path (most blocked dependents).
+ * - `composite`          — Combine criticality, capability fit, and current load.
  *
  * The scheduler retains only a round-robin cursor between calls. All mutable
  * task state lives in the {@link TaskQueue} passed to
@@ -26,22 +27,57 @@ import {
 // ---------------------------------------------------------------------------
 
 /**
- * The four scheduling strategies available to the {@link Scheduler}.
+ * The five scheduling strategies available to the {@link Scheduler}.
  *
  * - `round-robin`       — Equal distribution by agent index.
  * - `least-busy`        — Prefers the agent with the fewest `in_progress` tasks.
  * - `capability-match`  — Explicit requirements plus capability/keyword affinity.
  * - `dependency-first`  — Prioritise tasks that unblock the most other tasks.
+ * - `composite`         — Criticality ordering plus weighted fit and current load.
  *
  * `dependency-first` is the orchestrator default and suits dependency-heavy
  * DAGs. Use `round-robin` for interchangeable agents, `least-busy` for uneven
- * task durations, and `capability-match` for clearly differentiated roles.
+ * task durations, `capability-match` for clearly differentiated roles, and
+ * `composite` when criticality, eligibility, fit, and load should work together.
  */
 export type SchedulingStrategy =
   | 'round-robin'
   | 'least-busy'
   | 'capability-match'
   | 'dependency-first'
+  | 'composite'
+
+/** Relative weights used by the composite scheduling strategy. */
+export interface SchedulingWeights {
+  /** AgentSelector fit weight. Defaults to `0.7`. */
+  readonly fit: number
+  /** Available-capacity (`1 - normalizedLoad`) weight. Defaults to `0.3`. */
+  readonly load: number
+}
+
+/** Default composite weights: fit is primary, current load is secondary. */
+export const DEFAULT_SCHEDULING_WEIGHTS: SchedulingWeights = {
+  fit: 0.7,
+  load: 0.3,
+}
+
+export interface SchedulerWarning {
+  /** Stable machine-readable warning code inherited from AgentSelector. */
+  readonly code: 'NO_ELIGIBLE_AGENT'
+  readonly message: string
+  readonly taskId: string
+  readonly taskTitle: string
+  readonly reasons: readonly string[]
+  /** Explicit compatibility fallback selected after hard filtering failed. */
+  readonly fallback: 'zero-fit-current-load'
+}
+
+export interface SchedulerOptions {
+  /** Per-field composite overrides; omitted fields use the documented defaults. */
+  readonly weights?: Partial<SchedulingWeights>
+  /** Receives structured scheduler degradations without changing assignments. */
+  readonly onWarning?: (warning: SchedulerWarning) => void
+}
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -88,7 +124,7 @@ function countBlockedDependents(taskId: string, allTasks: Task[]): number {
 // ---------------------------------------------------------------------------
 
 /**
- * Maps pending tasks to available agents using one of four configurable strategies.
+ * Maps pending tasks to available agents using one of five configurable strategies.
  *
  * @example
  * ```ts
@@ -113,7 +149,23 @@ export class Scheduler {
   constructor(
     private readonly strategy: SchedulingStrategy = 'dependency-first',
     private readonly selectorContext: AgentSelectorContext = {},
-  ) {}
+    private readonly options: SchedulerOptions = {},
+  ) {
+    if (strategy === 'composite') {
+      const weights = this.resolvedWeights()
+      if (
+        !Number.isFinite(weights.fit)
+        || !Number.isFinite(weights.load)
+        || weights.fit < 0
+        || weights.load < 0
+        || (weights.fit === 0 && weights.load === 0)
+      ) {
+        throw new RangeError(
+          'Scheduling weights must be finite, non-negative, and not both zero.',
+        )
+      }
+    }
+  }
 
   // -------------------------------------------------------------------------
   // Primary API
@@ -150,6 +202,8 @@ export class Scheduler {
         return this.scheduleCapabilityMatch(unassigned, agents)
       case 'dependency-first':
         return this.scheduleDependencyFirst(unassigned, agents, tasks)
+      case 'composite':
+        return this.scheduleComposite(unassigned, agents, tasks)
     }
   }
 
@@ -332,5 +386,87 @@ export class Scheduler {
     this.roundRobinCursor = cursor
 
     return result
+  }
+
+  /**
+   * Composite: rank tasks by criticality, then choose an agent with
+   * `fitWeight * selectorFit + loadWeight * (1 - normalizedCurrentLoad)`.
+   *
+   * Load is read only from the supplied DAG snapshot's `in_progress` tasks.
+   * Assignments made earlier in this call are deliberately not folded into
+   * load, keeping the decision compatible with future one-ready-task calls.
+   *
+   * When hard filtering leaves no eligible agent, the selector's structured
+   * failure is emitted as a warning and the task follows an explicit zero-fit
+   * fallback across the full roster, using current load and ascending agent
+   * name as the deterministic tie-break.
+   */
+  private scheduleComposite(
+    unassigned: Task[],
+    agents: AgentConfig[],
+    allTasks: Task[],
+  ): Map<string, string> {
+    const ranked = [...unassigned].sort((a, b) =>
+      countBlockedDependents(b.id, allTasks)
+      - countBlockedDependents(a.id, allTasks))
+    const loads = new Map<string, number>(agents.map((agent) => [agent.name, 0]))
+    for (const task of allTasks) {
+      if (task.status === 'in_progress' && task.assignee && loads.has(task.assignee)) {
+        loads.set(task.assignee, (loads.get(task.assignee) ?? 0) + 1)
+      }
+    }
+    const maxLoad = Math.max(1, ...loads.values())
+    const weights = this.resolvedWeights()
+    const selector = new AgentSelector()
+    const result = new Map<string, string>()
+
+    for (const task of ranked) {
+      const selection = selector.select({
+        title: task.title,
+        description: task.description,
+        requires: task.requires,
+      }, agents, this.selectorContext)
+      const candidates = selection.error
+        ? agents.map((agent) => ({ agent, score: 0 }))
+        : selection.eligible
+
+      if (selection.error) {
+        this.options.onWarning?.({
+          code: selection.error.code,
+          message: selection.error.message,
+          taskId: task.id,
+          taskTitle: task.title,
+          reasons: selection.error.reasons,
+          fallback: 'zero-fit-current-load',
+        })
+      }
+
+      const rankedCandidates = candidates.map((candidate) => {
+        const normalizedLoad = (loads.get(candidate.agent.name) ?? 0) / maxLoad
+        return {
+          agent: candidate.agent,
+          score:
+            weights.fit * candidate.score
+            + weights.load * (1 - normalizedLoad),
+        }
+      }).sort((left, right) => {
+        const scoreOrder = right.score - left.score
+        if (scoreOrder !== 0) return scoreOrder
+        if (left.agent.name < right.agent.name) return -1
+        if (left.agent.name > right.agent.name) return 1
+        return 0
+      })
+
+      result.set(task.id, rankedCandidates[0]!.agent.name)
+    }
+
+    return result
+  }
+
+  private resolvedWeights(): SchedulingWeights {
+    return {
+      fit: this.options.weights?.fit ?? DEFAULT_SCHEDULING_WEIGHTS.fit,
+      load: this.options.weights?.load ?? DEFAULT_SCHEDULING_WEIGHTS.load,
+    }
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,7 +7,10 @@
 
 import type { ZodSchema } from 'zod'
 import type { SupportedProvider } from './llm/adapter.js'
-import type { SchedulingStrategy } from './orchestrator/scheduler.js'
+import type {
+  SchedulingStrategy,
+  SchedulingWeights,
+} from './orchestrator/scheduler.js'
 
 // ---------------------------------------------------------------------------
 // Content blocks
@@ -1583,8 +1586,8 @@ export interface Task {
 /**
  * Progress event emitted by the orchestrator during a run.
  *
- * **v0.3 addition:** `'task_skipped'` — consumers with exhaustive switches
- * on `type` will need to add a case for this variant.
+ * Additive variants include `'task_skipped'` and `'warning'`; consumers with
+ * exhaustive switches on `type` need to handle them.
  */
 export interface OrchestratorEvent {
   readonly type:
@@ -1596,6 +1599,7 @@ export interface OrchestratorEvent {
     | 'task_retry'
     | 'budget_exceeded'
     | 'message'
+    | 'warning'
     | 'error'
   readonly agent?: string
   readonly task?: string
@@ -1616,11 +1620,31 @@ export interface OrchestratorConfig {
    *   prompts; use it when agents have distinct, clearly described roles.
    * - `'dependency-first'` assigns tasks that unblock the most dependents
    *   first; use it for dependency-heavy DAGs.
+   * - `'composite'` ranks by dependency criticality, hard-filters with the
+   *   AgentSelector, then combines fit and current load.
    *
    * Defaults to `'dependency-first'`. Explicit task assignees are preserved
    * and are never replaced by this strategy.
    */
   readonly schedulingStrategy?: SchedulingStrategy
+  /**
+   * Relative weights for `'composite'` scheduling.
+   *
+   * `fit` multiplies the AgentSelector score and defaults to `0.7`. `load`
+   * multiplies `1 - normalizedCurrentLoad` and defaults to `0.3`. Values must
+   * be finite and non-negative, and may not both be zero. Ignored by the four
+   * compatibility strategies.
+   */
+  readonly schedulingWeights?: Partial<SchedulingWeights>
+  /**
+   * Reject coordinator plans that name an assignee outside the team roster.
+   *
+   * Defaults to `false`: invalid names are cleared, a structured `warning`
+   * progress event is emitted, and the configured scheduler assigns the task.
+   * When `true`, the run terminates with a structured `INVALID_ASSIGNEE`
+   * validation error before any planned task executes.
+   */
+  readonly strictAssignees?: boolean
   /**
    * Default execution-topology router for automatic `runTeam()` calls.
    *

--- a/packages/core/tests/coordinator-manifest.test.ts
+++ b/packages/core/tests/coordinator-manifest.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   COORDINATOR_ROLE_SUMMARY_MAX_CHARS,
+  buildCoordinatorOutputFormatSection,
   buildCoordinatorRosterManifest,
   buildCoordinatorRosterSection,
   parseTaskSpecs,
@@ -116,5 +117,16 @@ describe('coordinator roster manifest', () => {
       requiredBackend: 'llm',
       requiredProvider: 'anthropic',
     })
+  })
+
+  it('guides assignee selection through manifest capability tags', () => {
+    const section = buildCoordinatorOutputFormatSection()
+
+    expect(section).toContain(
+      'Prefer an agent whose manifest `capabilities` best match the task',
+    )
+    expect(section).toContain(
+      'use `roleSummary` and `tools` only as secondary assignment signals',
+    )
   })
 })

--- a/packages/core/tests/orchestrator.test.ts
+++ b/packages/core/tests/orchestrator.test.ts
@@ -1017,6 +1017,124 @@ describe('OpenMultiAgent', () => {
       })
     })
 
+    it('passes schedulingWeights from OrchestratorConfig into composite scheduling', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title":"Implement TypeScript","description":"Implement TypeScript service"}]\n```',
+      ]
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        schedulingStrategy: 'composite',
+        schedulingWeights: { fit: 0, load: 1 },
+      })
+      const team = oma.createTeam('t', teamCfg([
+        agentConfig('aaa-idle'),
+        {
+          ...agentConfig('coder'),
+          capabilities: ['typescript'],
+        },
+      ]))
+
+      const result = await oma.runTeam(
+        team,
+        'First implement the TypeScript service, then document the result.',
+        { planOnly: true },
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.tasks?.[0]?.assignee).toBe('aaa-idle')
+    })
+
+    it('surfaces composite no-eligible fallback through onProgress warning', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title":"Restricted","description":"Restricted task","requires":{"requiredCapabilities":["missing"]}}]\n```',
+      ]
+      const events: OrchestratorEvent[] = []
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        schedulingStrategy: 'composite',
+        onProgress: (event) => events.push(event),
+      })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker-a')]))
+
+      const result = await oma.runTeam(
+        team,
+        'First complete the restricted task, then document the outcome.',
+        { planOnly: true },
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.tasks?.[0]?.assignee).toBe('worker-a')
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'warning',
+        data: expect.objectContaining({
+          code: 'NO_ELIGIBLE_AGENT',
+          fallback: 'zero-fit-current-load',
+        }),
+      }))
+    })
+
+    it('warns and schedules a coordinator task with an invalid assignee by default', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title":"Research","description":"Research the topic","assignee":"ghost"}]\n```',
+      ]
+      const events: OrchestratorEvent[] = []
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onProgress: (event) => events.push(event),
+      })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker-a')]))
+
+      const result = await oma.runTeam(
+        team,
+        'First research the topic, then prepare a detailed implementation plan.',
+        { planOnly: true },
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.tasks?.[0]?.assignee).toBe('worker-a')
+      expect(events).toContainEqual({
+        type: 'warning',
+        task: 'Research',
+        data: {
+          code: 'INVALID_ASSIGNEE',
+          assignee: 'ghost',
+          taskTitle: 'Research',
+          fallback: 'clear-and-schedule',
+        },
+      })
+    })
+
+    it('returns a structured validation error for an invalid assignee in strict mode', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title":"Research","description":"Research the topic","assignee":"ghost"}]\n```',
+      ]
+      const events: OrchestratorEvent[] = []
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        strictAssignees: true,
+        onProgress: (event) => events.push(event),
+      })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker-a')]))
+
+      const result = await oma.runTeam(
+        team,
+        'First research the topic, then prepare a detailed implementation plan.',
+        { planOnly: true },
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.status?.code).toBe('error')
+      expect(result.errorInfo).toMatchObject({
+        kind: 'validation',
+        code: 'INVALID_ASSIGNEE',
+      })
+      expect(result.tasks).toEqual([])
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'error',
+        data: expect.objectContaining({ code: 'INVALID_ASSIGNEE' }),
+      }))
+    })
+
     it('supports coordinator model override without affecting workers', async () => {
       mockAdapterResponses = [
         '```json\n[{"title": "Research", "description": "Research", "assignee": "worker-a"}]\n```',

--- a/packages/core/tests/scheduler.test.ts
+++ b/packages/core/tests/scheduler.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { Scheduler } from '../src/orchestrator/scheduler.js'
 import { TaskQueue } from '../src/task/queue.js'
 import { createTask } from '../src/task/task.js'
-import type { AgentConfig, Task } from '../src/types.js'
+import type { AgentConfig, Task, TaskRequirements } from '../src/types.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -12,7 +12,14 @@ function agent(name: string, systemPrompt?: string): AgentConfig {
   return { name, model: 'test-model', systemPrompt }
 }
 
-function pendingTask(title: string, opts?: { assignee?: string; dependsOn?: string[] }): Task {
+function pendingTask(
+  title: string,
+  opts?: {
+    assignee?: string
+    dependsOn?: string[]
+    requires?: TaskRequirements
+  },
+): Task {
   return createTask({ title, description: title, assignee: opts?.assignee, ...opts })
 }
 
@@ -206,6 +213,143 @@ describe('Scheduler: dependency-first', () => {
     const s = new Scheduler('dependency-first')
     const assignments = s.schedule([], [agent('a')])
     expect(assignments.size).toBe(0)
+  })
+})
+
+describe('Scheduler: compatibility strategies', () => {
+  it('preserves the established behavior of all four pre-composite strategies', () => {
+    const agents = [
+      agent('a', 'Research and analyze evidence'),
+      agent('b', 'Implement TypeScript code'),
+    ]
+
+    const roundRobinTasks = [pendingTask('one'), pendingTask('two')]
+    expect([
+      ...new Scheduler('round-robin')
+        .schedule(roundRobinTasks, agents)
+        .values(),
+    ]).toEqual(['a', 'b'])
+
+    const busy: Task = {
+      ...pendingTask('busy'),
+      status: 'in_progress',
+      assignee: 'a',
+    }
+    const leastBusyTask = pendingTask('new')
+    expect(
+      new Scheduler('least-busy')
+        .schedule([busy, leastBusyTask], agents)
+        .get(leastBusyTask.id),
+    ).toBe('b')
+
+    const capabilityTask = pendingTask('Implement TypeScript code')
+    expect(
+      new Scheduler('capability-match')
+        .schedule([capabilityTask], agents)
+        .get(capabilityTask.id),
+    ).toBe('b')
+
+    const critical = pendingTask('critical')
+    const ordinary = pendingTask('ordinary')
+    const dependent = { ...pendingTask('dependent'), dependsOn: [critical.id] }
+    expect([
+      ...new Scheduler('dependency-first')
+        .schedule([ordinary, critical, dependent], agents)
+        .keys(),
+    ][0]).toBe(critical.id)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// composite
+// ---------------------------------------------------------------------------
+
+describe('Scheduler: composite', () => {
+  it('prioritises the most critical task and selects its highest-fit eligible agent', () => {
+    const s = new Scheduler('composite')
+    const agents: AgentConfig[] = [
+      { ...agent('researcher'), capabilities: ['worker', 'research'] },
+      { ...agent('coder'), capabilities: ['worker', 'typescript'] },
+    ]
+    const low = pendingTask('General task')
+    const critical = pendingTask('Implement TypeScript service', {
+      requires: { requiredCapabilities: ['worker'] },
+    })
+    const dependentA = { ...pendingTask('Dependent A'), dependsOn: [critical.id] }
+    const dependentB = { ...pendingTask('Dependent B'), dependsOn: [critical.id] }
+
+    const assignments = s.schedule(
+      [low, critical, dependentA, dependentB],
+      agents,
+    )
+
+    expect([...assignments.keys()][0]).toBe(critical.id)
+    expect(assignments.get(critical.id)).toBe('coder')
+  })
+
+  it('prefers the lower-load agent when fit is tied', () => {
+    const s = new Scheduler('composite')
+    const agents = [agent('alpha'), agent('beta')]
+    const busy: Task = {
+      ...pendingTask('Existing work'),
+      status: 'in_progress',
+      assignee: 'alpha',
+    }
+    const task = pendingTask('Unrelated neutral task')
+
+    const assignments = s.schedule([busy, task], agents)
+
+    expect(assignments.get(task.id)).toBe('beta')
+  })
+
+  it('honours configured fit and load weights', () => {
+    const agents: AgentConfig[] = [
+      { ...agent('coder'), capabilities: ['typescript'] },
+      agent('idle'),
+    ]
+    const busy: Task = {
+      ...pendingTask('Existing work'),
+      status: 'in_progress',
+      assignee: 'coder',
+    }
+    const task = pendingTask('Implement TypeScript')
+
+    const fitOnly = new Scheduler('composite', {}, {
+      weights: { fit: 1, load: 0 },
+    }).schedule([busy, task], agents)
+    const loadOnly = new Scheduler('composite', {}, {
+      weights: { fit: 0, load: 1 },
+    }).schedule([busy, task], agents)
+
+    expect(fitOnly.get(task.id)).toBe('coder')
+    expect(loadOnly.get(task.id)).toBe('idle')
+  })
+
+  it('warns and uses the explicit zero-fit load fallback when nobody is eligible', () => {
+    const warnings: unknown[] = []
+    const s = new Scheduler('composite', {}, {
+      onWarning: (warning) => warnings.push(warning),
+    })
+    const agents = [agent('busy'), agent('idle')]
+    const busy: Task = {
+      ...pendingTask('Existing work'),
+      status: 'in_progress',
+      assignee: 'busy',
+    }
+    const task = pendingTask('Restricted task', {
+      requires: { requiredCapabilities: ['missing'] },
+    })
+
+    const assignments = s.schedule([busy, task], agents)
+
+    expect(assignments.get(task.id)).toBe('idle')
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        code: 'NO_ELIGIBLE_AGENT',
+        taskId: task.id,
+        fallback: 'zero-fit-current-load',
+      }),
+    ])
   })
 })
 


### PR DESCRIPTION
## Summary

- Add a fifth `composite` scheduling strategy that ranks tasks by dependency criticality, hard-filters candidates through `AgentSelector`, and combines selector fit with current normalized load.
- Add configurable `schedulingWeights` with defaults of `fit: 0.7` and `load: 0.3`.
- Surface structured warnings when no agent satisfies explicit requirements, then use an explicit zero-fit/current-load fallback.
- Warn when coordinator output names an assignee outside the roster, and add opt-in `strictAssignees` validation that terminates invalid plans before task execution.
- Guide coordinator assignee selection using bounded manifest capability tags.
- Document the new behavior in the English and Chinese core READMEs.

## Motivation

Dependency-first scheduling previously determined task order but still assigned agents through a round-robin cursor. Capability fit, load, and dependency criticality were available only as mutually exclusive strategies. Coordinator-generated invalid assignees were also cleared silently, making degraded planning difficult to observe or reject.

This change composes those signals while preserving the existing strategies and adds an explicit validation boundary for coordinator assignments.

## Scope and impact

- Affected workspace: `@open-multi-agent/core`.
- Public API additions:
  - `SchedulingStrategy` now accepts `composite`.
  - `OrchestratorConfig.schedulingWeights` configures composite fit/load weights.
  - `OrchestratorConfig.strictAssignees` enables fail-closed coordinator assignee validation.
  - `OrchestratorEvent.type` now includes `warning`.
- Compatibility:
  - `dependency-first` remains the default.
  - The four existing scheduling strategy implementations are unchanged.
  - `strictAssignees` defaults to `false`; the compatibility path clears the invalid assignee, emits a warning, and schedules the task.
- Future scheduling compatibility:
  - Composite load reads only the current DAG snapshot's `in_progress` state and does not depend on batch-local assignment accumulation, leaving a direct path to ready-task scheduling.
- Security/privacy: no new secret handling or external data flow.
- Intentional non-goals: historical performance scoring and ready-task scheduler refactoring are not included.
- Dependency changes: none.

## Validation

- `npm run test -w @open-multi-agent/core -- --run tests/scheduler.test.ts tests/coordinator-manifest.test.ts tests/orchestrator.test.ts` — 91 tests passed.
- `npm run lint -w @open-multi-agent/core` — passed.
- `npm run test -w @open-multi-agent/core` — 116 files, 1658 tests passed.
- `npm run build -w @open-multi-agent/core` — passed.
- `git diff --check` — passed.

Provider E2E was not run because this deterministic core scheduling and validation change does not require real provider credentials. CI remains the source of truth for the complete Node 18/20/22 matrix.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING