### PR TITLE
chore(deps): restore AI SDK 7 development dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,74 @@
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "4.0.36",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.36.tgz",
+      "integrity": "sha512-N1P6bdW/aC5rxLeuGYgx3X4el3DoZy8UWlky+g+AeIZSmxaEi/AToHJL4cmZ6nCPHk1byqJWwC+PaOZG0hK0dw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.27.tgz",
+      "integrity": "sha512-6MsWnbNG0ZjZgzYimNNjnTAlOFXn+jdLMFB47dDVUsRNjxdUoTSduCQPZZeTKoUl0ZNwCjsJ31of49l/t1r9MA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.4.tgz",
+      "integrity": "sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.18",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.18.tgz",
+      "integrity": "sha512-UBNCrkxS5llgN2/RXLBRkjCFTIuL6YB1Goq5c+yRecnznhtX4XPjTwLHz2hrsTltTVZ0rqVegtnwFXdPBkjDHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.4",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8",
+        "undici": "^7.28.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
@@ -2905,6 +2973,13 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -2954,6 +3029,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "7.0.47",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.47.tgz",
+      "integrity": "sha512-e0MpNtufu6JmcmwMUTgM1smCRkP5z014iPaKgnCm7kmMsTSIZbOJN2vglhPq0WIj/6x7ewVi6W0FyIR0pjaE3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.36",
+        "@ai-sdk/provider": "4.0.4",
+        "@ai-sdk/provider-utils": "5.0.18"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -5851,6 +5944,16 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -6220,14 +6323,14 @@
       },
       "devDependencies": {
         "@agentclientprotocol/sdk": "^1.2.1",
-        "@ai-sdk/openai": "^3.0.89",
-        "@ai-sdk/provider": "^3.0.14",
+        "@ai-sdk/openai": "^4.0.0",
+        "@ai-sdk/provider": "^4.0.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
         "@google/genai": "^1.48.0",
         "@modelcontextprotocol/sdk": "^1.18.0",
         "@types/node": "^22.0.0",
         "@vitest/coverage-v8": "^2.1.9",
-        "ai": "^6.0.237",
+        "ai": "^7.0.0",
         "tsx": "^4.21.0",
         "typescript": "^5.6.0",
         "vitest": "^2.1.0"
@@ -6258,109 +6361,6 @@
         "ai": {
           "optional": true
         }
-      }
-    },
-    "packages/core/node_modules/@ai-sdk/openai": {
-      "version": "3.0.89",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.89.tgz",
-      "integrity": "sha512-G5Brp7duF/pPxaY1wa3pR4mV18qcEVtcrfZT4YxzheR2iP672auUdHoddCqyKS9RxTtZQyxXQ6bNiTcKvaWgIg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.40"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/core/node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.40",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
-      "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
-        "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.8"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/core/node_modules/@ai-sdk/provider": {
-      "version": "3.0.14",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
-      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "json-schema": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "packages/core/node_modules/ai": {
-      "version": "6.0.237",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.237.tgz",
-      "integrity": "sha512-TdiKxGoYrKQyaN6fkk1WRxA+XSQ8nO3LZo/QVnJsME54bMuddXqzJ4KrJozF5/czHfJ5BmgHJ4mJmGqRZHX3Hw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/gateway": "3.0.159",
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.40",
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/core/node_modules/ai/node_modules/@ai-sdk/gateway": {
-      "version": "3.0.159",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.159.tgz",
-      "integrity": "sha512-BJ1SMVpD2Qie/OVmQho1b1wb8rcGYC38p2D20MyP0+zUGBlXJOMfq1zP97+tl1oyT1u/A84R+oaYrUT18dIdWg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
-        "@ai-sdk/provider-utils": "4.0.40",
-        "@vercel/oidc": "3.2.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "packages/core/node_modules/ai/node_modules/@ai-sdk/provider-utils": {
-      "version": "4.0.40",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
-      "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.14",
-        "@standard-schema/spec": "^1.1.0",
-        "eventsource-parser": "^3.0.8"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "packages/core/node_modules/openai": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -131,14 +131,14 @@
   },
   "devDependencies": {
     "@agentclientprotocol/sdk": "^1.2.1",
-    "@ai-sdk/openai": "^3.0.89",
-    "@ai-sdk/provider": "^3.0.14",
+    "@ai-sdk/openai": "^4.0.0",
+    "@ai-sdk/provider": "^4.0.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
     "@google/genai": "^1.48.0",
     "@modelcontextprotocol/sdk": "^1.18.0",
     "@types/node": "^22.0.0",
     "@vitest/coverage-v8": "^2.1.9",
-    "ai": "^6.0.237",
+    "ai": "^7.0.0",
     "tsx": "^4.21.0",
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"


### PR DESCRIPTION
## Summary

- restore `ai` to `^7.0.0` and `@ai-sdk/openai` / `@ai-sdk/provider` to `^4.0.0` in core's development dependencies
- #453 lowered them while retargeting OpenAI to v6 and retaining Node 20, which left the `ai: ^5.0.0 || ^6.0.0 || ^7.0.0` optional peer range advertising a version no test exercised
- development dependencies only, so no published bytes change

## Known tradeoff

`ai@7` and `@ai-sdk/openai@4` declare `engines: node >=22` while core supports Node 20, so the Node 20 leg now logs EBADENGINE warnings. The repository sets no `engine-strict`, so `npm ci` still exits 0 and the suite passes.

## Validation

- `npm run lint`, `npm test`, `npm run build` on Node 22.23.1: all workspaces pass
- `npm ci` and `npm test` re-run on Node 20.19.4: install exits 0, core 1824 / create-oma-app 31 / otel 15 tests pass
- lockfile delta adds only AI SDK 7 transitives and removes nothing; `npm ci` from the new lockfile reproduces the tree

Refs #348, #453
