### PR TITLE
docs: add a release guide and cover the OTel adapter in post-publish smoke

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -1,0 +1,137 @@
+# Releasing
+
+This repository publishes three packages from one npm workspaces root. This file
+records what ships, in what order, and what CI proves at each stage. The
+day-to-day contribution flow is in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## What ships
+
+| Package | Version track | Tagged | Published |
+|---|---|---|---|
+| `@open-multi-agent/core` | The trunk. Git tags and GitHub Releases track this version. | `vX.Y.Z` | Every release |
+| `@open-multi-agent/otel` | Independent. Depends on core through a semver range, so a core release does not force a republish. | No tag | Only when it changes |
+| `create-oma-app` | Independent. Its templates pin core exactly, so it ships alongside every core release. | No tag | Every core release |
+
+The root `package.json` is `private` and is never published. Each published
+package sets `publishConfig.access` to `public`, so no extra access flag is
+needed at publish time.
+
+## Versioning and tags
+
+- Only core is tagged. Tags are `vX.Y.Z` matching the core version, lightweight
+  rather than annotated, pointing at the release commit.
+- `@open-multi-agent/otel` and `create-oma-app` carry their own version numbers
+  and are not tagged.
+- [`CHANGELOG.md`](../CHANGELOG.md) is a single root file keyed by core version,
+  with an `## Unreleased` section at the top.
+
+## The release commit
+
+Version bumps land on `main` through a normal pull request before anything is
+published. A release commit contains:
+
+- the version bump in `packages/core/package.json`
+- the version bump in `packages/otel/package.json`, when otel is part of this
+  release
+- the version bump in `packages/create-oma-app/package.json`
+- the new core version pinned in every create-oma-app template manifest:
+  - `packages/create-oma-app/templates/demo/package.json`
+  - `packages/create-oma-app/templates/pr-review/package.json`
+  - `packages/create-oma-app/templates/security/package.json`
+  - `packages/create-oma-app/template/package.json`, the shared base
+- the `CHANGELOG.md` entry, moved out of `## Unreleased`
+- the regenerated `package-lock.json`
+
+The first three are what users receive, and the `package` job in `ci.yml`
+asserts each of them equals the current core version. The base manifest is not
+covered by that assertion and is not user-facing either, because every overlay
+ships its own `package.json` that overwrites the base copy at scaffold time. Keep
+it in sync anyway so local tooling and the base layer do not disagree with the
+release, but a stale pin there does not reach a generated project. See
+[`packages/create-oma-app/AGENTS.md`](../packages/create-oma-app/AGENTS.md) for
+the full set of template traps.
+
+## Order
+
+Publishing is manual. No workflow in `.github/workflows/` publishes to npm, and
+none is triggered by pushing a tag.
+
+1. **Land the release commit on `main`** through a pull request, with CI green.
+   Everything below is cut from that commit.
+2. **Publish to npm in order: `core`, then `otel` when it is part of this
+   release, then `create-oma-app`.** create-oma-app pins core exactly, so core
+   has to resolve from the registry before a freshly scaffolded project can
+   install. otel depends on core through a normal dependency, so it also needs
+   core live first.
+3. **Tag the release commit `vX.Y.Z` and push the tag.** The tag comes after
+   publishing on purpose: an npm version can never be republished, while an
+   unpushed tag costs nothing to redo, so a publish that goes wrong leaves no
+   tag pointing at a version that is not on the registry. Note that
+   `git push --follow-tags` skips lightweight tags, so push the tag explicitly.
+4. **Publish the GitHub Release last**, after every package for that version is
+   live on npm. Publishing it triggers `release-smoke.yml`, which resolves the
+   published packages from the real registry. Releasing before they are live
+   makes that run fail.
+
+## What CI proves
+
+### Before merge
+
+`ci.yml` runs on every push and pull request targeting `main`.
+
+- **`package`** builds every workspace, then:
+  - imports each core entry point, runs the CLI help, and exercises the
+    evaluation gate on both its pass and fail paths
+  - asserts the core, otel, and create-oma-app tarballs ship exactly the
+    expected files
+  - packs core, installs it, and smoke-tests the installed `oma` bin
+  - asserts `templates/*/package.json` pin the current core version, and
+    typechecks the template against core
+  - resolves the lowest core version allowed by otel's dependency range, packs
+    it from npm, and installs the real core and otel tarballs into clean
+    consumers
+- **`scaffold-e2e`** runs `npm run test:scaffold`: pack, scaffold, install, and
+  run, all from local tarballs.
+- **`lint`**, **`test`** across Node 20/22/24, and **`coverage`** cover the rest.
+
+Running `npm pack --dry-run` inside a package locally mirrors the tarball
+assertion CI performs.
+
+### After the GitHub Release
+
+`release-smoke.yml` triggers on `release: published` and runs two independent
+jobs against the real registry.
+
+**`npx-scaffold`** proves the published bytes work from a user's point of view:
+
+- `npx create-oma-app@latest <project> --template pr-review --provider cloud`
+- the generated `package.json` pins `@open-multi-agent/core` at exactly the
+  release tag without its leading `v`
+- `npm install` resolves that same core version
+- `npm run demo` succeeds with no API key set, driving the real scheduler and
+  report generation from scripted responses
+- `reports/` contains Markdown, JSON, and HTML output carrying the expected
+  demo-mode markers
+
+The whole chain retries up to three times with a delay, so a stale npm cache or
+CDN propagation lag becomes a retry rather than a failure.
+
+**`otel-consumer`** covers `@open-multi-agent/otel`, which has no tag of its own
+and would otherwise get no post-publish coverage:
+
+- reads the otel version from `packages/otel/package.json` at the release commit,
+  since the release tag only names the core version
+- installs that otel version together with the released core and pinned
+  OpenTelemetry packages into a clean consumer
+- asserts the resolved core is the released one, which catches a core release
+  that has outgrown otel's dependency range (npm would quietly resolve an older
+  core rather than fail the install)
+- emits a span record through `createOtelTraceSink` and asserts it reaches an
+  `InMemorySpanExporter`
+
+When otel did not change in a given release, its version is already live from an
+earlier one and this job still proves the pairing holds against the new core.
+
+**This is a post-publish alarm, not a gate.** The release is already out when
+either job runs. A red run means the published bytes are broken and a fix
+release is needed; it does not block anything.

--- a/.github/workflows/release-smoke.yml
+++ b/.github/workflows/release-smoke.yml
@@ -6,11 +6,16 @@ name: Release smoke
 # pins installs from npm, and the deterministic no-key demo produces all three
 # disclosed report formats without making a model request.
 #
+# The second job covers @open-multi-agent/otel, which rides its own version
+# track and carries no git tag of its own, so it would otherwise have no
+# post-publish coverage at all.
+#
 # This is a POST-publish alarm, not a gate. The release is already out, so a red
 # run here means "the published bytes are broken, cut a fix" — it does not block
-# anything. The pre-merge equivalent (the `scaffold-e2e` job in ci.yml) proves
-# the same chain from LOCAL tarballs during the release window; this one proves
-# it from the real npm registry once the version is actually live.
+# anything. The pre-merge equivalents (`scaffold-e2e` and the `package` job's
+# tarball consumers in ci.yml) prove the same chains from LOCAL tarballs during
+# the release window; this one proves them from the real npm registry once the
+# version is actually live.
 on:
   release:
     types: [published]
@@ -108,3 +113,116 @@ jobs:
           grep -q "Simulated model responses" "$dashboard"
 
           echo "✓ create-oma-app@latest installs core@$want and runs the disclosed no-key demo from npm"
+
+  otel-consumer:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # For a release event GITHUB_SHA is the commit the tag points at, so a
+      # bare checkout lands on the release commit. Do not interpolate the tag
+      # name into `ref:`.
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install the published OTel adapter alongside the published core
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          # Re-check the registry on each retry instead of trusting a stale
+          # cached resolution of a version that was just published.
+          npm_config_prefer_online: 'true'
+        run: |
+          set -euo pipefail
+          core_want="${RELEASE_TAG#v}"   # v1.11.0 -> 1.11.0
+
+          # @open-multi-agent/otel rides its own version track and carries no git
+          # tag, so the version this release ships is whatever the release commit
+          # declares. When otel did not change this cycle that version is already
+          # live from an earlier release, and this job still proves the pairing
+          # holds against the core we just published.
+          otel_want=$(node -p "require('./packages/otel/package.json').version")
+          echo "this release ships core@$core_want with otel@$otel_want"
+
+          consumer="$RUNNER_TEMP/otel-consumer"
+          mkdir -p "$consumer"
+          printf '%s' '{"name":"otel-consumer","private":true,"type":"module"}' > "$consumer/package.json"
+
+          # The OpenTelemetry versions are pinned so an unrelated upstream
+          # release cannot turn this alarm red on its own.
+          install_consumer() {
+            ( cd "$consumer" && npm install --no-audit --no-fund \
+                "@open-multi-agent/core@$core_want" \
+                "@open-multi-agent/otel@$otel_want" \
+                '@opentelemetry/api@1.9.0' \
+                '@opentelemetry/sdk-trace-base@2.9.0' )
+          }
+
+          attempt=1
+          until install_consumer; do
+            if [ "$attempt" -ge 3 ]; then
+              echo "::error::otel@$otel_want failed to install alongside core@$core_want after $attempt attempts"
+              exit 1
+            fi
+            echo "retrying after npm propagation delay (attempt $attempt)…"
+            attempt=$((attempt + 1))
+            sleep 30
+          done
+
+          installed_otel=$(node -p "require('$consumer/node_modules/@open-multi-agent/otel/package.json').version")
+          installed_core=$(node -p "require('$consumer/node_modules/@open-multi-agent/core/package.json').version")
+          if [ "$installed_otel" != "$otel_want" ]; then
+            echo "::error::installed otel@$installed_otel but this release ships otel@$otel_want"
+            exit 1
+          fi
+          # A core release that outgrows otel's dependency range resolves an
+          # older core here instead of failing the install, so compare rather
+          # than trusting npm to have errored.
+          if [ "$installed_core" != "$core_want" ]; then
+            echo "::error::otel@$otel_want resolved core@$installed_core instead of the released core@$core_want"
+            exit 1
+          fi
+
+      - name: Export a span through the published adapter
+        run: |
+          set -euo pipefail
+          consumer="$RUNNER_TEMP/otel-consumer"
+          cat > "$consumer/smoke.mjs" <<'FIXTURE'
+          import { BasicTracerProvider, InMemorySpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
+          import { createOtelTraceSink } from '@open-multi-agent/otel'
+
+          const exporter = new InMemorySpanExporter()
+          const provider = new BasicTracerProvider({ spanProcessors: [new SimpleSpanProcessor(exporter)] })
+          const sink = createOtelTraceSink({ tracerProvider: provider })
+
+          const traceId = 'a'.repeat(32)
+          const spanId = '1'.repeat(16)
+          const base = (recordId, sequence) => ({
+            schemaVersion: 2, recordId, sequence, timestampUnixMs: sequence,
+            runId: 'release-smoke', attempt: 1, traceId, spanId,
+          })
+
+          sink.emit({
+            ...base('start', 1), recordType: 'span_start', kind: 'run',
+            name: 'oma.run', startUnixMs: 1, attributes: {},
+          })
+          sink.emit({
+            ...base('end', 2), recordType: 'span_end', kind: 'run',
+            name: 'oma.run', startUnixMs: 1, endUnixMs: 2, durationMs: 1,
+            status: { code: 'ok' }, attributes: {},
+          })
+
+          const flushed = await sink.forceFlush({ timeoutMs: 5000 })
+          if (flushed.status !== 'ok') throw new Error('OTel flush failed: ' + flushed.status)
+
+          const spans = exporter.getFinishedSpans()
+          if (!spans.some((span) => span.name === 'oma.run')) {
+            throw new Error('the published adapter did not export the run span')
+          }
+
+          await sink.shutdown({ timeoutMs: 5000 })
+          await provider.shutdown()
+          console.log('published OTel adapter exported ' + spans.length + ' span(s)')
+          FIXTURE
+          node "$consumer/smoke.mjs"
+
+          echo "✓ the published otel adapter installs against the released core and exports spans"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Examples and core E2E tests may require real provider credentials. Unit tests mo
 - OpenTelemetry APIs, SDKs, semantic-convention packages, and exporters belong in `@open-multi-agent/otel`, never in the core root import. The application owns its tracer/provider lifecycle unless an API explicitly says otherwise.
 - Treat `docs/` as the source of truth for subsystem behavior. Keep this file to rules and concise invariants; link to docs instead of copying long explanations.
 - Follow conventional commits when a commit is requested. Reference a PR or issue when one exists. The full contribution flow is in [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md).
+- Publishing spans three packages with independent version tracks, a fixed publish order, and template pins that must move with the core version. Do not infer any of that from this file: [`.github/RELEASING.md`](.github/RELEASING.md) is the source of truth.
 - **Managed Git worktrees share repository metadata.** Never repair access by changing `.git` ownership or permissions. Use the current tool's normal Git and approval flow.
 - **Keep worktree dependencies isolated.** Run `npm ci` in each worktree and never symlink `node_modules` from another checkout.
 
@@ -62,20 +63,9 @@ Before finishing, report every command run and its outcome. If a relevant check 
 
 ## Architecture entry points
 
-Use this map to locate code; use the linked docs for behavior and contracts.
+`packages/core/src/` is organized one directory per subsystem (`orchestrator/`, `agent/`, `team/`, `task/`, `tool/`, `llm/`, `memory/`, `observability/`, `eval/`, `dashboard/`, `cli/`); run `ls packages/core/src/` to locate code, and use the linked docs below for behavior and contracts. Inside `orchestrator/`, `orchestrator.ts` is the entry point that the peer modules in that directory hang off.
 
-| Area | Entry points |
-|---|---|
-| Orchestration | `packages/core/src/orchestrator/orchestrator.ts` facade plus sibling run-context, budget, retry, task-execution, coordinator, consensus, and scheduler modules |
-| Agents and backends | `packages/core/src/agent/` — runner, pool, structured output, loop detection, process backend, and ACP backend |
-| Teams and tasks | `packages/core/src/team/`, `packages/core/src/task/` — roster, messaging, shared-memory binding, dependency queue, and task state |
-| Tools | `packages/core/src/tool/` — definitions, executor, MCP bridge, text fallback, built-ins, sandbox, and delegation |
-| LLM adapters | `packages/core/src/llm/` — adapter factory, provider adapters, OpenAI-compatible helpers, and reasoning fallback |
-| Memory and recovery | `packages/core/src/memory/` — shared memory, stores, file backends, and checkpointing |
-| Observability | `packages/core/src/observability/` for core records/sinks/stores; `packages/otel/src/` for the optional OpenTelemetry adapter |
-| Evaluation | `packages/core/src/eval/` — scorers, EvalSets, stores, offline/online runners, reports, and gates |
-| Dashboard and CLI | `packages/core/src/dashboard/`, `packages/core/src/cli/oma.ts` |
-| Public exports | `packages/core/src/index.ts` plus dedicated subpath entry points for observability, evaluation, MCP, AI SDK, ACP, process backends, and classifiers |
+The published surface is `packages/core/src/index.ts` plus the dedicated subpath entry points declared under `exports` in `packages/core/package.json`: `/observability`, `/observability/file`, `/eval`, `/eval/file`, `/mcp`, `/ai-sdk`, `/acp`, `/process`, and `/classifiers`. Keep that declaration and the backing source files in sync when adding or renaming one.
 
 `OpenMultiAgent` exposes three primary modes: `runAgent()` for a one-shot agent, `runTeam()` for coordinator-generated task DAGs, and `runTasks()` for explicit dependency pipelines. See the [core package README](packages/core/README.md#architecture) for the conceptual architecture.
 
@@ -97,6 +87,8 @@ These constraints span multiple files and can cause behavioral or compatibility 
 
 ## Subsystem documentation
 
+**This table is a curated selection, not a complete index.** `docs/` contains more files than are listed here. Run `ls docs/` for the full set before concluding that a topic is undocumented.
+
 | Topic | Source of truth |
 |---|---|
 | Context strategies and reasoning round-tripping | [docs/context-management.md](docs/context-management.md) |
@@ -108,6 +100,7 @@ These constraints span multiple files and can cause behavioral or compatibility 
 | Evaluation, scorers, stores, reports, sampling, and gates | [docs/evaluation.md](docs/evaluation.md) |
 | CLI commands and JSON schemas | [docs/cli.md](docs/cli.md) |
 | Process and ACP backends | [docs/external-agents.md](docs/external-agents.md) |
+| Routing, scheduling, consensus, recovery, and replay | [model-routing](docs/model-routing.md), [execution-routing](docs/execution-routing.md), [task-scheduling](docs/task-scheduling.md), [consensus](docs/consensus.md), [adaptive-recovery](docs/adaptive-recovery.md), [plan-replay](docs/plan-replay.md) |
 
 ## Adding an LLM adapter
 

--- a/packages/create-oma-app/CLAUDE.md
+++ b/packages/create-oma-app/CLAUDE.md
@@ -1,0 +1,3 @@
+# Claude Code instructions
+
+@AGENTS.md


### PR DESCRIPTION
## What

**`.github/RELEASING.md` (new).** The repository publishes three packages with
independent version tracks, a fixed publish order, and template pins that must
move with the core version. None of that was written down, so anyone cutting a
release had to reconstruct it from package manifests, git tags, and the
workflows. The guide records what ships, the ordered steps and why each depends
on the previous one, what a release commit must contain, and what CI proves
before merge versus what release-smoke proves after publish.

**`otel-consumer` job in `release-smoke.yml`.** `@open-multi-agent/otel` has its
own version track and no git tag, so post-publish verification covered core and
create-oma-app but never otel. The new job installs the published otel next to
the released core in a clean consumer and exports a span through
`createOtelTraceSink`. It also asserts the resolved core is the released one,
which catches a core release that has outgrown otel's dependency range: npm
resolves an older core in that case rather than failing the install.

**Root `AGENTS.md`.** The per-area entry point table drifted as subsystems
moved, so it is replaced by the directory layout plus the published export
surface. The subsystem documentation table is now marked as a curated selection
rather than a complete index of `docs/`, with the routing and scheduling docs
added. A Claude Code shim joins the existing `packages/create-oma-app/AGENTS.md`
so package-level rules load there the same way they do at the repository root.

## Verification

- `release-smoke.yml` parses, and both new run blocks pass `bash -n`.
- The `otel-consumer` logic was executed locally against the real registry with
  `RELEASE_TAG=v1.13.0`: it resolved `core@1.13.0` with `otel@0.1.0`, installed
  cleanly, and exported one span through the published adapter.
- The version assertions were negative-tested to confirm they fail on a
  mismatch rather than passing vacuously.
- `git diff --check` is clean. No source, template, or generated output changed,
  so the workspace test suites are unaffected.
