### PR TITLE
fix(core): enforce TaskRequirements as global hard constraints

### DIFF
--- a/docs/task-scheduling.md
+++ b/docs/task-scheduling.md
@@ -97,11 +97,12 @@ enters results, task trace attributes, checkpoint snapshots, or plan artifacts.
 
 ## Assignment strategies
 
-Unassigned tasks are scheduled when they become ready. `dependency-first` and
-`composite` order the current ready set by downstream criticality; each selected
-task is then assigned individually. `round-robin` retains its cursor,
-`least-busy` reads current `in_progress` load, and `capability-match` retains its
-hard eligibility filter.
+Before any task is dispatched, the complete plan is validated against explicit
+task requirements. Every scheduling strategy filters to eligible agents first;
+the configured strategy only ranks or rotates within that eligible set.
+`dependency-first` and `composite` order the current ready set by downstream
+criticality, `round-robin` retains its cursor, and `least-busy` reads current
+`in_progress` load.
 
 Agents may declare `description`, `capabilities`, `costTier`, and
 `latencyClass`; none is inferred when omitted. Explicit `runTasks()` specs and
@@ -109,14 +110,14 @@ coordinator-generated tasks may add `requires` with `requiredTools`,
 `requiredCapabilities`, `requiredBackend`, and `requiredProvider`. Tool
 requirements are checked against the final resolved grant set, after presets,
 allowlists, denylists, and framework rails.
+Provider requirements are also checked after worker model routing. Incompatible
+fallback routes are removed rather than crossing the declared provider boundary.
 
-`capability-match` and `composite` deliberately differ when a task's `requires`
-cannot be satisfied:
-
-| Strategy | No eligible agent |
-|---|---|
-| `capability-match` | Terminates scheduling with `NO_ELIGIBLE_AGENT`. |
-| `composite` | Emits a structured `NO_ELIGIBLE_AGENT` warning, then falls back to zero fit plus current load. |
+When no roster candidate satisfies an unassigned task, validation fails with
+`INVALID_TASK_REQUIREMENTS` and an issue code of `NO_ELIGIBLE_AGENT`. When an
+explicit assignee exists but does not satisfy the requirements, the issue code
+is `ASSIGNEE_REQUIREMENTS_MISMATCH`. Both cases fail before worker execution;
+hard requirements never fall back to an ineligible agent.
 
 `composite` maximizes `fitWeight * fit + loadWeight * (1 - normalizedCurrentLoad)`.
 `schedulingWeights.fit` and `schedulingWeights.load` default to `0.7` and `0.3`,

--- a/docs/tool-configuration.md
+++ b/docs/tool-configuration.md
@@ -306,7 +306,9 @@ Backend and provider checks use their structured configuration fields.
 
 Neither permissions nor capabilities are ever inferred from `systemPrompt` or
 other prose. When no candidate satisfies the hard requirements, the selector
