### PR TITLE
feat(core): add task-scoped results and structured handoffs

### DIFF
--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -112,7 +112,16 @@ On each successfully completed task, the orchestrator writes a `CheckpointSnapsh
   `continued_from` link to the prior attempt.
 - **Task queue state** — every task and its status partition (pending / in-progress / completed / failed / blocked / skipped).
 - **Shared memory** — the turn counter is always recorded. The full entry snapshot is embedded **only when the checkpoint store differs from the team's shared-memory store**. When they are the same store (the default for `checkpoint: true`), the entries are already durable there, so re-embedding them every task would be wasted ~O(N²) write volume across a long run; resume reads them straight from the store instead. Either way, resume rehydrates shared memory correctly.
-- **Completed task results** — `taskId`, `assignee`, and `result` for each finished task, so resumed agents see prior outputs.
+- **Completed task results** — `taskId`, `assignee`, raw `result`, and the
+  JSON-safe `AgentRunResult` for each finished task. This preserves per-task
+  `structured`, normalized status/error details, token usage, tool calls, and
+  messages so `TeamRunResult.taskResults` can be rebuilt after restore. The
+  in-process-only raw `error` object is not persisted. If caller-added result
+  data cannot be JSON-serialized, checkpoint durability wins: the full result
+  is omitted for that task and restore rebuilds the legacy minimal result.
+- **Task handoff/provenance config** — `dependencyPayload`, logical `role`, and
+  validated task `metadata` remain on the queue snapshot, so resumed consumers
+  use the same data-flow and trace references as the original run.
 
 Snapshots are stored as JSON under a reserved namespace: `__oma_checkpoint__/<runId>/latest` (or `__oma_checkpoint__/latest` when no `runId` is set). Keys under `__oma_checkpoint__/` are reserved — shared-memory snapshot/restore deliberately skips them so one store can hold both agent memory and checkpoints.
 
@@ -138,7 +147,13 @@ const orchestrator = new OpenMultiAgent({
 
 ## Redacting persisted secrets
 
-A checkpoint stores completed task results — and, for a separate checkpoint store, the shared-memory snapshot — **verbatim**. Redaction elsewhere (traces, dashboard) does **not** reach this path, so a secret an agent emits into its answer lands on disk. To scrub it, wrap the durable store with **`RedactingStore`**:
+A checkpoint stores completed task results — including structured values,
+messages, and tool calls — and, for a separate checkpoint store, the
+shared-memory snapshot **verbatim**. Task metadata has its own validation and
+credential redaction boundary, but agent-produced results do not. Redaction
+elsewhere (traces, dashboard) does **not** reach this path, so a secret an agent
+emits into its answer lands on disk. To scrub it, wrap the durable store with
+**`RedactingStore`**:
 
 ```typescript
 import { RedactingStore, FileStore } from '@open-multi-agent/core'

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -277,7 +277,18 @@ Used with **`oma task --file`**.
 ```
 
 - **`dependsOn`** — Task titles (not internal ids), same convention as the coordinator output in the library.
-- Optional per-task fields: `memoryScope` (`"dependencies"` \| `"all"`), `maxRetries`, `retryDelayMs`, `retryBackoff`. When retry is enabled (`maxRetries > 0`), backoff is jittered and provably-terminal failures — 4xx client errors other than 408/409/429, plus token-budget and invalid-message errors — skip retries automatically; no extra config.
+- Optional per-task fields: `memoryScope` (`"dependencies"` \| `"all"`),
+  `dependencyPayload` (`"output"` \| `"structured"` \| `"both"`), `role`,
+  `priority`, bounded `metadata`, `maxRetries`, `retryDelayMs`, and
+  `retryBackoff`. `dependencyPayload` defaults to raw output; structured modes
+  require a validated upstream structured result and enforce the same 64 KiB
+  per-dependency limit as the SDK. Task metadata follows the bounds and
+  credential-redaction rules in
+  [Task scheduling and dispatch](task-scheduling.md#task-role-and-provenance-metadata).
+  When retry is enabled (`maxRetries > 0`), backoff is jittered and
+  provably-terminal failures — 4xx client errors other than 408/409/429, plus
+  token-budget and invalid-message errors — skip retries automatically; no
+  extra config.
 - **`tasks`** must be a non-empty array; each item needs string `title` and `description`.
 
 If **`--team path.json`** is passed, the file’s top-level `team` property is ignored and the external file is used instead (useful when the same team definition is shared across several pipeline files).
@@ -327,7 +338,10 @@ Every invocation prints **one JSON document** to stdout, followed by a newline.
 }
 ```
 
-`agentResults` keys are agent names. When an agent ran multiple tasks, the library merges results; the CLI mirrors the merged `AgentRunResult` fields.
+`agentResults` keys are agent names. When an agent ran multiple tasks, the
+library merges results; the CLI mirrors the merged `AgentRunResult` fields.
+`taskResults` is also emitted when available, keyed by stable task ID with each
+unmerged result. `--include-messages` applies to both indexes.
 
 **Successful historical dashboard export**
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -101,11 +101,15 @@ const receipt = buildExecutionReceipt(result, trace)
 
 The receipt reports `mode`, distinct `rolesExecuted`, start-time-based
 `executionOrder`, cross-role `dependencyEdges`, `independentRolesCount`, token
-usage, duration, and whether the record is `partial`. `independentReviewOccurred`
-is true only when at least two different worker roles executed and at least one
-task dependency connects two different roles. Parallel roles with no dependency
-edge do not count as an independent review chain. Coordinator planning entries
-(`coordinator` and `coordinator:*`) are excluded.
+usage, duration, and whether the record is `partial`. For compatibility,
+`rolesExecuted` continues to mean concrete assignee names;
+`workerInstancesExecuted` makes that meaning explicit and
+`taskRolesExecuted` lists distinct caller-declared logical task roles when
+present. `independentReviewOccurred` is true only when at least two different
+worker instances executed and at least one task dependency connects two
+different assignees. Parallel workers with no dependency edge do not count as
+an independent review chain. Coordinator planning entries (`coordinator` and
+`coordinator:*`) are excluded.
 
 For `runTeam()`, the receipt also carries its stable `id` plus
 `routingDecisionId` and, when tracing is enabled, `routingDecisionSpanId`.
@@ -642,7 +646,8 @@ the priority-chain path without pretending every choice came from a router:
 
 The event/span's `receiptId` points to the eventual `ExecutionReceipt`; the
 receipt points back with `routingDecisionId` and `routingDecisionSpanId`.
-Neither record duplicates task roles, order, or dependency edges.
+The decision records do not duplicate actual task roles, order, or dependency
+edges; those remain post-execution receipt/task facts.
 
 The `TraceEvent` union now has eight members, including `routing_decision`.
 Internally, `LegacyCallbackTraceSink` maps v2 records back to the exact legacy

--- a/docs/task-scheduling.md
+++ b/docs/task-scheduling.md
@@ -24,6 +24,77 @@ Task failure and skip propagation still belong to `TaskQueue`. A failed or
 skipped task cascades to its dependents immediately, while unrelated branches
 continue.
 
+## Task results and dependency payloads
+
+`TeamRunResult.agentResults` remains keyed by agent name and preserves its
+existing merge behavior when one agent executes multiple tasks. Task runs also
+populate `TeamRunResult.taskResults`, keyed by stable task ID, so every task's
+unmerged `AgentRunResult` remains available:
+
+```ts
+const result = await orchestrator.runTasks(team, tasks)
+const extractTask = result.tasks?.find(task => task.title === 'Extract')
+const extracted = extractTask
+  ? result.taskResults?.get(extractTask.id)?.structured
+  : undefined
+```
+
+The two indexes reference the same underlying executions. Run-level token usage
+and metrics are calculated once from the internal results; exposing
+`taskResults` does not count usage twice.
+
+Direct dependencies still inject raw `output` by default. An explicit task can
+opt into validated structured handoff:
+
+```ts
+{
+  title: 'Review',
+  description: 'Review validated extraction records.',
+  dependsOn: ['Extract'],
+  dependencyPayload: 'structured', // 'output' (default) | 'structured' | 'both'
+}
+```
+
+`structured` injects only canonical JSON derived from the dependency's
+successful `AgentRunResult.structured`; narrative text in `output` is excluded.
+`both` injects labeled raw and structured sections. A missing or non-serializable
+structured value fails the dependent task with a machine-readable validation
+error—OMA never silently falls back to raw output. Each opt-in dependency
+payload is limited to 64 KiB before the consumer agent is invoked. The default
+`output` path is unchanged for 1.x compatibility.
+
+## Task role and provenance metadata
+
+`assignee` identifies the concrete worker instance. `role` can separately name
+the logical business function, and bounded `metadata` can carry references such
+as `sourceFile`, `supplierId`, or `documentId`:
+
+```ts
+{
+  title: 'Read supplier reply 01',
+  description: 'Extract the simulated quote.',
+  assignee: 'supplier-reader-01',
+  role: 'supplier-extraction',
+  metadata: {
+    sourceFile: 'fixtures/supplier-01.json',
+    supplierId: 'supplier-01',
+  },
+}
+```
+
+Task metadata allows at most 16 entries. Keys are 1–64 characters, begin with a
+letter, and otherwise use letters, digits, `.`, `_`, or `-`; each string is at
+most 1024 characters and each homogeneous scalar array at most 16 values.
+Credential-like keys and the reserved `oma.` prefix are rejected.
+Credential-like text in allowed string values is redacted before the metadata
+enters results, task trace attributes, checkpoint snapshots, or plan artifacts.
+
+`TaskExecutionRecord` retains `role` and `metadata`. Task spans expose
+`oma.task.role` and `oma.task.meta.<key>`, while legacy task trace events expose
+`taskRole` and `taskMetadata`. Execution receipts keep the legacy
+`rolesExecuted` assignee semantics and add `workerInstancesExecuted` plus
+`taskRolesExecuted` so worker replicas are not confused with business roles.
+
 ## Assignment strategies
 
 Unassigned tasks are scheduled when they become ready. `dependency-first` and

--- a/packages/core/src/cli/oma.ts
+++ b/packages/core/src/cli/oma.ts
@@ -35,7 +35,15 @@ import type { StoredRun } from '../observability/store.js'
 import { FileTraceStore, FileTraceStoreError } from '../observability/file-store.js'
 import { emptyTraceSinkStats, type FlushResult, type TraceSink } from '../observability/sink.js'
 import type { SupportedProvider } from '../llm/adapter.js'
-import type { AgentRunResult, CoordinatorConfig, OrchestratorConfig, TeamConfig, TeamRunResult } from '../types.js'
+import { validateTaskMetadata } from '../task/metadata.js'
+import type {
+  AgentRunResult,
+  CoordinatorConfig,
+  OrchestratorConfig,
+  TaskMetadata,
+  TeamConfig,
+  TeamRunResult,
+} from '../types.js'
 
 // ---------------------------------------------------------------------------
 // Exit codes
@@ -570,6 +578,10 @@ function asTaskSpecs(v: unknown, label: string): ReadonlyArray<{
   assignee?: string
   dependsOn?: string[]
   memoryScope?: 'dependencies' | 'all'
+  dependencyPayload?: 'output' | 'structured' | 'both'
+  role?: string
+  priority?: 'low' | 'normal' | 'high' | 'critical'
+  metadata?: TaskMetadata
   maxRetries?: number
   retryDelayMs?: number
   retryBackoff?: number
@@ -581,6 +593,10 @@ function asTaskSpecs(v: unknown, label: string): ReadonlyArray<{
     assignee?: string
     dependsOn?: string[]
     memoryScope?: 'dependencies' | 'all'
+    dependencyPayload?: 'output' | 'structured' | 'both'
+    role?: string
+    priority?: 'low' | 'normal' | 'high' | 'critical'
+    metadata?: TaskMetadata
     maxRetries?: number
     retryDelayMs?: number
     retryBackoff?: number
@@ -601,6 +617,34 @@ function asTaskSpecs(v: unknown, label: string): ReadonlyArray<{
     }
     if (item['memoryScope'] === 'all' || item['memoryScope'] === 'dependencies') {
       row.memoryScope = item['memoryScope']
+    }
+    if (
+      item['dependencyPayload'] === 'output'
+      || item['dependencyPayload'] === 'structured'
+      || item['dependencyPayload'] === 'both'
+    ) {
+      row.dependencyPayload = item['dependencyPayload']
+    }
+    if (typeof item['role'] === 'string') row.role = item['role']
+    if (
+      item['priority'] === 'low'
+      || item['priority'] === 'normal'
+      || item['priority'] === 'high'
+      || item['priority'] === 'critical'
+    ) {
+      row.priority = item['priority']
+    }
+    if (item['metadata'] !== undefined) {
+      if (!isObject(item['metadata'])) {
+        throw new OmaValidationError(`${label}[${i}].metadata: object expected`)
+      }
+      try {
+        row.metadata = validateTaskMetadata(item['metadata'] as TaskMetadata)!
+      } catch (error) {
+        throw new OmaValidationError(
+          `${label}[${i}].metadata: ${error instanceof Error ? error.message : String(error)}`,
+        )
+      }
     }
     if (typeof item['maxRetries'] === 'number') row.maxRetries = item['maxRetries']
     if (typeof item['retryDelayMs'] === 'number') row.retryDelayMs = item['retryDelayMs']
@@ -635,6 +679,14 @@ export function serializeTeamRunResult(result: TeamRunResult, opts: CliJsonOptio
   for (const [k, v] of result.agentResults) {
     agentResults[k] = serializeAgentResult(v, opts.includeMessages)
   }
+  const taskResults: Record<string, unknown> | undefined = result.taskResults === undefined
+    ? undefined
+    : Object.fromEntries(
+        [...result.taskResults].map(([k, v]) => [
+          k,
+          serializeAgentResult(v, opts.includeMessages),
+        ]),
+      )
   return {
     success: result.success,
     goal: result.goal,
@@ -642,6 +694,7 @@ export function serializeTeamRunResult(result: TeamRunResult, opts: CliJsonOptio
     routingDecision: result.routingDecision,
     totalTokenUsage: result.totalTokenUsage,
     agentResults,
+    ...(taskResults !== undefined ? { taskResults } : {}),
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -327,6 +327,7 @@ export type {
   RunTeamOptions,
   RunTasksOptions,
   RunTaskSpec,
+  TaskMetadata,
   TaskRequirements,
   RestoreOptions,
   ModelRouteConfig,

--- a/packages/core/src/observability/execution-receipt.ts
+++ b/packages/core/src/observability/execution-receipt.ts
@@ -25,7 +25,12 @@ export interface ExecutionReceipt {
   /** Machine-readable warnings copied from the run result, when present. */
   readonly flags?: readonly RunFlag[]
   readonly mode: 'single' | 'multi-agent'
+  /** Legacy worker/assignee list retained for compatibility. */
   readonly rolesExecuted: readonly string[]
+  /** Explicit alias that distinguishes concrete worker instances from task roles. */
+  readonly workerInstancesExecuted?: readonly string[]
+  /** Distinct caller-declared logical task roles observed in executed tasks. */
+  readonly taskRolesExecuted?: readonly string[]
   readonly executionOrder: readonly string[]
   readonly dependencyEdges: readonly ExecutionReceiptDependencyEdge[]
   readonly independentRolesCount: number
@@ -48,6 +53,7 @@ interface TraceFacts {
 interface TaskFact {
   readonly id?: string
   readonly role?: string
+  readonly taskRole?: string
   readonly dependsOn: readonly string[]
   readonly startMs?: number
 }
@@ -112,6 +118,7 @@ function readTraceTaskFacts(trace: TraceFacts): Map<string, TaskFact> {
     const candidate: TaskFact = {
       id,
       role: readWorkerRole(event['agent']),
+      taskRole: readString(event['taskRole']),
       dependsOn: [],
       startMs: isFiniteNumber(event['startMs']) ? event['startMs'] : undefined,
     }
@@ -128,6 +135,7 @@ function emptyReceipt(): ExecutionReceipt {
   return {
     mode: 'single',
     rolesExecuted: [],
+    workerInstancesExecuted: [],
     executionOrder: [],
     dependencyEdges: [],
     independentRolesCount: 0,
@@ -189,6 +197,7 @@ function buildAgentReceipt(result: AgentRunResult, trace: TraceFacts): Execution
     ...(flags ? { flags } : {}),
     mode: rolesExecuted.length > 1 ? 'multi-agent' : 'single',
     rolesExecuted,
+    workerInstancesExecuted: rolesExecuted,
     executionOrder,
     dependencyEdges: [],
     independentRolesCount: rolesExecuted.length,
@@ -230,6 +239,7 @@ function buildTeamReceipt(result: TeamRunResult, trace: TraceFacts): ExecutionRe
 
     const rawRole = readString(value['assignee'])
     const role = readWorkerRole(rawRole) ?? traced?.role
+    const taskRole = readString(value['role']) ?? traced?.taskRole
     const rawDependsOn = value['dependsOn']
     const dependsOn = Array.isArray(rawDependsOn)
       ? rawDependsOn.filter((dependency): dependency is string => typeof dependency === 'string')
@@ -241,7 +251,7 @@ function buildTeamReceipt(result: TeamRunResult, trace: TraceFacts): ExecutionRe
     if (!id || (!rawRole && !traced?.role) || !Array.isArray(rawDependsOn)) partial = true
     if (Array.isArray(rawDependsOn) && dependsOn.length !== rawDependsOn.length) partial = true
     if (role && startMs === undefined) partial = true
-    taskFacts.push({ id, role, dependsOn, startMs })
+    taskFacts.push({ id, role, taskRole, dependsOn, startMs })
   }
 
   const rolesExecuted: string[] = []
@@ -266,6 +276,10 @@ function buildTeamReceipt(result: TeamRunResult, trace: TraceFacts): ExecutionRe
   const executionOrder = orderComplete && earliestByRole.size === rolesExecuted.length
     ? [...rolesExecuted].sort((left, right) => earliestByRole.get(left)! - earliestByRole.get(right)!)
     : []
+  const taskRolesExecuted = [...new Set(taskFacts
+    .filter((task) => task.role !== undefined)
+    .map((task) => task.taskRole)
+    .filter((role): role is string => role !== undefined))]
 
   const roleByTaskId = new Map<string, string>()
   for (const task of taskFacts) {
@@ -303,6 +317,8 @@ function buildTeamReceipt(result: TeamRunResult, trace: TraceFacts): ExecutionRe
     ...(flags ? { flags } : {}),
     mode: rolesExecuted.length > 1 ? 'multi-agent' : 'single',
     rolesExecuted,
+    workerInstancesExecuted: rolesExecuted,
+    ...(taskRolesExecuted.length > 0 ? { taskRolesExecuted } : {}),
     executionOrder,
     dependencyEdges,
     independentRolesCount: rolesExecuted.length,

--- a/packages/core/src/orchestrator/coordinator.ts
+++ b/packages/core/src/orchestrator/coordinator.ts
@@ -17,6 +17,7 @@ import type {
   OrchestratorConfig,
   RunIdentity,
   Task,
+  TaskMetadata,
   TaskRequirements,
   TokenUsage,
 } from '../types.js'
@@ -622,11 +623,13 @@ export async function buildSynthesisPrompt(
 export function loadSpecsIntoQueue(
   specs: ReadonlyArray<ParsedTaskSpec & {
     memoryScope?: 'dependencies' | 'all'
+    dependencyPayload?: 'output' | 'structured' | 'both'
     maxRetries?: number
     retryDelayMs?: number
     retryBackoff?: number
     role?: string
     priority?: 'low' | 'normal' | 'high' | 'critical'
+    metadata?: TaskMetadata
     requires?: TaskRequirements
   }>,
   agentConfigs: AgentConfig[],
@@ -653,11 +656,13 @@ export function loadSpecsIntoQueue(
         ? spec.assignee
         : undefined,
       memoryScope: spec.memoryScope,
+      dependencyPayload: spec.dependencyPayload,
       maxRetries: spec.maxRetries,
       retryDelayMs: spec.retryDelayMs,
       retryBackoff: spec.retryBackoff,
       role: spec.role,
       priority: spec.priority,
+      metadata: spec.metadata,
       requires: spec.requires,
       verify: resolveVerify(spec.verify, verifyJudges),
     })

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -80,6 +80,7 @@ import { TaskQueue } from '../task/queue.js'
 import { Checkpoint } from '../memory/checkpoint.js'
 import { InMemoryStore } from '../memory/store.js'
 import { createTask, validateTaskDependencies } from '../task/task.js'
+import { validateTaskMetadata } from '../task/metadata.js'
 import { Scheduler } from './scheduler.js'
 import { CostBudgetExceededError, TokenBudgetExceededError } from '../errors.js'
 import {
@@ -1134,6 +1135,10 @@ export class OpenMultiAgent {
       dependsOn: task.dependsOn ?? [],
       description: task.description,
       memoryScope: task.memoryScope,
+      dependencyPayload: task.dependencyPayload,
+      role: task.role,
+      priority: task.priority,
+      metadata: task.metadata,
       requires: task.requires,
       maxRetries: task.maxRetries,
       retryDelayMs: task.retryDelayMs,
@@ -1213,6 +1218,12 @@ export class OpenMultiAgent {
           ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
           ...(task.dependsOn.length > 0 ? { dependsOn: task.dependsOn } : {}),
           ...(task.memoryScope !== undefined ? { memoryScope: task.memoryScope } : {}),
+          ...(task.dependencyPayload !== undefined
+            ? { dependencyPayload: task.dependencyPayload }
+            : {}),
+          ...(task.role !== undefined ? { role: task.role } : {}),
+          ...(task.priority !== undefined ? { priority: task.priority } : {}),
+          ...(task.metadata !== undefined ? { metadata: task.metadata } : {}),
           ...(task.maxRetries !== undefined ? { maxRetries: task.maxRetries } : {}),
           ...(task.retryDelayMs !== undefined ? { retryDelayMs: task.retryDelayMs } : {}),
           ...(task.retryBackoff !== undefined ? { retryBackoff: task.retryBackoff } : {}),
@@ -1320,11 +1331,13 @@ export class OpenMultiAgent {
             assignee: t.assignee,
             dependsOn: t.dependsOn,
             memoryScope: t.memoryScope,
+            dependencyPayload: t.dependencyPayload,
             maxRetries: t.maxRetries,
             retryDelayMs: t.retryDelayMs,
             retryBackoff: t.retryBackoff,
             role: t.role,
             priority: t.priority,
+            metadata: t.metadata,
             verify: t.verify,
           })),
           team.getAgents(),
@@ -1459,11 +1472,13 @@ export class OpenMultiAgent {
         assignee: t.assignee,
         dependsOn: t.dependsOn,
         memoryScope: t.memoryScope,
+        dependencyPayload: t.dependencyPayload,
         maxRetries: t.maxRetries,
         retryDelayMs: t.retryDelayMs,
         retryBackoff: t.retryBackoff,
         role: t.role,
         priority: t.priority,
+        metadata: t.metadata,
         requires: t.requires,
         verify: t.verify,
       })),
@@ -1731,6 +1746,14 @@ export class OpenMultiAgent {
       ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
       ...(task.dependsOn && task.dependsOn.length > 0 ? { dependsOn: [...task.dependsOn] } : {}),
       ...(task.memoryScope !== undefined ? { memoryScope: task.memoryScope } : {}),
+      ...(task.dependencyPayload !== undefined
+        ? { dependencyPayload: task.dependencyPayload }
+        : {}),
+      ...(task.role !== undefined ? { role: task.role } : {}),
+      ...(task.priority !== undefined ? { priority: task.priority } : {}),
+      ...(task.metadata !== undefined
+        ? { metadata: validateTaskMetadata(task.metadata) }
+        : {}),
       ...(task.requires !== undefined ? { requires: task.requires } : {}),
       result: undefined,
       createdAt: now,
@@ -1873,6 +1896,10 @@ export class OpenMultiAgent {
       dependsOn: task.dependsOn ?? [],
       description: task.description,
       memoryScope: task.memoryScope,
+      dependencyPayload: task.dependencyPayload,
+      role: task.role,
+      priority: task.priority,
+      metadata: task.metadata,
       requires: task.requires,
       maxRetries: task.maxRetries,
       retryDelayMs: task.retryDelayMs,
@@ -1952,13 +1979,16 @@ export class OpenMultiAgent {
       const task = taskById.get(completed.taskId)
       const assignee = completed.assignee ?? task?.assignee ?? 'unknown'
       const output = completed.result ?? task?.result ?? ''
-      agentResults.set(`${assignee}:${completed.taskId}`, {
-        success: true,
-        output,
-        messages: [],
-        tokenUsage: ZERO_USAGE,
-        toolCalls: [],
-      })
+      agentResults.set(
+        `${assignee}:${completed.taskId}`,
+        completed.agentResult ?? {
+          success: true,
+          output,
+          messages: [],
+          tokenUsage: ZERO_USAGE,
+          toolCalls: [],
+        },
+      )
     }
 
     return agentResults
@@ -2009,6 +2039,14 @@ export class OpenMultiAgent {
     let totalUsage: TokenUsage = ZERO_USAGE
     let overallSuccess = true
     const collapsed = new Map<string, AgentRunResult>()
+    const taskResults = new Map<string, AgentRunResult>()
+
+    for (const task of tasks ?? []) {
+      if (!task.assignee) continue
+      const exact = agentResults.get(`${task.assignee}:${task.id}`)
+        ?? (task.id === 'short-circuit' ? agentResults.get(task.assignee) : undefined)
+      if (exact !== undefined) taskResults.set(task.id, exact)
+    }
 
     for (const [key, result] of agentResults) {
       // Strip the `:taskId` suffix to get the agent name
@@ -2072,6 +2110,7 @@ export class OpenMultiAgent {
       goal,
       tasks,
       agentResults: collapsed,
+      taskResults,
       totalTokenUsage: totalUsage,
       metrics,
     }
@@ -2091,6 +2130,10 @@ export class OpenMultiAgent {
       dependsOn: task.dependsOn ?? [],
       description: task.description,
       memoryScope: task.memoryScope,
+      dependencyPayload: task.dependencyPayload,
+      role: task.role,
+      priority: task.priority,
+      metadata: task.metadata,
       requires: task.requires,
       maxRetries: task.maxRetries,
       retryDelayMs: task.retryDelayMs,

--- a/packages/core/src/orchestrator/task-execution.ts
+++ b/packages/core/src/orchestrator/task-execution.ts
@@ -24,6 +24,7 @@ import type {
 import type { AgentPool } from '../agent/pool.js'
 import type { Team } from '../team/team.js'
 import type { TaskQueue } from '../task/queue.js'
+import { taskMetadataTraceAttributes } from '../task/metadata.js'
 import type { Checkpoint } from '../memory/checkpoint.js'
 import { emitTrace, generateSpanId } from '../utils/trace.js'
 import { classifyRunFailure, statusOnly } from '../observability/status.js'
@@ -179,11 +180,22 @@ export async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Prom
   // and the run continues — the next completed task retries the write.
   const save = async (): Promise<void> => {
     const sharedMem = ctx.team.getSharedMemoryInstance()
-    const completedTaskResults = queue.getByStatus('completed').map((task) => ({
-      taskId: task.id,
-      ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
-      ...(task.result !== undefined ? { result: task.result } : {}),
-    }))
+    const completedTaskResults = queue.getByStatus('completed').map((task) => {
+      const agentResult = task.assignee === undefined
+        ? undefined
+        : ctx.agentResults.get(`${task.assignee}:${task.id}`)
+      const checkpointAgentResult = agentResult === undefined
+        ? undefined
+        : toCheckpointAgentResult(agentResult)
+      return {
+        taskId: task.id,
+        ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
+        ...(task.result !== undefined ? { result: task.result } : {}),
+        ...(checkpointAgentResult !== undefined
+          ? { agentResult: checkpointAgentResult }
+          : {}),
+      }
+    })
 
     const snapshot: CheckpointSnapshot = {
       version: 2,
@@ -228,6 +240,19 @@ export async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Prom
       type: 'error',
       data: { kind: 'checkpoint_save_failed', error },
     } satisfies OrchestratorEvent)
+  }
+}
+
+function toCheckpointAgentResult(
+  result: AgentRunResult,
+): Omit<AgentRunResult, 'error'> | undefined {
+  const { error: _error, ...candidate } = result
+  try {
+    return JSON.parse(JSON.stringify(candidate)) as Omit<AgentRunResult, 'error'>
+  } catch {
+    // A custom structured value or tool input can be non-JSON-safe. Preserve
+    // checkpoint durability and let restore use the legacy minimal task result.
+    return undefined
   }
 }
 
@@ -536,6 +561,8 @@ export async function executeQueue(
           'oma.task.id': task.id,
           'oma.task.title': task.title,
           ...(task.assignee ? { 'oma.agent.name': task.assignee } : {}),
+          ...(task.role ? { 'oma.task.role': task.role } : {}),
+          ...taskMetadataTraceAttributes(task.metadata),
         },
       })
       if (taskSpan) ctx.taskSpans.set(task.id, taskSpan)
@@ -600,12 +627,80 @@ export async function executeQueue(
           data: task,
         } satisfies OrchestratorEvent)
 
-        // Build the prompt: task description + dependency-only context by default.
-        const prompt = await buildTaskPrompt(task, team, queue, ctx.revealCoordinatorContext)
-
-        // Trace + abort + team tool context (delegate_to_agent)
+        const taskStartMs = taskSpan?.startUnixMs ?? Date.now()
         const taskSpanId = config.onTrace ? generateSpanId() : undefined
         const agentSpanId = config.onTrace ? generateSpanId() : undefined
+        const legacyTaskEvent = (
+          success: boolean,
+          endMs: number,
+          retries: number,
+        ) => config.onTrace ? {
+            type: 'task',
+            runId: ctx.runId ?? '',
+            spanId: taskSpanId ?? generateSpanId(),
+            taskId: task.id,
+            taskTitle: task.title,
+            ...(task.role !== undefined ? { taskRole: task.role } : {}),
+            ...(task.metadata !== undefined ? { taskMetadata: task.metadata } : {}),
+            agent: assignee,
+            success,
+            retries,
+            startMs: taskStartMs,
+            endMs,
+            durationMs: endMs - taskStartMs,
+          } as const : undefined
+
+        // Build the prompt: task description + dependency-only context by default.
+        let prompt: string
+        try {
+          prompt = await buildTaskPrompt(
+            task,
+            team,
+            queue,
+            ctx.revealCoordinatorContext,
+            ctx.agentResults,
+          )
+        } catch (error) {
+          if (!(error instanceof DependencyPayloadError)) throw error
+          const taskEndMs = Date.now()
+          const message = errorMessage(error)
+          const classified = classifyRunFailure(error, { kind: 'validation' })
+          const failure: AgentRunResult = {
+            success: false,
+            output: message,
+            messages: [],
+            tokenUsage: ZERO_USAGE,
+            toolCalls: [],
+            status: classified.status,
+            errorInfo: classified.errorInfo,
+            error,
+          }
+          ctx.agentResults.set(`${assignee}:${task.id}`, failure)
+          ctx.taskMetrics.set(task.id, {
+            startMs: taskStartMs,
+            endMs: taskEndMs,
+            durationMs: Math.max(0, taskEndMs - taskStartMs),
+            tokenUsage: ZERO_USAGE,
+            toolCalls: [],
+            retries: 0,
+          })
+          queue.fail(task.id, message)
+          const taskLegacyEvent = legacyTaskEvent(false, taskEndMs, 0)
+          taskSpan?.end({
+            status: classified.status,
+            error: classified.errorInfo,
+            ...(taskLegacyEvent ? { legacyEvent: taskLegacyEvent } : {}),
+          })
+          config.onProgress?.({
+            type: 'error',
+            task: task.id,
+            agent: assignee,
+            data: failure,
+          } satisfies OrchestratorEvent)
+          return
+        }
+
+        // Trace + abort + team tool context (delegate_to_agent)
         const traceBase: Partial<RunOptions> = {
           identity: ctx.identity,
           runId: ctx.runId,
@@ -674,7 +769,6 @@ export async function executeQueue(
             }
           : undefined
 
-        const taskStartMs = taskSpan?.startUnixMs ?? Date.now()
         let retryCount = 0
 
         const result = await executeWithRetry(
@@ -744,19 +838,7 @@ export async function executeQueue(
 
         const taskEndMs = Date.now()
 
-        const taskLegacyEvent = config.onTrace ? {
-            type: 'task',
-            runId: ctx.runId ?? '',
-            spanId: taskSpanId ?? generateSpanId(),
-            taskId: task.id,
-            taskTitle: task.title,
-            agent: assignee,
-            success: result.success,
-            retries: retryCount,
-            startMs: taskStartMs,
-            endMs: taskEndMs,
-            durationMs: taskEndMs - taskStartMs,
-          } as const : undefined
+        const taskLegacyEvent = legacyTaskEvent(result.success, taskEndMs, retryCount)
 
         ctx.agentResults.set(`${assignee}:${task.id}`, result)
 
@@ -968,6 +1050,7 @@ export async function buildTaskPrompt(
   team: Team,
   queue: TaskQueue,
   revealContext?: RevealCoordinatorContext,
+  agentResults?: ReadonlyMap<string, AgentRunResult>,
 ): Promise<string> {
   const lines: string[] = []
 
@@ -999,9 +1082,49 @@ export async function buildTaskPrompt(
     const depResults: string[] = []
     for (const depId of task.dependsOn) {
       const depTask = queue.get(depId)
-      if (depTask?.status === 'completed' && depTask.result) {
-        depResults.push(`### ${depTask.title} (by ${depTask.assignee ?? 'unknown'})\n${depTask.result}`)
+      if (depTask?.status !== 'completed') continue
+
+      const heading = `### ${depTask.title} (by ${depTask.assignee ?? 'unknown'})`
+      const payloadMode = task.dependencyPayload ?? 'output'
+      if (payloadMode === 'output') {
+        if (depTask.result) depResults.push(`${heading}\n${depTask.result}`)
+        continue
       }
+
+      const dependencyResult = depTask.assignee === undefined
+        ? undefined
+        : agentResults?.get(`${depTask.assignee}:${depTask.id}`)
+      if (!dependencyResult?.success || dependencyResult.structured === undefined) {
+        throw new DependencyPayloadError(
+          'DEPENDENCY_STRUCTURED_RESULT_MISSING',
+          `Task "${task.title}" requires a structured result from dependency ` +
+            `"${depTask.title}" (${depTask.id}), but none is available.`,
+        )
+      }
+
+      let structured: string
+      try {
+        structured = stableJsonStringify(dependencyResult.structured)
+      } catch {
+        throw new DependencyPayloadError(
+          'DEPENDENCY_STRUCTURED_SERIALIZATION_FAILED',
+          `Task "${task.title}" could not serialize the structured result from ` +
+            `dependency "${depTask.title}" (${depTask.id}).`,
+        )
+      }
+
+      const payload = payloadMode === 'structured'
+        ? `${heading}\n#### Validated structured result\n${structured}`
+        : [
+            heading,
+            '#### Raw output',
+            depTask.result ?? dependencyResult.output,
+            '',
+            '#### Validated structured result',
+            structured,
+          ].join('\n')
+      assertDependencyPayloadSize(task, depTask, payload)
+      depResults.push(payload)
     }
     if (depResults.length > 0) {
       lines.push('', '## Context from prerequisite tasks', '', ...depResults)
@@ -1020,4 +1143,71 @@ export async function buildTaskPrompt(
   }
 
   return lines.join('\n')
+}
+
+const MAX_DEPENDENCY_PAYLOAD_BYTES = 64 * 1_024
+
+class DependencyPayloadError extends Error {
+  constructor(
+    readonly code:
+      | 'DEPENDENCY_STRUCTURED_RESULT_MISSING'
+      | 'DEPENDENCY_STRUCTURED_SERIALIZATION_FAILED'
+      | 'DEPENDENCY_PAYLOAD_TOO_LARGE',
+    message: string,
+  ) {
+    super(message)
+    this.name = 'DependencyPayloadError'
+  }
+}
+
+function assertDependencyPayloadSize(task: Task, dependency: Task, payload: string): void {
+  const bytes = Buffer.byteLength(payload, 'utf8')
+  if (bytes <= MAX_DEPENDENCY_PAYLOAD_BYTES) return
+  throw new DependencyPayloadError(
+    'DEPENDENCY_PAYLOAD_TOO_LARGE',
+    `Task "${task.title}" dependency payload from "${dependency.title}" ` +
+      `is ${bytes} bytes; the limit is ${MAX_DEPENDENCY_PAYLOAD_BYTES} bytes.`,
+  )
+}
+
+function stableJsonStringify(value: unknown): string {
+  const normalized = normalizeJsonValue(value, new Set<object>())
+  const serialized = JSON.stringify(normalized)
+  if (serialized === undefined) {
+    throw new TypeError('Structured dependency result is not JSON-serializable.')
+  }
+  return serialized
+}
+
+function normalizeJsonValue(value: unknown, ancestors: Set<object>): unknown {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value === 'bigint') throw new TypeError('BigInt is not JSON-serializable.')
+  if (typeof value === 'undefined' || typeof value === 'function' || typeof value === 'symbol') {
+    return undefined
+  }
+
+  const object = value as object
+  if (ancestors.has(object)) throw new TypeError('Circular structured dependency result.')
+  ancestors.add(object)
+  try {
+    if (value instanceof Date) return value.toJSON()
+    if (Array.isArray(value)) {
+      return value.map(item => normalizeJsonValue(item, ancestors) ?? null)
+    }
+
+    const record = value as Record<string, unknown> & { toJSON?: () => unknown }
+    if (typeof record.toJSON === 'function') {
+      return normalizeJsonValue(record.toJSON(), ancestors)
+    }
+
+    const normalized: Record<string, unknown> = {}
+    for (const key of Object.keys(record).sort()) {
+      const child = normalizeJsonValue(record[key], ancestors)
+      if (child !== undefined) normalized[key] = child
+    }
+    return normalized
+  } finally {
+    ancestors.delete(object)
+  }
 }

--- a/packages/core/src/task/metadata.ts
+++ b/packages/core/src/task/metadata.ts
@@ -1,0 +1,93 @@
+import type { TaskMetadata, TraceAttributeValue } from '../types.js'
+import { isSensitiveName, redactSensitiveText } from '../utils/redaction.js'
+
+const TASK_METADATA_KEY = /^[A-Za-z][A-Za-z0-9_.-]{0,63}$/
+const MAX_TASK_METADATA_ENTRIES = 16
+const MAX_TASK_METADATA_STRING_LENGTH = 1_024
+const MAX_TASK_METADATA_ARRAY_LENGTH = 16
+
+function normalizeScalar(
+  value: unknown,
+  key: string,
+): string | number | boolean {
+  if (typeof value === 'string') {
+    if (value.length > MAX_TASK_METADATA_STRING_LENGTH) {
+      throw new Error(
+        `task metadata value for "${key}" must contain at most ` +
+          `${MAX_TASK_METADATA_STRING_LENGTH} characters.`,
+      )
+    }
+    return redactSensitiveText(value)
+  }
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number' && Number.isFinite(value)) return value
+  throw new Error(`task metadata value for "${key}" is not a supported trace attribute.`)
+}
+
+function normalizeValue(value: unknown, key: string): TraceAttributeValue {
+  if (!Array.isArray(value)) return normalizeScalar(value, key)
+  if (value.length > MAX_TASK_METADATA_ARRAY_LENGTH) {
+    throw new Error(
+      `task metadata array for "${key}" must contain at most ` +
+        `${MAX_TASK_METADATA_ARRAY_LENGTH} values.`,
+    )
+  }
+
+  let elementType: 'string' | 'number' | 'boolean' | undefined
+  const normalized: Array<string | number | boolean> = []
+  for (const item of value) {
+    const itemType = typeof item
+    if (itemType !== 'string' && itemType !== 'number' && itemType !== 'boolean') {
+      throw new Error(`task metadata array for "${key}" must contain scalar values.`)
+    }
+    if (elementType !== undefined && itemType !== elementType) {
+      throw new Error(`task metadata array for "${key}" must be homogeneous.`)
+    }
+    elementType = itemType
+    normalized.push(normalizeScalar(item, key))
+  }
+  return Object.freeze(normalized) as TraceAttributeValue
+}
+
+/** Validate, redact, and defensively copy task-scoped business metadata. */
+export function validateTaskMetadata(
+  metadata: TaskMetadata | undefined,
+): TaskMetadata | undefined {
+  if (metadata === undefined) return undefined
+  if (metadata === null || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    throw new Error('task metadata must be a record of trace attribute values.')
+  }
+
+  const entries = Object.entries(metadata as Readonly<Record<string, unknown>>)
+  if (entries.length > MAX_TASK_METADATA_ENTRIES) {
+    throw new Error(`task metadata must contain at most ${MAX_TASK_METADATA_ENTRIES} entries.`)
+  }
+
+  const normalized: Array<readonly [string, TraceAttributeValue]> = []
+  for (const [key, value] of entries) {
+    if (!TASK_METADATA_KEY.test(key)) {
+      throw new Error(
+        `task metadata key "${key}" must match [A-Za-z][A-Za-z0-9_.-]{0,63}.`,
+      )
+    }
+    if (key.toLowerCase().startsWith('oma.')) {
+      throw new Error(`task metadata key "${key}" uses the reserved "oma." prefix.`)
+    }
+    if (isSensitiveName(key)) {
+      throw new Error(`task metadata key "${key}" is credential-like and is not allowed.`)
+    }
+    normalized.push([key, normalizeValue(value, key)])
+  }
+
+  return Object.freeze(Object.fromEntries(normalized))
+}
+
+/** Flatten task metadata into reserved trace attributes. */
+export function taskMetadataTraceAttributes(
+  metadata: TaskMetadata | undefined,
+): Readonly<Record<string, TraceAttributeValue>> {
+  if (metadata === undefined) return {}
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => [`oma.task.meta.${key}`, value]),
+  )
+}

--- a/packages/core/src/task/queue.ts
+++ b/packages/core/src/task/queue.ts
@@ -8,6 +8,7 @@
 
 import type { Task, TaskQueueSnapshot, TaskSnapshot, TaskStatus } from '../types.js'
 import { isTaskReady } from './task.js'
+import { validateTaskMetadata } from './metadata.js'
 
 // ---------------------------------------------------------------------------
 // Event types
@@ -523,8 +524,10 @@ export class TaskQueue {
       ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
       ...(task.dependsOn !== undefined ? { dependsOn: [...task.dependsOn] } : {}),
       ...(task.memoryScope !== undefined ? { memoryScope: task.memoryScope } : {}),
+      ...(task.dependencyPayload !== undefined ? { dependencyPayload: task.dependencyPayload } : {}),
       ...(task.role !== undefined ? { role: task.role } : {}),
       ...(task.priority !== undefined ? { priority: task.priority } : {}),
+      ...(task.metadata !== undefined ? { metadata: task.metadata } : {}),
       ...(task.requires !== undefined ? { requires: task.requires } : {}),
       ...(task.result !== undefined ? { result: task.result } : {}),
       createdAt: task.createdAt.toISOString(),
@@ -544,8 +547,14 @@ export class TaskQueue {
       ...(snapshot.assignee !== undefined ? { assignee: snapshot.assignee } : {}),
       ...(snapshot.dependsOn !== undefined ? { dependsOn: [...snapshot.dependsOn] } : {}),
       ...(snapshot.memoryScope !== undefined ? { memoryScope: snapshot.memoryScope } : {}),
+      ...(snapshot.dependencyPayload !== undefined
+        ? { dependencyPayload: snapshot.dependencyPayload }
+        : {}),
       ...(snapshot.role !== undefined ? { role: snapshot.role } : {}),
       ...(snapshot.priority !== undefined ? { priority: snapshot.priority } : {}),
+      ...(snapshot.metadata !== undefined
+        ? { metadata: validateTaskMetadata(snapshot.metadata) }
+        : {}),
       ...(snapshot.requires !== undefined ? { requires: snapshot.requires } : {}),
       ...(snapshot.result !== undefined ? { result: snapshot.result } : {}),
       createdAt: TaskQueue.parseSnapshotDate(snapshot.createdAt),

--- a/packages/core/src/task/task.ts
+++ b/packages/core/src/task/task.ts
@@ -10,9 +10,11 @@ import { randomUUID } from 'node:crypto'
 import type {
   ConsensusVerifyOptions,
   Task,
+  TaskMetadata,
   TaskRequirements,
   TaskStatus,
 } from '../types.js'
+import { validateTaskMetadata } from './metadata.js'
 
 // ---------------------------------------------------------------------------
 // Factory
@@ -37,15 +39,18 @@ export function createTask(input: {
   assignee?: string
   dependsOn?: string[]
   memoryScope?: 'dependencies' | 'all'
+  dependencyPayload?: 'output' | 'structured' | 'both'
   maxRetries?: number
   retryDelayMs?: number
   retryBackoff?: number
   role?: string
   priority?: 'low' | 'normal' | 'high' | 'critical'
+  metadata?: TaskMetadata
   requires?: TaskRequirements
   verify?: ConsensusVerifyOptions
 }): Task {
   const now = new Date()
+  const metadata = validateTaskMetadata(input.metadata)
   return {
     id: randomUUID(),
     title: input.title,
@@ -54,6 +59,7 @@ export function createTask(input: {
     assignee: input.assignee,
     dependsOn: input.dependsOn ? [...input.dependsOn] : undefined,
     memoryScope: input.memoryScope,
+    dependencyPayload: input.dependencyPayload,
     result: undefined,
     createdAt: now,
     updatedAt: now,
@@ -62,6 +68,7 @@ export function createTask(input: {
     retryBackoff: input.retryBackoff,
     role: input.role,
     priority: input.priority,
+    metadata,
     requires: input.requires,
     verify: input.verify,
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1130,6 +1130,9 @@ export interface TaskRequirements {
   readonly requiredProvider?: SupportedProvider
 }
 
+/** Bounded, trace-safe business references attached to one task. */
+export type TaskMetadata = Readonly<Record<string, TraceAttributeValue>>
+
 /** Input task descriptor accepted by {@link OpenMultiAgent.runTasks}. */
 export interface RunTaskSpec {
   readonly title: string
@@ -1137,6 +1140,20 @@ export interface RunTaskSpec {
   readonly assignee?: string
   readonly dependsOn?: string[]
   readonly memoryScope?: 'dependencies' | 'all'
+  /**
+   * Payload injected for each direct dependency.
+   *
+   * Defaults to `output` for backwards compatibility. `structured` injects
+   * only the dependency's validated structured value; `both` labels and
+   * injects both forms.
+   */
+  readonly dependencyPayload?: 'output' | 'structured' | 'both'
+  /**
+   * Bounded business references such as `sourceFile`, `supplierId`, or
+   * `documentId`. Values are validated and credential-like content is redacted
+   * before entering task results, traces, or checkpoints.
+   */
+  readonly metadata?: TaskMetadata
   readonly maxRetries?: number
   readonly retryDelayMs?: number
   readonly retryBackoff?: number
@@ -1422,6 +1439,15 @@ export interface TeamRunResult extends RunOutcomeFields {
   readonly planOnly?: boolean
   /** Keyed by agent name. */
   readonly agentResults: Map<string, AgentRunResult>
+  /**
+   * Unmerged per-task results keyed by stable task id.
+   *
+   * Runtime-produced task runs populate this map while retaining
+   * {@link agentResults} for backwards compatibility. It remains optional so
+   * older serialized results and caller-authored fixtures continue to
+   * type-check.
+   */
+  readonly taskResults?: Map<string, AgentRunResult>
   readonly totalTokenUsage: TokenUsage
   /** Aggregated run-level metrics computed from per-task data. */
   readonly metrics?: RunMetrics
@@ -1435,6 +1461,10 @@ export interface PlanTaskArtifact {
   readonly assignee?: string
   readonly dependsOn?: readonly string[]
   readonly memoryScope?: 'dependencies' | 'all'
+  readonly dependencyPayload?: 'output' | 'structured' | 'both'
+  readonly role?: string
+  readonly priority?: 'low' | 'normal' | 'high' | 'critical'
+  readonly metadata?: TaskMetadata
   readonly maxRetries?: number
   readonly retryDelayMs?: number
   readonly retryBackoff?: number
@@ -1531,6 +1561,11 @@ export interface TaskExecutionRecord {
    * task; `undefined` when the task did not set them.
    */
   readonly memoryScope?: 'dependencies' | 'all'
+  readonly dependencyPayload?: 'output' | 'structured' | 'both'
+  /** Logical business role, distinct from the concrete worker in `assignee`. */
+  readonly role?: string
+  readonly priority?: 'low' | 'normal' | 'high' | 'critical'
+  readonly metadata?: TaskMetadata
   readonly maxRetries?: number
   readonly retryDelayMs?: number
   readonly retryBackoff?: number
@@ -1556,10 +1591,17 @@ export interface Task {
    * - `all`: full shared-memory summary
    */
   readonly memoryScope?: 'dependencies' | 'all'
+  /**
+   * Selects the representation of direct dependency results injected into the
+   * task prompt. Defaults to `output`.
+   */
+  readonly dependencyPayload?: 'output' | 'structured' | 'both'
   /** Caller-defined task role used by model routing rules. */
   readonly role?: string
   /** Caller-defined task priority used by model routing rules. */
   readonly priority?: 'low' | 'normal' | 'high' | 'critical'
+  /** Validated, bounded business references carried through result/trace/checkpoint. */
+  readonly metadata?: TaskMetadata
   /** Explicit hard requirements used by capability-aware scheduling. */
   readonly requires?: TaskRequirements
   result?: string
@@ -1883,8 +1925,10 @@ export interface TaskSnapshot {
   readonly assignee?: string
   readonly dependsOn?: readonly string[]
   readonly memoryScope?: 'dependencies' | 'all'
+  readonly dependencyPayload?: 'output' | 'structured' | 'both'
   readonly role?: string
   readonly priority?: 'low' | 'normal' | 'high' | 'critical'
+  readonly metadata?: TaskMetadata
   readonly requires?: TaskRequirements
   readonly result?: string
   readonly createdAt: string
@@ -1911,6 +1955,11 @@ export interface CompletedTaskCheckpoint {
   readonly taskId: string
   readonly assignee?: string
   readonly result?: string
+  /**
+   * Full JSON-serializable task result. The in-process-only `error` object is
+   * deliberately omitted; normalized `status` / `errorInfo` remain available.
+   */
+  readonly agentResult?: Omit<AgentRunResult, 'error'>
 }
 
 interface CheckpointSnapshotBase {
@@ -2094,6 +2143,8 @@ export interface TaskTrace extends TraceEventBase {
   readonly type: 'task'
   readonly taskId: string
   readonly taskTitle: string
+  readonly taskRole?: string
+  readonly taskMetadata?: TaskMetadata
   readonly success: boolean
   readonly retries: number
 }

--- a/packages/core/tests/cli.test.ts
+++ b/packages/core/tests/cli.test.ts
@@ -126,6 +126,7 @@ describe('serializeTeamRunResult', () => {
         routerVersion: 'deterministic-v1',
       },
       agentResults: new Map([['alice', ar]]),
+      taskResults: new Map([['task-1', ar]]),
       totalTokenUsage: { input_tokens: 1, output_tokens: 2 },
     }
     const json = serializeTeamRunResult(tr, { pretty: false, includeMessages: false })
@@ -136,6 +137,11 @@ describe('serializeTeamRunResult', () => {
       output: 'ok',
     })
     expect((json.agentResults as Record<string, unknown>)['alice']).not.toHaveProperty('messages')
+    expect((json.taskResults as Record<string, unknown>)['task-1']).toMatchObject({
+      success: true,
+      output: 'ok',
+    })
+    expect((json.taskResults as Record<string, unknown>)['task-1']).not.toHaveProperty('messages')
   })
 
   it('includes messages when requested', () => {

--- a/packages/core/tests/dependency-payload.test.ts
+++ b/packages/core/tests/dependency-payload.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import type {
+  AgentConfig,
+  AgentRunResult,
+  OrchestratorEvent,
+} from '../src/types.js'
+
+function processAgent(
+  name: string,
+  source: string,
+  afterRun?: (result: AgentRunResult) => AgentRunResult,
+): AgentConfig {
+  return {
+    name,
+    systemPrompt: `${name} system prompt`,
+    backend: {
+      kind: 'process',
+      command: process.execPath,
+      args: ['-e', source],
+    },
+    ...(afterRun ? { afterRun } : {}),
+  }
+}
+
+const PRODUCER_SOURCE = `
+  process.stdin.resume()
+  process.stdout.write('EXTRA-NARRATIVE\\n{"z":1,"a":{"d":4,"b":2}}')
+`
+
+const ECHO_SOURCE = `
+  process.stdin.setEncoding('utf8')
+  let input = ''
+  process.stdin.on('data', chunk => { input += chunk })
+  process.stdin.on('end', () => process.stdout.write(input))
+`
+
+function structuredProducer(name = 'producer'): AgentConfig {
+  return processAgent(name, PRODUCER_SOURCE, result => ({
+    ...result,
+    structured: { z: 1, a: { d: 4, b: 2 } },
+    tokenUsage: { input_tokens: 2, output_tokens: 1 },
+  }))
+}
+
+function echoReviewer(afterRun?: (result: AgentRunResult) => AgentRunResult): AgentConfig {
+  return processAgent('reviewer', ECHO_SOURCE, afterRun)
+}
+
+describe('structured dependency payloads', () => {
+  it('injects only canonical validated JSON and preserves token accounting', async () => {
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('structured-handoff', {
+      name: 'structured-handoff',
+      agents: [
+        structuredProducer(),
+        echoReviewer(result => ({
+          ...result,
+          tokenUsage: { input_tokens: 3, output_tokens: 4 },
+        })),
+      ],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Extract', description: 'Extract a record.', assignee: 'producer' },
+      {
+        title: 'Review',
+        description: 'Review the validated record.',
+        assignee: 'reviewer',
+        dependsOn: ['Extract'],
+        dependencyPayload: 'structured',
+      },
+    ], { maxTokenBudget: 20 })
+
+    const reviewer = result.agentResults.get('reviewer')
+    expect(result.success).toBe(true)
+    expect(reviewer?.output).toContain('#### Validated structured result')
+    expect(reviewer?.output).toContain('{"a":{"b":2,"d":4},"z":1}')
+    expect(reviewer?.output).not.toContain('EXTRA-NARRATIVE')
+    expect(result.totalTokenUsage).toEqual({ input_tokens: 5, output_tokens: 5 })
+  })
+
+  it('labels raw and structured forms when both are requested', async () => {
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('both-handoff', {
+      name: 'both-handoff',
+      agents: [structuredProducer(), echoReviewer()],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Extract', description: 'Extract a record.', assignee: 'producer' },
+      {
+        title: 'Review',
+        description: 'Compare both representations.',
+        assignee: 'reviewer',
+        dependsOn: ['Extract'],
+        dependencyPayload: 'both',
+      },
+    ])
+
+    const output = result.agentResults.get('reviewer')?.output ?? ''
+    expect(output).toContain('#### Raw output\nEXTRA-NARRATIVE')
+    expect(output).toContain('#### Validated structured result\n{"a":{"b":2,"d":4},"z":1}')
+  })
+
+  it('fails the dependent task with a machine-readable error when structured data is missing', async () => {
+    const reviewerAfterRun = vi.fn((result: AgentRunResult) => result)
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('missing-structured', {
+      name: 'missing-structured',
+      agents: [
+        processAgent('producer', `process.stdout.write('plain output')`),
+        echoReviewer(reviewerAfterRun),
+      ],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Extract', description: 'Return plain text.', assignee: 'producer' },
+      {
+        title: 'Review',
+        description: 'Require structured data.',
+        assignee: 'reviewer',
+        dependsOn: ['Extract'],
+        dependencyPayload: 'structured',
+      },
+    ])
+
+    const reviewTask = result.tasks?.find(task => task.title === 'Review')
+    expect(result.success).toBe(false)
+    expect(reviewTask?.status).toBe('failed')
+    expect(result.taskResults?.get(reviewTask!.id)?.errorInfo).toMatchObject({
+      kind: 'validation',
+      code: 'DEPENDENCY_STRUCTURED_RESULT_MISSING',
+    })
+    expect(reviewerAfterRun).not.toHaveBeenCalled()
+  })
+
+  it('rejects an oversized structured dependency before invoking the consumer', async () => {
+    const reviewerAfterRun = vi.fn((result: AgentRunResult) => result)
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('large-structured', {
+      name: 'large-structured',
+      agents: [
+        processAgent('producer', `process.stdout.write('ok')`, result => ({
+          ...result,
+          structured: { payload: 'x'.repeat(70_000) },
+        })),
+        echoReviewer(reviewerAfterRun),
+      ],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Extract', description: 'Return a large record.', assignee: 'producer' },
+      {
+        title: 'Review',
+        description: 'Consume the record.',
+        assignee: 'reviewer',
+        dependsOn: ['Extract'],
+        dependencyPayload: 'structured',
+      },
+    ])
+
+    const reviewTask = result.tasks?.find(task => task.title === 'Review')
+    expect(result.taskResults?.get(reviewTask!.id)?.errorInfo?.code)
+      .toBe('DEPENDENCY_PAYLOAD_TOO_LARGE')
+    expect(reviewerAfterRun).not.toHaveBeenCalled()
+  })
+
+  it('reports non-JSON structured data without falling back to raw output', async () => {
+    const reviewerAfterRun = vi.fn((result: AgentRunResult) => result)
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('non-json-structured', {
+      name: 'non-json-structured',
+      agents: [
+        processAgent('producer', `process.stdout.write('raw fallback must not run')`, result => ({
+          ...result,
+          structured: { count: 1n },
+        })),
+        echoReviewer(reviewerAfterRun),
+      ],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Extract', description: 'Return a non-JSON value.', assignee: 'producer' },
+      {
+        title: 'Review',
+        description: 'Consume only validated JSON.',
+        assignee: 'reviewer',
+        dependsOn: ['Extract'],
+        dependencyPayload: 'structured',
+      },
+    ])
+
+    const reviewTask = result.tasks?.find(task => task.title === 'Review')
+    expect(result.taskResults?.get(reviewTask!.id)?.errorInfo?.code)
+      .toBe('DEPENDENCY_STRUCTURED_SERIALIZATION_FAILED')
+    expect(result.taskResults?.get(reviewTask!.id)?.output)
+      .not.toContain('raw fallback must not run')
+    expect(reviewerAfterRun).not.toHaveBeenCalled()
+  })
+
+  it('restores structured dependency data from a checkpoint before resuming a consumer', async () => {
+    const store = new InMemoryStore()
+    const abort = new AbortController()
+    const firstOma = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      onProgress(event: OrchestratorEvent) {
+        if (event.type === 'task_complete') abort.abort()
+      },
+    })
+    const agents = [structuredProducer(), echoReviewer()]
+    const firstTeam = firstOma.createTeam('checkpoint-handoff-first', {
+      name: 'checkpoint-handoff-first',
+      agents,
+    })
+
+    const interrupted = await firstOma.runTasks(firstTeam, [
+      { title: 'Extract', description: 'Extract a record.', assignee: 'producer' },
+      {
+        title: 'Review',
+        description: 'Review after restore.',
+        assignee: 'reviewer',
+        dependsOn: ['Extract'],
+        dependencyPayload: 'structured',
+      },
+    ], {
+      abortSignal: abort.signal,
+      checkpoint: { store, runId: 'structured-handoff' },
+    })
+    expect(interrupted.success).toBe(false)
+
+    const resumedOma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const resumedTeam = resumedOma.createTeam('checkpoint-handoff-resumed', {
+      name: 'checkpoint-handoff-resumed',
+      agents,
+    })
+    const restored = await resumedOma.restore(resumedTeam, {
+      checkpoint: { store, runId: 'structured-handoff' },
+    })
+
+    expect(restored.success).toBe(true)
+    expect(restored.agentResults.get('reviewer')?.output)
+      .toContain('{"a":{"b":2,"d":4},"z":1}')
+    expect(restored.agentResults.get('reviewer')?.output).not.toContain('EXTRA-NARRATIVE')
+  })
+})

--- a/packages/core/tests/execution-receipt.test.ts
+++ b/packages/core/tests/execution-receipt.test.ts
@@ -37,6 +37,7 @@ function task(
   assignee: string,
   dependsOn: readonly string[],
   startMs: number,
+  role?: string,
 ): TaskExecutionRecord {
   return {
     id,
@@ -44,6 +45,7 @@ function task(
     assignee,
     status: 'completed',
     dependsOn,
+    ...(role ? { role } : {}),
     metrics: {
       startMs,
       endMs: startMs + 10,
@@ -143,6 +145,25 @@ describe('buildExecutionReceipt', () => {
     expect(receipt.independentRolesCount).toBe(6)
     expect(receipt.dependencyEdges).toEqual([])
     expect(receipt.independentReviewOccurred).toBe(false)
+  })
+
+  it('keeps worker instances distinct from repeated logical task roles', () => {
+    const receipt = buildExecutionReceipt(teamResult([
+      task('supplier-1', 'supplier-reader-01', [], 100, 'supplier-extraction'),
+      task('supplier-2', 'supplier-reader-02', [], 101, 'supplier-extraction'),
+      task('supplier-3', 'supplier-reader-03', [], 102, 'supplier-extraction'),
+      task('review', 'evidence-reviewer', ['supplier-1', 'supplier-2', 'supplier-3'], 200, 'evidence-review'),
+    ]))
+
+    expect(receipt.rolesExecuted).toEqual([
+      'supplier-reader-01',
+      'supplier-reader-02',
+      'supplier-reader-03',
+      'evidence-reviewer',
+    ])
+    expect(receipt.workerInstancesExecuted).toEqual(receipt.rolesExecuted)
+    expect(receipt.taskRolesExecuted).toEqual(['supplier-extraction', 'evidence-review'])
+    expect(receipt.independentRolesCount).toBe(4)
   })
 
   it('excludes coordinator planning records from executed worker roles', () => {

--- a/packages/core/tests/task-metadata.test.ts
+++ b/packages/core/tests/task-metadata.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { Checkpoint } from '../src/memory/checkpoint.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import { buildExecutionReceipt } from '../src/observability/execution-receipt.js'
+import { TRACE_RECORD_OBSERVER } from '../src/observability/runtime.js'
+import type { TraceRecord } from '../src/observability/records.js'
+import type {
+  AgentConfig,
+  AgentRunResult,
+  OrchestratorConfig,
+  TaskMetadata,
+  TraceEvent,
+} from '../src/types.js'
+
+function worker(afterRun?: (result: AgentRunResult) => AgentRunResult): AgentConfig {
+  return {
+    name: 'supplier-reader-01',
+    systemPrompt: 'Read one supplier document.',
+    backend: {
+      kind: 'process',
+      command: process.execPath,
+      args: ['-e', `process.stdout.write('read complete')`],
+    },
+    ...(afterRun ? { afterRun } : {}),
+  }
+}
+
+describe('task role and metadata', () => {
+  it('preserves bounded metadata through result, trace, checkpoint, restore, and receipt', async () => {
+    const store = new InMemoryStore()
+    const records: TraceRecord[] = []
+    const legacyTrace: TraceEvent[] = []
+    const config = {
+      defaultModel: 'mock-model',
+      onTrace(event: TraceEvent) {
+        legacyTrace.push(event)
+      },
+      [TRACE_RECORD_OBSERVER](record: TraceRecord) {
+        records.push(record)
+      },
+    } as OrchestratorConfig & {
+      [TRACE_RECORD_OBSERVER]: (record: TraceRecord) => void
+    }
+    const oma = new OpenMultiAgent(config)
+    const team = oma.createTeam('task-metadata', {
+      name: 'task-metadata',
+      agents: [worker()],
+    })
+    const metadata: TaskMetadata = {
+      sourceFile: 'fixtures/supplier-01.json',
+      supplierId: 'supplier-01',
+      auditRef: 'reference sk-abcdefghijklmnopqrstuvwxyz',
+      batch: 4,
+    }
+
+    const result = await oma.runTasks(team, [{
+      title: 'Read supplier reply',
+      description: 'Extract one simulated supplier reply.',
+      assignee: 'supplier-reader-01',
+      role: 'supplier-extraction',
+      metadata,
+    }], { checkpoint: { store, runId: 'task-metadata' } })
+
+    const task = result.tasks?.[0]
+    expect(task).toMatchObject({
+      assignee: 'supplier-reader-01',
+      role: 'supplier-extraction',
+      metadata: {
+        sourceFile: 'fixtures/supplier-01.json',
+        supplierId: 'supplier-01',
+        auditRef: 'reference [redacted]',
+        batch: 4,
+      },
+    })
+    expect(Object.isFrozen(task?.metadata)).toBe(true)
+
+    const taskSpan = records.find(record =>
+      record.recordType === 'span_start'
+      && record.kind === 'task'
+      && record.name === 'execute_task')
+    expect(taskSpan?.attributes).toMatchObject({
+      'oma.task.role': 'supplier-extraction',
+      'oma.task.meta.sourceFile': 'fixtures/supplier-01.json',
+      'oma.task.meta.supplierId': 'supplier-01',
+      'oma.task.meta.auditRef': 'reference [redacted]',
+      'oma.task.meta.batch': 4,
+    })
+    expect(legacyTrace.find(event => event.type === 'task')).toMatchObject({
+      taskRole: 'supplier-extraction',
+      taskMetadata: task?.metadata,
+    })
+
+    const snapshot = await new Checkpoint(store, { runId: 'task-metadata' }).loadLatest()
+    expect(snapshot?.queue.tasks[0]).toMatchObject({
+      role: 'supplier-extraction',
+      metadata: task?.metadata,
+    })
+
+    const restoredOma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const restoredTeam = restoredOma.createTeam('task-metadata-restored', {
+      name: 'task-metadata-restored',
+      agents: [worker()],
+    })
+    const restored = await restoredOma.restore(restoredTeam, {
+      checkpoint: { store, runId: 'task-metadata' },
+    })
+    expect(restored.tasks?.[0]).toMatchObject({
+      role: 'supplier-extraction',
+      metadata: task?.metadata,
+    })
+
+    expect(buildExecutionReceipt(result)).toMatchObject({
+      rolesExecuted: ['supplier-reader-01'],
+      workerInstancesExecuted: ['supplier-reader-01'],
+      taskRolesExecuted: ['supplier-extraction'],
+    })
+  })
+
+  it('rejects credential-like metadata keys before an agent runs', async () => {
+    const afterRun = vi.fn((result: AgentRunResult) => result)
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('invalid-task-metadata', {
+      name: 'invalid-task-metadata',
+      agents: [worker(afterRun)],
+    })
+
+    await expect(oma.runTasks(team, [{
+      title: 'Read supplier reply',
+      description: 'Should not start.',
+      assignee: 'supplier-reader-01',
+      metadata: { apiKey: 'must-not-persist' },
+    }])).rejects.toThrow('credential-like')
+    expect(afterRun).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/tests/task-results.test.ts
+++ b/packages/core/tests/task-results.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import type { AgentConfig, AgentRunResult } from '../src/types.js'
+
+function structuredProcessAgent(afterRun: (result: AgentRunResult) => AgentRunResult): AgentConfig {
+  return {
+    name: 'worker',
+    systemPrompt: 'Return the task sequence as JSON.',
+    backend: {
+      kind: 'process',
+      command: process.execPath,
+      args: ['-e', `
+        process.stdin.setEncoding('utf8')
+        let input = ''
+        process.stdin.on('data', chunk => { input += chunk })
+        process.stdin.on('end', () => {
+          process.stdout.write(input.includes('# Task: First') ? '{"sequence":1}' : '{"sequence":2}')
+        })
+      `],
+    },
+    afterRun,
+  }
+}
+
+describe('TeamRunResult taskResults', () => {
+  it('keeps each task result when one agent executes multiple tasks without double-counting usage', async () => {
+    const afterRun = vi.fn((result: AgentRunResult): AgentRunResult => {
+      const structured = JSON.parse(result.output) as { sequence: number }
+      return {
+        ...result,
+        structured,
+        tokenUsage: {
+          input_tokens: structured.sequence,
+          output_tokens: structured.sequence * 2,
+        },
+        toolCalls: [{
+          toolName: `tool-${structured.sequence}`,
+          input: { sequence: structured.sequence },
+          output: 'ok',
+          duration: structured.sequence,
+        }],
+      }
+    })
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('task-results', {
+      name: 'task-results',
+      agents: [structuredProcessAgent(afterRun)],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'First', description: 'Return sequence 1.', assignee: 'worker' },
+      {
+        title: 'Second',
+        description: 'Return sequence 2.',
+        assignee: 'worker',
+        dependsOn: ['First'],
+      },
+    ])
+
+    const first = result.tasks?.find(task => task.title === 'First')
+    const second = result.tasks?.find(task => task.title === 'Second')
+    expect(first).toBeDefined()
+    expect(second).toBeDefined()
+    expect(result.taskResults?.get(first!.id)?.structured).toEqual({ sequence: 1 })
+    expect(result.taskResults?.get(second!.id)?.structured).toEqual({ sequence: 2 })
+    expect(result.taskResults?.get(first!.id)?.toolCalls[0]?.toolName).toBe('tool-1')
+    expect(result.agentResults.get('worker')?.structured).toEqual({ sequence: 2 })
+    expect(result.agentResults.get('worker')?.tokenUsage).toEqual({
+      input_tokens: 3,
+      output_tokens: 6,
+    })
+    expect(result.totalTokenUsage).toEqual({ input_tokens: 3, output_tokens: 6 })
+  })
+
+  it('rehydrates full task-scoped results from a checkpoint', async () => {
+    const store = new InMemoryStore()
+    const afterRun = vi.fn((result: AgentRunResult): AgentRunResult => {
+      const structured = JSON.parse(result.output) as { sequence: number }
+      return {
+        ...result,
+        structured,
+        tokenUsage: { input_tokens: structured.sequence, output_tokens: 0 },
+        toolCalls: [{
+          toolName: `tool-${structured.sequence}`,
+          input: {},
+          output: 'ok',
+          duration: 1,
+        }],
+      }
+    })
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('checkpoint-task-results', {
+      name: 'checkpoint-task-results',
+      agents: [structuredProcessAgent(afterRun)],
+    })
+
+    const initial = await oma.runTasks(team, [
+      { title: 'First', description: 'Return sequence 1.', assignee: 'worker' },
+      {
+        title: 'Second',
+        description: 'Return sequence 2.',
+        assignee: 'worker',
+        dependsOn: ['First'],
+      },
+    ], { checkpoint: { store, runId: 'task-results-run' } })
+    const restored = await oma.restore(team, {
+      checkpoint: { store, runId: 'task-results-run' },
+    })
+
+    expect(afterRun).toHaveBeenCalledTimes(2)
+    for (const task of initial.tasks ?? []) {
+      expect(restored.taskResults?.get(task.id)).toMatchObject({
+        success: true,
+        output: initial.taskResults?.get(task.id)?.output,
+        structured: initial.taskResults?.get(task.id)?.structured,
+        tokenUsage: initial.taskResults?.get(task.id)?.tokenUsage,
+        toolCalls: initial.taskResults?.get(task.id)?.toolCalls,
+      })
+    }
+    expect(restored.totalTokenUsage).toEqual({ input_tokens: 3, output_tokens: 0 })
+  })
+
+  it('keeps checkpoints durable when a custom result is not JSON-serializable', async () => {
+    const store = new InMemoryStore()
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = oma.createTeam('non-json-checkpoint-result', {
+      name: 'non-json-checkpoint-result',
+      agents: [structuredProcessAgent(result => ({
+        ...result,
+        structured: { count: 1n },
+      }))],
+    })
+
+    const initial = await oma.runTasks(team, [
+      { title: 'First', description: 'Return a non-JSON result.', assignee: 'worker' },
+    ], { checkpoint: { store, runId: 'non-json-task-result' } })
+    const restored = await oma.restore(team, {
+      checkpoint: { store, runId: 'non-json-task-result' },
+    })
+
+    const taskId = initial.tasks?.[0]?.id
+    expect(taskId).toBeDefined()
+    const restoredTaskResult = restored.taskResults?.get(taskId!)
+    expect(restoredTaskResult).toMatchObject({
+      success: true,
+      output: initial.taskResults?.get(taskId!)?.output,
+      tokenUsage: { input_tokens: 0, output_tokens: 0 },
+      toolCalls: [],
+    })
+    expect(restoredTaskResult).not.toHaveProperty('structured')
+  })
+})


### PR DESCRIPTION
## Summary

- Expose unmerged `TeamRunResult.taskResults` entries keyed by stable task ID, including checkpoint restore and CLI serialization.
- Add opt-in structured dependency handoff with canonical JSON, explicit validation errors, and a 64 KiB per-dependency limit.
- Preserve bounded task role/provenance metadata across task records, traces, checkpoints, plan artifacts, CLI input, and execution receipts.

## Motivation

Explicit task pipelines currently collapse multiple runs by the same agent into one `agentResults` entry, pass only narrative output to dependents, and cannot durably distinguish logical task roles from concrete worker instances. These gaps make structured, auditable document pipelines harder to build and resume safely.

## Scope and impact

- Affected workspace: `@open-multi-agent/core`, plus core documentation.
- Public APIs are additive: `TeamRunResult.taskResults`, `RunTaskSpec.dependencyPayload`, `TaskMetadata`, and explicit receipt worker/task-role fields.
- Compatibility is preserved: `agentResults` merge behavior and `rolesExecuted` semantics are unchanged, while dependency payloads still default to raw `output`.
- Structured handoff never silently falls back to narrative output. Missing, non-serializable, or oversized payloads fail the dependent task with machine-readable validation codes.
- Task metadata is bounded, validates keys and values, rejects credential-like keys, and redacts sensitive-looking text before persistence or tracing.
- Checkpoints persist full task results only when they are JSON-serializable; otherwise they retain the legacy minimal result so checkpoint durability is preserved.
- No provider adapters, scheduling policy, dependencies, release configuration, or examples were changed.

## Validation

- `npm run test -w @open-multi-agent/core -- tests/task-results.test.ts tests/dependency-payload.test.ts tests/task-metadata.test.ts tests/execution-receipt.test.ts tests/cli.test.ts` — 5 files / 36 tests passed.
- `npm run lint -w @open-multi-agent/core` — passed.
- `npm run test -w @open-multi-agent/core` — 120 files / 1693 tests passed.
- `npm run build -w @open-multi-agent/core` — passed.
- `git diff --cached --check` — passed.
- Provider E2E was not run because no provider integration or real-provider tool loop changed.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING