### PR TITLE
test: resolve tsx CLI through Node module resolution

### DIFF
--- a/packages/core/tests/eval-cli.test.ts
+++ b/packages/core/tests/eval-cli.test.ts
@@ -7,8 +7,9 @@ import { spawnSync } from 'node:child_process'
 
 import { describe, expect, it } from 'vitest'
 
+import { tsxCli } from './helpers/tsx-cli.js'
+
 const cliSource = fileURLToPath(new URL('../src/cli/oma.ts', import.meta.url))
-const tsxBinary = fileURLToPath(new URL('../../../node_modules/.bin/tsx', import.meta.url))
 const fixtures = fileURLToPath(new URL('./fixtures/eval/', import.meta.url))
 const setPath = join(fixtures, 'set.json')
 
@@ -23,7 +24,7 @@ function temporaryDirectory(): string {
 }
 
 function runCli(args: readonly string[], cwd = temporaryDirectory()): CliRun {
-  const result = spawnSync(tsxBinary, [cliSource, ...args], {
+  const result = spawnSync(process.execPath, [tsxCli, cliSource, ...args], {
     cwd,
     encoding: 'utf8',
     env: { ...process.env, NO_COLOR: '1' },

--- a/packages/core/tests/eval-gate-cli.test.ts
+++ b/packages/core/tests/eval-gate-cli.test.ts
@@ -7,8 +7,9 @@ import { spawnSync } from 'node:child_process'
 
 import { describe, expect, it } from 'vitest'
 
+import { tsxCli } from './helpers/tsx-cli.js'
+
 const cliSource = fileURLToPath(new URL('../src/cli/oma.ts', import.meta.url))
-const tsxBinary = fileURLToPath(new URL('../../../node_modules/.bin/tsx', import.meta.url))
 const fixtures = fileURLToPath(new URL('./fixtures/eval/', import.meta.url))
 const setPath = join(fixtures, 'set.json')
 const targetPath = join(fixtures, 'target.mjs')
@@ -27,7 +28,7 @@ function temporaryDirectory(): string {
 }
 
 function runCli(args: readonly string[], cwd = temporaryDirectory()): CliRun {
-  const result = spawnSync(tsxBinary, [cliSource, ...args], {
+  const result = spawnSync(process.execPath, [tsxCli, cliSource, ...args], {
     cwd,
     encoding: 'utf8',
     env: { ...process.env, NO_COLOR: '1' },

--- a/packages/core/tests/helpers/tsx-cli.ts
+++ b/packages/core/tests/helpers/tsx-cli.ts
@@ -1,0 +1,18 @@
+import { createRequire } from 'node:module'
+
+/**
+ * Absolute path to the `tsx` CLI entry point, for tests that run the `oma` CLI
+ * from TypeScript source in a child process.
+ *
+ * Resolved through Node's module resolution rather than a path with a fixed
+ * number of `..` segments: `node_modules/.bin` does not always sit directly
+ * above the workspace. A git worktree has no local `node_modules` and resolves
+ * upwards to the main checkout, and a non-hoisted install places `node_modules`
+ * inside the workspace. A wrong guess made `spawnSync` fail to launch at all,
+ * surfacing as `status: null` instead of a CLI exit code.
+ *
+ * Spawn it with `process.execPath` rather than executing it directly, so the
+ * call does not depend on the `node_modules/.bin` shim, which is a `.cmd`
+ * wrapper on Windows that `spawnSync` cannot launch without a shell.
+ */
+export const tsxCli = createRequire(import.meta.url).resolve('tsx/cli')

--- a/scripts/eval-example-smoke.mjs
+++ b/scripts/eval-example-smoke.mjs
@@ -1,9 +1,12 @@
 import { spawn } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { join } from 'node:path'
 
 const root = fileURLToPath(new URL('..', import.meta.url))
-const tsx = join(root, 'node_modules', 'tsx', 'dist', 'cli.mjs')
+// Resolved rather than joined onto `root`: a git worktree has no local
+// `node_modules` and resolves upwards to the main checkout.
+const tsx = createRequire(import.meta.url).resolve('tsx/cli')
 const example = join(
   root,
   'packages',

--- a/scripts/observability-example-smoke.mjs
+++ b/scripts/observability-example-smoke.mjs
@@ -1,9 +1,12 @@
 import { spawn } from 'node:child_process'
+import { createRequire } from 'node:module'
 import { fileURLToPath } from 'node:url'
 import { join } from 'node:path'
 
 const root = fileURLToPath(new URL('..', import.meta.url))
-const tsx = join(root, 'node_modules', 'tsx', 'dist', 'cli.mjs')
+// Resolved rather than joined onto `root`: a git worktree has no local
+// `node_modules` and resolves upwards to the main checkout.
+const tsx = createRequire(import.meta.url).resolve('tsx/cli')
 const directory = join(root, 'packages', 'core', 'examples', 'integrations', 'observability-v2')
 const examples = [
   'batching-exporter.ts',


### PR DESCRIPTION
## Problem

`packages/core/tests/eval-cli.test.ts` and `packages/core/tests/eval-gate-cli.test.ts` located the `tsx` binary with a fixed number of `..` segments:

```ts
const tsxBinary = fileURLToPath(new URL('../../../node_modules/.bin/tsx', import.meta.url))
```

That assumes a hoisted install sitting directly above the workspace. Two common layouts break it:

- A **git worktree** has no local `node_modules` and resolves upwards to the main checkout.
- A **non-hoisted install** keeps `node_modules` inside the workspace.

In both cases the path points at nothing, `spawnSync` never launches, and all 12 tests in these two suites fail with `expected null to be 0` because `result.status` is `null` rather than a CLI exit code. The failure looks like a CLI regression, but nothing in the CLI ran.

`scripts/eval-example-smoke.mjs` and `scripts/observability-example-smoke.mjs` had the same assumption via `join(root, 'node_modules', 'tsx', 'dist', 'cli.mjs')`, so they are fixed here too.

## Change

Resolve `tsx/cli` through Node's own module resolution, behind a shared `packages/core/tests/helpers/tsx-cli.ts`:

```ts
export const tsxCli = createRequire(import.meta.url).resolve('tsx/cli')
```

The child process is now spawned as `process.execPath` plus the resolved entry point instead of executing the `node_modules/.bin` shim. `.bin/tsx` is a symlink to that same `dist/cli.mjs` with a `#!/usr/bin/env node` shebang, so the spawned command is unchanged, and it drops a Windows hazard: the shim there is a `.cmd` wrapper, which `spawnSync` cannot launch without a shell on Node 18.20.2+ / 20.12.2+. `process.execPath` also matches the existing style in `tests/process-backend-lifecycle.test.ts`.

No product behavior changes, so there is nothing to update in `docs/`. The two CLI suites passing from a worktree with no local `node_modules` is the verification.

## Verification

Run from a git worktree with no local `node_modules` and no hand-linked tsx:

| Command | Result |
|---|---|
| `npm run test -w @open-multi-agent/core` | 121 files / 1765 tests passed |
| `npm run lint -w @open-multi-agent/core` | clean |
| `npm run build -w @open-multi-agent/core` | clean |
| `npm run test:eval-examples` | 1 passed |
| `npm run test:observability-examples` | 7 passed |
| `git diff --check` | clean |

Before this change, the same worktree failed 12 tests across the two suites; the failure also reproduces on `origin/main`.

One note for anyone running the smoke scripts from a fresh worktree: `npm run test:observability-examples` still needs `npm run build -w @open-multi-agent/core` first, because those examples import the package's own `dist/` through its `exports` map. That requirement predates this change and is unrelated to the tsx path.