-returns `NO_ELIGIBLE_AGENT`; a caller must choose any fallback explicitly.
+returns `NO_ELIGIBLE_AGENT`. Team and explicit-task execution validate the
+complete plan before dispatch and fail with `INVALID_TASK_REQUIREMENTS`; no
+scheduling strategy may fall back to an ineligible agent.
 
 ## Per-call gating with `onToolCall`
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -150,14 +150,15 @@ const orchestrator = new OpenMultiAgent({
 
 | Strategy | Assignment behavior | Recommended when |
 |----------|---------------------|------------------|
-| `dependency-first` (default) | Assigns tasks that unblock the most downstream work first, rotating agents | The task graph has meaningful dependencies |
-| `round-robin` | Distributes tasks in queue order across the roster | Agents are interchangeable |
-| `least-busy` | Chooses the agent with the fewest active or newly assigned tasks | Task duration varies and load balance matters |
+| `dependency-first` (default) | Assigns tasks that unblock the most downstream work first, rotating eligible agents | The task graph has meaningful dependencies |
+| `round-robin` | Distributes tasks in queue order across eligible agents | Agents are interchangeable |
+| `least-busy` | Chooses the eligible agent with the fewest active or newly assigned tasks | Task duration varies and load balance matters |
 | `capability-match` | Filters explicit task requirements, then prefers declared capability tags before legacy keyword affinity | Tasks or agents declare differentiated requirements/capabilities |
-| `composite` | Ranks tasks by blocked dependents, hard-filters with `AgentSelector`, then maximizes `fitWeight * fit + loadWeight * (1 - normalizedCurrentLoad)` | Criticality, capability fit, and current load should influence one decision |
+| `composite` | Ranks tasks by blocked dependents, then maximizes fit and available capacity across eligible agents | Criticality, capability fit, and current load should influence one decision |
 
 Agents may declare `description`, `capabilities`, `costTier`, and
-`latencyClass`, and tasks may add hard `requires` constraints; set
+`latencyClass`, and tasks may add hard `requires` constraints. All strategies
+fail before worker execution when those constraints cannot be satisfied; set
 `strictAssignees: true` to fail fast when a coordinator plan names an agent
 outside the roster. Weight semantics, load normalization, `NO_ELIGIBLE_AGENT`
 and `INVALID_ASSIGNEE` behavior, approval compatibility, and progress-event

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -145,17 +145,18 @@ const orchestrator = new OpenMultiAgent({
 
 | 策略 | 分配行为 | 适用场景 |
 |------|----------|----------|
-| `dependency-first`（默认） | 优先分配能解锁最多下游工作的任务，并轮转选择 Agent | 任务图存在明确依赖关系 |
-| `round-robin` | 按队列顺序在 Agent roster 中轮转分配 | Agent 能力可以互换 |
-| `least-busy` | 选择当前活跃任务或本批新分配任务最少的 Agent | 任务耗时差异较大，需要负载均衡 |
+| `dependency-first`（默认） | 优先分配能解锁最多下游工作的任务，并在合格 Agent 中轮转选择 | 任务图存在明确依赖关系 |
+| `round-robin` | 按队列顺序在合格 Agent 中轮转分配 | Agent 能力可以互换 |
+| `least-busy` | 选择当前活跃任务或本批新分配任务最少的合格 Agent | 任务耗时差异较大，需要负载均衡 |
 | `capability-match` | 先过滤显式任务要求，再优先匹配声明的能力标签，最后使用兼容的关键词亲和度 | 任务或 Agent 声明了有区分度的要求/能力 |
-| `composite` | 按阻塞的下游任务数排列任务，经 `AgentSelector` 硬过滤后，最大化 `fitWeight * fit + loadWeight * (1 - normalizedCurrentLoad)` | 需要在一次决策中同时考虑关键度、能力匹配与当前负载 |
+| `composite` | 按阻塞的下游任务数排列任务，再在合格 Agent 中综合选择匹配度与可用容量最优者 | 需要在一次决策中同时考虑关键度、能力匹配与当前负载 |
 
 Agent 可声明 `description`、`capabilities`、`costTier` 与 `latencyClass`，
-任务可通过 `requires` 声明硬性过滤条件；设置 `strictAssignees: true` 可在
-coordinator 计划引用 roster 之外的 Agent 时提前失败。权重语义、负载归一化、
-`NO_ELIGIBLE_AGENT` 与 `INVALID_ASSIGNEE` 行为、审批兼容与 progress 事件迁移
-见[任务调度与派发](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/task-scheduling.md)。
+任务可通过 `requires` 声明硬约束。任何调度策略无法满足这些约束时，都会在
+worker 执行前失败；设置 `strictAssignees: true` 可在 coordinator 计划引用
+roster 之外的 Agent 时提前失败。权重语义、负载归一化、`NO_ELIGIBLE_AGENT`
+与 `INVALID_ASSIGNEE` 行为、审批兼容与 progress 事件迁移见
+[任务调度与派发](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/task-scheduling.md)。
 
 ## 核心能力
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -2,6 +2,25 @@
  * @fileoverview Framework-specific error classes.
  */
 
+import type { TaskRequirementIssue } from './types.js'
+
+/**
+ * Raised before task execution when a task has no eligible agent or its
+ * explicit assignee does not satisfy the task's hard requirements.
+ */
+export class InvalidTaskRequirementsError extends Error {
+  readonly code = 'INVALID_TASK_REQUIREMENTS'
+
+  constructor(readonly issues: readonly TaskRequirementIssue[]) {
+    super(
+      `Task requirements are unsatisfied: ${issues
+        .map((issue) => `${issue.code} for "${issue.taskTitle}"`)
+        .join(', ')}.`,
+    )
+    this.name = 'InvalidTaskRequirementsError'
+  }
+}
+
 /**
  * Raised when an agent or orchestrator run exceeds its configured token budget.
  */
@@ -102,6 +121,7 @@ function extractStatus(error: unknown): number | undefined {
  * limits (429), and all 5xx server errors — is retryable.
  */
 export function isRetryableError(error: unknown): boolean {
+  if (error instanceof InvalidTaskRequirementsError) return false
   if (error instanceof TokenBudgetExceededError) return false
   if (error instanceof CostBudgetExceededError) return false
   if (error instanceof InvalidMessageError) return false

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,7 +86,10 @@ export type {
   SchedulerOptions,
   SchedulerWarning,
 } from './orchestrator/scheduler.js'
-export { AgentSelector } from './orchestrator/agent-selector.js'
+export {
+  AgentSelector,
+  validateTaskRequirements,
+} from './orchestrator/agent-selector.js'
 export type {
   AgentSelectionFailure,
   AgentSelectionResult,
@@ -172,7 +175,7 @@ export type { RegisterBuiltInToolsOptions } from './tool/built-in/index.js'
 
 export { createAdapter } from './llm/adapter.js'
 export type { SupportedProvider } from './llm/adapter.js'
-export { TokenBudgetExceededError, CostBudgetExceededError, InvalidMessageError, LLMCallTimeoutError, isRetryableError } from './errors.js'
+export { TokenBudgetExceededError, CostBudgetExceededError, InvalidMessageError, InvalidTaskRequirementsError, LLMCallTimeoutError, isRetryableError } from './errors.js'
 export { createRunIdentity, createRestoreIdentity, validateRunId } from './observability/identity.js'
 export { classifyRunFailure } from './observability/status.js'
 export type {
@@ -328,6 +331,7 @@ export type {
   RunTasksOptions,
   RunTaskSpec,
   TaskMetadata,
+  TaskRequirementIssue,
   TaskRequirements,
   RestoreOptions,
   ModelRouteConfig,

--- a/packages/core/src/orchestrator/agent-selector.ts
+++ b/packages/core/src/orchestrator/agent-selector.ts
@@ -10,6 +10,8 @@
 import type {
   AgentConfig,
   OrchestratorConfig,
+  Task,
+  TaskRequirementIssue,
   TaskRequirements,
 } from '../types.js'
 import type { SupportedProvider } from '../llm/adapter.js'
@@ -32,6 +34,8 @@ export interface AgentSelectorContext {
   readonly defaultToolPreset?: OrchestratorConfig['defaultToolPreset']
   /** Team workers register delegation; standalone selection does not. */
   readonly includeDelegateTool?: boolean
+  /** Resolve the effective worker config for one task before hard filtering. */
+  readonly resolveCandidate?: (task: Task, candidate: AgentConfig) => AgentConfig
 }
 
 export interface EligibleAgentScore {
@@ -216,4 +220,80 @@ export class AgentSelector {
       eligible,
     }
   }
+}
+
+export function hasExplicitTaskRequirements(
+  requires: TaskRequirements | undefined,
+): boolean {
+  return requires !== undefined && (
+    (requires.requiredTools?.length ?? 0) > 0
+    || (requires.requiredCapabilities?.length ?? 0) > 0
+    || requires.requiredBackend !== undefined
+    || requires.requiredProvider !== undefined
+  )
+}
+
+/**
+ * Validate every task's hard requirements before any task is dispatched.
+ *
+ * Unassigned tasks must have at least one eligible roster candidate. Explicitly
+ * assigned tasks are checked only against their named agent so assignment
+ * conflicts fail instead of being silently reassigned.
+ */
+export function validateTaskRequirements(
+  tasks: readonly Task[],
+  candidates: readonly AgentConfig[],
+  context: AgentSelectorContext = {},
+): readonly TaskRequirementIssue[] {
+  const selector = new AgentSelector()
+  const issues: TaskRequirementIssue[] = []
+
+  for (const task of tasks) {
+    if (
+      task.status === 'completed'
+      || task.status === 'failed'
+      || task.status === 'skipped'
+    ) continue
+    if (!hasExplicitTaskRequirements(task.requires)) continue
+
+    if (task.assignee !== undefined) {
+      const assignee = candidates.find((candidate) => candidate.name === task.assignee)
+      // Unknown assignees retain the existing INVALID_ASSIGNEE/not-found path.
+      if (!assignee) continue
+      const effectiveAssignee = context.resolveCandidate?.(task, assignee) ?? assignee
+      const selection = selector.select({
+        title: task.title,
+        description: task.description,
+        requires: task.requires,
+      }, [effectiveAssignee], context)
+      if (selection.error) {
+        issues.push({
+          code: 'ASSIGNEE_REQUIREMENTS_MISMATCH',
+          taskId: task.id,
+          taskTitle: task.title,
+          assignee: task.assignee,
+          reasons: selection.error.reasons,
+        })
+      }
+      continue
+    }
+
+    const effectiveCandidates = candidates.map((candidate) =>
+      context.resolveCandidate?.(task, candidate) ?? candidate)
+    const selection = selector.select({
+      title: task.title,
+      description: task.description,
+      requires: task.requires,
+    }, effectiveCandidates, context)
+    if (selection.error) {
+      issues.push({
+        code: 'NO_ELIGIBLE_AGENT',
+        taskId: task.id,
+        taskTitle: task.title,
+        reasons: selection.error.reasons,
+      })
+    }
+  }
+
+  return issues
 }

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -49,6 +49,7 @@ import type {
   ConsensusOptions,
   ConsensusResult,
   CoordinatorConfig,
+  ModelRoutingPolicy,
   PlanArtifact,
   PlanTaskArtifact,
   OrchestratorConfig,
@@ -82,7 +83,15 @@ import { InMemoryStore } from '../memory/store.js'
 import { createTask, validateTaskDependencies } from '../task/task.js'
 import { validateTaskMetadata } from '../task/metadata.js'
 import { Scheduler } from './scheduler.js'
-import { CostBudgetExceededError, TokenBudgetExceededError } from '../errors.js'
+import {
+  CostBudgetExceededError,
+  InvalidTaskRequirementsError,
+  TokenBudgetExceededError,
+} from '../errors.js'
+import {
+  validateTaskRequirements,
+  type AgentSelectorContext,
+} from './agent-selector.js'
 import {
   createRestoreIdentity,
   resolveRestoreMetadata,
@@ -307,14 +316,13 @@ export class OpenMultiAgent {
     }
   }
 
-  private createScheduler(): Scheduler {
+  private createScheduler(
+    modelRouting?: ModelRoutingPolicy,
+    tasks: () => readonly Task[] = () => [],
+  ): Scheduler {
     return new Scheduler(
       this.config.schedulingStrategy,
-      {
-        defaultProvider: this.config.defaultProvider,
-        defaultToolPreset: this.config.defaultToolPreset,
-        includeDelegateTool: true,
-      },
+      this.agentSelectorContext(modelRouting, tasks),
       {
         weights: this.config.schedulingWeights,
         onWarning: (warning) => {
@@ -326,6 +334,31 @@ export class OpenMultiAgent {
         },
       },
     )
+  }
+
+  private agentSelectorContext(
+    modelRouting?: ModelRoutingPolicy,
+    tasks: () => readonly Task[] = () => [],
+  ): AgentSelectorContext {
+    return {
+      defaultProvider: this.config.defaultProvider,
+      defaultToolPreset: this.config.defaultToolPreset,
+      includeDelegateTool: true,
+      ...(modelRouting ? {
+        resolveCandidate: (task: Task, candidate: AgentConfig): AgentConfig => {
+          const base = applyDefaultToolPreset(
+            applyAgentDefaults(candidate, this.config),
+            this.config.defaultToolPreset,
+          )
+          return withModelRoute(base, routeMatches(modelRouting, {
+            phase: 'worker',
+            agent: candidate.name,
+            task,
+            leaf: isLeafTask(task, tasks()),
+          }))
+        },
+      } : {}),
+    }
   }
 
   private beginOnlineEvaluation(input: unknown): PendingOnlineEvaluation | undefined {
@@ -923,7 +956,7 @@ export class OpenMultiAgent {
     const taskSpecs = parseTaskSpecs(decompositionResult.output)
 
     const queue = new TaskQueue()
-    const scheduler = this.createScheduler()
+    const scheduler = this.createScheduler(options?.modelRouting, () => queue.list())
     const taskMetrics = new Map<string, TaskExecutionMetrics>()
 
     if (taskSpecs && taskSpecs.length > 0) {
@@ -1011,6 +1044,32 @@ export class OpenMultiAgent {
         })
         queue.add(task)
       }
+    }
+
+    const requirementIssues = validateTaskRequirements(
+      queue.list(),
+      agentConfigs,
+      this.agentSelectorContext(options?.modelRouting, () => queue.list()),
+    )
+    if (requirementIssues.length > 0) {
+      const error = new InvalidTaskRequirementsError(requirementIssues)
+      const classified = classifyRunFailure(error, { kind: 'validation' })
+      this.config.onProgress?.({
+        type: 'error',
+        data: {
+          code: error.code,
+          issues: requirementIssues,
+          error: classified.errorInfo,
+        },
+      })
+      return finish(this.buildTeamRunResult(
+        agentResults,
+        identity,
+        goal,
+        [],
+        classified.status,
+        classified.errorInfo,
+      ))
     }
 
     // ------------------------------------------------------------------
@@ -1363,6 +1422,7 @@ export class OpenMultiAgent {
             role: t.role,
             priority: t.priority,
             metadata: t.metadata,
+            requires: t.requires,
             verify: t.verify,
           })),
           team.getAgents(),
@@ -1807,6 +1867,25 @@ export class OpenMultiAgent {
     governanceDeclaration?: GovernanceDeclaration,
     routingDecisionInput?: RoutingDecisionRecordInput,
   ): Promise<TeamRunResult> {
+    const agentConfigs = team.getAgents()
+    const requirementIssues = validateTaskRequirements(
+      queue.list(),
+      agentConfigs,
+      this.agentSelectorContext(options?.modelRouting, () => queue.list()),
+    )
+    if (requirementIssues.length > 0) {
+      const error = new InvalidTaskRequirementsError(requirementIssues)
+      this.config.onProgress?.({
+        type: 'error',
+        data: {
+          code: error.code,
+          issues: requirementIssues,
+          error: classifyRunFailure(error, { kind: 'validation' }).errorInfo,
+        },
+      })
+      throw error
+    }
+
     const newRunFacts = identity === undefined
       ? createRunFacts(identityOptionsForRun(options))
       : undefined
@@ -1816,8 +1895,7 @@ export class OpenMultiAgent {
     const routingDecision = routingDecisionInput
       ? recordRoutingDecision(runIdentity, traceRuntime, routingDecisionInput)
       : undefined
-    const agentConfigs = team.getAgents()
-    const scheduler = this.createScheduler()
+    const scheduler = this.createScheduler(options?.modelRouting, () => queue.list())
     if (this.config.onApproval) {
       scheduler.autoAssign(queue, agentConfigs)
     }

--- a/packages/core/src/orchestrator/scheduler.ts
+++ b/packages/core/src/orchestrator/scheduler.ts
@@ -19,6 +19,7 @@ import type { AgentConfig, Task } from '../types.js'
 import type { TaskQueue } from '../task/queue.js'
 import {
   AgentSelector,
+  hasExplicitTaskRequirements,
   type AgentSelectorContext,
 } from './agent-selector.js'
 
@@ -61,6 +62,7 @@ export const DEFAULT_SCHEDULING_WEIGHTS: SchedulingWeights = {
   load: 0.3,
 }
 
+/** @deprecated Hard requirement failures are now fail-closed errors. */
 export interface SchedulerWarning {
   /** Stable machine-readable warning code inherited from AgentSelector. */
   readonly code: 'NO_ELIGIBLE_AGENT'
@@ -75,7 +77,7 @@ export interface SchedulerWarning {
 export interface SchedulerOptions {
   /** Per-field composite overrides; omitted fields use the documented defaults. */
   readonly weights?: Partial<SchedulingWeights>
-  /** Receives structured scheduler degradations without changing assignments. */
+  /** @deprecated Hard requirement failures are no longer downgraded to warnings. */
   readonly onWarning?: (warning: SchedulerWarning) => void
 }
 
@@ -187,11 +189,15 @@ export class Scheduler {
    * @returns A `Map<taskId, agentName>` for every unassigned pending task.
    */
   schedule(tasks: Task[], agents: AgentConfig[]): Map<string, string> {
-    if (agents.length === 0) return new Map()
-
     const unassigned = tasks.filter(
       (t) => t.status === 'pending' && !t.assignee,
     )
+    if (agents.length === 0) {
+      const constrained = unassigned.find((task) =>
+        hasExplicitTaskRequirements(task.requires))
+      if (constrained) this.eligibleAgents(constrained, agents)
+      return new Map()
+    }
 
     switch (this.strategy) {
       case 'round-robin':
@@ -219,7 +225,13 @@ export class Scheduler {
     agents: AgentConfig[],
     allTasks: Task[],
   ): string | undefined {
-    if (agents.length === 0 || task.status !== 'pending' || task.assignee) {
+    if (task.status !== 'pending' || task.assignee) {
+      return undefined
+    }
+    if (agents.length === 0) {
+      if (hasExplicitTaskRequirements(task.requires)) {
+        this.eligibleAgents(task, agents)
+      }
       return undefined
     }
 
@@ -296,9 +308,10 @@ export class Scheduler {
   ): Map<string, string> {
     const result = new Map<string, string>()
     for (const task of unassigned) {
-      const agent = agents[this.roundRobinCursor % agents.length]!
+      const eligible = this.eligibleAgents(task, agents)
+      const agent = eligible[this.roundRobinCursor % eligible.length]!
       result.set(task.id, agent.name)
-      this.roundRobinCursor = (this.roundRobinCursor + 1) % agents.length
+      this.roundRobinCursor = (this.roundRobinCursor + 1) % eligible.length
     }
     return result
   }
@@ -326,12 +339,13 @@ export class Scheduler {
 
     const result = new Map<string, string>()
     for (const task of unassigned) {
+      const eligible = this.eligibleAgents(task, agents)
       // Pick the agent with the lowest current load.
-      let bestAgent = agents[0]!
+      let bestAgent = eligible[0]!
       let bestLoad = load.get(bestAgent.name) ?? 0
 
-      for (let i = 1; i < agents.length; i++) {
-        const agent = agents[i]!
+      for (let i = 1; i < eligible.length; i++) {
+        const agent = eligible[i]!
         const agentLoad = load.get(agent.name) ?? 0
         if (agentLoad < bestLoad) {
           bestLoad = agentLoad
@@ -365,16 +379,14 @@ export class Scheduler {
     const selector = new AgentSelector()
 
     for (const task of unassigned) {
-      const selection = selector.select({
-        title: task.title,
-        description: task.description,
-        requires: task.requires,
-      }, agents, this.selectorContext)
+      const selection = this.selectTaskAgents(task, agents, selector)
       if (selection.error) {
         throw new Error(
           `Scheduler capability-match: ${selection.error.code}: ${selection.error.reasons.join(' ')}`,
         )
       }
+      const eligibleAgents = agents.filter((agent) =>
+        selection.eligible.some((entry) => entry.agent === agent))
 
       // Preserve the legacy scheduler's roster-order tie-break while reusing
       // the selector's eligibility and scoring kernel. The public selector and
@@ -390,8 +402,8 @@ export class Scheduler {
       }
 
       if (bestScore === 0) {
-        bestAgent = agents[this.roundRobinCursor % agents.length]!
-        this.roundRobinCursor = (this.roundRobinCursor + 1) % agents.length
+        bestAgent = eligibleAgents[this.roundRobinCursor % eligibleAgents.length]!
+        this.roundRobinCursor = (this.roundRobinCursor + 1) % eligibleAgents.length
       }
 
       result.set(task.id, bestAgent.name)
@@ -425,9 +437,10 @@ export class Scheduler {
     let cursor = this.roundRobinCursor
 
     for (const task of ranked) {
-      const agent = agents[cursor % agents.length]!
+      const eligible = this.eligibleAgents(task, agents)
+      const agent = eligible[cursor % eligible.length]!
       result.set(task.id, agent.name)
-      cursor = (cursor + 1) % agents.length
+      cursor = (cursor + 1) % eligible.length
     }
 
     // Advance the shared cursor for consistency with round-robin.
@@ -444,10 +457,8 @@ export class Scheduler {
    * Assignments made earlier in this call are deliberately not folded into
    * load, keeping the decision compatible with future one-ready-task calls.
    *
-   * When hard filtering leaves no eligible agent, the selector's structured
-   * failure is emitted as a warning and the task follows an explicit zero-fit
-   * fallback across the full roster, using current load and ascending agent
-   * name as the deterministic tie-break.
+   * Hard filtering is fail-closed. No load or fit fallback may reintroduce an
+   * ineligible agent.
    */
   private scheduleComposite(
     unassigned: Task[],
@@ -469,27 +480,12 @@ export class Scheduler {
     const result = new Map<string, string>()
 
     for (const task of ranked) {
-      const selection = selector.select({
-        title: task.title,
-        description: task.description,
-        requires: task.requires,
-      }, agents, this.selectorContext)
-      const candidates = selection.error
-        ? agents.map((agent) => ({ agent, score: 0 }))
-        : selection.eligible
-
+      const selection = this.selectTaskAgents(task, agents, selector)
       if (selection.error) {
-        this.options.onWarning?.({
-          code: selection.error.code,
-          message: selection.error.message,
-          taskId: task.id,
-          taskTitle: task.title,
-          reasons: selection.error.reasons,
-          fallback: 'zero-fit-current-load',
-        })
+        throw this.noEligibleAgentError(task, selection.error.reasons)
       }
 
-      const rankedCandidates = candidates.map((candidate) => {
+      const rankedCandidates = selection.eligible.map((candidate) => {
         const normalizedLoad = (loads.get(candidate.agent.name) ?? 0) / maxLoad
         return {
           agent: candidate.agent,
@@ -509,6 +505,55 @@ export class Scheduler {
     }
 
     return result
+  }
+
+  private eligibleAgents(task: Task, agents: AgentConfig[]): AgentConfig[] {
+    const selection = this.selectTaskAgents(task, agents)
+    if (selection.error) {
+      throw this.noEligibleAgentError(task, selection.error.reasons)
+    }
+    const eligible = new Set(selection.eligible.map((entry) => entry.agent))
+    return agents.filter((agent) => eligible.has(agent))
+  }
+
+  private selectTaskAgents(
+    task: Task,
+    agents: AgentConfig[],
+    selector = new AgentSelector(),
+  ): ReturnType<AgentSelector['select']> {
+    const effectiveAgents = agents.map((agent) =>
+      this.selectorContext.resolveCandidate?.(task, agent) ?? agent)
+    const originalByEffective = new Map(
+      effectiveAgents.map((effective, index) => [effective, agents[index]!] as const),
+    )
+    const selection = selector.select({
+      title: task.title,
+      description: task.description,
+      requires: task.requires,
+    }, effectiveAgents, this.selectorContext)
+    const remap = (agent: AgentConfig | undefined): AgentConfig | undefined =>
+      agent === undefined ? undefined : originalByEffective.get(agent)
+    return {
+      ...selection,
+      agent: remap(selection.agent),
+      eligible: selection.eligible.map((entry) => ({
+        ...entry,
+        agent: originalByEffective.get(entry.agent)!,
+      })),
+    }
+  }
+
+  private noEligibleAgentError(task: Task, reasons: readonly string[]): Error {
+    return Object.assign(
+      new Error(
+        `Scheduler ${this.strategy}: NO_ELIGIBLE_AGENT for task "${task.title}": ${reasons.join(' ')}`,
+      ),
+      {
+        code: 'NO_ELIGIBLE_AGENT',
+        taskId: task.id,
+        reasons,
+      },
+    )
   }
 
   private resolvedWeights(): SchedulingWeights {

--- a/packages/core/src/orchestrator/task-execution.ts
+++ b/packages/core/src/orchestrator/task-execution.ts
@@ -38,6 +38,8 @@ import {
   type RunContext,
   type RevealCoordinatorContext,
 } from './run-context.js'
+import { InvalidTaskRequirementsError } from '../errors.js'
+import { validateTaskRequirements } from './agent-selector.js'
 import { recordRunUsage, buildCostEstimateContext } from './budget.js'
 import {
   routeMatches,
@@ -541,6 +543,31 @@ export async function executeQueue(
       const completedThisRound: Task[] = []
 
       const dispatchPromises = pending.map(async (task): Promise<void> => {
+      const requirementIssues = validateTaskRequirements(
+        [task],
+        team.getAgents(),
+        {
+          defaultProvider: config.defaultProvider,
+          defaultToolPreset: config.defaultToolPreset,
+          includeDelegateTool: true,
+          resolveCandidate: (candidateTask, candidate) => {
+            const base = applyDefaultToolPreset(
+              applyAgentDefaults(candidate, config),
+              config.defaultToolPreset,
+            )
+            return withModelRoute(base, routeMatches(ctx.modelRouting, {
+              phase: 'worker',
+              agent: candidate.name,
+              task: candidateTask,
+              leaf: ctx.taskLeafById.get(candidateTask.id),
+            }))
+          },
+        },
+      )
+      if (requirementIssues.length > 0) {
+        throw new InvalidTaskRequirementsError(requirementIssues)
+      }
+
       // Mark in-progress
       queue.update(task.id, { status: 'in_progress' as TaskStatus })
 
@@ -733,9 +760,14 @@ export async function executeQueue(
           applyAgentDefaults(agentConfig, config),
           config.defaultToolPreset,
         )
-        const routedConfigs = routeChain(workerRoute).map(route =>
-          withModelRoute(workerBaseConfig, route),
-        )
+        const routedConfigs = routeChain(workerRoute)
+          .map(route => withModelRoute(workerBaseConfig, route))
+          .filter(candidate =>
+            validateTaskRequirements([task], [candidate], {
+              defaultProvider: config.defaultProvider,
+              defaultToolPreset: config.defaultToolPreset,
+              includeDelegateTool: true,
+            }).length === 0)
         const workerEffectiveConfig = routedConfigs[0] ?? workerBaseConfig
         const routedAgents = routedConfigs.map(route =>
           buildAgent(route, { includeDelegateTool: true }),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1130,6 +1130,15 @@ export interface TaskRequirements {
   readonly requiredProvider?: SupportedProvider
 }
 
+/** Structured reason why a task cannot satisfy its hard requirements. */
+export interface TaskRequirementIssue {
+  readonly code: 'NO_ELIGIBLE_AGENT' | 'ASSIGNEE_REQUIREMENTS_MISMATCH'
+  readonly taskId: string
+  readonly taskTitle: string
+  readonly assignee?: string
+  readonly reasons: readonly string[]
+}
+
 /** Bounded, trace-safe business references attached to one task. */
 export type TaskMetadata = Readonly<Record<string, TraceAttributeValue>>
 
@@ -1602,7 +1611,7 @@ export interface Task {
   readonly priority?: 'low' | 'normal' | 'high' | 'critical'
   /** Validated, bounded business references carried through result/trace/checkpoint. */
   readonly metadata?: TaskMetadata
-  /** Explicit hard requirements used by capability-aware scheduling. */
+  /** Explicit hard requirements enforced before assignment and execution. */
   readonly requires?: TaskRequirements
   result?: string
   readonly createdAt: Date
@@ -1658,15 +1667,16 @@ export interface OrchestratorConfig {
    *   agents are interchangeable.
    * - `'least-busy'` prefers the agent with the fewest active tasks; use it to
    *   balance work when task duration varies.
-   * - `'capability-match'` compares task text with agent names and system
-   *   prompts; use it when agents have distinct, clearly described roles.
+   * - `'capability-match'` ranks eligible agents using declared capabilities
+   *   and task affinity; use it when agents have distinct roles.
    * - `'dependency-first'` assigns tasks that unblock the most dependents
    *   first; use it for dependency-heavy DAGs.
    * - `'composite'` ranks by dependency criticality, hard-filters with the
    *   AgentSelector, then combines fit and current load.
    *
+   * All strategies hard-filter explicit task requirements before ranking.
    * Defaults to `'dependency-first'`. Explicit task assignees are preserved
-   * and are never replaced by this strategy.
+   * and must satisfy any declared requirements.
    */
   readonly schedulingStrategy?: SchedulingStrategy
   /**

--- a/packages/core/tests/agent-selector.test.ts
+++ b/packages/core/tests/agent-selector.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
-import { AgentSelector } from '../src/orchestrator/agent-selector.js'
+import {
+  AgentSelector,
+  validateTaskRequirements,
+} from '../src/orchestrator/agent-selector.js'
 import { Scheduler } from '../src/orchestrator/scheduler.js'
 import { createTask } from '../src/task/task.js'
-import type { AgentConfig } from '../src/types.js'
+import type { AgentConfig, TaskRequirements } from '../src/types.js'
 
 describe('AgentSelector', () => {
   it('hard-filters a high-keyword candidate that lacks a required tool', () => {
@@ -78,6 +81,46 @@ describe('AgentSelector', () => {
     })
   })
 
+  it.each<{
+    requirements: TaskRequirements
+    candidate: AgentConfig
+    reason: string
+  }>([
+    {
+      requirements: { requiredTools: ['file_edit'] },
+      candidate: { name: 'reader', model: 'test', tools: ['file_read'] },
+      reason: 'missing required tools',
+    },
+    {
+      requirements: { requiredCapabilities: ['typescript'] },
+      candidate: { name: 'generalist', model: 'test' },
+      reason: 'missing required capabilities',
+    },
+    {
+      requirements: { requiredBackend: 'process' },
+      candidate: { name: 'llm-worker', model: 'test' },
+      reason: 'does not satisfy required backend process',
+    },
+    {
+      requirements: { requiredProvider: 'anthropic' },
+      candidate: { name: 'openai-worker', model: 'test', provider: 'openai' },
+      reason: 'does not satisfy required provider anthropic',
+    },
+  ])('hard-filters each requirement field independently', ({
+    requirements,
+    candidate,
+    reason,
+  }) => {
+    const result = new AgentSelector().select({
+      title: 'Restricted',
+      description: 'Restricted task',
+      requires: requirements,
+    }, [candidate])
+
+    expect(result.error?.code).toBe('NO_ELIGIBLE_AGENT')
+    expect(result.error?.reasons.join(' ')).toContain(reason)
+  })
+
   it('handles one candidate and empty requirements as pure soft scoring', () => {
     const solo: AgentConfig = {
       name: 'solo',
@@ -145,5 +188,44 @@ describe('Scheduler capability-match with AgentSelector', () => {
     expect(() => new Scheduler('capability-match').schedule([task], [
       { name: 'reader', model: 'test', tools: ['file_read'] },
     ])).toThrow('NO_ELIGIBLE_AGENT')
+  })
+})
+
+describe('task requirement preflight', () => {
+  it('reports an explicit assignee that does not satisfy requirements', () => {
+    const task = createTask({
+      title: 'Edit',
+      description: 'Edit a file.',
+      assignee: 'reader',
+      requires: { requiredTools: ['file_edit'] },
+    })
+
+    expect(validateTaskRequirements([task], [
+      { name: 'reader', model: 'test', tools: ['file_read'] },
+      { name: 'editor', model: 'test', tools: ['file_edit'] },
+    ])).toEqual([
+      expect.objectContaining({
+        code: 'ASSIGNEE_REQUIREMENTS_MISMATCH',
+        taskId: task.id,
+        assignee: 'reader',
+      }),
+    ])
+  })
+
+  it('reports an unassigned task when the full roster is ineligible', () => {
+    const task = createTask({
+      title: 'Anthropic task',
+      description: 'Use the required provider.',
+      requires: { requiredProvider: 'anthropic' },
+    })
+
+    expect(validateTaskRequirements([task], [
+      { name: 'openai-worker', model: 'test', provider: 'openai' },
+    ])).toEqual([
+      expect.objectContaining({
+        code: 'NO_ELIGIBLE_AGENT',
+        taskId: task.id,
+      }),
+    ])
   })
 })

--- a/packages/core/tests/checkpoint.test.ts
+++ b/packages/core/tests/checkpoint.test.ts
@@ -336,6 +336,62 @@ describe('OpenMultiAgent checkpoint/restore', () => {
     expect((await resumedTeam.getSharedMemoryInstance()!.read('seed/note'))?.value).toEqual({ keep: true })
   })
 
+  it('restores requirements and validates pending work against the resumed roster', async () => {
+    const checkpointStore = new InMemoryStore()
+    const scripted = scriptedAdapter(['first output', 'must not run'])
+    const abort = new AbortController()
+    const orchestrator = new OpenMultiAgent({
+      onProgress(event) {
+        if (event.type === 'task_complete') abort.abort()
+      },
+    })
+    const initialTeam = new Team({
+      name: 'team',
+      agents: [{
+        ...worker('worker', scripted.adapter),
+        capabilities: ['typescript'],
+      }],
+    })
+    const constrainedTasks: RunTaskSpec[] = [
+      {
+        title: 'first',
+        description: 'do first',
+        assignee: 'worker',
+        requires: { requiredCapabilities: ['typescript'] },
+      },
+      {
+        title: 'second',
+        description: 'do second',
+        assignee: 'worker',
+        dependsOn: ['first'],
+        requires: { requiredCapabilities: ['typescript'] },
+      },
+    ]
+
+    await orchestrator.runTasks(initialTeam, constrainedTasks, {
+      abortSignal: abort.signal,
+      checkpoint: { store: checkpointStore },
+    })
+    expect(scripted.calls()).toBe(1)
+
+    const resumedTeam = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+    })
+    await expect(orchestrator.restore(resumedTeam, {
+      checkpoint: { store: checkpointStore },
+    })).rejects.toMatchObject({
+      code: 'INVALID_TASK_REQUIREMENTS',
+      issues: [
+        expect.objectContaining({
+          code: 'ASSIGNEE_REQUIREMENTS_MISMATCH',
+          taskTitle: 'second',
+        }),
+      ],
+    })
+    expect(scripted.calls()).toBe(1)
+  })
+
   it('restore against an empty store starts a fresh task run', async () => {
     const store = new InMemoryStore()
     const scripted = scriptedAdapter(['fresh output'])
@@ -353,6 +409,31 @@ describe('OpenMultiAgent checkpoint/restore', () => {
     expect(scripted.calls()).toBe(1)
     expect(result.tasks?.[0]?.status).toBe('completed')
     expect((await store.list()).some((entry) => isCheckpointKey(entry.key))).toBe(true)
+  })
+
+  it('restore against an empty store preserves and validates task requirements', async () => {
+    const store = new InMemoryStore()
+    const scripted = scriptedAdapter(['must not run'])
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', scripted.adapter)],
+      sharedMemoryStore: store,
+    })
+    const orchestrator = new OpenMultiAgent()
+
+    await expect(orchestrator.restore(team, [{
+      title: 'restricted',
+      description: 'requires a missing capability',
+      assignee: 'worker',
+      requires: { requiredCapabilities: ['missing'] },
+    }], { checkpoint: { store } })).rejects.toMatchObject({
+      code: 'INVALID_TASK_REQUIREMENTS',
+      issues: [
+        expect.objectContaining({ code: 'ASSIGNEE_REQUIREMENTS_MISMATCH' }),
+      ],
+    })
+
+    expect(scripted.calls()).toBe(0)
   })
 
   it('checkpoint/restore works with a custom async MemoryStore', async () => {

--- a/packages/core/tests/error-classification.test.ts
+++ b/packages/core/tests/error-classification.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   isRetryableError,
+  InvalidTaskRequirementsError,
   TokenBudgetExceededError,
   InvalidMessageError,
   LLMCallTimeoutError,
@@ -37,9 +38,15 @@ describe('isRetryableError', () => {
     expect(isRetryableError({ statusCode: 503 })).toBe(true)
   })
 
-  it('classifies budget and invalid-message framework errors as terminal', () => {
+  it('classifies budget, invalid-message, and task-requirement errors as terminal', () => {
     expect(isRetryableError(new TokenBudgetExceededError('a', 100, 50))).toBe(false)
     expect(isRetryableError(new InvalidMessageError('bad'))).toBe(false)
+    expect(isRetryableError(new InvalidTaskRequirementsError([{
+      code: 'NO_ELIGIBLE_AGENT',
+      taskId: 'task-1',
+      taskTitle: 'Restricted',
+      reasons: ['worker excluded'],
+    }]))).toBe(false)
   })
 
   it('classifies a per-call timeout as retryable', () => {

--- a/packages/core/tests/orchestrator.test.ts
+++ b/packages/core/tests/orchestrator.test.ts
@@ -339,6 +339,64 @@ describe('OpenMultiAgent', () => {
       expect(capturedPrompts).toEqual([])
     })
 
+    it('rejects an explicit assignee that does not satisfy hard requirements before dispatch', async () => {
+      const events: OrchestratorEvent[] = []
+      const oma = new OpenMultiAgent({
+        defaultModel: 'mock-model',
+        onProgress: (event) => events.push(event),
+      })
+      const team = oma.createTeam('t', teamCfg([
+        { ...agentConfig('reader'), tools: ['file_read'] },
+        { ...agentConfig('editor'), tools: ['file_edit'] },
+      ]))
+
+      await expect(oma.runTasks(team, [{
+        title: 'Edit',
+        description: 'Edit a file.',
+        assignee: 'reader',
+        requires: { requiredTools: ['file_edit'] },
+      }])).rejects.toMatchObject({
+        code: 'INVALID_TASK_REQUIREMENTS',
+        issues: [
+          expect.objectContaining({
+            code: 'ASSIGNEE_REQUIREMENTS_MISMATCH',
+            assignee: 'reader',
+          }),
+        ],
+      })
+
+      expect(capturedPrompts).toEqual([])
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'error',
+        data: expect.objectContaining({ code: 'INVALID_TASK_REQUIREMENTS' }),
+      }))
+    })
+
+    it('rejects a plan with no eligible agent before dispatch', async () => {
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg([agentConfig('worker')]))
+
+      await expect(oma.runTasks(team, [
+        {
+          title: 'Unrestricted predecessor',
+          description: 'Must not start before the full plan is validated.',
+        },
+        {
+          title: 'Restricted',
+          description: 'Requires a missing capability.',
+          dependsOn: ['Unrestricted predecessor'],
+          requires: { requiredCapabilities: ['missing'] },
+        },
+      ])).rejects.toMatchObject({
+        code: 'INVALID_TASK_REQUIREMENTS',
+        issues: [
+          expect.objectContaining({ code: 'NO_ELIGIBLE_AGENT' }),
+        ],
+      })
+
+      expect(capturedPrompts).toEqual([])
+    })
+
     it.each<{
       strategy: SchedulingStrategy
       expected: Record<string, string>
@@ -524,6 +582,31 @@ describe('OpenMultiAgent', () => {
       expect(team.getAgents()[0]?.model).toBe('default-worker-model')
     })
 
+    it('rejects a model route that overrides a required provider before dispatch', async () => {
+      const oma = new OpenMultiAgent({ defaultModel: 'default-model' })
+      const team = oma.createTeam('t', teamCfg([
+        { ...agentConfig('worker-a'), provider: 'anthropic' },
+      ]))
+
+      await expect(oma.runTasks(team, [{
+        title: 'Anthropic only',
+        description: 'Run on the required provider.',
+        assignee: 'worker-a',
+        requires: { requiredProvider: 'anthropic' },
+      }], {
+        modelRouting: {
+          rules: [{
+            match: { phase: 'worker' },
+            route: { model: 'routed-model', provider: 'openai' },
+          }],
+        },
+      })).rejects.toMatchObject({
+        code: 'INVALID_TASK_REQUIREMENTS',
+      })
+
+      expect(capturedPrompts).toEqual([])
+    })
+
     it('routes critical dependent tasks to an explicit premium model', async () => {
       mockAdapterResponses = ['research output', 'review output']
 
@@ -595,6 +678,43 @@ describe('OpenMultiAgent', () => {
         'backup-model',
       ])
       expect(capturedAdapterProviders).toEqual(['anthropic', 'openai'])
+    })
+
+    it('does not use a fallback route that violates a required provider', async () => {
+      mockAdapterHandler = () =>
+        Object.assign(new Error('provider unavailable'), { status: 503 })
+
+      const oma = new OpenMultiAgent({ defaultModel: 'default-model' })
+      const team = oma.createTeam('t', teamCfg([
+        { ...agentConfig('worker-a'), provider: 'anthropic' },
+      ]))
+
+      const result = await oma.runTasks(team, [{
+        title: 'Anthropic fallback boundary',
+        description: 'Do not cross the provider boundary.',
+        assignee: 'worker-a',
+        requires: { requiredProvider: 'anthropic' },
+        maxRetries: 1,
+        retryDelayMs: 0,
+      }], {
+        modelRouting: {
+          rules: [{
+            match: { phase: 'worker' },
+            route: {
+              model: 'primary-model',
+              provider: 'anthropic',
+              fallback: [{ model: 'backup-model', provider: 'openai' }],
+            },
+          }],
+        },
+      })
+
+      expect(result.success).toBe(false)
+      expect(capturedAdapterProviders).toEqual(['anthropic'])
+      expect(capturedChatOptions.map(options => options.model)).toEqual([
+        'primary-model',
+        'primary-model',
+      ])
     })
 
     it('fails over after a retryable provider error while onAgentStream is enabled', async () => {
@@ -1083,7 +1203,7 @@ describe('OpenMultiAgent', () => {
       expect(result.tasks?.[0]?.assignee).toBe('aaa-idle')
     })
 
-    it('surfaces composite no-eligible fallback through onProgress warning', async () => {
+    it('rejects a coordinator plan with unsatisfied requirements before planOnly succeeds', async () => {
       mockAdapterResponses = [
         '```json\n[{"title":"Restricted","description":"Restricted task","requires":{"requiredCapabilities":["missing"]}}]\n```',
       ]
@@ -1101,15 +1221,46 @@ describe('OpenMultiAgent', () => {
         { planOnly: true },
       )
 
-      expect(result.success).toBe(true)
-      expect(result.tasks?.[0]?.assignee).toBe('worker-a')
+      expect(result.success).toBe(false)
+      expect(result.errorInfo).toMatchObject({
+        kind: 'validation',
+        code: 'INVALID_TASK_REQUIREMENTS',
+      })
+      expect(result.tasks).toEqual([])
       expect(events).toContainEqual(expect.objectContaining({
-        type: 'warning',
+        type: 'error',
         data: expect.objectContaining({
-          code: 'NO_ELIGIBLE_AGENT',
-          fallback: 'zero-fit-current-load',
+          code: 'INVALID_TASK_REQUIREMENTS',
+          issues: [
+            expect.objectContaining({ code: 'NO_ELIGIBLE_AGENT' }),
+          ],
         }),
       }))
+      expect(capturedPrompts).toHaveLength(1)
+    })
+
+    it('rejects a coordinator assignee that conflicts with hard requirements', async () => {
+      mockAdapterResponses = [
+        '```json\n[{"title":"Edit","description":"Edit a file","assignee":"reader","requires":{"requiredTools":["file_edit"]}}]\n```',
+      ]
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const team = oma.createTeam('t', teamCfg([
+        { ...agentConfig('reader'), tools: ['file_read'] },
+        { ...agentConfig('editor'), tools: ['file_edit'] },
+      ]))
+
+      const result = await oma.runTeam(
+        team,
+        'First edit the file, then review the result.',
+        { planOnly: true },
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.errorInfo).toMatchObject({
+        kind: 'validation',
+        code: 'INVALID_TASK_REQUIREMENTS',
+      })
+      expect(capturedPrompts).toHaveLength(1)
     })
 
     it('warns and schedules a coordinator task with an invalid assignee by default', async () => {
@@ -2076,6 +2227,33 @@ describe('OpenMultiAgent', () => {
         retryDelayMs: 500,
         retryBackoff: 3,
       })
+    })
+
+    it('round-trips requirements and revalidates them before plan replay', async () => {
+      mockAdapterResponses = [
+        '```json\n[' +
+          '{"title":"Typed work","description":"Implement TypeScript","assignee":"worker","requires":{"requiredCapabilities":["typescript"]}}' +
+          ']\n```',
+      ]
+      const oma = new OpenMultiAgent({ defaultModel: 'mock-model' })
+      const planningTeam = oma.createTeam('planning', teamCfg([
+        { ...agentConfig('worker'), capabilities: ['typescript'] },
+      ]))
+
+      const planOnlyResult = await oma.runTeam(planningTeam, complexGoal, { planOnly: true })
+      const plan = oma.createPlanArtifact(planOnlyResult)
+      expect(plan.tasks[0]?.requires).toEqual({
+        requiredCapabilities: ['typescript'],
+      })
+
+      capturedPrompts = []
+      const replayTeam = oma.createTeam('replay', teamCfg([
+        agentConfig('worker'),
+      ]))
+      await expect(oma.runFromPlan(replayTeam, plan)).rejects.toMatchObject({
+        code: 'INVALID_TASK_REQUIREMENTS',
+      })
+      expect(capturedPrompts).toEqual([])
     })
   })
 

--- a/packages/core/tests/scheduler.test.ts
+++ b/packages/core/tests/scheduler.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { Scheduler } from '../src/orchestrator/scheduler.js'
+import type { SchedulingStrategy } from '../src/orchestrator/scheduler.js'
 import { TaskQueue } from '../src/task/queue.js'
 import { createTask } from '../src/task/task.js'
 import type { AgentConfig, Task, TaskRequirements } from '../src/types.js'
@@ -67,7 +68,10 @@ describe('Scheduler: round-robin', () => {
 
   it('returns empty map when no agents', () => {
     const s = new Scheduler('round-robin')
-    const tasks = [pendingTask('t1')]
+    const tasks = [
+      pendingTask('t1'),
+      pendingTask('t2', { requires: {} }),
+    ]
     expect(s.schedule(tasks, []).size).toBe(0)
   })
 
@@ -258,6 +262,61 @@ describe('Scheduler: compatibility strategies', () => {
         .keys(),
     ][0]).toBe(critical.id)
   })
+
+  it.each([
+    'round-robin',
+    'least-busy',
+    'capability-match',
+    'dependency-first',
+    'composite',
+  ] satisfies SchedulingStrategy[])(
+    '%s applies hard requirements before strategy-specific ranking',
+    (strategy) => {
+      const scheduler = new Scheduler(strategy)
+      const agents: AgentConfig[] = [
+        {
+          ...agent('ineligible'),
+          capabilities: ['typescript'],
+          tools: ['file_read'],
+          provider: 'openai',
+        },
+        {
+          ...agent('eligible'),
+          capabilities: ['typescript'],
+          tools: ['file_edit'],
+          provider: 'anthropic',
+        },
+      ]
+      const task = pendingTask('Restricted', {
+        requires: {
+          requiredTools: ['file_edit'],
+          requiredCapabilities: ['typescript'],
+          requiredBackend: 'llm',
+          requiredProvider: 'anthropic',
+        },
+      })
+
+      expect(scheduler.schedule([task], agents).get(task.id)).toBe('eligible')
+    },
+  )
+
+  it.each([
+    'round-robin',
+    'least-busy',
+    'capability-match',
+    'dependency-first',
+    'composite',
+  ] satisfies SchedulingStrategy[])(
+    '%s fails closed when no agent satisfies hard requirements',
+    (strategy) => {
+      const task = pendingTask('Restricted', {
+        requires: { requiredCapabilities: ['missing'] },
+      })
+
+      expect(() => new Scheduler(strategy).schedule([task], [agent('worker')]))
+        .toThrow('NO_ELIGIBLE_AGENT')
+    },
+  )
 })
 
 // ---------------------------------------------------------------------------
@@ -325,7 +384,7 @@ describe('Scheduler: composite', () => {
     expect(loadOnly.get(task.id)).toBe('idle')
   })
 
-  it('warns and uses the explicit zero-fit load fallback when nobody is eligible', () => {
+  it('fails closed when nobody is eligible', () => {
     const warnings: unknown[] = []
     const s = new Scheduler('composite', {}, {
       onWarning: (warning) => warnings.push(warning),
@@ -340,16 +399,8 @@ describe('Scheduler: composite', () => {
       requires: { requiredCapabilities: ['missing'] },
     })
 
-    const assignments = s.schedule([busy, task], agents)
-
-    expect(assignments.get(task.id)).toBe('idle')
-    expect(warnings).toEqual([
-      expect.objectContaining({
-        code: 'NO_ELIGIBLE_AGENT',
-        taskId: task.id,
-        fallback: 'zero-fit-current-load',
-      }),
-    ])
+    expect(() => s.schedule([busy, task], agents)).toThrow('NO_ELIGIBLE_AGENT')
+    expect(warnings).toEqual([])
   })
 })
 


### PR DESCRIPTION
## Summary

- Enforce `requiredTools`, `requiredCapabilities`, `requiredBackend`, and `requiredProvider` across all five scheduling strategies.
- Preflight complete task DAGs and fail with structured `INVALID_TASK_REQUIREMENTS` issues when no agent is eligible or an explicit assignee does not satisfy the requirements.
- Revalidate at the dispatch boundary, remove Composite's zero-fit fail-open fallback, preserve `requires` through restore paths, and document the global hard-constraint contract.

## Motivation

`TaskRequirements` was documented as an explicit hard constraint, but the default dependency-first scheduler ignored it, explicit assignees bypassed eligibility checks, and Composite could continue with an ineligible agent. This allowed an approved plan to dispatch work to an agent without the required tools, capabilities, backend, or provider.

## Scope and impact

Affected areas: `@open-multi-agent/core` orchestration, scheduling, task execution, checkpoint restore, public error/types exports, tests, and scheduling/tool documentation.

Public behavior change: tasks that declare `requires` now fail closed before worker execution when the roster cannot satisfy them. Explicit assignee conflicts return `ASSIGNEE_REQUIREMENTS_MISMATCH`; unassigned tasks with no eligible candidate return `NO_ELIGIBLE_AGENT`; both are aggregated under `INVALID_TASK_REQUIREMENTS` with candidate exclusion reasons.

Compatibility: tasks without `requires` retain existing behavior. This intentionally removes the previous Composite fail-open behavior; no compatibility switch is provided. No dependencies were added or changed.

Security/privacy: fail-closed validation prevents ineligible worker, provider, and tool dispatch. No new secrets, telemetry payload classes, or external integrations are introduced.

Non-goals: soft matching remains the existing capability/keyword scoring path; this change does not add a best-effort mode or automatic reassignment for incompatible explicit assignees.

## Validation

- `npm run test -w @open-multi-agent/core` — passed (120 test files, 1,748 tests)
- Focused core tests — passed (6 test files, 157 tests)
- `npm run lint -w @open-multi-agent/core` — passed
- `npm run build -w @open-multi-agent/core` — passed
- `git diff --check` — passed

Provider E2E was not run because this behavior is covered by mocked unit/integration paths and does not require live provider credentials. CI remains the source of truth for the complete Node 18/20/22 matrix.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING