### PR TITLE
feat(core): add Japanese and Korean routing support

### DIFF
--- a/docs/execution-routing.md
+++ b/docs/execution-routing.md
@@ -83,9 +83,18 @@ including the compatibility-only `legacy-deterministic` label.
 - An empty roster cannot select the Single path; otherwise the goal heuristic decides.
 - English sequence, coordination, parallelism, and multi-deliverable signals remain supported.
 - Chinese sequence markers (`先…然后`, `第一步/第二步`), circled steps, action enumerations, semicolon-separated clauses, and connected action verbs are recognized.
-- Length uses a cheap script-aware information estimate. CJK characters count as 2.25 units; ordinary Latin word runs approximate token density; long unbroken runs keep their raw length.
+- Japanese (`まず…次に`, `第一に…第二に`, `ステップ1/手順1`) and Korean (`먼저…그다음`, `첫째…둘째`, `1단계/2단계`) sequence markers are recognized, and dense `、` enumeration counts for kana- and Hangul-initial lists as well as Han. Each marker pair must appear, so a lone marker does not force Team.
+- Length uses a cheap script-aware information estimate. CJK characters — Han, Japanese kana, and Korean Hangul — count as 2.25 units; ordinary Latin word runs approximate token density; long unbroken runs keep their raw length.
 
-This policy is intentionally honest, cheap, and language-neutral rather than semantically ambitious. Semantically equivalent English and Chinese goals should select the same execution mode. Applications that need domain-specific semantics should inject an `ExecutionRouter` or declare an explicit mode/governance topology.
+Language coverage is tiered honestly rather than claimed uniform:
+
+- **Chinese, Japanese, and Korean** are one tier: the structural markers above plus 2.25-unit length weighting.
+- **Latin-script languages** share English's length treatment (word runs approximate token density). The structural word patterns are English-specific, so other Latin languages are routed by length and punctuation, not by their own sequence words.
+- **Other scripts** fall back conservatively: each non-space character counts as one unit and no structural markers apply, so routing relies on the length threshold alone.
+
+CJK verb-connective sequencing is a deliberate non-goal. Chinese keeps a verb-connective pattern because its verbs are invariant tokens, but Japanese and Korean verbs inflect (Japanese て-form, Korean agglutinative endings), so matching them would require morphological analysis this heuristic intentionally avoids; explicit markers and enumeration cover the structural signal instead.
+
+This policy is intentionally honest, cheap, and language-neutral rather than semantically ambitious. Semantically equivalent English, Chinese, Japanese, and Korean goals should select the same execution mode. Applications that need domain-specific semantics should inject an `ExecutionRouter` or declare an explicit mode/governance topology.
 
 ## Governance boundary
 
@@ -93,4 +102,4 @@ Execution Routing does not declare governance. The consequential-tool fallback s
 
 ## Behavior change
 
-The built-in automatic route now recognizes short Chinese multi-stage goals and script-weighted length instead of relying on English-only word patterns plus raw character count. Equivalent goals translated between English and Chinese no longer change Single/Team topology in the routing stability gate. Existing English structural-pattern regressions retain their previous outcomes. Script weighting intentionally changes a detailed, long English single-action goal from `team` to `single` when its estimated information length remains bounded; this case is locked by a regression test. Multilingual applications may also observe corrected automatic routes for Chinese structured goals.
+The built-in automatic route recognizes short CJK (Chinese, Japanese, Korean) multi-stage goals and script-weighted length instead of relying on English-only word patterns plus raw character count. Equivalent goals translated between English, Chinese, Japanese, and Korean no longer change Single/Team topology in the routing stability gate. Existing English and Chinese outcomes, including structural-pattern regressions, retain their previous behavior. Script weighting intentionally changes a detailed, long English single-action goal from `team` to `single` when its estimated information length remains bounded; this case is locked by a regression test. Multilingual applications may also observe corrected automatic routes for CJK structured goals.

--- a/packages/core/src/orchestrator/short-circuit.ts
+++ b/packages/core/src/orchestrator/short-circuit.ts
@@ -10,13 +10,31 @@ import type { AgentConfig } from '../types.js'
 import { AgentSelector } from './agent-selector.js'
 
 /**
+ * Unicode ranges treated as CJK for both the length estimate and the dense
+ * enumeration signal: CJK Unified Ideographs + Extension A + Compatibility
+ * Ideographs (Chinese), Japanese kana, and Korean Hangul syllables. Defined
+ * once so length weighting and enumeration detection cover the same scripts.
+ */
+const CJK_RANGES = '\\u3400-\\u4dbf\\u4e00-\\u9fff\\uf900-\\ufaff\\u3040-\\u30ff\\uac00-\\ud7af'
+
+/**
  * Regex patterns that indicate a goal requires multi-agent coordination.
  *
  * Each pattern targets a distinct complexity signal:
- * - Sequencing:     "first … then", "先…然后", numbered and circled lists
+ * - Sequencing:     "first … then", "先…然后", "まず…次に", "먼저…그다음",
+ *                   numbered/ordinal and circled lists
  * - Coordination:   "collaborate", "coordinate", "review each other"
  * - Parallel work:  "in parallel", "at the same time", "concurrently"
  * - Multi-phase:    multilingual enumeration and action verbs joined by connectives
+ *
+ * Non-goal — CJK verb-connective sequencing: Chinese keeps a verb-connective
+ * pattern (构建…并…测试) because its verbs are invariant tokens. Japanese and
+ * Korean verbs inflect (Japanese て-form 書いて/作成し, Korean agglutinative
+ * endings 만들고/작성한), so a fixed verb list would miss most conjugations and
+ * matching them reliably would require morphological analysis. The honest,
+ * cheap-heuristic positioning deliberately rejects that. Japanese/Korean
+ * sequencing is instead covered by explicit ordinal/step markers and by CJK
+ * enumeration punctuation, never by a verb lexicon.
  */
 export const COMPLEXITY_PATTERNS: RegExp[] = [
   // Explicit sequencing
@@ -27,6 +45,17 @@ export const COMPLEXITY_PATTERNS: RegExp[] = [
   /^\s*\d+[\.\)]/m,                       // numbered list items ("1. …", "2) …")
   /(?:首先|先).{1,60}(?:然后|接着|再)(?:.{1,60}(?:最后))?/,
   /第[一二三四五六七八九十\d]+步.{1,80}第[一二三四五六七八九十\d]+步/,
+  // Japanese sequencing — both markers of a pair must appear, so a lone まず or
+  // 次に stays simple (mirrors the Chinese 先…然后 shape). The trailing 最後に in
+  // まず…次に…最後に is optional and does not change the match.
+  /(?:まず|最初に).{1,80}(?:次に|それから|続いて)(?:.{1,80}最後に)?/,
+  /第[一二三四五六七八九十\d]+に.{1,80}第[一二三四五六七八九十\d]+に/,
+  /(?:ステップ|手順)\s*\d.{1,80}(?:ステップ|手順)\s*\d/,
+  // Korean sequencing — pair required, same shape. Particle-attached hangul
+  // (agglutinative) keeps the markers intact, so explicit markers still fire.
+  /먼저.{1,80}(?:그\s*다음|그리고\s*나서)(?:.{1,80}마지막으로)?/,
+  /(?:첫째|첫\s*번째).{1,80}(?:둘째|두\s*번째)/,
+  /\d\s*단계.{1,80}\d\s*단계/,
   /[①②③④⑤⑥⑦⑧⑨⑩].{1,100}[②③④⑤⑥⑦⑧⑨⑩]/,
 
   // Coordination language — must be an imperative directive aimed at the agents
@@ -44,7 +73,10 @@ export const COMPLEXITY_PATTERNS: RegExp[] = [
   /\bat\s+the\s+same\s+time\b/i,
 
   // Enumerations and multiple deliverables joined by connectives
-  /(?:[\u3400-\u9fff][^、\n]{0,39}、){5}/, // dense CJK-only enumeration
+  // Dense CJK enumeration (5+ 、-separated items). Reuses the shared CJK ranges
+  // so kana- and Hangul-initial lists count the same as Han-initial ones. The 、
+  // separator is intentional — Latin/English comma lists keep prior behavior.
+  new RegExp(`(?:[${CJK_RANGES}][^、\\n]{0,39}、){5}`),
   /[^；\n]{2,80}；[^；\n]{2,80}/,            // Chinese semicolon-separated clauses
   // Matches patterns like "build X, then deploy Y and test Z"
   /\b(?:build|create|implement|design|write|develop)\b[^.!?\n]{5,80}\b(?:and|then)\b[^.!?\n]{5,80}\b(?:build|create|implement|design|write|develop|test|review|deploy)\b/i,
@@ -63,7 +95,7 @@ export const COMPLEXITY_PATTERNS: RegExp[] = [
  */
 export const SIMPLE_GOAL_MAX_LENGTH = 200
 
-const CJK_CHARACTER = /[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\u3040-\u30ff\uac00-\ud7af]/
+const CJK_CHARACTER = new RegExp(`[${CJK_RANGES}]`)
 const LATIN_ALPHANUMERIC = /[A-Za-z0-9]/
 const NORMAL_LATIN_RUN_UNITS = 4
 const LONG_UNBROKEN_RUN = 32

--- a/packages/core/tests/fixtures/eval/routing-stability-set.json
+++ b/packages/core/tests/fixtures/eval/routing-stability-set.json
@@ -29,6 +29,18 @@
             "language": "zh",
             "variantType": "translation",
             "text": "给初学者解释什么是 DNS。说明域名、IP 地址、DNS 解析器各是什么，并一步步讲清楚在浏览器里输入 example.com 时发生了什么。用通俗语言和一个类比。"
+          },
+          {
+            "id": "translated-ja",
+            "language": "ja",
+            "variantType": "translation",
+            "text": "初心者に DNS とは何かを説明して。ドメイン名、IP アドレス、DNS リゾルバが何かを述べ、example.com と入力したとき何が起きるかを分かりやすく説明して。平易な言葉と一つのたとえで。"
+          },
+          {
+            "id": "translated-ko",
+            "language": "ko",
+            "variantType": "translation",
+            "text": "초보자에게 DNS가 무엇인지 설명해 줘. 도메인 이름, IP 주소, DNS 리졸버가 무엇인지 말하고, example.com을 입력하면 무슨 일이 일어나는지 쉽게 설명해 줘. 쉬운 말과 하나의 비유로."
           }
         ],
         "comparisonPairs": {
@@ -60,6 +72,18 @@
             "language": "zh",
             "variantType": "translation",
             "text": "从读延迟、写吞吐、许可协议三个维度比较 PostgreSQL、MySQL、SQLite，给出一张表。"
+          },
+          {
+            "id": "translated-ja",
+            "language": "ja",
+            "variantType": "translation",
+            "text": "PostgreSQL、MySQL、SQLite を読み取り遅延、書き込みスループット、ライセンスの三つの観点で比較して、表を一つ返して。"
+          },
+          {
+            "id": "translated-ko",
+            "language": "ko",
+            "variantType": "translation",
+            "text": "PostgreSQL, MySQL, SQLite를 읽기 지연, 쓰기 처리량, 라이선스 세 가지 관점에서 비교해서 표를 하나 반환해 줘."
           }
         ],
         "comparisonPairs": {
@@ -96,6 +120,18 @@
             "language": "zh",
             "variantType": "translation",
             "text": "电汇请求：从尾号 7710 付款；可信登记收款账户为 8812，但本次付给 4290；CFO 已批准，controller 批准缺失。判定 PROCEED 或 HOLD。"
+          },
+          {
+            "id": "translated-ja",
+            "language": "ja",
+            "variantType": "translation",
+            "text": "電信送金の依頼：末尾 7710 の口座から支払う；信頼できる登録簿の受取人は 8812 だが、本件は 4290 に支払う；CFO は承認済み、controller の承認は欠落。PROCEED か HOLD を判定して。"
+          },
+          {
+            "id": "translated-ko",
+            "language": "ko",
+            "variantType": "translation",
+            "text": "전신 송금 요청: 끝자리 7710 계좌에서 지불; 신뢰할 수 있는 등록부의 수취인은 8812이지만 이 건은 4290으로 지불; CFO는 승인했고 controller 승인은 누락. PROCEED 또는 HOLD를 판정해 줘."
           }
         ],
         "comparisonPairs": {
@@ -132,6 +168,18 @@
             "language": "zh",
             "variantType": "translation",
             "text": "请求进行密钥轮换但回滚方案缺失。reviewer 标记 ROLLBACK_MISSING，security 决定 HOLD_ROTATION，operator 记录 NOT_EXECUTED，按此顺序。"
+          },
+          {
+            "id": "translated-ja",
+            "language": "ja",
+            "variantType": "translation",
+            "text": "鍵のローテーションが要求されているがロールバック計画が欠落している。reviewer が ROLLBACK_MISSING を記録し、security が HOLD_ROTATION を決定し、operator が NOT_EXECUTED を記録する、この順序で。"
+          },
+          {
+            "id": "translated-ko",
+            "language": "ko",
+            "variantType": "translation",
+            "text": "키 로테이션이 요청되었지만 롤백 계획이 없다. reviewer가 ROLLBACK_MISSING을 기록하고, security가 HOLD_ROTATION을 결정하고, operator가 NOT_EXECUTED를 기록한다, 이 순서로."
           }
         ],
         "comparisonPairs": {

--- a/packages/core/tests/keywords.test.ts
+++ b/packages/core/tests/keywords.test.ts
@@ -69,6 +69,33 @@ describe('utils/keywords', () => {
       ])
     })
 
