### PR TITLE
feat(core): add adaptive plan recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ OMA combines dynamic orchestration with the control, evidence, and recovery path
 
 - **Production essentials.** Run reliably, diagnose failures, and prevent quality regressions.
 
-  - **Reliability:** Resume interrupted runs from checkpoints. Retries, timeouts, loop detection, and token and cost budgets keep execution bounded.
+  - **Reliability:** Resume interrupted runs from checkpoints or opt into append-only plan repair at task outcome barriers. Retries, timeouts, loop detection, and token and cost budgets keep execution bounded.
   - **Observability:** Follow each run through stable identity, execution receipts, and traces; query them in TraceStore, replay the task DAG and span waterfall in the offline Run Viewer, or export through the optional OpenTelemetry adapter.
   - **Evaluation:** Use the same run records for versioned EvalSets, reference scorers, offline reports, CI gates, regression baselines, and production sampling.
   - **Safety and privacy:** Keep tools default-deny, gate individual calls, and apply explicit privacy controls to telemetry and persisted state.
@@ -153,7 +153,7 @@ Need to embed agent capabilities in an existing product or business system? Emai
 |---|---|
 | Install and run | [Core package guide](packages/core/README.md) · [Examples](packages/core/examples/README.md) · [CLI](docs/cli.md) |
 | Configure models and tools | [Providers](docs/providers.md) · [Tools and sandbox](docs/tool-configuration.md) · [External agents](docs/external-agents.md) |
-| Operate reliably | [Observability](docs/observability.md) · [Evaluation](docs/evaluation.md) · [Checkpoint and resume](docs/checkpoint.md) · [Context management](docs/context-management.md) |
+| Operate reliably | [Observability](docs/observability.md) · [Evaluation](docs/evaluation.md) · [Checkpoint and resume](docs/checkpoint.md) · [Adaptive recovery](docs/adaptive-recovery.md) · [Context management](docs/context-management.md) |
 | Control orchestration | [Consensus](docs/consensus.md) · [Execution routing](docs/execution-routing.md) · [Model routing](docs/model-routing.md) · [Task scheduling](docs/task-scheduling.md) · [Plan replay](docs/plan-replay.md) · [Shared memory](docs/shared-memory.md) |
 
 ## Contributing

--- a/README_zh.md
+++ b/README_zh.md
@@ -60,7 +60,7 @@ OMA 将动态编排与生产所需的控制、证据和恢复能力结合起来�
 
 - **生产必备。** 让运行可恢复、故障可诊断，并及时发现质量退化。
 
-  - **可靠性：** 通过 Checkpoint 从断点恢复中断的运行；重试、超时、循环检测与 token、成本双预算让执行始终有明确边界。
+  - **可靠性：** 通过 Checkpoint 从断点恢复中断的运行，或选择在任务结果屏障处启用仅追加式计划修复；重试、超时、循环检测与 token、成本双预算让执行始终有明确边界。
   - **可观测性：** 通过稳定的运行标识、执行回执与 Trace 跟踪每次运行；使用 TraceStore 查询记录，在离线 Run Viewer 中回放任务 DAG 与 span 瀑布，或通过可选的 OpenTelemetry 适配器导出。
   - **评测：** 使用同一套运行记录支撑版本化 EvalSet、参考 scorer 打分、离线报告、CI gate、回归基线与线上采样。
   - **安全与隐私：** 内置工具默认拒绝，支持逐次调用 gate，并对遥测与持久化状态应用显式的隐私控制。
@@ -157,7 +157,7 @@ Core 用户可以在本地保存 trace，并用离线 Run Viewer 查看。只有
 |---|---|
 | 安装与运行 | [核心包使用指南](packages/core/README_zh.md) · [示例](packages/core/examples/README.md) · [CLI](docs/cli.md) |
 | 配置模型与工具 | [Provider](docs/providers.md) · [工具与沙箱](docs/tool-configuration.md) · [外部 Agent](docs/external-agents.md) |
-| 稳定运行 | [可观测性](docs/observability.md) · [评测](docs/evaluation.md) · [Checkpoint 与恢复](docs/checkpoint.md) · [上下文管理](docs/context-management.md) |
+| 稳定运行 | [可观测性](docs/observability.md) · [评测](docs/evaluation.md) · [Checkpoint 与恢复](docs/checkpoint.md) · [自适应恢复](docs/adaptive-recovery.md) · [上下文管理](docs/context-management.md) |
 | 控制编排 | [Consensus](docs/consensus.md) · [执行路由](docs/execution-routing.md) · [模型路由](docs/model-routing.md) · [任务调度](docs/task-scheduling.md) · [计划回放](docs/plan-replay.md) · [共享记忆](docs/shared-memory.md) |
 
 ## 参与贡献

--- a/docs/adaptive-recovery.md
+++ b/docs/adaptive-recovery.md
@@ -1,0 +1,131 @@
+# Adaptive recovery
+
+OMA keeps task graphs fixed by default. Opt into `recovery.mode: 'repairable'`
+when an application needs to revise the not-yet-executed part of a run after a
+task succeeds, fails, or is rejected by consensus verification.
+
+Adaptive recovery is an outcome barrier, not another retry:
+
+1. A task produces an outcome.
+2. The configured `Replanner` (or `onTaskOutcome` callback) may propose a
+   `PlanPatch`.
+3. OMA validates agent eligibility, limits, task states, references, and the
+   resulting DAG.
+4. The optional `onPlanPatch` gate approves or rejects the proposal.
+5. OMA applies the patch atomically, persists a checkpoint when checkpointing
+   is enabled, then publishes newly-ready work.
+6. Only after that barrier does the triggering task complete or fail and
+   release or cascade its original dependents.
+
+This ordering prevents an original downstream task from starting while its
+replacement is still being decided.
+
+## Configure a replanner
+
+```ts
+import {
+  OpenMultiAgent,
+  type Replanner,
+  type TaskOutcome,
+} from '@open-multi-agent/core'
+
+const replanner: Replanner = {
+  name: 'fallback-search',
+  replan(outcome: TaskOutcome) {
+    if (outcome.kind !== 'failure' || outcome.task.title !== 'Search') {
+      return undefined
+    }
+
+    const oldAnalysis = outcome.tasks.find((task) => task.title === 'Analysis')
+    if (!oldAnalysis) return undefined
+
+    return {
+      reason: 'Primary search failed; use the fallback source.',
+      supersedePending: [oldAnalysis.id],
+      addTasks: [
+        {
+          key: 'fallback-search',
+          title: 'Fallback Search',
+          description: 'Fetch the source through the fallback path.',
+          assignee: 'researcher-b',
+        },
+        {
+          key: 'replacement-analysis',
+          title: 'Replacement Analysis',
+          description: 'Analyze the fallback result.',
+          assignee: 'analyst',
+          dependsOn: ['fallback-search'],
+        },
+      ],
+    }
+  },
+}
+
+const result = await oma.runTasks(team, tasks, {
+  recovery: {
+    mode: 'repairable',
+    replanner,
+    maxPlanRevisions: 3,
+    maxAddedTasks: 20,
+    onPlanPatch: async (patch, outcome) => {
+      return await applicationPolicyApproves(patch, outcome)
+    },
+  },
+})
+```
+
+`onTaskOutcome` is a shorthand for applications that do not need a named
+`Replanner` object. Configure one or the other, not both. A custom replanner may
+call an LLM or another service, but that external I/O and its usage accounting
+remain owned by the application.
+
+## Patch operations
+
+- `addTasks` appends tasks. Every appended task has a patch-local `key`.
+  Dependencies may refer to another key in the same patch or to an existing
+  task ID.
+- `retargetPending` changes the assignee of a `pending` or `blocked` task after
+  the new agent passes the same eligibility checks used by scheduling.
+- `supersedePending` marks a `pending` or `blocked` task `skipped`. Replacement
+  tasks are appended rather than rewriting or deleting history.
+
+Started or terminal tasks cannot be retargeted or superseded. A failure or
+verification rejection is classified as recovered only when the accepted patch
+appends at least one replacement task. Successful tasks may append or reshape
+downstream work without being marked recovered.
+
+Patch references use task IDs, not titles. This avoids ambiguity when multiple
+runtime tasks have the same title.
+
+## Failure, durability, and restore
+
+Without an accepted patch, existing behavior is unchanged: failed tasks cascade
+failure to their dependents while independent branches may continue.
+
+Accepted revisions are stored in queue snapshot version 2. Snapshot version 1
+remains the fixed-DAG format and is still readable. When checkpointing is
+enabled, OMA saves the patched graph before it dispatches appended work. If that
+save fails, the unpublished patch is rolled back and the original failure path
+continues.
+
+Restore resets an interrupted task for execution while retaining durable plan
+revision history. A revision with the same trigger task and outcome is not
+appended twice after a crash.
+
+Historical tasks remain truthful in `result.tasks`: a repaired failure is still
+`failed` with `recoveredByRevision`, and a replaced branch is `skipped` with
+`supersededByRevision`. Those historical records do not make the overall run
+fail when the active repaired graph finishes successfully. Accepted revisions
+are returned in `result.planRevisions`.
+
+## Boundaries
+
+- Recovery is opt-in. Existing callers remain fixed-DAG.
+- `runFromPlan()` is exact replay and rejects repairable recovery.
+- Repairable recovery is incompatible with legacy round-based `onApproval`.
+  Use `onTaskDispatch` and/or `onPlanPatch` gates.
+- Limits reject further patches; they never silently truncate a patch.
+- Policy, validation, approval, revision, and checkpoint decisions are exposed
+  through progress events and observability spans.
+- A repair is forward-only. OMA does not undo external side effects already
+  performed by a task.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -192,7 +192,7 @@ Coordinator -> Task DAG -> Scheduler -> AgentPool
                     `-- results -> evaluation (offline / sampled, observe-only)
 ```
 
-The coordinator plans once; the scheduler owns execution order. Agents share results through memory, while checkpoints and traces form separate recovery and observability paths. Evaluation observes completed results and never changes them. Detailed contracts live in the linked subsystem guides below.
+The coordinator plans once by default; the scheduler owns execution order. Applications can opt into append-only adaptive recovery when task outcomes need to revise the unstarted part of the graph. Agents share results through memory, while checkpoints and traces form separate recovery and observability paths. Evaluation observes completed results and never changes them. Detailed contracts live in the linked subsystem guides below.
 
 ## Examples
 
@@ -233,7 +233,7 @@ See [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/d
 | Bound work | `maxTurns`, `timeoutMs`, `callTimeoutMs`, `contextStrategy`, `loopDetection` |
 | Control spend | `maxTokenBudget`; `maxCostBudget` + application-owned `estimateCost` |
 | Limit tools | `tools` / `toolPreset`, `cwd` / `defaultCwd`, tool-output caps |
-| Recover | Task retries, checkpointing, and `restore()` |
+| Recover | Task retries, checkpointing, `restore()`, and opt-in adaptive plan repair |
 | Review work | `planOnly`, `onPlanReady`, and approval callbacks |
 | Observe | Trace sinks, TraceStore, execution receipts, Run Viewer, or the optional OTel adapter |
 
@@ -254,7 +254,7 @@ See the [observability guide](https://github.com/open-multi-agent/open-multi-age
 | Area | Guides |
 |---|---|
 | Build agents | [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md), [tools](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md), [context](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) |
-| Run reliably | [Evaluation](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/evaluation.md), [checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md), [execution routing](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/execution-routing.md), [model routing](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/model-routing.md), [consensus](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/consensus.md) |
+| Run reliably | [Evaluation](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/evaluation.md), [checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md), [adaptive recovery](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/adaptive-recovery.md), [execution routing](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/execution-routing.md), [model routing](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/model-routing.md), [consensus](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/consensus.md) |
 | Control workflows | [Plan preview & replay](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/plan-replay.md), [shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md), [external agents](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/external-agents.md) |
 | Operate | [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md), [CLI](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/cli.md), [production examples](examples/production/README.md) |
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -185,7 +185,7 @@ Coordinator -> 任务 DAG -> Scheduler -> AgentPool
                     `-- 结果 -> 评测（离线 / 抽样，仅观察）
 ```
 
-Coordinator 只负责产生计划，Scheduler 负责执行顺序。Agent 通过记忆共享结果，checkpoint 与 trace 分别形成恢复和可观测路径。评测只观察已完成的结果，不会改变它们。详细契约见下方各子系统指南。
+默认情况下，Coordinator 只负责产生一次计划，Scheduler 负责执行顺序。当任务结果需要修改任务图中尚未执行的部分时，应用可以选择启用仅追加式自适应恢复。Agent 通过记忆共享结果，checkpoint 与 trace 分别形成恢复和可观测路径。评测只观察已完成的结果，不会改变它们。详细契约见下方各子系统指南。
 
 ## 示例
 
@@ -226,7 +226,7 @@ Coordinator 只负责产生计划，Scheduler 负责执行顺序。Agent 通过�
 | 限定工作量 | `maxTurns`、`timeoutMs`、`callTimeoutMs`、`contextStrategy`、`loopDetection` |
 | 控制成本 | `maxTokenBudget`；`maxCostBudget` + 应用自有 `estimateCost` |
 | 限制工具 | `tools` / `toolPreset`、`cwd` / `defaultCwd`、工具输出上限 |
-| 故障恢复 | 任务重试、checkpoint 与 `restore()` |
+| 故障恢复 | 任务重试、checkpoint、`restore()` 与可选的自适应计划修复 |
 | 人工把关 | `planOnly`、`onPlanReady` 与审批回调 |
 | 统一观测 | Trace sink、TraceStore、执行回执、Run Viewer，或可选 OTel adapter |
 
@@ -247,7 +247,7 @@ Core 已提供运行标识、trace sink、执行回执、可查询的内存/文�
 | 主题 | 指南 |
 |---|---|
 | 构建 agent | [Provider](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md)、[工具](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md)、[上下文](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) |
-| 稳定运行 | [评测](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/evaluation.md)、[Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md)、[执行路由](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/execution-routing.md)、[模型路由](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/model-routing.md)、[Consensus](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/consensus.md) |
+| 稳定运行 | [评测](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/evaluation.md)、[Checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md)、[自适应恢复](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/adaptive-recovery.md)、[执行路由](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/execution-routing.md)、[模型路由](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/model-routing.md)、[Consensus](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/consensus.md) |
 | 控制流程 | [计划预览与回放](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/plan-replay.md)、[共享记忆](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md)、[外部 agent](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/external-agents.md) |
 | 生产运维 | [可观测性](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md)、[CLI](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/cli.md)、[生产示例](examples/production/README.md) |
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -327,6 +327,14 @@ export type {
   RunTeamOptions,
   RunTasksOptions,
   RunTaskSpec,
+  PlanPatchTaskSpec,
+  PlanPatchRetarget,
+  PlanPatch,
+  PlanRevision,
+  TaskVerificationOutcome,
+  TaskOutcome,
+  Replanner,
+  RecoveryOptions,
   TaskMetadata,
   TaskRequirements,
   RestoreOptions,
@@ -361,6 +369,8 @@ export type {
   CheckpointRunIdentity,
   CompletedTaskCheckpoint,
   TaskQueueSnapshot,
+  TaskQueueSnapshotV1,
+  TaskQueueSnapshotV2,
   TaskSnapshot,
 
   // Trace

--- a/packages/core/src/memory/checkpoint.ts
+++ b/packages/core/src/memory/checkpoint.ts
@@ -96,7 +96,11 @@ export class Checkpoint {
     if (value === null || typeof value !== 'object') return false
     const snapshot = value as Record<string, unknown>
     if (snapshot['version'] !== 1 && snapshot['version'] !== 2) return false
-    if (snapshot['mode'] !== 'runTeam' && snapshot['mode'] !== 'runTasks') return false
+    if (
+      snapshot['mode'] !== 'runTeam'
+      && snapshot['mode'] !== 'runTasks'
+      && snapshot['mode'] !== 'runFromPlan'
+    ) return false
     if (typeof snapshot['createdAt'] !== 'string') return false
     if (!Array.isArray(snapshot['completedTaskResults'])) return false
     if (snapshot['metadata'] !== undefined) {
@@ -120,6 +124,12 @@ export class Checkpoint {
     const queue = snapshot['queue']
     if (queue === null || typeof queue !== 'object') return false
     const queueRecord = queue as Record<string, unknown>
-    return queueRecord['version'] === 1 && Array.isArray(queueRecord['tasks'])
+    if (queueRecord['version'] !== 1 && queueRecord['version'] !== 2) return false
+    if (!Array.isArray(queueRecord['tasks'])) return false
+    if (queueRecord['version'] === 2) {
+      if (!Number.isInteger(queueRecord['planRevision'])) return false
+      if (!Array.isArray(queueRecord['planRevisions'])) return false
+    }
+    return true
   }
 }

--- a/packages/core/src/observability/records.ts
+++ b/packages/core/src/observability/records.ts
@@ -29,6 +29,8 @@ export type SpanEventName =
   | 'loop_detected'
   | 'stream_chunk'
   | 'consensus_verdict'
+  | 'recovery_decision'
+  | 'plan_revision_applied'
 
 export interface TraceRecordBase {
   readonly schemaVersion: 2

--- a/packages/core/src/orchestrator/consensus.ts
+++ b/packages/core/src/orchestrator/consensus.ts
@@ -325,7 +325,14 @@ export async function runTaskVerify(
   result: AgentRunResult,
   sharedMem: ReturnType<Team['getSharedMemoryInstance']>,
   ctx: RunContext,
-): Promise<AgentRunResult> {
+): Promise<{
+  readonly result: AgentRunResult
+  readonly verification: {
+    readonly verdict: 'accepted' | 'rejected'
+    readonly dissent: readonly string[]
+    readonly rounds: number
+  }
+}> {
   const verify = task.verify!
   const { team, config } = ctx
   const assigneeConfig = team.getAgents().find((a) => a.name === assignee)
@@ -415,8 +422,15 @@ export async function runTaskVerify(
   const useRevision =
     consensus.verdict === 'accepted' && consensus.answer && consensus.answer !== result.output
   return {
-    ...result,
-    output: useRevision ? consensus.answer : result.output,
-    tokenUsage: addUsage(result.tokenUsage, consensus.tokenUsage),
+    result: {
+      ...result,
+      output: useRevision ? consensus.answer : result.output,
+      tokenUsage: addUsage(result.tokenUsage, consensus.tokenUsage),
+    },
+    verification: {
+      verdict: consensus.verdict,
+      dissent: [...consensus.dissent],
+      rounds: consensus.rounds,
+    },
   }
 }

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -50,6 +50,7 @@ import type {
   ConsensusResult,
   CoordinatorConfig,
   PlanArtifact,
+  PlanRevision,
   PlanTaskArtifact,
   OrchestratorConfig,
   OrchestratorEvent,
@@ -154,6 +155,7 @@ import {
   type ConsequentialConfirmationState,
 } from './consequential.js'
 import { runConsensusCore, applyConsensusDefaults, type ConsensusAgentDefaults } from './consensus.js'
+import { resolveRecoveryOptions } from './recovery.js'
 import {
   createOnlineEvaluator,
   NOOP_ONLINE_EVALUATION,
@@ -227,8 +229,8 @@ function resolveRunBudgets(
  */
 export class OpenMultiAgent {
   private readonly config: Required<
-    Omit<OrchestratorConfig, 'onApproval' | 'onTaskDispatch' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'evaluation' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
-  > & Pick<OrchestratorConfig, 'onApproval' | 'onTaskDispatch' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'evaluation' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint'>
+    Omit<OrchestratorConfig, 'onApproval' | 'onTaskDispatch' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'evaluation' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint' | 'recovery'>
+  > & Pick<OrchestratorConfig, 'onApproval' | 'onTaskDispatch' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'evaluation' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint' | 'recovery'>
 
   private readonly teams: Map<string, Team> = new Map()
   private readonly fallbackCheckpointStore = new InMemoryStore()
@@ -294,6 +296,7 @@ export class OpenMultiAgent {
       estimateCost: config.estimateCost,
       defaultToolPreset: config.defaultToolPreset,
       checkpoint: config.checkpoint,
+      recovery: config.recovery,
       onApproval: config.onApproval,
       onTaskDispatch: config.onTaskDispatch,
       onPlanReady: config.onPlanReady,
@@ -1067,6 +1070,8 @@ export class OpenMultiAgent {
       modelRouting: options?.modelRouting,
       taskById: new Map(queue.list().map((task) => [task.id, task])),
       taskLeafById: new Map(queue.list().map((task) => [task.id, isLeafTask(task, queue.list())])),
+      recovery: resolveRecoveryOptions(this.config.recovery, options?.recovery),
+      recoveryPatchSignatures: new Set(),
     }
 
     const planTasks = queue.list()
@@ -1169,6 +1174,8 @@ export class OpenMultiAgent {
       retryDelayMs: task.retryDelayMs,
       retryBackoff: task.retryBackoff,
       verify: task.verify,
+      supersededByRevision: task.supersededByRevision,
+      recoveredByRevision: task.recoveredByRevision,
       metrics: taskMetrics.get(task.id),
     }))
 
@@ -1197,7 +1204,14 @@ export class OpenMultiAgent {
         ctx.outcomeErrorInfo = classified.errorInfo
       }
       return finish(this.buildTeamRunResult(
-        agentResults, identity, goal, taskRecords, ctx.outcomeStatus, ctx.outcomeErrorInfo,
+        agentResults,
+        identity,
+        goal,
+        taskRecords,
+        ctx.outcomeStatus,
+        ctx.outcomeErrorInfo,
+        false,
+        queue.getPlanRevisions(),
       ))
     }
     agentResults.set('coordinator', synthesis.result)
@@ -1209,7 +1223,14 @@ export class OpenMultiAgent {
     // buildTeamRunResult, so we do not increment completedTaskCount here.
 
     return finish(this.buildTeamRunResult(
-      agentResults, identity, goal, taskRecords, ctx.outcomeStatus, ctx.outcomeErrorInfo,
+      agentResults,
+      identity,
+      goal,
+      taskRecords,
+      ctx.outcomeStatus,
+      ctx.outcomeErrorInfo,
+      false,
+      queue.getPlanRevisions(),
     ))
   }
 
@@ -1272,6 +1293,9 @@ export class OpenMultiAgent {
     options?: RunTasksOptions,
   ): Promise<TeamRunResult> {
     const pendingEvaluation = this.beginOnlineEvaluation(plan)
+    if (resolveRecoveryOptions(this.config.recovery, options?.recovery).mode !== 'fixed') {
+      throw new Error('runFromPlan requires fixed recovery so the frozen plan remains exact.')
+    }
     if (plan.version !== 1) {
       throw new Error(`Unsupported plan artifact version: ${String(plan.version)}`)
     }
@@ -1283,6 +1307,12 @@ export class OpenMultiAgent {
       throw new Error(`Invalid plan artifact: ${validation.errors.join(' ')}`)
     }
     queue.addBatch(tasks)
+    const activeCheckpoint = this.createActiveCheckpoint(
+      team,
+      options?.checkpoint ?? this.config.checkpoint,
+      'runFromPlan',
+      plan.goal,
+    )
 
     return this.executeExplicitTaskQueue(
       team,
@@ -1290,7 +1320,7 @@ export class OpenMultiAgent {
       options,
       plan.goal,
       undefined,
-      undefined,
+      activeCheckpoint,
       undefined,
       undefined,
       undefined,
@@ -1385,6 +1415,9 @@ export class OpenMultiAgent {
         )
       }
       if (this.isPlanArtifact(tasksOrOptions)) {
+        if (resolveRecoveryOptions(this.config.recovery, options?.recovery).mode !== 'fixed') {
+          throw new Error('restore from a plan artifact requires fixed recovery so the plan remains exact.')
+        }
         const queue = new TaskQueue()
         const tasks = this.tasksFromPlan(tasksOrOptions)
         const validation = validateTaskDependencies(tasks)
@@ -1425,6 +1458,13 @@ export class OpenMultiAgent {
           startedAtMs: evaluationStartedAtMs,
         },
       )
+    }
+
+    if (
+      snapshot.mode === 'runFromPlan'
+      && resolveRecoveryOptions(this.config.recovery, options?.recovery).mode !== 'fixed'
+    ) {
+      throw new Error('restore of a runFromPlan checkpoint requires fixed recovery so the plan remains exact.')
     }
 
     const sharedMem = team.getSharedMemoryInstance()
@@ -1855,6 +1895,8 @@ export class OpenMultiAgent {
       modelRouting: options?.modelRouting,
       taskById: new Map(queue.list().map((task) => [task.id, task])),
       taskLeafById: new Map(queue.list().map((task) => [task.id, isLeafTask(task, queue.list())])),
+      recovery: resolveRecoveryOptions(this.config.recovery, options?.recovery),
+      recoveryPatchSignatures: new Set(),
     }
 
     await executeQueue(queue, ctx)
@@ -1934,6 +1976,8 @@ export class OpenMultiAgent {
       retryDelayMs: task.retryDelayMs,
       retryBackoff: task.retryBackoff,
       verify: task.verify,
+      supersededByRevision: task.supersededByRevision,
+      recoveredByRevision: task.recoveredByRevision,
       metrics: ctx.taskMetrics.get(task.id),
     }))
 
@@ -1944,6 +1988,8 @@ export class OpenMultiAgent {
       taskRecords,
       ctx.outcomeStatus,
       ctx.outcomeErrorInfo,
+      false,
+      queue.getPlanRevisions(),
     )
     const resultWithRouting = {
       ...result,
@@ -2065,11 +2111,13 @@ export class OpenMultiAgent {
     forcedStatus?: RunStatus,
     forcedErrorInfo?: StructuredTraceError,
     allowIncompleteTasks = false,
+    planRevisions?: readonly PlanRevision[],
   ): TeamRunResult {
     let totalUsage: TokenUsage = ZERO_USAGE
     let overallSuccess = true
     const collapsed = new Map<string, AgentRunResult>()
     const taskResults = new Map<string, AgentRunResult>()
+    const taskRecordsById = new Map((tasks ?? []).map((task) => [task.id, task]))
 
     for (const task of tasks ?? []) {
       if (!task.assignee) continue
@@ -2083,7 +2131,10 @@ export class OpenMultiAgent {
       const agentName = key.includes(':') ? key.split(':')[0]! : key
 
       totalUsage = addUsage(totalUsage, result.tokenUsage)
-      if (!result.success) overallSuccess = false
+      const taskId = key.includes(':') ? key.slice(key.indexOf(':') + 1) : undefined
+      const recovered = taskId !== undefined
+        && taskRecordsById.get(taskId)?.recoveredByRevision !== undefined
+      if (!result.success && !recovered) overallSuccess = false
 
       const existing = collapsed.get(agentName)
       if (!existing) {
@@ -2117,11 +2168,17 @@ export class OpenMultiAgent {
 
     const metrics = computeRunMetrics(tasks)
 
-    const statuses = [...agentResults.values()]
-      .map((result) => result.status)
+    const statuses = [...agentResults.entries()]
+      .filter(([key]) => {
+        const taskId = key.includes(':') ? key.slice(key.indexOf(':') + 1) : undefined
+        return taskId === undefined
+          || taskRecordsById.get(taskId)?.recoveredByRevision === undefined
+      })
+      .map(([, result]) => result.status)
       .filter((status): status is RunStatus => status !== undefined)
     const firstStatus = (code: RunStatus['code']) => statuses.find((status) => status.code === code)
-    const taskFailed = tasks?.some((task) => task.status === 'failed') ?? false
+    const taskFailed = tasks?.some((task) =>
+      task.status === 'failed' && task.recoveredByRevision === undefined) ?? false
     const taskIncomplete = tasks?.some((task) =>
       task.status === 'pending' || task.status === 'in_progress' || task.status === 'blocked'
     ) ?? false
@@ -2144,6 +2201,7 @@ export class OpenMultiAgent {
       ...(errorInfo !== undefined ? { errorInfo } : {}),
       goal,
       tasks,
+      ...(planRevisions && planRevisions.length > 0 ? { planRevisions } : {}),
       agentResults: collapsed,
       taskResults,
       totalTokenUsage: totalUsage,

--- a/packages/core/src/orchestrator/recovery.ts
+++ b/packages/core/src/orchestrator/recovery.ts
@@ -1,0 +1,206 @@
+/**
+ * @fileoverview Opt-in runtime plan repair contracts and validation helpers.
+ *
+ * The executor owns the outcome barrier and durable commit ordering. This
+ * module keeps policy resolution and eligibility checks deterministic.
+ */
+
+import type {
+  AgentConfig,
+  PlanPatch,
+  RecoveryOptions,
+  Task,
+  TaskOutcome,
+  TaskVerificationOutcome,
+  AgentRunResult,
+} from '../types.js'
+import type { TaskQueue } from '../task/queue.js'
+import { AgentSelector } from './agent-selector.js'
+
+export interface ResolvedRecoveryOptions {
+  readonly mode: 'fixed' | 'repairable'
+  readonly onTaskOutcome?: RecoveryOptions['onTaskOutcome']
+  readonly onPlanPatch?: RecoveryOptions['onPlanPatch']
+  readonly maxPlanRevisions: number
+  readonly maxAddedTasks: number
+}
+
+const DEFAULT_MAX_PLAN_REVISIONS = 3
+const DEFAULT_MAX_ADDED_TASKS = 20
+
+export function resolveRecoveryOptions(
+  configured: RecoveryOptions | undefined,
+  perRun: RecoveryOptions | undefined,
+): ResolvedRecoveryOptions {
+  const selected = perRun ?? configured
+  if (!selected || (selected.mode ?? 'fixed') === 'fixed') {
+    return {
+      mode: 'fixed',
+      maxPlanRevisions: DEFAULT_MAX_PLAN_REVISIONS,
+      maxAddedTasks: DEFAULT_MAX_ADDED_TASKS,
+    }
+  }
+  if (selected.onTaskOutcome && selected.replanner) {
+    throw new Error("Recovery mode 'repairable' accepts either onTaskOutcome or replanner, not both.")
+  }
+  const onTaskOutcome = selected.onTaskOutcome
+    ?? (selected.replanner
+      ? (outcome: TaskOutcome) => selected.replanner!.replan(outcome)
+      : undefined)
+  if (!onTaskOutcome) {
+    throw new Error("Recovery mode 'repairable' requires onTaskOutcome or replanner.")
+  }
+  return {
+    mode: 'repairable',
+    onTaskOutcome,
+    onPlanPatch: selected.onPlanPatch,
+    maxPlanRevisions: positiveInteger(
+      selected.maxPlanRevisions,
+      DEFAULT_MAX_PLAN_REVISIONS,
+      'maxPlanRevisions',
+    ),
+    maxAddedTasks: positiveInteger(
+      selected.maxAddedTasks,
+      DEFAULT_MAX_ADDED_TASKS,
+      'maxAddedTasks',
+    ),
+  }
+}
+
+export function buildTaskOutcome(input: {
+  readonly queue: TaskQueue
+  readonly task: Task
+  readonly result: AgentRunResult
+  readonly verification?: TaskVerificationOutcome
+  readonly tokenBudgetRemaining?: number
+  readonly costBudgetRemaining?: number
+}): TaskOutcome {
+  const kind = input.verification?.verdict === 'rejected'
+    ? 'verification_rejected'
+    : input.result.success
+      ? 'success'
+      : 'failure'
+  return {
+    kind,
+    task: cloneTask(input.task),
+    result: cloneAgentResult(input.result),
+    ...(input.verification ? { verification: { ...input.verification } } : {}),
+    planRevision: input.queue.getPlanRevision(),
+    tasks: input.queue.list().map(cloneTask),
+    ...(input.tokenBudgetRemaining !== undefined
+      ? { tokenBudgetRemaining: input.tokenBudgetRemaining }
+      : {}),
+    ...(input.costBudgetRemaining !== undefined
+      ? { costBudgetRemaining: input.costBudgetRemaining }
+      : {}),
+  }
+}
+
+export function validatePlanPatchEligibility(
+  patch: PlanPatch,
+  queue: TaskQueue,
+  agents: readonly AgentConfig[],
+  context: {
+    readonly defaultProvider?: AgentConfig['provider']
+    readonly defaultToolPreset?: 'readonly' | 'readwrite' | 'full'
+  },
+): void {
+  const byName = new Map(agents.map((agent) => [agent.name, agent]))
+  const selector = new AgentSelector()
+
+  for (const retarget of patch.retargetPending ?? []) {
+    const task = queue.get(retarget.taskId)
+    const agent = byName.get(retarget.assignee)
+    if (!task) throw new Error(`Plan patch retarget task "${retarget.taskId}" not found.`)
+    if (!agent) throw new Error(`Plan patch retarget agent "${retarget.assignee}" is not in the team roster.`)
+    const selection = selector.select(task, [agent], {
+      defaultProvider: context.defaultProvider,
+      defaultToolPreset: context.defaultToolPreset,
+      includeDelegateTool: true,
+    })
+    if (selection.error) {
+      throw new Error(
+        `Plan patch retarget agent "${retarget.assignee}" is ineligible for task ` +
+          `"${task.id}": ${selection.error.reasons.join(' ')}`,
+      )
+    }
+  }
+
+  for (const task of patch.addTasks ?? []) {
+    const candidates = task.assignee === undefined
+      ? agents
+      : byName.has(task.assignee)
+        ? [byName.get(task.assignee)!]
+        : []
+    if (task.assignee !== undefined && candidates.length === 0) {
+      throw new Error(`Plan patch task "${task.key}" names unknown assignee "${task.assignee}".`)
+    }
+    const selection = selector.select(task, candidates, {
+      defaultProvider: context.defaultProvider,
+      defaultToolPreset: context.defaultToolPreset,
+      includeDelegateTool: true,
+    })
+    if (selection.error) {
+      throw new Error(
+        `No eligible agent for plan patch task "${task.key}": ${selection.error.reasons.join(' ')}`,
+      )
+    }
+  }
+}
+
+export function countAddedTasks(revisions: readonly { readonly addedTasks: Readonly<Record<string, string>> }[]): number {
+  return revisions.reduce((sum, revision) => sum + Object.keys(revision.addedTasks).length, 0)
+}
+
+export function planPatchSignature(patch: PlanPatch): string {
+  return JSON.stringify({
+    reason: patch.reason,
+    addTasks: patch.addTasks ?? [],
+    retargetPending: patch.retargetPending ?? [],
+    supersedePending: patch.supersedePending ?? [],
+  })
+}
+
+function positiveInteger(value: number | undefined, fallback: number, name: string): number {
+  if (value === undefined) return fallback
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`Recovery ${name} must be a positive integer.`)
+  }
+  return value
+}
+
+function cloneTask(task: Task): Task {
+  return {
+    ...task,
+    ...(task.dependsOn !== undefined ? { dependsOn: [...task.dependsOn] } : {}),
+    ...(task.metadata !== undefined ? { metadata: { ...task.metadata } } : {}),
+    ...(task.requires !== undefined
+      ? {
+          requires: {
+            ...task.requires,
+            ...(task.requires.requiredTools !== undefined
+              ? { requiredTools: [...task.requires.requiredTools] }
+              : {}),
+            ...(task.requires.requiredCapabilities !== undefined
+              ? { requiredCapabilities: [...task.requires.requiredCapabilities] }
+              : {}),
+          },
+        }
+      : {}),
+    ...(task.verify !== undefined
+      ? { verify: { ...task.verify, judges: [...task.verify.judges] } }
+      : {}),
+    createdAt: new Date(task.createdAt),
+    updatedAt: new Date(task.updatedAt),
+  }
+}
+
+function cloneAgentResult(result: AgentRunResult): AgentRunResult {
+  return {
+    ...result,
+    messages: [...result.messages],
+    tokenUsage: { ...result.tokenUsage },
+    toolCalls: result.toolCalls.map((call) => ({ ...call })),
+    ...(result.errorInfo !== undefined ? { errorInfo: { ...result.errorInfo } } : {}),
+  }
+}

--- a/packages/core/src/orchestrator/run-context.ts
+++ b/packages/core/src/orchestrator/run-context.ts
@@ -28,6 +28,7 @@ import type { Team } from '../team/team.js'
 import type { Scheduler } from './scheduler.js'
 import type { Checkpoint } from '../memory/checkpoint.js'
 import type { TraceRuntime, TraceSpan } from '../observability/runtime.js'
+import type { ResolvedRecoveryOptions } from './recovery.js'
 import { createRunIdentity, validateRunMetadata } from '../observability/identity.js'
 
 export const ZERO_USAGE: TokenUsage = { input_tokens: 0, output_tokens: 0 }
@@ -166,8 +167,10 @@ export interface RunContext {
    */
   readonly revealCoordinatorContext?: RevealCoordinatorContext
   readonly modelRouting?: ModelRoutingPolicy
-  readonly taskById: ReadonlyMap<string, Task>
-  readonly taskLeafById: ReadonlyMap<string, boolean>
+  readonly taskById: Map<string, Task>
+  readonly taskLeafById: Map<string, boolean>
+  readonly recovery: ResolvedRecoveryOptions
+  readonly recoveryPatchSignatures: Set<string>
 }
 
 export interface ActiveCheckpoint {

--- a/packages/core/src/orchestrator/task-execution.ts
+++ b/packages/core/src/orchestrator/task-execution.ts
@@ -18,6 +18,7 @@ import type {
   Task,
   TaskExecutionMetrics,
   TaskStatus,
+  TaskVerificationOutcome,
   TeamInfo,
   TokenUsage,
 } from '../types.js'
@@ -46,9 +47,16 @@ import {
   applyAgentDefaults,
   applyDefaultToolPreset,
   buildAgent,
+  isLeafTask,
 } from './agent-config.js'
 import { executeWithRetry } from './retry.js'
 import { runTaskVerify } from './consensus.js'
+import {
+  buildTaskOutcome,
+  countAddedTasks,
+  planPatchSignature,
+  validatePlanPatchEligibility,
+} from './recovery.js'
 
 /**
  * Build {@link TeamInfo} for tool context, including nested `runDelegatedAgent`
@@ -164,9 +172,9 @@ export function buildTaskAgentTeamInfo(
   }
 }
 
-export async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Promise<void> {
+export async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Promise<boolean> {
   const active = ctx.checkpoint
-  if (!active) return
+  if (!active) return true
   const checkpointSpan = ctx.traceRuntime?.startSpan({
     kind: 'checkpoint',
     name: 'save_checkpoint',
@@ -232,6 +240,7 @@ export async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Prom
   try {
     await nextSave
     checkpointSpan?.end({ status: statusOnly('ok') })
+    return true
   } catch (error) {
     const classified = classifyRunFailure(error, { kind: 'store' })
     checkpointSpan?.event('checkpoint_failed', {})
@@ -240,6 +249,7 @@ export async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Prom
       type: 'error',
       data: { kind: 'checkpoint_save_failed', error },
     } satisfies OrchestratorEvent)
+    return false
   }
 }
 
@@ -273,6 +283,252 @@ function evaluateDispatchGate(
   return 'allow'
 }
 
+async function applyRecoveryAtOutcome(
+  queue: TaskQueue,
+  task: Task,
+  result: AgentRunResult,
+  verification: TaskVerificationOutcome | undefined,
+  ctx: RunContext,
+): Promise<boolean> {
+  const recovery = ctx.recovery
+  if (recovery.mode === 'fixed' || !recovery.onTaskOutcome) return false
+
+  const trigger = verification?.verdict === 'rejected'
+    ? 'verification_rejected' as const
+    : result.success
+      ? 'success' as const
+      : 'failure' as const
+
+  // A patch may have been durably committed immediately before a crash while
+  // this trigger task was still in_progress. Restore resets the task, so do not
+  // append the same repair a second time when it settles again.
+  if (queue.getPlanRevisions().some((revision) =>
+    revision.triggerTaskId === task.id && revision.trigger === trigger)) {
+    ctx.config.onProgress?.({
+      type: 'recovery_decision',
+      task: task.id,
+      data: { decision: 'already_applied', trigger, planRevision: queue.getPlanRevision() },
+    })
+    return false
+  }
+
+  const tokenUsed = ctx.cumulativeUsage.input_tokens + ctx.cumulativeUsage.output_tokens
+  const outcome = buildTaskOutcome({
+    queue,
+    task: queue.get(task.id) ?? task,
+    result,
+    verification,
+    ...(ctx.maxTokenBudget !== undefined
+      ? { tokenBudgetRemaining: Math.max(0, ctx.maxTokenBudget - tokenUsed) }
+      : {}),
+    ...(ctx.maxCostBudget !== undefined
+      ? { costBudgetRemaining: Math.max(0, ctx.maxCostBudget - ctx.cumulativeCost) }
+      : {}),
+  })
+
+  const policySpan = ctx.traceRuntime?.startSpan({
+    kind: 'callback',
+    name: 'recovery_policy_callback',
+    parent: ctx.taskSpans.get(task.id) ?? ctx.traceRuntime?.root,
+    attributes: {
+      'oma.callback.name': 'onTaskOutcome',
+      'oma.task.id': task.id,
+      'oma.plan.trigger': trigger,
+    },
+  })
+  let patch
+  try {
+    patch = await recovery.onTaskOutcome(outcome)
+  } catch (error) {
+    const classified = classifyRunFailure(error, { kind: 'callback' })
+    policySpan?.end({ status: classified.status, error: classified.errorInfo })
+    ctx.config.onProgress?.({
+      type: 'error',
+      task: task.id,
+      data: { kind: 'recovery_policy_failed', error },
+    })
+    return false
+  }
+  policySpan?.event('recovery_decision', { 'oma.recovery.proposed': patch !== undefined })
+  policySpan?.end({ status: statusOnly('ok') })
+  if (!patch) {
+    ctx.config.onProgress?.({
+      type: 'recovery_decision',
+      task: task.id,
+      data: { decision: 'no_patch', trigger, planRevision: queue.getPlanRevision() },
+    })
+    return false
+  }
+
+  if (queue.getPlanRevision() >= recovery.maxPlanRevisions) {
+    ctx.config.onProgress?.({
+      type: 'warning',
+      task: task.id,
+      data: {
+        code: 'RECOVERY_REVISION_LIMIT',
+        maxPlanRevisions: recovery.maxPlanRevisions,
+      },
+    })
+    return false
+  }
+  const addedSoFar = countAddedTasks(queue.getPlanRevisions())
+  const requestedAdded = patch.addTasks?.length ?? 0
+  if (addedSoFar + requestedAdded > recovery.maxAddedTasks) {
+    ctx.config.onProgress?.({
+      type: 'warning',
+      task: task.id,
+      data: {
+        code: 'RECOVERY_ADDED_TASK_LIMIT',
+        maxAddedTasks: recovery.maxAddedTasks,
+        requestedAdded,
+        addedSoFar,
+      },
+    })
+    return false
+  }
+  const signature = planPatchSignature(patch)
+  if (ctx.recoveryPatchSignatures.has(signature)) {
+    ctx.config.onProgress?.({
+      type: 'warning',
+      task: task.id,
+      data: { code: 'RECOVERY_PATCH_REPEATED' },
+    })
+    return false
+  }
+
+  try {
+    validatePlanPatchEligibility(patch, queue, ctx.team.getAgents(), {
+      defaultProvider: ctx.config.defaultProvider,
+      defaultToolPreset: ctx.config.defaultToolPreset,
+    })
+  } catch (error) {
+    ctx.config.onProgress?.({
+      type: 'warning',
+      task: task.id,
+      data: { code: 'RECOVERY_PATCH_INELIGIBLE', error },
+    })
+    return false
+  }
+
+  if (recovery.onPlanPatch) {
+    const approvalSpan = ctx.traceRuntime?.startSpan({
+      kind: 'callback',
+      name: 'plan_patch_approval_callback',
+      parent: ctx.taskSpans.get(task.id) ?? ctx.traceRuntime?.root,
+      attributes: {
+        'oma.callback.name': 'onPlanPatch',
+        'oma.task.id': task.id,
+        'oma.plan.trigger': trigger,
+      },
+    })
+    let approved = false
+    try {
+      approved = await recovery.onPlanPatch(patch, outcome)
+    } catch (error) {
+      const classified = classifyRunFailure(error, { kind: 'callback' })
+      approvalSpan?.end({ status: classified.status, error: classified.errorInfo })
+      ctx.config.onProgress?.({
+        type: 'error',
+        task: task.id,
+        data: { kind: 'recovery_approval_failed', error },
+      })
+      return false
+    }
+    approvalSpan?.event('approval_decision', { 'oma.approval.approved': approved })
+    approvalSpan?.end({ status: statusOnly(approved ? 'ok' : 'rejected') })
+    if (!approved) {
+      ctx.config.onProgress?.({
+        type: 'recovery_decision',
+        task: task.id,
+        data: { decision: 'rejected', trigger, planRevision: queue.getPlanRevision() },
+      })
+      return false
+    }
+  }
+
+  const revisionSpan = ctx.traceRuntime?.startSpan({
+    kind: 'plan',
+    name: 'apply_plan_revision',
+    parent: ctx.taskSpans.get(task.id) ?? ctx.traceRuntime.root,
+    attributes: {
+      'oma.plan.revision.previous': queue.getPlanRevision(),
+      'oma.plan.trigger': trigger,
+      'oma.task.id': task.id,
+    },
+  })
+
+  let applied
+  try {
+    applied = queue.applyPlanPatch(patch, task.id, trigger)
+  } catch (error) {
+    const classified = classifyRunFailure(error, { kind: 'validation' })
+    revisionSpan?.end({ status: classified.status, error: classified.errorInfo })
+    ctx.config.onProgress?.({
+      type: 'warning',
+      task: task.id,
+      data: { code: 'RECOVERY_PATCH_INVALID', error },
+    })
+    return false
+  }
+
+  const durable = await saveRunCheckpoint(queue, ctx)
+  if (!durable && ctx.checkpoint) {
+    queue.restorePlanSnapshot(applied.before)
+    revisionSpan?.end({
+      status: statusOnly('error', 'Plan revision checkpoint failed.'),
+      error: {
+        kind: 'store',
+        code: 'PLAN_REVISION_NOT_DURABLE',
+        message: 'Plan revision was rolled back because its checkpoint failed.',
+      },
+    })
+    ctx.config.onProgress?.({
+      type: 'warning',
+      task: task.id,
+      data: {
+        code: 'PLAN_REVISION_NOT_DURABLE',
+        revision: applied.revision.version,
+      },
+    })
+    return false
+  }
+
+  ctx.recoveryPatchSignatures.add(signature)
+  queue.publishPlanRevision(applied.revision)
+  const tasks = queue.list()
+  ctx.taskById.clear()
+  ctx.taskLeafById.clear()
+  for (const candidate of tasks) {
+    ctx.taskById.set(candidate.id, candidate)
+    ctx.taskLeafById.set(candidate.id, isLeafTask(candidate, tasks))
+  }
+  revisionSpan?.event('plan_revision_applied', {
+    'oma.plan.revision': applied.revision.version,
+    'oma.plan.added_tasks': Object.keys(applied.revision.addedTasks).length,
+    'oma.plan.superseded_tasks': applied.revision.supersededTaskIds.length,
+    'oma.plan.retargeted_tasks': applied.revision.retargetedTasks.length,
+  })
+  revisionSpan?.end({
+    status: statusOnly('ok'),
+    attributes: { 'oma.plan.revision': applied.revision.version },
+  })
+  ctx.config.onProgress?.({
+    type: 'plan_revision',
+    task: task.id,
+    data: applied.revision,
+  })
+  ctx.config.onProgress?.({
+    type: 'recovery_decision',
+    task: task.id,
+    data: {
+      decision: 'applied',
+      trigger,
+      planRevision: applied.revision.version,
+    },
+  })
+  return true
+}
+
 /**
  * Execute all tasks in `queue` using agents in `pool`, respecting dependencies
  * and running independent tasks in parallel.
@@ -289,6 +545,9 @@ export async function executeQueue(
 ): Promise<void> {
   const { team, pool, scheduler, config } = ctx
   const legacyRoundMode = config.onApproval !== undefined
+  if (legacyRoundMode && ctx.recovery.mode !== 'fixed') {
+    throw new Error('Runtime recovery is incompatible with legacy onApproval round scheduling.')
+  }
   const readyTaskIds = new Set<string>()
   const inFlight = new Map<string, Promise<void>>()
   const dispatchErrors: unknown[] = []
@@ -901,12 +1160,17 @@ export async function executeQueue(
           // queue, shared memory, progress events, and agentResults as one consistent
           // result. Judge usage is charged to the same parent budget as the rest of the run.
           let effective = result
+          let verification: TaskVerificationOutcome | undefined
           if (task.verify && !ctx.budgetExceededTriggered) {
-            effective = await runTaskVerify(task, assignee, result, sharedMem, ctx)
+            const verified = await runTaskVerify(task, assignee, result, sharedMem, ctx)
+            effective = verified.result
+            verification = verified.verification
           }
 
           // Reflect the verified result in the per-task record the caller receives.
           ctx.agentResults.set(`${assignee}:${task.id}`, effective)
+
+          await applyRecoveryAtOutcome(queue, task, effective, verification, ctx)
 
           // Persist result into shared memory so other agents can read it
           if (sharedMem) {
@@ -940,6 +1204,7 @@ export async function executeQueue(
             ...(taskLegacyEvent ? { legacyEvent: { ...taskLegacyEvent, success: effective.success } } : {}),
           })
         } else {
+          await applyRecoveryAtOutcome(queue, task, result, undefined, ctx)
           queue.fail(task.id, result.output)
           taskSpan?.end({
             status: result.status ?? statusOnly('error', result.output),

--- a/packages/core/src/task/queue.ts
+++ b/packages/core/src/task/queue.ts
@@ -6,8 +6,16 @@
  * orchestrators can react without polling.
  */
 
-import type { Task, TaskQueueSnapshot, TaskSnapshot, TaskStatus } from '../types.js'
-import { isTaskReady } from './task.js'
+import { randomUUID } from 'node:crypto'
+import type {
+  PlanPatch,
+  PlanRevision,
+  Task,
+  TaskQueueSnapshot,
+  TaskSnapshot,
+  TaskStatus,
+} from '../types.js'
+import { createTask, isTaskReady, validateTaskDependencies } from './task.js'
 import { validateTaskMetadata } from './metadata.js'
 
 // ---------------------------------------------------------------------------
@@ -55,6 +63,8 @@ type HandlerFor<E extends TaskQueueEvent> = E extends 'all:complete'
  */
 export class TaskQueue {
   private readonly tasks = new Map<string, Task>()
+  private planRevision = 0
+  private planRevisions: PlanRevision[] = []
 
   /** Listeners keyed by event type, stored as symbol → handler pairs. */
   private readonly listeners = new Map<
@@ -101,8 +111,7 @@ export class TaskQueue {
   /** Returns a serializable snapshot of all tasks and their status partitions. */
   snapshot(): TaskQueueSnapshot {
     const tasks = this.list()
-    return {
-      version: 1,
+    const base = {
       tasks: tasks.map(TaskQueue.taskToSnapshot),
       pending: tasks.filter((task) => task.status === 'pending').map((task) => task.id),
       inProgress: tasks.filter((task) => task.status === 'in_progress').map((task) => task.id),
@@ -111,6 +120,14 @@ export class TaskQueue {
       blocked: tasks.filter((task) => task.status === 'blocked').map((task) => task.id),
       skipped: tasks.filter((task) => task.status === 'skipped').map((task) => task.id),
     }
+    return this.planRevision === 0
+      ? { version: 1, ...base }
+      : {
+          version: 2,
+          ...base,
+          planRevision: this.planRevision,
+          planRevisions: this.planRevisions.map(TaskQueue.clonePlanRevision),
+        }
   }
 
   /**
@@ -125,10 +142,6 @@ export class TaskQueue {
     snapshot: TaskQueueSnapshot,
     options: { readonly resetInProgress?: boolean } = {},
   ): TaskQueue {
-    if (snapshot.version !== 1) {
-      throw new Error(`TaskQueue.fromSnapshot: unsupported snapshot version ${String(snapshot.version)}.`)
-    }
-
     const queue = new TaskQueue()
     const tasks = snapshot.tasks.map((task) => TaskQueue.taskFromSnapshot(task))
     const restored = options.resetInProgress
@@ -138,7 +151,248 @@ export class TaskQueue {
     for (const task of restored) {
       queue.tasks.set(task.id, task)
     }
+    if (snapshot.version === 2) {
+      TaskQueue.validatePlanSnapshot(snapshot)
+      queue.planRevision = snapshot.planRevision
+      queue.planRevisions = snapshot.planRevisions.map(TaskQueue.clonePlanRevision)
+    }
     return queue
+  }
+
+  /** Current append-only runtime plan revision. */
+  getPlanRevision(): number {
+    return this.planRevision
+  }
+
+  /** Immutable copies of the accepted runtime plan-repair history. */
+  getPlanRevisions(): readonly PlanRevision[] {
+    return this.planRevisions.map(TaskQueue.clonePlanRevision)
+  }
+
+  /**
+   * Atomically apply an append-only plan patch without publishing queue events.
+   *
+   * Call {@link publishPlanRevision} after durable persistence succeeds. Until
+   * then, newly-ready tasks are present in the queue but invisible to the
+   * event-driven executor.
+   */
+  applyPlanPatch(
+    patch: PlanPatch,
+    triggerTaskId: string,
+    trigger: PlanRevision['trigger'],
+  ): { readonly revision: PlanRevision; readonly before: TaskQueueSnapshot } {
+    const reason = patch.reason.trim()
+    if (!reason) throw new Error('TaskQueue.applyPlanPatch: patch reason must not be empty.')
+
+    const addSpecs = [...(patch.addTasks ?? [])]
+    const retargets = [...(patch.retargetPending ?? [])]
+    const supersedeIds = [...(patch.supersedePending ?? [])]
+    if (addSpecs.length === 0 && retargets.length === 0 && supersedeIds.length === 0) {
+      throw new Error('TaskQueue.applyPlanPatch: patch must contain at least one operation.')
+    }
+    if (trigger !== 'success' && addSpecs.length === 0) {
+      throw new Error(
+        'TaskQueue.applyPlanPatch: failure recovery must append at least one replacement task.',
+      )
+    }
+
+    const before = this.snapshot()
+    const draft = new Map<string, Task>(
+      Array.from(this.tasks, ([id, task]) => [id, TaskQueue.cloneTask(task)]),
+    )
+    const nextVersion = this.planRevision + 1
+    const now = new Date()
+    const triggerTask = draft.get(triggerTaskId)
+    if (!triggerTask) {
+      throw new Error(`TaskQueue.applyPlanPatch: trigger task "${triggerTaskId}" not found.`)
+    }
+    if (triggerTask.status !== 'in_progress') {
+      throw new Error(
+        `TaskQueue.applyPlanPatch: trigger task "${triggerTaskId}" must be in_progress; ` +
+          `it is ${triggerTask.status}.`,
+      )
+    }
+
+    const retargetIds = new Set<string>()
+    for (const retarget of retargets) {
+      if (retargetIds.has(retarget.taskId)) {
+        throw new Error(`TaskQueue.applyPlanPatch: task "${retarget.taskId}" is retargeted more than once.`)
+      }
+      retargetIds.add(retarget.taskId)
+      const task = draft.get(retarget.taskId)
+      if (!task) throw new Error(`TaskQueue.applyPlanPatch: task "${retarget.taskId}" not found.`)
+      if (task.status !== 'pending' && task.status !== 'blocked') {
+        throw new Error(
+          `TaskQueue.applyPlanPatch: only pending or blocked tasks can be retargeted; ` +
+            `"${task.id}" is ${task.status}.`,
+        )
+      }
+      if (!retarget.assignee.trim()) {
+        throw new Error(`TaskQueue.applyPlanPatch: retarget assignee for "${task.id}" must not be empty.`)
+      }
+      draft.set(task.id, { ...task, assignee: retarget.assignee, updatedAt: now })
+    }
+
+    const superseded = new Set<string>()
+    for (const taskId of supersedeIds) {
+      if (superseded.has(taskId)) {
+        throw new Error(`TaskQueue.applyPlanPatch: task "${taskId}" is superseded more than once.`)
+      }
+      if (retargetIds.has(taskId)) {
+        throw new Error(`TaskQueue.applyPlanPatch: task "${taskId}" cannot be retargeted and superseded.`)
+      }
+      superseded.add(taskId)
+      const task = draft.get(taskId)
+      if (!task) throw new Error(`TaskQueue.applyPlanPatch: task "${taskId}" not found.`)
+      if (task.status !== 'pending' && task.status !== 'blocked') {
+        throw new Error(
+          `TaskQueue.applyPlanPatch: only pending or blocked tasks can be superseded; ` +
+            `"${task.id}" is ${task.status}.`,
+        )
+      }
+      draft.set(task.id, {
+        ...task,
+        status: 'skipped',
+        result: `Superseded by plan revision ${nextVersion}: ${reason}`,
+        supersededByRevision: nextVersion,
+        updatedAt: now,
+      })
+    }
+
+    const keys = new Set<string>()
+    const created = new Map<string, Task>()
+    for (const spec of addSpecs) {
+      const key = spec.key.trim()
+      if (!key) throw new Error('TaskQueue.applyPlanPatch: appended task key must not be empty.')
+      if (keys.has(key)) {
+        throw new Error(`TaskQueue.applyPlanPatch: appended task key "${key}" is duplicated.`)
+      }
+      if (draft.has(key)) {
+        throw new Error(
+          `TaskQueue.applyPlanPatch: appended task key "${key}" conflicts with an existing task id.`,
+        )
+      }
+      keys.add(key)
+      const task = createTask({
+        title: spec.title,
+        description: spec.description,
+        assignee: spec.assignee,
+        memoryScope: spec.memoryScope,
+        dependencyPayload: spec.dependencyPayload,
+        metadata: spec.metadata,
+        maxRetries: spec.maxRetries,
+        retryDelayMs: spec.retryDelayMs,
+        retryBackoff: spec.retryBackoff,
+        role: spec.role,
+        priority: spec.priority,
+        requires: spec.requires,
+        verify: spec.verify,
+      })
+      created.set(key, task)
+    }
+
+    const addedTasks: Record<string, string> = {}
+    for (const spec of addSpecs) {
+      const task = created.get(spec.key.trim())!
+      const dependencies = (spec.dependsOn ?? []).map((reference) => {
+        const newTask = created.get(reference)
+        const dependencyId = newTask?.id ?? reference
+        const dependency = draft.get(dependencyId) ?? newTask
+        if (!dependency) {
+          throw new Error(
+            `TaskQueue.applyPlanPatch: appended task "${spec.key}" has unknown dependency "${reference}".`,
+          )
+        }
+        if (dependency.status === 'failed' || dependency.status === 'skipped') {
+          throw new Error(
+            `TaskQueue.applyPlanPatch: appended task "${spec.key}" cannot depend on ` +
+              `${dependency.status} task "${dependency.id}".`,
+          )
+        }
+        return dependencyId
+      })
+      if (new Set(dependencies).size !== dependencies.length) {
+        throw new Error(`TaskQueue.applyPlanPatch: appended task "${spec.key}" has duplicate dependencies.`)
+      }
+      const resolved: Task = {
+        ...task,
+        id: task.id || randomUUID(),
+        ...(dependencies.length > 0 ? { dependsOn: dependencies } : {}),
+      }
+      created.set(spec.key.trim(), resolved)
+      addedTasks[spec.key.trim()] = resolved.id
+      draft.set(resolved.id, resolved)
+    }
+
+    // Resolve references between appended tasks after every patch-local id exists.
+    for (const spec of addSpecs) {
+      const task = created.get(spec.key.trim())!
+      const dependencies = (spec.dependsOn ?? []).map((reference) =>
+        created.get(reference)?.id ?? reference)
+      const allTasks = Array.from(draft.values())
+      const taskById = new Map(allTasks.map((candidate) => [candidate.id, candidate]))
+      const pendingTask: Task = {
+        ...task,
+        ...(dependencies.length > 0 ? { dependsOn: dependencies } : { dependsOn: undefined }),
+        status: 'pending',
+      }
+      const status: TaskStatus = isTaskReady(pendingTask, allTasks, taskById)
+        ? 'pending'
+        : 'blocked'
+      draft.set(task.id, { ...pendingTask, status })
+    }
+
+    const validation = validateTaskDependencies(Array.from(draft.values()))
+    if (!validation.valid) {
+      throw new Error(`TaskQueue.applyPlanPatch: invalid patched graph: ${validation.errors.join(' ')}`)
+    }
+
+    const revision: PlanRevision = {
+      id: randomUUID(),
+      version: nextVersion,
+      triggerTaskId,
+      trigger,
+      reason,
+      addedTasks,
+      retargetedTasks: retargets.map((item) => ({ ...item })),
+      supersededTaskIds: [...supersedeIds],
+      createdAt: now.toISOString(),
+    }
+
+    if (trigger !== 'success') {
+      draft.set(triggerTaskId, {
+        ...draft.get(triggerTaskId)!,
+        recoveredByRevision: nextVersion,
+        updatedAt: now,
+      })
+    }
+    this.tasks.clear()
+    for (const [id, task] of draft) this.tasks.set(id, task)
+    this.planRevision = nextVersion
+    this.planRevisions = [...this.planRevisions, revision]
+    return { revision: TaskQueue.clonePlanRevision(revision), before }
+  }
+
+  /** Roll back an unpublished plan patch while preserving queue listeners. */
+  restorePlanSnapshot(snapshot: TaskQueueSnapshot): void {
+    const restored = TaskQueue.fromSnapshot(snapshot)
+    this.tasks.clear()
+    for (const task of restored.list()) this.tasks.set(task.id, task)
+    this.planRevision = restored.planRevision
+    this.planRevisions = [...restored.planRevisions]
+  }
+
+  /** Publish buffered skipped/ready events after a plan revision is durable. */
+  publishPlanRevision(revision: PlanRevision): void {
+    for (const taskId of revision.supersededTaskIds) {
+      const task = this.tasks.get(taskId)
+      if (task) this.emit('task:skipped', task)
+    }
+    for (const taskId of Object.values(revision.addedTasks)) {
+      const task = this.tasks.get(taskId)
+      if (task?.status === 'pending') this.emit('task:ready', task)
+    }
+    if (this.isComplete()) this.emitAllComplete()
   }
 
   // ---------------------------------------------------------------------------
@@ -535,6 +789,12 @@ export class TaskQueue {
       ...(task.maxRetries !== undefined ? { maxRetries: task.maxRetries } : {}),
       ...(task.retryDelayMs !== undefined ? { retryDelayMs: task.retryDelayMs } : {}),
       ...(task.retryBackoff !== undefined ? { retryBackoff: task.retryBackoff } : {}),
+      ...(task.supersededByRevision !== undefined
+        ? { supersededByRevision: task.supersededByRevision }
+        : {}),
+      ...(task.recoveredByRevision !== undefined
+        ? { recoveredByRevision: task.recoveredByRevision }
+        : {}),
     }
   }
 
@@ -562,6 +822,56 @@ export class TaskQueue {
       ...(snapshot.maxRetries !== undefined ? { maxRetries: snapshot.maxRetries } : {}),
       ...(snapshot.retryDelayMs !== undefined ? { retryDelayMs: snapshot.retryDelayMs } : {}),
       ...(snapshot.retryBackoff !== undefined ? { retryBackoff: snapshot.retryBackoff } : {}),
+      ...(snapshot.supersededByRevision !== undefined
+        ? { supersededByRevision: snapshot.supersededByRevision }
+        : {}),
+      ...(snapshot.recoveredByRevision !== undefined
+        ? { recoveredByRevision: snapshot.recoveredByRevision }
+        : {}),
+    }
+  }
+
+  private static cloneTask(task: Task): Task {
+    return {
+      ...task,
+      ...(task.dependsOn !== undefined ? { dependsOn: [...task.dependsOn] } : {}),
+      createdAt: new Date(task.createdAt),
+      updatedAt: new Date(task.updatedAt),
+    }
+  }
+
+  private static clonePlanRevision(revision: PlanRevision): PlanRevision {
+    return {
+      ...revision,
+      addedTasks: { ...revision.addedTasks },
+      retargetedTasks: revision.retargetedTasks.map((item) => ({ ...item })),
+      supersededTaskIds: [...revision.supersededTaskIds],
+    }
+  }
+
+  private static validatePlanSnapshot(
+    snapshot: Extract<TaskQueueSnapshot, { readonly version: 2 }>,
+  ): void {
+    if (
+      !Number.isInteger(snapshot.planRevision)
+      || snapshot.planRevision < 1
+      || snapshot.planRevisions.length !== snapshot.planRevision
+    ) {
+      throw new Error('TaskQueue.fromSnapshot: invalid plan revision sequence.')
+    }
+    const taskIds = new Set(snapshot.tasks.map((task) => task.id))
+    for (const [index, revision] of snapshot.planRevisions.entries()) {
+      if (revision.version !== index + 1 || !taskIds.has(revision.triggerTaskId)) {
+        throw new Error('TaskQueue.fromSnapshot: invalid plan revision history.')
+      }
+      const referenced = [
+        ...Object.values(revision.addedTasks),
+        ...revision.retargetedTasks.map((item) => item.taskId),
+        ...revision.supersededTaskIds,
+      ]
+      if (referenced.some((taskId) => !taskIds.has(taskId))) {
+        throw new Error('TaskQueue.fromSnapshot: plan revision references an unknown task.')
+      }
     }
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1164,6 +1164,103 @@ export interface RunTaskSpec {
   readonly verify?: ConsensusVerifyOptions
 }
 
+/** One task appended by an opt-in runtime plan repair. */
+export interface PlanPatchTaskSpec extends RunTaskSpec {
+  /**
+   * Patch-local stable key. Dependencies of another appended task may refer to
+   * this key; dependencies on the existing graph must use a task id.
+   */
+  readonly key: string
+}
+
+/** Reassign a task that has not started. */
+export interface PlanPatchRetarget {
+  readonly taskId: string
+  readonly assignee: string
+}
+
+/**
+ * Append-only repair of the not-yet-executed portion of a task graph.
+ *
+ * Existing topology is immutable. Replacing a branch means superseding its
+ * pending/blocked nodes and appending replacement tasks with new dependencies.
+ */
+export interface PlanPatch {
+  readonly reason: string
+  readonly addTasks?: readonly PlanPatchTaskSpec[]
+  readonly retargetPending?: readonly PlanPatchRetarget[]
+  readonly supersedePending?: readonly string[]
+}
+
+/** Accepted description of one runtime plan repair. */
+export interface PlanRevision {
+  readonly id: string
+  readonly version: number
+  readonly triggerTaskId: string
+  readonly trigger: 'success' | 'failure' | 'verification_rejected'
+  readonly reason: string
+  readonly addedTasks: Readonly<Record<string, string>>
+  readonly retargetedTasks: readonly PlanPatchRetarget[]
+  readonly supersededTaskIds: readonly string[]
+  readonly createdAt: string
+}
+
+/** Verification facts exposed to a recovery policy without judge credentials. */
+export interface TaskVerificationOutcome {
+  readonly verdict: 'accepted' | 'rejected'
+  readonly dissent: readonly string[]
+  readonly rounds: number
+}
+
+/** Stable facts available at the task-outcome recovery barrier. */
+export interface TaskOutcome {
+  readonly kind: 'success' | 'failure' | 'verification_rejected'
+  readonly task: Readonly<Task>
+  readonly result: Readonly<AgentRunResult>
+  readonly verification?: TaskVerificationOutcome
+  readonly planRevision: number
+  readonly tasks: readonly Readonly<Task>[]
+  readonly tokenBudgetRemaining?: number
+  readonly costBudgetRemaining?: number
+}
+
+/** Policy object that can propose an append-only repair at a task outcome barrier. */
+export interface Replanner {
+  readonly name?: string
+  replan(
+    outcome: TaskOutcome,
+  ): PlanPatch | undefined | Promise<PlanPatch | undefined>
+}
+
+/**
+ * Opt-in runtime plan repair. Omitted or `mode: 'fixed'` preserves the exact
+ * existing DAG lifecycle.
+ */
+export interface RecoveryOptions {
+  readonly mode?: 'fixed' | 'repairable'
+  /**
+   * Called before the triggering task is completed or failed, so no dependent
+   * can be dispatched ahead of an accepted patch.
+   */
+  readonly onTaskOutcome?: (
+    outcome: TaskOutcome,
+  ) => PlanPatch | undefined | Promise<PlanPatch | undefined>
+  /**
+   * First-class replanner policy. Mutually exclusive with `onTaskOutcome`.
+   * The application owns any external I/O performed by a custom replanner.
+   */
+  readonly replanner?: Replanner
+  /** Approval gate for a validated patch. Omitted means the policy owns approval. */
+  readonly onPlanPatch?: (
+    patch: Readonly<PlanPatch>,
+    outcome: TaskOutcome,
+  ) => boolean | Promise<boolean>
+  /** Maximum accepted revisions in one run. Default `3`. */
+  readonly maxPlanRevisions?: number
+  /** Maximum cumulative tasks appended by revisions. Default `20`. */
+  readonly maxAddedTasks?: number
+}
+
 /** Per-call options for {@link OpenMultiAgent.runTasks}. */
 export interface RunTasksOptions extends RunIdentityOptions {
   readonly abortSignal?: AbortSignal
@@ -1194,6 +1291,11 @@ export interface RunTasksOptions extends RunIdentityOptions {
    * coordinator model selection is unchanged.
    */
   readonly modelRouting?: ModelRoutingPolicy
+  /**
+   * Opt-in runtime repair policy. `runFromPlan()` rejects non-fixed recovery so
+   * a frozen plan remains an exact replay contract.
+   */
+  readonly recovery?: RecoveryOptions
 }
 
 /**
@@ -1431,6 +1533,8 @@ export interface TeamRunResult extends RunOutcomeFields {
   readonly governanceReason?: GovernanceUnsatisfiedReason
   readonly goal?: string
   readonly tasks?: readonly TaskExecutionRecord[]
+  /** Accepted append-only runtime plan revisions, in application order. */
+  readonly planRevisions?: readonly PlanRevision[]
   /**
    * True when the run was a plan-only invocation (`runTeam(team, goal, { planOnly: true })`).
    * The coordinator decomposed the goal but no task agents executed.
@@ -1572,6 +1676,10 @@ export interface TaskExecutionRecord {
   readonly requires?: TaskRequirements
   /** Verify config attached to this task, if any. Populated in `planOnly` results for inspection. */
   readonly verify?: ConsensusVerifyOptions
+  /** Plan revision that logically superseded this unstarted task. */
+  readonly supersededByRevision?: number
+  /** Plan revision that repaired this task's failed/rejected outcome. */
+  readonly recoveredByRevision?: number
   readonly metrics?: TaskExecutionMetrics
 }
 
@@ -1619,6 +1727,10 @@ export interface Task {
    * parent `maxTokenBudget`. Tasks without `verify` run unchanged.
    */
   readonly verify?: ConsensusVerifyOptions
+  /** Plan revision that logically superseded this unstarted task. */
+  readonly supersededByRevision?: number
+  /** Plan revision that repaired this task's failed/rejected outcome. */
+  readonly recoveredByRevision?: number
 }
 
 // ---------------------------------------------------------------------------
@@ -1639,6 +1751,8 @@ export interface OrchestratorEvent {
     | 'task_complete'
     | 'task_skipped'
     | 'task_retry'
+    | 'plan_revision'
+    | 'recovery_decision'
     | 'budget_exceeded'
     | 'message'
     | 'warning'
@@ -1740,6 +1854,8 @@ export interface OrchestratorConfig {
    * and `restore`. Per-call options override this value. Defaults to off.
    */
   readonly checkpoint?: boolean | CheckpointOptions
+  /** Default opt-in runtime repair policy. Per-run recovery replaces it. */
+  readonly recovery?: RecoveryOptions
   /**
    * Fallback tool grant for agents that declare neither {@link AgentConfig.tools}
    * nor {@link AgentConfig.toolPreset}. Built-in tools are opt-in (default-deny):
@@ -1936,10 +2052,12 @@ export interface TaskSnapshot {
   readonly maxRetries?: number
   readonly retryDelayMs?: number
   readonly retryBackoff?: number
+  readonly supersededByRevision?: number
+  readonly recoveredByRevision?: number
 }
 
-/** Serializable state of a {@link TaskQueue}. */
-export interface TaskQueueSnapshot {
+/** Legacy serializable state of a {@link TaskQueue}. */
+export interface TaskQueueSnapshotV1 {
   readonly version: 1
   readonly tasks: readonly TaskSnapshot[]
   readonly pending: readonly string[]
@@ -1949,6 +2067,23 @@ export interface TaskQueueSnapshot {
   readonly blocked: readonly string[]
   readonly skipped: readonly string[]
 }
+
+/** Serializable adaptive-plan state of a {@link TaskQueue}. */
+export interface TaskQueueSnapshotV2 {
+  readonly version: 2
+  readonly tasks: readonly TaskSnapshot[]
+  readonly pending: readonly string[]
+  readonly inProgress: readonly string[]
+  readonly completed: readonly string[]
+  readonly failed: readonly string[]
+  readonly blocked: readonly string[]
+  readonly skipped: readonly string[]
+  readonly planRevision: number
+  readonly planRevisions: readonly PlanRevision[]
+}
+
+/** Serializable state of a {@link TaskQueue}. */
+export type TaskQueueSnapshot = TaskQueueSnapshotV1 | TaskQueueSnapshotV2
 
 /** Result recorded for a completed task inside a checkpoint. */
 export interface CompletedTaskCheckpoint {
@@ -1963,7 +2098,7 @@ export interface CompletedTaskCheckpoint {
 }
 
 interface CheckpointSnapshotBase {
-  readonly mode: 'runTeam' | 'runTasks'
+  readonly mode: 'runTeam' | 'runTasks' | 'runFromPlan'
   readonly createdAt: string
   /** Validated per-run metadata inherited by future restore attempts. */
   readonly metadata?: Readonly<Record<string, TraceAttributeValue>>

--- a/packages/core/tests/adaptive-recovery.test.ts
+++ b/packages/core/tests/adaptive-recovery.test.ts
@@ -1,0 +1,568 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { Checkpoint } from '../src/memory/checkpoint.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import { TaskQueue } from '../src/task/queue.js'
+import { createTask } from '../src/task/task.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMChatOptions,
+  LLMMessage,
+  LLMResponse,
+  OrchestratorEvent,
+  TaskOutcome,
+  MemoryEntry,
+  MemoryStore,
+  CheckpointSnapshot,
+  PlanArtifact,
+} from '../src/types.js'
+
+function userPrompt(messages: LLMMessage[]): string {
+  return [...messages].reverse().find((message) => message.role === 'user')
+    ?.content
+    .filter((block): block is { type: 'text'; text: string } => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n') ?? ''
+}
+
+function taskTitle(messages: LLMMessage[]): string {
+  return userPrompt(messages).match(/^# Task: (.+)$/m)?.[1] ?? ''
+}
+
+function response(text: string, options: LLMChatOptions): LLMResponse {
+  return {
+    id: `response-${text}`,
+    content: [{ type: 'text', text }],
+    model: options.model,
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function adapter(
+  handler: (title: string) => string | Error,
+  calls: string[],
+): LLMAdapter {
+  return {
+    name: 'adaptive-recovery-test',
+    async chat(messages, options) {
+      const title = taskTitle(messages)
+      calls.push(title)
+      const value = handler(title)
+      if (value instanceof Error) throw value
+      return response(value, options)
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: {} }
+    },
+  }
+}
+
+function agent(name: string, llm: LLMAdapter): AgentConfig {
+  return {
+    name,
+    model: 'test-model',
+    systemPrompt: `You are ${name}.`,
+    adapter: llm,
+  }
+}
+
+describe('adaptive runtime recovery', () => {
+  it('repairs a failed branch by superseding old downstream work and appending replacements', async () => {
+    const calls: string[] = []
+    const events: OrchestratorEvent[] = []
+    const llm = adapter(
+      (title) => title === 'Search' ? new Error('search unavailable') : `completed ${title}`,
+      calls,
+    )
+    const oma = new OpenMultiAgent({
+      maxConcurrency: 2,
+      onProgress: (event) => events.push(event),
+    })
+    const team = oma.createTeam('repair', {
+      name: 'repair',
+      agents: [agent('worker-a', llm), agent('worker-b', llm)],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Search', description: 'Search the primary source.', assignee: 'worker-a' },
+      {
+        title: 'Analysis',
+        description: 'Analyze the primary source.',
+        assignee: 'worker-a',
+        dependsOn: ['Search'],
+      },
+    ], {
+      recovery: {
+        mode: 'repairable',
+        onTaskOutcome: (outcome: TaskOutcome) => {
+          if (outcome.kind !== 'failure' || outcome.task.title !== 'Search') return undefined
+          const oldAnalysis = outcome.tasks.find((task) => task.title === 'Analysis')!
+          return {
+            reason: 'Primary search failed; use the fallback source.',
+            supersedePending: [oldAnalysis.id],
+            addTasks: [
+              {
+                key: 'fallback-search',
+                title: 'Fallback Search',
+                description: 'Search the fallback source.',
+                assignee: 'worker-b',
+              },
+              {
+                key: 'replacement-analysis',
+                title: 'Replacement Analysis',
+                description: 'Analyze the fallback source.',
+                assignee: 'worker-b',
+                dependsOn: ['fallback-search'],
+              },
+            ],
+          }
+        },
+      },
+    })
+
+    expect(calls).toEqual(['Search', 'Fallback Search', 'Replacement Analysis'])
+    expect(result.success).toBe(true)
+    expect(result.tasks?.find((task) => task.title === 'Search')).toMatchObject({
+      status: 'failed',
+      recoveredByRevision: 1,
+    })
+    expect(result.tasks?.find((task) => task.title === 'Analysis')).toMatchObject({
+      status: 'skipped',
+      supersededByRevision: 1,
+    })
+    expect(result.tasks?.find((task) => task.title === 'Fallback Search')?.status).toBe('completed')
+    expect(result.tasks?.find((task) => task.title === 'Replacement Analysis')?.status).toBe('completed')
+    expect(result.planRevisions).toHaveLength(1)
+    expect(result.planRevisions?.[0]).toMatchObject({
+      version: 1,
+      trigger: 'failure',
+      reason: 'Primary search failed; use the fallback source.',
+    })
+    expect(events.some((event) => event.type === 'plan_revision')).toBe(true)
+  })
+
+  it('holds original downstream dispatch until a success expansion is applied', async () => {
+    const calls: string[] = []
+    const llm = adapter((title) => `completed ${title}`, calls)
+    const oma = new OpenMultiAgent({ maxConcurrency: 3 })
+    const team = oma.createTeam('expand', {
+      name: 'expand',
+      agents: [agent('worker', llm)],
+    })
+
+    const onTaskOutcome = vi.fn((outcome: TaskOutcome) => {
+      if (outcome.kind !== 'success' || outcome.task.title !== 'Upstream') return undefined
+      const oldDownstream = outcome.tasks.find((task) => task.title === 'Old Downstream')!
+      return {
+        reason: 'Expand work from the actual upstream result.',
+        supersedePending: [oldDownstream.id],
+        addTasks: [
+          {
+            key: 'branch-a',
+            title: 'Branch A',
+            description: 'Process branch A.',
+            assignee: 'worker',
+            dependsOn: [outcome.task.id],
+          },
+          {
+            key: 'branch-b',
+            title: 'Branch B',
+            description: 'Process branch B.',
+            assignee: 'worker',
+            dependsOn: [outcome.task.id],
+          },
+        ],
+      }
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Upstream', description: 'Produce structured scope.', assignee: 'worker' },
+      {
+        title: 'Old Downstream',
+        description: 'Original downstream.',
+        assignee: 'worker',
+        dependsOn: ['Upstream'],
+      },
+    ], {
+      recovery: { mode: 'repairable', onTaskOutcome },
+    })
+
+    expect(calls).toEqual(['Upstream', 'Branch A', 'Branch B'])
+    expect(result.success).toBe(true)
+    expect(result.tasks?.find((task) => task.title === 'Old Downstream')).toMatchObject({
+      status: 'skipped',
+      supersededByRevision: 1,
+    })
+    expect(result.tasks?.filter((task) => task.status === 'completed').map((task) => task.title))
+      .toEqual(['Upstream', 'Branch A', 'Branch B'])
+  })
+
+  it('preserves fixed DAG cascade behavior when recovery is omitted', async () => {
+    const calls: string[] = []
+    const llm = adapter(
+      (title) => title === 'Search' ? new Error('search unavailable') : `completed ${title}`,
+      calls,
+    )
+    const oma = new OpenMultiAgent()
+    const team = oma.createTeam('fixed', {
+      name: 'fixed',
+      agents: [agent('worker', llm)],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Search', description: 'Search.', assignee: 'worker' },
+      {
+        title: 'Analysis',
+        description: 'Analyze.',
+        assignee: 'worker',
+        dependsOn: ['Search'],
+      },
+    ])
+
+    expect(calls).toEqual(['Search'])
+    expect(result.success).toBe(false)
+    expect(result.tasks?.map((task) => task.status)).toEqual(['failed', 'failed'])
+  })
+
+  it('accepts a first-class replanner policy and applies its repair', async () => {
+    const calls: string[] = []
+    const replan = vi.fn((outcome: TaskOutcome) => outcome.kind === 'failure'
+      ? {
+          reason: 'Replanner selected a fallback agent.',
+          addTasks: [{
+            key: 'fallback',
+            title: 'Fallback',
+            description: 'Recover through the fallback agent.',
+            assignee: 'worker-b',
+          }],
+        }
+      : undefined)
+    const llm = adapter(
+      (title) => title === 'Primary' ? new Error('primary unavailable') : `completed ${title}`,
+      calls,
+    )
+    const oma = new OpenMultiAgent()
+    const team = oma.createTeam('replanner', {
+      name: 'replanner',
+      agents: [agent('worker-a', llm), agent('worker-b', llm)],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Primary', description: 'Use the primary path.', assignee: 'worker-a' },
+    ], {
+      recovery: {
+        mode: 'repairable',
+        replanner: { name: 'fallback-policy', replan },
+      },
+    })
+
+    expect(replan).toHaveBeenCalledTimes(2)
+    expect(calls).toEqual(['Primary', 'Fallback'])
+    expect(result.success).toBe(true)
+  })
+
+  it('keeps the original failure path when plan-patch approval rejects a proposal', async () => {
+    const calls: string[] = []
+    const events: OrchestratorEvent[] = []
+    const approval = vi.fn(() => false)
+    const llm = adapter(
+      (title) => title === 'Primary' ? new Error('primary unavailable') : `completed ${title}`,
+      calls,
+    )
+    const oma = new OpenMultiAgent({ onProgress: (event) => events.push(event) })
+    const team = oma.createTeam('approval', {
+      name: 'approval',
+      agents: [agent('worker', llm)],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Primary', description: 'Use the primary path.', assignee: 'worker' },
+    ], {
+      recovery: {
+        mode: 'repairable',
+        onTaskOutcome: (outcome) => outcome.kind === 'failure'
+          ? {
+              reason: 'Try fallback.',
+              addTasks: [{
+                key: 'fallback',
+                title: 'Fallback',
+                description: 'Use fallback.',
+                assignee: 'worker',
+              }],
+            }
+          : undefined,
+        onPlanPatch: approval,
+      },
+    })
+
+    expect(approval).toHaveBeenCalledTimes(1)
+    expect(calls).toEqual(['Primary'])
+    expect(result.success).toBe(false)
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'recovery_decision',
+      data: expect.objectContaining({ decision: 'rejected' }),
+    }))
+  })
+
+  it('appends investigation work when consensus verification rejects evidence', async () => {
+    const workerCalls: string[] = []
+    const judgeCalls: string[] = []
+    const worker = adapter((title) => `completed ${title}`, workerCalls)
+    const judge = adapter(
+      () => '{"accept":false,"critique":"sources conflict"}',
+      judgeCalls,
+    )
+    const oma = new OpenMultiAgent()
+    const team = oma.createTeam('verification-repair', {
+      name: 'verification-repair',
+      agents: [agent('worker', worker)],
+    })
+
+    const result = await oma.runTasks(team, [{
+      title: 'Verify Evidence',
+      description: 'Validate the available evidence.',
+      assignee: 'worker',
+      verify: {
+        judges: [agent('judge', judge)],
+        quorum: 1,
+        maxRounds: 1,
+        onDissent: 'reject',
+      },
+    }], {
+      recovery: {
+        mode: 'repairable',
+        onTaskOutcome: (outcome) => outcome.kind === 'verification_rejected'
+          ? {
+              reason: 'The evidence conflicted; gather a second source.',
+              addTasks: [{
+                key: 'supplemental-investigation',
+                title: 'Supplemental Investigation',
+                description: 'Gather and reconcile an independent source.',
+                assignee: 'worker',
+              }],
+            }
+          : undefined,
+      },
+    })
+
+    expect(judgeCalls).toHaveLength(1)
+    expect(workerCalls).toEqual(['Verify Evidence', 'Supplemental Investigation'])
+    expect(result.success).toBe(true)
+    expect(result.tasks?.find((task) => task.title === 'Verify Evidence')).toMatchObject({
+      status: 'completed',
+      recoveredByRevision: 1,
+    })
+    expect(result.tasks?.find((task) => task.title === 'Supplemental Investigation')?.status)
+      .toBe('completed')
+  })
+
+  it('persists plan revision history in checkpoint queue snapshot v2', async () => {
+    const calls: string[] = []
+    const store = new InMemoryStore()
+    const llm = adapter(
+      (title) => title === 'Search' ? new Error('search unavailable') : `completed ${title}`,
+      calls,
+    )
+    const oma = new OpenMultiAgent()
+    const team = oma.createTeam('checkpoint-repair', {
+      name: 'checkpoint-repair',
+      agents: [agent('worker', llm)],
+    })
+
+    await oma.runTasks(team, [
+      { title: 'Search', description: 'Search.', assignee: 'worker' },
+    ], {
+      checkpoint: { store },
+      recovery: {
+        mode: 'repairable',
+        onTaskOutcome: (outcome) => outcome.kind === 'failure'
+          ? {
+              reason: 'Use fallback.',
+              addTasks: [{
+                key: 'fallback',
+                title: 'Fallback',
+                description: 'Fetch fallback.',
+                assignee: 'worker',
+              }],
+            }
+          : undefined,
+      },
+    })
+
+    const snapshot = await new Checkpoint(store).loadLatest()
+    expect(snapshot?.queue.version).toBe(2)
+    if (snapshot?.queue.version !== 2) throw new Error('expected adaptive queue snapshot')
+    expect(snapshot.queue.planRevision).toBe(1)
+    expect(snapshot.queue.planRevisions).toHaveLength(1)
+    expect(snapshot.queue.planRevisions[0]).toMatchObject({
+      trigger: 'failure',
+      reason: 'Use fallback.',
+    })
+  })
+
+  it('rolls back a repair and preserves failure cascade when patch checkpointing fails', async () => {
+    const calls: string[] = []
+    const events: OrchestratorEvent[] = []
+    const store = new FailingStore()
+    const llm = adapter(
+      (title) => title === 'Search' ? new Error('search unavailable') : `completed ${title}`,
+      calls,
+    )
+    const oma = new OpenMultiAgent({ onProgress: (event) => events.push(event) })
+    const team = oma.createTeam('rollback-repair', {
+      name: 'rollback-repair',
+      agents: [agent('worker', llm)],
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Search', description: 'Search.', assignee: 'worker' },
+      {
+        title: 'Analysis',
+        description: 'Analyze.',
+        assignee: 'worker',
+        dependsOn: ['Search'],
+      },
+    ], {
+      checkpoint: { store },
+      recovery: {
+        mode: 'repairable',
+        onTaskOutcome: (outcome) => outcome.kind === 'failure'
+          ? {
+              reason: 'Use fallback.',
+              supersedePending: [
+                outcome.tasks.find((task) => task.title === 'Analysis')!.id,
+              ],
+              addTasks: [{
+                key: 'fallback',
+                title: 'Fallback',
+                description: 'Fetch fallback.',
+                assignee: 'worker',
+              }],
+            }
+          : undefined,
+      },
+    })
+
+    expect(calls).toEqual(['Search'])
+    expect(result.success).toBe(false)
+    expect(result.tasks?.map((task) => task.status)).toEqual(['failed', 'failed'])
+    expect(result.tasks?.some((task) => task.title === 'Fallback')).toBe(false)
+    expect(events.some((event) =>
+      event.type === 'warning'
+      && (event.data as { code?: string }).code === 'PLAN_REVISION_NOT_DURABLE')).toBe(true)
+  })
+
+  it('restores a crash-boundary revision without appending the repair twice', async () => {
+    const calls: string[] = []
+    const store = new InMemoryStore()
+    const queue = new TaskQueue()
+    const primary = createTask({
+      title: 'Primary',
+      description: 'Use the primary source.',
+      assignee: 'worker',
+    })
+    queue.add(primary)
+    queue.update(primary.id, { status: 'in_progress' })
+    const { revision } = queue.applyPlanPatch({
+      reason: 'Use fallback after the primary failure.',
+      addTasks: [{
+        key: 'fallback',
+        title: 'Fallback',
+        description: 'Use the fallback source.',
+        assignee: 'worker',
+      }],
+    }, primary.id, 'failure')
+    queue.publishPlanRevision(revision)
+
+    const checkpoint: CheckpointSnapshot = {
+      version: 2,
+      mode: 'runTasks',
+      createdAt: new Date().toISOString(),
+      identity: {
+        runId: 'adaptive-restore',
+        attempt: 1,
+        lastTraceId: '00000000000000000000000000000001',
+        lastRootSpanId: '0000000000000001',
+      },
+      queue: queue.snapshot(),
+      completedTaskResults: [],
+    }
+    await new Checkpoint(store).save(checkpoint)
+
+    const llm = adapter(
+      (title) => title === 'Primary' ? new Error('primary unavailable') : `completed ${title}`,
+      calls,
+    )
+    const oma = new OpenMultiAgent({ maxConcurrency: 1 })
+    const team = oma.createTeam('adaptive-restore', {
+      name: 'adaptive-restore',
+      agents: [agent('worker', llm)],
+    })
+    const replan = vi.fn((outcome: TaskOutcome) => outcome.kind === 'failure'
+      ? {
+          reason: 'This duplicate proposal must not be called.',
+          addTasks: [{
+            key: 'duplicate',
+            title: 'Duplicate',
+            description: 'Must not be appended.',
+            assignee: 'worker',
+          }],
+        }
+      : undefined)
+
+    const result = await oma.restore(team, {
+      checkpoint: { store },
+      recovery: {
+        mode: 'repairable',
+        replanner: { replan },
+      },
+    })
+
+    expect(replan).toHaveBeenCalledTimes(1)
+    expect(calls).toEqual(['Primary', 'Fallback'])
+    expect(result.success).toBe(true)
+    expect(result.tasks?.map((task) => task.title)).toEqual(['Primary', 'Fallback'])
+    expect(result.tasks?.find((task) => task.title === 'Primary')?.recoveredByRevision).toBe(1)
+  })
+
+  it('keeps runFromPlan and its checkpoints exact', async () => {
+    const calls: string[] = []
+    const store = new InMemoryStore()
+    const llm = adapter((title) => `completed ${title}`, calls)
+    const oma = new OpenMultiAgent()
+    const team = oma.createTeam('exact-plan', {
+      name: 'exact-plan',
+      agents: [agent('worker', llm)],
+    })
+    const plan: PlanArtifact = {
+      version: 1,
+      tasks: [{
+        id: 'planned-task',
+        title: 'Planned Task',
+        description: 'Execute exactly.',
+        assignee: 'worker',
+      }],
+    }
+    const recovery = {
+      mode: 'repairable' as const,
+      replanner: { replan: () => undefined },
+    }
+
+    await expect(oma.runFromPlan(team, plan, { recovery }))
+      .rejects.toThrow('runFromPlan requires fixed recovery')
+    await oma.runFromPlan(team, plan, { checkpoint: { store } })
+    expect((await new Checkpoint(store).loadLatest())?.mode).toBe('runFromPlan')
+    await expect(oma.restore(team, { checkpoint: { store }, recovery }))
+      .rejects.toThrow('runFromPlan checkpoint requires fixed recovery')
+  })
+})
+
+class FailingStore implements MemoryStore {
+  async get(): Promise<MemoryEntry | null> { return null }
+  async set(): Promise<void> { throw new Error('checkpoint unavailable') }
+  async list(): Promise<MemoryEntry[]> { return [] }
+  async delete(): Promise<void> {}
+  async clear(): Promise<void> {}
+}

--- a/packages/core/tests/task-queue.test.ts
+++ b/packages/core/tests/task-queue.test.ts
@@ -131,6 +131,146 @@ describe('TaskQueue', () => {
     expect(q.list().find((t) => t.id === 'c')!.status).toBe('failed')
   })
 
+  it('applies an append-only plan patch atomically and publishes events later', () => {
+    const q = new TaskQueue()
+    const readyHandler = vi.fn()
+    const skippedHandler = vi.fn()
+    q.on('task:ready', readyHandler)
+    q.on('task:skipped', skippedHandler)
+    q.add(task('source'))
+    q.add(task('old-downstream', { dependsOn: ['source'] }))
+    q.update('source', { status: 'in_progress' })
+    readyHandler.mockClear()
+
+    const applied = q.applyPlanPatch({
+      reason: 'Use a fallback source.',
+      supersedePending: ['old-downstream'],
+      addTasks: [
+        {
+          key: 'fallback',
+          title: 'Fallback',
+          description: 'Fetch from the fallback source.',
+          assignee: 'worker',
+        },
+        {
+          key: 'replacement',
+          title: 'Replacement',
+          description: 'Consume the fallback.',
+          assignee: 'worker',
+          dependsOn: ['fallback'],
+        },
+      ],
+    }, 'source', 'failure')
+
+    expect(q.getPlanRevision()).toBe(1)
+    expect(q.get('source')?.recoveredByRevision).toBe(1)
+    expect(q.get('old-downstream')?.status).toBe('skipped')
+    expect(q.get('old-downstream')?.supersededByRevision).toBe(1)
+    expect(q.get(applied.revision.addedTasks['fallback']!)?.status).toBe('pending')
+    expect(q.get(applied.revision.addedTasks['replacement']!)?.status).toBe('blocked')
+    expect(readyHandler).not.toHaveBeenCalled()
+    expect(skippedHandler).not.toHaveBeenCalled()
+
+    q.publishPlanRevision(applied.revision)
+    expect(readyHandler).toHaveBeenCalledTimes(1)
+    expect(skippedHandler).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects an invalid plan patch without changing the queue', () => {
+    const q = new TaskQueue()
+    q.add(task('source'))
+    q.add(task('downstream', { dependsOn: ['source'] }))
+    q.update('source', { status: 'in_progress' })
+    const before = q.snapshot()
+
+    expect(() => q.applyPlanPatch({
+      reason: 'Invalid repair.',
+      addTasks: [{
+        key: 'replacement',
+        title: 'Replacement',
+        description: 'Cannot depend on a missing task.',
+        dependsOn: ['missing'],
+      }],
+    }, 'source', 'failure')).toThrow('unknown dependency')
+
+    expect(q.snapshot()).toEqual(before)
+  })
+
+  it('rejects a patch outside the trigger outcome barrier', () => {
+    const q = new TaskQueue()
+    q.add(task('source'))
+    const before = q.snapshot()
+
+    expect(() => q.applyPlanPatch({
+      reason: 'Too early.',
+      addTasks: [{
+        key: 'replacement',
+        title: 'Replacement',
+        description: 'Must not be appended.',
+      }],
+    }, 'source', 'failure')).toThrow('must be in_progress')
+
+    expect(q.snapshot()).toEqual(before)
+  })
+
+  it('does not classify a failure as recovered without an appended replacement', () => {
+    const q = new TaskQueue()
+    q.add(task('source'))
+    q.add(task('downstream', { dependsOn: ['source'] }))
+    const before = q.snapshot()
+
+    expect(() => q.applyPlanPatch({
+      reason: 'Only retarget downstream.',
+      retargetPending: [{ taskId: 'downstream', assignee: 'worker-b' }],
+    }, 'source', 'failure')).toThrow('must append at least one replacement task')
+
+    expect(q.snapshot()).toEqual(before)
+  })
+
+  it('round-trips adaptive plan revisions through snapshot v2', () => {
+    const q = new TaskQueue()
+    q.add(task('source'))
+    q.update('source', { status: 'in_progress' })
+    const { revision } = q.applyPlanPatch({
+      reason: 'Add follow-up.',
+      addTasks: [{
+        key: 'follow-up',
+        title: 'Follow-up',
+        description: 'Continue after source.',
+        dependsOn: ['source'],
+      }],
+    }, 'source', 'success')
+    q.publishPlanRevision(revision)
+
+    const snapshot = q.snapshot()
+    expect(snapshot.version).toBe(2)
+    const restored = TaskQueue.fromSnapshot(snapshot)
+    expect(restored.getPlanRevision()).toBe(1)
+    expect(restored.getPlanRevisions()).toEqual([revision])
+    expect(restored.list()).toEqual(q.list())
+  })
+
+  it('rejects a corrupt adaptive revision sequence during restore', () => {
+    const q = new TaskQueue()
+    q.add(task('source'))
+    q.update('source', { status: 'in_progress' })
+    q.applyPlanPatch({
+      reason: 'Add follow-up.',
+      addTasks: [{
+        key: 'follow-up',
+        title: 'Follow-up',
+        description: 'Continue.',
+      }],
+    }, 'source', 'success')
+    const snapshot = q.snapshot()
+    if (snapshot.version !== 2) throw new Error('expected adaptive snapshot')
+
+    expect(() => TaskQueue.fromSnapshot({
+      ...snapshot,
+      planRevision: 2,
+    })).toThrow('invalid plan revision sequence')
+  })
+
   // -------------------------------------------------------------------------
   // Completion
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add an opt-in `Replanner` and append-only `PlanPatch` contract for runtime DAG repair
- apply validated plan revisions at a task-outcome barrier before downstream dispatch or failure cascade
- persist adaptive queue revisions, roll back unpublished patches when checkpoint writes fail, and preserve restore idempotency
- expose revision history in results, progress events, and observability spans

## Motivation

OMA could retry a task, switch a retryable provider route, and cascade failures, but it could not revise the unstarted portion of a workflow from actual task outcomes. This change adds a bounded and auditable repair path for fallback acquisition, agent reassignment, verification conflicts, alternative tools, and outcome-driven downstream expansion.

## Scope and impact

- **Workspace:** `@open-multi-agent/core`, plus root/core documentation.
- **Public API:** adds `Replanner`, `RecoveryOptions`, `TaskOutcome`, `PlanPatch`, `PlanRevision`, adaptive queue snapshot v2, revision markers on task records, and `TeamRunResult.planRevisions`.
- **Compatibility:** recovery is opt-in; omitted or `mode: "fixed"` preserves existing fixed-DAG behavior. Queue snapshot v1 remains readable.
- **Replay:** `runFromPlan()` and checkpoints created by it remain exact and reject repairable recovery.
- **Durability:** when checkpointing is enabled, a patch is saved before appended tasks are published; a failed save rolls the patch back.
- **Security/privacy:** no new network dependency or automatic external call is introduced. Application-owned replanners receive in-process task outcome data and own any external I/O.
- **Intentional non-goals:** no built-in LLM replanner, no rollback of external side effects already performed by a task, and no mid-task conversation recovery.
- **Dependencies:** none.

## Validation

- `npm run lint -w @open-multi-agent/core` — passed
- `npm run build -w @open-multi-agent/core` — passed
- `npm run test -w @open-multi-agent/core -- --no-cache` — passed, 121 files / 1740 tests
- `npx vitest run --no-cache packages/core/tests/task-queue.test.ts packages/core/tests/adaptive-recovery.test.ts` — passed, 34 tests
- `git diff --check` and `git diff --cached --check` — passed
- Provider E2E was not run because provider adapters were not changed and those tests require real credentials.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING
