### PR TITLE
chore: release core v1.13.0 + create-oma-app v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 ## Unreleased
 
+## 1.13.0 - 2026-07-24
+
+### Added
+
+- Execution routing can now be selected explicitly with `mode`, customized
+  through `ExecutionRouter`, or left to the built-in `DeterministicRouter`.
+  Every `runTeam()` topology choice exposes a structured routing decision and
+  trace linkage.
+- Structured governance declarations support required or preferred roles,
+  ordered review paths, budget-aware degradation, post-execution conclusions,
+  and privacy-preserving execution receipts.
+- Consequential tools can be declared through `ToolDefinition.consequential`.
+  Undeclared runs expose a machine-readable disclosure flag and can opt into
+  confirmation through the existing `onToolCall` gate.
+- Model routes can declare ordered fallback routes for retryable worker
+  provider failures.
+- Agents and tasks can declare structured capabilities and hard requirements.
+  The scheduler adds `capability-match` and weighted `composite` strategies,
+  structured warnings, and optional strict assignee validation.
+- `TeamRunResult.taskResults` preserves unmerged results by task ID. Explicit
+  tasks can choose raw, structured, or combined dependency payloads and attach
+  bounded role/provenance metadata.
+- `OrchestratorConfig.onTaskDispatch(task)` provides a native per-task pipeline
+  approval gate. It is mutually exclusive with `onApproval`.
+- The offline Run Viewer surfaces execution-routing decisions, and Evaluation
+  includes a language-neutral routing-stability gate.
+
 ### Changed
 
 - Task DAG execution is event-driven by default. A downstream task now starts
@@ -15,11 +42,19 @@
   eligibility/fallback contracts are preserved.
 - Abort, budget exhaustion, and task-dispatch approval rejection now stop new
   dispatches, drain in-flight work, and then skip remaining tasks.
+- Automatic execution routing recognizes structured Chinese, Japanese, and
+  Korean goals and uses script-aware information length instead of relying on
+  English-only word patterns and raw character count.
 
-### Added
+### Fixed
 
-- `OrchestratorConfig.onTaskDispatch(task)` provides a native per-task pipeline
-  approval gate. It is mutually exclusive with `onApproval`.
+- CJK keyword extraction and zero-score fallback no longer select an
+  ineligible agent or lose a valid keyword-based match.
+- Governed `planOnly` runs validate and return the declared role DAG without
+  executing agents.
+- Explicit execution modes, governance floors, and per-run token/cost ceilings
+  now resolve through a documented precedence order and disclose overrides or
+  budget degradation instead of silently changing topology.
 
 ### Compatibility
 
@@ -30,3 +65,11 @@
 - Custom UIs that depend on round-grouped progress timing can temporarily
   configure `onApproval: async () => true`; event-driven consumers should
   migrate to task-ID correlation.
+- Raw dependency output remains the default. Structured dependency handoff,
+  governance declarations, consequential confirmation, and custom execution
+  routing are opt-in.
+- New result fields remain optional in public TypeScript interfaces so older
+  serialized results and caller-authored fixtures continue to type-check.
+- `@open-multi-agent/otel@0.1.0` is not republished; its
+  `@open-multi-agent/core@^1.11.0` dependency remains compatible with core
+  `1.13.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6560,7 +6560,7 @@
     },
     "packages/core": {
       "name": "@open-multi-agent/core",
-      "version": "1.12.1",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
@@ -6613,7 +6613,7 @@
       }
     },
     "packages/create-oma-app": {
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "bin": {
         "create-oma-app": "dist/index.js"

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -119,9 +119,15 @@ const governed = await orchestrator.runTeam(team, 'Review the evidence and asses
   requiredRoles: ['researcher', 'analyst'],
   requiredOrder: ['researcher', 'analyst'],
 })
+
+if (governed.governanceConclusion !== 'satisfied') {
+  throw new Error('Required governance was not satisfied by the executed topology.')
+}
 ```
 
 `required` and `preferred` both bypass automatic decomposition and the simple-goal short circuit. OMA creates one task per declared roster name, assigns it to that agent, and chains tasks in `requiredOrder`; dependency outputs are passed to downstream roles. The topology comes only from these structured fields, so equivalent goals in different languages use the same roles and order. `none` or an omitted `governanceIntent` preserves the existing automatic `runTeam()` behavior.
+
+After execution, `governanceConclusion` is `satisfied`, `unsatisfied`, or `not-applicable`. Governance-sensitive applications must check it separately from `success`: the verdict comes from the structured execution receipt, not from role names or approval wording in the model answer. See [Tool configuration](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md#declared-governance-roles-in-runteam).
 
 ## Scheduling
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -119,9 +119,15 @@ const governed = await orchestrator.runTeam(team, 'Review the evidence and asses
   requiredRoles: ['researcher', 'analyst'],
   requiredOrder: ['researcher', 'analyst'],
 })
+
+if (governed.governanceConclusion !== 'satisfied') {
+  throw new Error('Required governance was not satisfied by the executed topology.')
+}
 ```
 
 `required` 与 `preferred` 都会绕过自动拆解和简单目标短路。OMA 为每个声明的 roster 名称创建一个任务、指派给该 Agent，并按 `requiredOrder` 串联任务；依赖输出会传递给下游角色。拓扑只来自这些结构化字段，因此不同语言的等价目标会得到相同的角色与顺序。`none` 或省略 `governanceIntent` 时保持现有的自动 `runTeam()` 行为。
+
+执行结束后，`governanceConclusion` 的值为 `satisfied`、`unsatisfied` 或 `not-applicable`。对治理有要求的应用必须将它与 `success` 分开检查：该结论来自结构化执行回执，而不是模型回答中的角色名称或批准措辞。详见[工具配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md#declared-governance-roles-in-runteam)。
 
 ## 调度
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.12.1",
+  "version": "1.13.0",
   "description": "TypeScript multi-agent framework: one runTeam() call from goal to result. Auto task decomposition and parallel execution for multi-step LLM jobs. Deploys anywhere Node.js runs.",
   "files": [
     "dist",

--- a/packages/create-oma-app/package.json
+++ b/packages/create-oma-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-oma-app",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Scaffold PR review, security analysis, and multi-agent DAG starters on @open-multi-agent/core.",
   "type": "module",
   "bin": {

--- a/packages/create-oma-app/template/package.json
+++ b/packages/create-oma-app/template/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.12.1"
+    "@open-multi-agent/core": "1.13.0"
   },
   "devDependencies": {
     "tsx": "^4.21.0"

--- a/packages/create-oma-app/templates/demo/package.json
+++ b/packages/create-oma-app/templates/demo/package.json
@@ -8,7 +8,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.12.1"
+    "@open-multi-agent/core": "1.13.0"
   },
   "devDependencies": {
     "tsx": "^4.21.0"

--- a/packages/create-oma-app/templates/pr-review/package.json
+++ b/packages/create-oma-app/templates/pr-review/package.json
@@ -8,7 +8,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.12.1",
+    "@open-multi-agent/core": "1.13.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/create-oma-app/templates/security/package.json
+++ b/packages/create-oma-app/templates/security/package.json
@@ -8,7 +8,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.12.1",
+    "@open-multi-agent/core": "1.13.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- bump `@open-multi-agent/core` from `1.12.1` to `1.13.0`
- bump `create-oma-app` from `0.5.0` to `0.6.0` and pin all generated starters to core `1.13.0`
- finalize the `1.13.0` changelog for the routing, governance, scheduling, task-handoff, and consequential-tool changes already merged to `main`
- keep `@open-multi-agent/otel` at `0.1.0`; its core dependency range remains `^1.11.0`

## Motivation

Prepare the coordinated npm release for changes merged after `v1.12.1`. The scaffolder must be published with an exact core `1.13.0` pin so the post-release registry smoke validates one coherent release.

## Scope and impact

Affected workspaces: `@open-multi-agent/core`, `create-oma-app`, root release metadata, and starter manifests.

The underlying public APIs and behavior were introduced by previously merged PRs. This release metadata documents execution routing, structured governance and receipts, consequential-tool confirmation, model-route fallback, capability-aware scheduling, event-driven DAG execution, task-scoped results, structured dependency payloads, and multilingual routing.

Compatibility and migration notes are recorded in `CHANGELOG.md`: `onApproval` retains legacy round scheduling, raw dependency output remains the default, and new result fields remain optional for older serialized results and caller-authored fixtures.

Security/privacy impact: none from this release-only diff. Production dependency audit reports zero vulnerabilities.

Intentional non-goals: no OTel version bump, npm publication, tag, or GitHub Release in this PR.

## Validation

- `npm ci` — passed
- `npm run lint` on Node 22 — passed
- `npm test` on Node 22 — passed: core 1,722; create-oma-app 31; OTel 15 tests
- `npm run build` on Node 22 — passed
- `npm run typecheck:template -w create-oma-app` — all three templates passed
- `npm run test:scaffold` — packed CLI, all template/runtime combinations, no-key demos, Cloud gate, and Ollama gate passed
- CI-equivalent `npm run test:observability-pack` with published minimum core `1.11.0` — core-only, core + OTel, and minimum-core scenarios passed
- `npm run test:observability-examples` on Node 22 — 7 examples passed
- `npm run test:eval-examples` — passed
- `npm run bench:observability:ci` — passed
- dry-run packs — core `1.13.0`, create-oma-app `0.6.0`, and unchanged OTel `0.1.0` contain the expected files
- `npm audit --omit=dev` — zero production vulnerabilities
- `git diff --check origin/main...HEAD` — passed

Provider E2E was not run because this release diff does not modify provider adapters and the merged orchestration behavior is covered by deterministic tests.

## Checklist

- [x] Tests cover the shipped behavior; this release-only diff changes versions, exact starter pins, and changelog metadata
- [x] User-facing release documentation is updated
- [x] Compatibility and migration requirements are documented
- [x] The only dependency change is the intentional exact starter pin to core `1.13.0`; package ownership boundaries are unchanged