+    it('segments Japanese words without spaces', () => {
+      expect(extractKeywords('コード品質を分析してレビューレポートを作成する')).toEqual([
+        'コード',
+        '品質',
+        '分析',
+        'レビュー',
+        'レポート',
+        '作成',
+        'する',
+      ])
+    })
+
+    it('segments Korean with particles attached to stems (agglutinative)', () => {
+      // Intl.Segmenter keeps object/verb particles attached (품질을, 분석하고,
+      // 보고서를). Substring keywordScore still matches these against bare stems
+      // in the other direction, which is why agent selection stays robust
+      // without any stemming. This test pins that surface behaviour.
+      expect(extractKeywords('코드 품질을 분석하고 리뷰 보고서를 작성한다')).toEqual([
+        '코드',
+        '품질을',
+        '분석하고',
+        '리뷰',
+        '보고서를',
+        '작성한다',
+      ])
+    })
+
     it('preserves pure-English punctuation and length behaviour', () => {
       expect(extractKeywords("Writer's notes don't include tiny API words")).toEqual([
         'writer',

--- a/packages/core/tests/routing-stability-eval.test.ts
+++ b/packages/core/tests/routing-stability-eval.test.ts
@@ -37,7 +37,7 @@ const FIXED_MODEL_OUTPUT = `\`\`\`json
 \`\`\``
 
 type FamilyKind = 'benign' | 'governance'
-type Language = 'en' | 'zh'
+type Language = 'en' | 'zh' | 'ja' | 'ko'
 type VariantType = 'short' | 'detailed' | 'translation'
 
 interface RoutingVariant {
@@ -173,8 +173,8 @@ function parseRoutingFamily(input: unknown, caseId: string): RoutingFamily {
     if (!isRecord(value)) throw new TypeError(`${context} must be an object.`)
     const language = requiredString(value, 'language', context)
     const variantType = requiredString(value, 'variantType', context)
-    if (language !== 'en' && language !== 'zh') {
-      throw new TypeError(`${context}.language must be en or zh.`)
+    if (language !== 'en' && language !== 'zh' && language !== 'ja' && language !== 'ko') {
+      throw new TypeError(`${context}.language must be en, zh, ja, or ko.`)
     }
     if (variantType !== 'short' && variantType !== 'detailed' && variantType !== 'translation') {
       throw new TypeError(`${context}.variantType is invalid.`)
@@ -522,9 +522,15 @@ describe('runTeam routing stability EvalSet', () => {
     expect(evalSet.cases).toHaveLength(4)
     for (const evalCase of evalSet.cases) {
       const family = parseRoutingFamily(evalCase.input, evalCase.id)
+      // Each family carries one short + one detailed English anchor plus three
+      // equivalent translations (Chinese, Japanese, Korean). The Japanese and
+      // Korean translations join the existing en/zh goals in the all-pairs flip
+      // gate so equivalent CJK goals cannot change execution topology.
       expect(family.variants.map((variant) => variant.variantType)).toEqual([
         'short',
         'detailed',
+        'translation',
+        'translation',
         'translation',
       ])
       expect(variantById(family.variants, 'short-en')).toMatchObject({
@@ -539,6 +545,14 @@ describe('runTeam routing stability EvalSet', () => {
       expect(variantById(family.variants, 'detailed-en').text.length).toBeGreaterThan(200)
       expect(variantById(family.variants, 'translated-cn')).toMatchObject({
         language: 'zh',
+        variantType: 'translation',
+      })
+      expect(variantById(family.variants, 'translated-ja')).toMatchObject({
+        language: 'ja',
+        variantType: 'translation',
+      })
+      expect(variantById(family.variants, 'translated-ko')).toMatchObject({
+        language: 'ko',
         variantType: 'translation',
       })
 

--- a/packages/core/tests/short-circuit.test.ts
+++ b/packages/core/tests/short-circuit.test.ts
@@ -146,6 +146,70 @@ describe('isSimpleGoal', () => {
       expect(isSimpleGoal(english)).toBe(expected)
       expect(isSimpleGoal(chinese)).toBe(expected)
     })
+
+    // Japanese: explicit sequence/ordinal/step markers and CJK enumeration, not
+    // a verb lexicon (see COMPLEXITY_PATTERNS non-goal note). Pairs are required,
+    // so a lone marker stays simple.
+    it.each([
+      'まず要件を設計し、次にサービスを実装し、最後にテストを書く',
+      '最初にデータを集め、それから傾向を分析する',
+      '第一に要件を収集し、第二に機能を実装する',
+      'ステップ1で環境を準備し、ステップ2でコードを書く',
+      '手順1で環境を準備し、手順2でコードを書く',
+      '① 資料を収集 ② 資料を分析 ③ レポートを出力',
+      'りんご、みかん、ぶどう、いちご、もも、なし',
+    ])('treats a Japanese multi-stage goal as complex: "%s"', (goal) => {
+      expect(isSimpleGoal(goal)).toBe(false)
+    })
+
+    // Korean: same marker-based approach. Agglutinative particles stay attached
+    // to the markers, so explicit 먼저/그다음, 첫째/둘째, N단계 pairs still fire.
+    it.each([
+      '먼저 요구사항을 수집하고, 그다음 기능을 구현한다',
+      '먼저 자료를 모으고 그리고 나서 분석한다',
+      '첫째 자료를 수집하고, 둘째 자료를 분석한다',
+      '첫 번째로 요구사항을 모으고 두 번째로 구현한다',
+      '1단계에서 환경을 준비하고 2단계에서 코드를 작성한다',
+      '① 자료 수집 ② 자료 분석 ③ 보고서 출력',
+      '사과、귤、포도、딸기、복숭아、배',
+    ])('treats a Korean multi-stage goal as complex: "%s"', (goal) => {
+      expect(isSimpleGoal(goal)).toBe(false)
+    })
+
+    it.each([
+      ['この報告書を一段落で要約して', 'ja single summarize'],
+      ['まず一言で挨拶して', 'ja lone まず — no pair'],
+      ['次に何をすべきか教えて', 'ja lone 次に — no pair'],
+      ['이 보고서를 한 문단으로 요약해 줘', 'ko single summarize'],
+      ['먼저 무엇을 해야 하는지 알려 줘', 'ko lone 먼저 — no pair'],
+    ])('keeps a Japanese/Korean single-action goal simple (%s)', (goal) => {
+      expect(isSimpleGoal(goal)).toBe(true)
+    })
+
+    it.each([
+      [
+        'Summarize this report in one paragraph',
+        '用一段话总结这份报告',
+        'この報告書を一段落で要約して',
+        '이 보고서를 한 문단으로 요약해 줘',
+        true,
+      ],
+      [
+        'First collect the requirements, then implement the feature',
+        '先收集需求，然后实现功能',
+        'まず要件を収集し、次に機能を実装する',
+        '먼저 요구사항을 수집하고, 그다음 기능을 구현한다',
+        false,
+      ],
+    ])(
+      'routes equivalent English, Chinese, Japanese, and Korean goals consistently',
+      (english, chinese, japanese, korean, expected) => {
+        expect(isSimpleGoal(english)).toBe(expected)
+        expect(isSimpleGoal(chinese)).toBe(expected)
+        expect(isSimpleGoal(japanese)).toBe(expected)
+        expect(isSimpleGoal(korean)).toBe(expected)
+      },
+    )
   })
 
   // -------------------------------------------------------------------------
@@ -210,6 +274,45 @@ describe('selectBestAgent', () => {
       { name: '营销专家', model: 'test', systemPrompt: '制定品牌策略和市场推广方案' },
       { name: '代码评审员', model: 'test', systemPrompt: '分析代码质量并生成评审报告' },
       { name: '数据分析师', model: 'test', systemPrompt: '分析销售数据并生成趋势报告' },
+    ]
+
+    expect(selectBestAgent(goal, agents)).toBe(agents[expectedIndex])
+  })
+
+  // Intl.Segmenter surfaces Japanese words (コード, 品質, 分析, レビュー…) without
+  // spaces, so keyword affinity works the same way it does for Chinese.
+  it.each([
+    ['コード品質を分析してレビューレポートを作成する', 1],
+    ['販売データを分析して傾向レポートを作成する', 2],
+    ['ブランド戦略と市場推進の企画を立てる', 0],
+  ])('selects the semantically matching Japanese agent for "%s"', (goal, expectedIndex) => {
+    const agents: AgentConfig[] = [
+      { name: 'マーケティング担当', model: 'test', systemPrompt: 'ブランド戦略と市場推進の企画を立てる' },
+      { name: 'コードレビュアー', model: 'test', systemPrompt: 'コード品質を分析してレビューレポートを生成する' },
+      { name: 'データ分析官', model: 'test', systemPrompt: '販売データを分析して傾向レポートを生成する' },
+    ]
+
+    expect(selectBestAgent(goal, agents)).toBe(agents[expectedIndex])
+  })
+
+  // Korean is agglutinative: Intl.Segmenter keeps particles attached to stems
+  // (품질을, 분석하고, 보고서를), so a keyword can miss when goal and prompt attach
+  // different affixes to the same stem. The bidirectional, substring keywordScore
+  // absorbs most of this — a bare stem in one text is a substring of the attached
+  // form in the other — so at least one direction usually matches and multiple
+  // noun tokens carry the selection. Known limitation: if BOTH sides attach
+  // different affixes to the same stem so neither surface form contains the other
+  // (분석과 vs 분석하고), that stem is missed. We intentionally do not add stemming
+  // or morphological analysis; real rosters resolve via the remaining tokens.
+  it.each([
+    ['코드 품질을 분석하고 리뷰 보고서를 작성한다', 1],
+    ['판매 데이터를 분석하고 추세 보고서를 작성한다', 2],
+    ['브랜드 전략과 시장 홍보 방안을 수립한다', 0],
+  ])('selects the semantically matching Korean agent for "%s"', (goal, expectedIndex) => {
+    const agents: AgentConfig[] = [
+      { name: '마케팅 담당자', model: 'test', systemPrompt: '브랜드 전략과 시장 홍보 방안을 수립한다' },
+      { name: '코드 리뷰어', model: 'test', systemPrompt: '코드 품질을 분석하고 리뷰 보고서를 생성한다' },
+      { name: '데이터 분석가', model: 'test', systemPrompt: '판매 데이터를 분석하고 추세 보고서를 생성한다' },
     ]
 
     expect(selectBestAgent(goal, agents)).toBe(agents[expectedIndex])


### PR DESCRIPTION
## Summary

- Add Japanese and Korean sequence, ordinal, step, and dense-enumeration signals to the built-in automatic execution router.
- Apply the existing CJK information-length weighting consistently to Han, kana, and Hangul.
- Extend routing-stability fixtures and agent-selection regressions so equivalent English, Chinese, Japanese, and Korean goals retain consistent topology.

## Motivation

Automatic routing already covered English and Chinese structural signals, but equivalent short Japanese and Korean multi-stage goals could be classified differently because their sequence markers were not recognized. This change closes that language-dependent routing gap while keeping the heuristic explicit and deterministic.

## Scope and impact

- **Affected areas:** `@open-multi-agent/core` automatic routing, routing-stability evaluation fixtures, unit tests, and execution-routing documentation.
- **Behavior change:** short Japanese or Korean goals with supported multi-stage markers or dense `、` enumerations may now select Team instead of Single. Single-action goals and lone markers remain on the existing path.
- **Public API:** no API or type changes.
- **Compatibility and migration:** additive behavior; no migration required.
- **Dependencies:** none added or changed.
- **Security and privacy:** no change.
- **Intentional non-goal:** no Japanese or Korean morphological analysis or verb-connective lexicon; explicit structural markers remain the boundary.

## Validation

- `git diff --check c3108660a95a978a216ed8137a41367004704ba4...053115fbdb005d41b651393c0c5b275786038ff5` — passed.
- `npm run test -w @open-multi-agent/core -- short-circuit.test.ts keywords.test.ts routing-stability-eval.test.ts` — passed: 3 files, 111 tests.
- `npm run lint -w @open-multi-agent/core` — passed.
- `npm run test -w @open-multi-agent/core` — passed: 120 files, 1,722 tests.
- `npm run build -w @open-multi-agent/core` was not run because no public entry points, declarations, CLI output, or package-output contract changed.
- Provider E2E was not run because this is deterministic routing behavior and does not change a provider path.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING
