### PR TITLE
fix(core): reject invalid task dependency graphs

### DIFF
--- a/packages/core/src/orchestrator/coordinator.ts
+++ b/packages/core/src/orchestrator/coordinator.ts
@@ -23,7 +23,7 @@ import type {
 } from '../types.js'
 import type { Team } from '../team/team.js'
 import type { TaskQueue } from '../task/queue.js'
-import { createTask } from '../task/task.js'
+import { createTask, validateTaskDependencies } from '../task/task.js'
 import { classifyRunFailure } from '../observability/status.js'
 import type { TraceRuntime, TraceSpan } from '../observability/runtime.js'
 import { totalTokens, DEFAULT_MODEL } from './run-context.js'
@@ -673,13 +673,16 @@ export function loadSpecsIntoQueue(
     createdTasks.push(task)
   }
 
-  // Second pass: resolve title-based dependsOn to IDs.
+  // Second pass: resolve title-based dependsOn to IDs. Keep the resolved
+  // tasks local until the whole graph has been validated so callers never
+  // observe a partially loaded invalid plan.
+  const resolvedTasks: Array<{ task: Task; unresolvedDeps: string[] }> = []
   for (let i = 0; i < createdTasks.length; i++) {
     const spec = specs[i]!
     const task = createdTasks[i]!
 
     if (!spec.dependsOn || spec.dependsOn.length === 0) {
-      queue.add(task)
+      resolvedTasks.push({ task, unresolvedDeps: [] })
       continue
     }
 
@@ -703,7 +706,19 @@ export function loadSpecsIntoQueue(
       ...task,
       dependsOn: resolvedDeps.length > 0 ? resolvedDeps : undefined,
     }
-    queue.add(taskWithDeps)
+    resolvedTasks.push({ task: taskWithDeps, unresolvedDeps })
+  }
+
+  const validation = validateTaskDependencies(resolvedTasks.map(({ task }) => task))
+  if (!validation.valid) {
+    throw Object.assign(
+      new Error(`Invalid task dependencies: ${validation.errors.join(' ')}`),
+      { code: 'INVALID_TASK_DEPENDENCIES' },
+    )
+  }
+
+  for (const { task, unresolvedDeps } of resolvedTasks) {
+    queue.add(task)
     if (unresolvedDeps.length > 0) {
       queue.fail(
         task.id,

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -972,9 +972,34 @@ export class OpenMultiAgent {
           },
         })
       }
-      // Map title-based dependsOn references to real task IDs so we can
-      // build the dependency graph before adding tasks to the queue.
-      loadSpecsIntoQueue(taskSpecs, agentConfigs, queue, options?.verifyJudges)
+      // Map title-based dependsOn references to real task IDs and reject an
+      // invalid coordinator DAG before any task can be dispatched or the
+      // coordinator can synthesise an answer from incomplete work.
+      try {
+        loadSpecsIntoQueue(taskSpecs, agentConfigs, queue, options?.verifyJudges)
+      } catch (error) {
+        const classified = classifyRunFailure(error, { kind: 'validation' })
+        this.config.onProgress?.({
+          type: 'agent_complete',
+          agent: 'coordinator',
+          data: decompositionResult,
+        })
+        this.config.onProgress?.({
+          type: 'error',
+          data: {
+            code: 'INVALID_TASK_DEPENDENCIES',
+            error: classified.errorInfo,
+          },
+        })
+        return finish(this.buildTeamRunResult(
+          agentResults,
+          identity,
+          goal,
+          [],
+          classified.status,
+          classified.errorInfo,
+        ))
+      }
     } else {
       // Coordinator failed to produce structured output — fall back to
       // one task per agent using the goal as the description.
@@ -1419,6 +1444,10 @@ export class OpenMultiAgent {
     const identity = createRestoreIdentity(snapshot, restoreIdentityOptions)
 
     const queue = TaskQueue.fromSnapshot(snapshot.queue, { resetInProgress: true })
+    const validation = validateTaskDependencies(queue.list())
+    if (!validation.valid) {
+      throw new Error(`Invalid checkpoint task dependencies: ${validation.errors.join(' ')}`)
+    }
     const agentResults = this.agentResultsFromCheckpoint(snapshot, queue)
     const checkpointForResume: ActiveCheckpoint | undefined = activeCheckpoint
       ? {
@@ -2035,6 +2064,7 @@ export class OpenMultiAgent {
     tasks?: readonly TaskExecutionRecord[],
     forcedStatus?: RunStatus,
     forcedErrorInfo?: StructuredTraceError,
+    allowIncompleteTasks = false,
   ): TeamRunResult {
     let totalUsage: TokenUsage = ZERO_USAGE
     let overallSuccess = true
@@ -2092,11 +2122,16 @@ export class OpenMultiAgent {
       .filter((status): status is RunStatus => status !== undefined)
     const firstStatus = (code: RunStatus['code']) => statuses.find((status) => status.code === code)
     const taskFailed = tasks?.some((task) => task.status === 'failed') ?? false
+    const taskIncomplete = tasks?.some((task) =>
+      task.status === 'pending' || task.status === 'in_progress' || task.status === 'blocked'
+    ) ?? false
     const status = forcedStatus
       ?? firstStatus('budget_exhausted')
       ?? firstStatus('timeout')
       ?? firstStatus('cancelled')
-      ?? (overallSuccess && !taskFailed ? statusOnly('ok') : statusOnly('error'))
+      ?? (overallSuccess && !taskFailed && (!taskIncomplete || allowIncompleteTasks)
+        ? statusOnly('ok')
+        : statusOnly('error'))
     const errorInfo = forcedErrorInfo ?? [...agentResults.values()]
       .find((result) => result.status?.code === status.code && result.errorInfo !== undefined)
       ?.errorInfo
@@ -2142,7 +2177,7 @@ export class OpenMultiAgent {
       metrics: undefined,
     }))
     return {
-      ...this.buildTeamRunResult(agentResults, identity, goal, tasks),
+      ...this.buildTeamRunResult(agentResults, identity, goal, tasks, undefined, undefined, true),
       planOnly: true,
     }
   }

--- a/packages/core/tests/orchestrator.test.ts
+++ b/packages/core/tests/orchestrator.test.ts
@@ -327,6 +327,18 @@ describe('OpenMultiAgent', () => {
       expect(result.success).toBe(true)
     })
 
+    it('rejects cyclic task dependencies before dispatch', async () => {
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg())
+
+      await expect(oma.runTasks(team, [
+        { title: 'Task A', description: 'Do A', assignee: 'worker-a', dependsOn: ['Task B'] },
+        { title: 'Task B', description: 'Do B', assignee: 'worker-b', dependsOn: ['Task A'] },
+      ])).rejects.toThrow('Invalid task dependencies: Cyclic dependency detected')
+
+      expect(capturedPrompts).toEqual([])
+    })
+
     it.each<{
       strategy: SchedulingStrategy
       expected: Record<string, string>
@@ -957,6 +969,33 @@ describe('OpenMultiAgent', () => {
       expect(result.success).toBe(true)
       // Should have coordinator result
       expect(result.agentResults.has('coordinator')).toBe(true)
+    })
+
+    it('returns a validation failure for a coordinator-generated cyclic DAG', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title":"Task A","description":"Do A","assignee":"worker-a","dependsOn":["Task B"]},{"title":"Task B","description":"Do B","assignee":"worker-b","dependsOn":["Task A"]}]\n```',
+      ]
+      const events: OrchestratorEvent[] = []
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onProgress: (event) => events.push(event),
+      })
+      const team = oma.createTeam('t', teamCfg())
+
+      const result = await oma.runTeam(
+        team,
+        'First research the topic, then produce a detailed report with recommendations.',
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.status?.code).toBe('error')
+      expect(result.errorInfo).toMatchObject({ kind: 'validation' })
+      expect(result.tasks).toEqual([])
+      expect(capturedPrompts).toHaveLength(1)
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'error',
+        data: expect.objectContaining({ code: 'INVALID_TASK_DEPENDENCIES' }),
+      }))
     })
 
     it('falls back to one-task-per-agent when coordinator output is unparseable', async () => {


### PR DESCRIPTION
## Summary
- validate resolved task graphs before loading them into a queue
- report coordinator-generated invalid DAGs as validation failures before synthesis
- reject invalid checkpoint graphs and prevent unresolved tasks from reporting success

## Tests
- npm run test -w @open-multi-agent/core -- orchestrator.test.ts
- npm run lint -w @open-multi-agent/core
- npm run build -w @open-multi-agent/core
- npm run test -w @open-multi-agent/core