### PR TITLE
ci: enforce coverage and add DeepSeek provider canary

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,6 +43,8 @@ npm run test:e2e
 
 Set `DEEPSEEK_E2E_MODEL` to override the DeepSeek canary model; it defaults to `deepseek-v4-flash`.
 
+The `Provider Canary` workflow runs the DeepSeek suite daily and can also be started manually. Maintainers must configure `DEEPSEEK_API_KEY` as a GitHub Actions repository secret; never add a provider credential to source files or workflow YAML.
+
 Run checks that match the surface you changed and record the commands and results in the PR description. For code changes, start with `npm run lint && npm test`; also run `npm run build` when package output or public entry points may be affected, and `npm run test:scaffold` when changing `create-oma-app` scaffolding or templates.
 
 CI is the source of truth for the full pre-merge matrix. It runs lint, unit tests on Node 18/20/22, coverage, workspace builds, package/import smoke tests, template type-checking, tarball assertions, and the scaffold E2E test.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -54,9 +57,9 @@ jobs:
       - run: npm run test:coverage
       - uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: true
           files: ./packages/core/coverage/lcov.info
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   package:
     runs-on: ubuntu-latest

--- a/.github/workflows/provider-canary.yml
+++ b/.github/workflows/provider-canary.yml
@@ -1,0 +1,33 @@
+name: Provider Canary
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * *'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: provider-canary-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deepseek:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Require the DeepSeek canary credential
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: test -n "$DEEPSEEK_API_KEY"
+      - name: Run the DeepSeek provider canary
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: npm run test:e2e:deepseek -w @open-multi-agent/core

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,6 +67,7 @@
     "test:coverage": "vitest run --coverage",
     "lint": "tsc --noEmit",
     "test:e2e": "RUN_E2E=1 vitest run tests/e2e/",
+    "test:e2e:deepseek": "RUN_E2E=1 vitest run tests/e2e/deepseek-e2e.test.ts",
     "test:semantic-routing-shadow": "RUN_E2E=1 vitest run --reporter=dot tests/e2e/semantic-routing-shadow.test.ts",
     "prepublishOnly": "npm run build"
   },

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -5,6 +5,12 @@ export default defineConfig({
     coverage: {
       include: ['src/**'],
       reporter: ['text', 'html', 'lcov', 'json'],
+      thresholds: {
+        statements: 87,
+        branches: 84,
+        functions: 93,
+        lines: 87,
+      },
     },
     exclude: [
       ...configDefaults.exclude,


### PR DESCRIPTION
## Summary

- enforce global Vitest coverage floors from the current core baseline
- make Codecov uploads fail CI and authenticate through GitHub OIDC
- add a scheduled/manual DeepSeek provider canary backed by a GitHub Actions secret

## Motivation

Coverage reports were generated but regressions did not fail Vitest, Codecov upload errors were non-blocking, and real-provider E2E suites had no independent automated canary.

## Scope and impact

- Affected areas: core test configuration, CI workflows, package scripts, and contributor documentation.
- Public API and runtime behavior: none.
- Compatibility or migration impact: none.
- Security: `DEEPSEEK_API_KEY` remains a GitHub Actions repository secret and is only injected into the scheduled/manual provider workflow. The key is not stored in source or workflow YAML.
- Dependencies: none.
- Intentional non-goal: provider E2E remains separate from deterministic PR test semantics.

## Validation

- `npm ci` — passed
- `npm run lint -w @open-multi-agent/core` — passed
- `npm run test:coverage -w @open-multi-agent/core` — passed: 123 files, 1,803 tests; statements/lines 87.78%, branches 84.27%, functions 93.8%
- negative threshold check with `--coverage.thresholds.lines=100` — failed as expected with exit code 1
- `git diff --check` — passed
- package JSON and both workflow YAML files parsed successfully
- DeepSeek E2E was not run locally because the credential is stored only in GitHub Actions; the new workflow will provide the real-provider validation after it lands

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING