### PR TITLE
chore: release core v1.14.0 + otel v0.1.1 + create-oma-app v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 ## Unreleased
 
+## 1.14.0 - 2026-08-01
+
+### Added
+
+- Adaptive plan recovery lets a run revise the not-yet-executed part of its task
+  graph. Opt in with `recovery.mode: 'repairable'`, then supply a `Replanner` or
+  an `onTaskOutcome` callback that proposes an append-only `PlanPatch`. Patches
+  are validated for agent eligibility, limits, task states, references, and the
+  resulting DAG, gated through the optional `onPlanPatch` approval, and applied
+  atomically at a task-outcome barrier before downstream dispatch or failure
+  cascade. Revision history is exposed in results, progress events, and
+  observability spans.
+- Hybrid semantic execution routing supplements the deterministic router with a
+  single structured semantic assessment. Opt in with
+  `executionRouting: { strategy: 'hybrid' }`. The release adds a
+  provider-neutral `TaskProfiler` interface, a built-in `LLMTaskProfiler`, a
+  strict task-profile schema, typed routing failures with timeout and fallback
+  metadata, and semantic-routing observability.
+- DeepSeek V4 Flash reasoning controls. `AgentConfig.thinking.enabled` now maps
+  to DeepSeek's native `thinking.type`, and `thinking.effort` accepts the
+  DeepSeek-only value `'max'` without forwarding it to OpenAI, Azure OpenAI, or
+  GitHub Copilot.
+- `validateTaskRequirements` is exported for callers that want to check task
+  requirements against a roster before dispatch.
+- New typed errors are exported for the failure modes above:
+  `InvalidTaskRequirementsError`, `UnsupportedToolCallError`,
+  `RoutingDeclarationRequiredError`, `RoutingProfilerFailedError`, and
+  `RoutingTimeoutError`.
+
+### Changed
+
+- **Node.js 20 or newer is now required.** The `engines` floor moved from 18 to
+  20 across `@open-multi-agent/core`, `@open-multi-agent/otel`, and
+  `create-oma-app`. Node 18 reached end of life on 2025-04-30.
+- The bundled `openai` dependency moved from v4 to v6. OpenAI user aborts are
+  now classified as cancellation rather than as a retryable failure, and
+  unsupported custom tool calls are rejected explicitly instead of being passed
+  through.
+- Task requirements are enforced as global hard constraints. A task whose
+  requirements no agent satisfies is now rejected rather than assigned to an
+  ineligible agent.
+
+### Fixed
+
+- Invalid task dependency graphs are rejected up front instead of executing a
+  partially valid plan.
+- The coordinator fails closed on an invalid plan rather than continuing with a
+  plan it could not validate.
+
+### Compatibility
+
+- Automatic `runTeam()` routing remains deterministic. Hybrid semantic routing
+  is opt-in through `executionRouting.strategy` and does not change existing
+  runs.
+- Adaptive plan recovery is opt-in. Task graphs stay fixed unless
+  `recovery.mode` selects `'repairable'`.
+- Runs that previously succeeded with an invalid task DAG or an unsatisfiable
+  task requirement now fail at validation time. This surfaces a defect that was
+  previously silent; correct graphs and rosters are unaffected.
+- Adaptive recovery adds a version 2 task-queue snapshot carrying plan-revision
+  history. `TaskQueue.fromSnapshot()` still accepts version 1 snapshots, so
+  checkpoints written by earlier releases remain restorable.
+- Every public export from 1.13.0 is still exported. New result and
+  configuration fields remain optional, so existing callers and serialized
+  results continue to type-check.
+
 ## 1.13.0 - 2026-07-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -6311,7 +6311,7 @@
     },
     "packages/core": {
       "name": "@open-multi-agent/core",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
@@ -6394,7 +6394,7 @@
       }
     },
     "packages/create-oma-app": {
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "bin": {
         "create-oma-app": "dist/index.js"
@@ -6410,7 +6410,7 @@
     },
     "packages/otel": {
       "name": "@open-multi-agent/otel",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@open-multi-agent/core": "^1.11.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "TypeScript multi-agent framework: one runTeam() call from goal to result. Auto task decomposition and parallel execution for multi-step LLM jobs. Deploys anywhere Node.js runs.",
   "files": [
     "dist",

--- a/packages/create-oma-app/package.json
+++ b/packages/create-oma-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-oma-app",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Scaffold PR review, security analysis, and multi-agent DAG starters on @open-multi-agent/core.",
   "type": "module",
   "bin": {

--- a/packages/create-oma-app/template/package.json
+++ b/packages/create-oma-app/template/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.13.0"
+    "@open-multi-agent/core": "1.14.0"
   },
   "devDependencies": {
     "tsx": "^4.21.0"

--- a/packages/create-oma-app/templates/demo/package.json
+++ b/packages/create-oma-app/templates/demo/package.json
@@ -11,7 +11,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.13.0"
+    "@open-multi-agent/core": "1.14.0"
   },
   "devDependencies": {
     "tsx": "^4.21.0"

--- a/packages/create-oma-app/templates/pr-review/package.json
+++ b/packages/create-oma-app/templates/pr-review/package.json
@@ -11,7 +11,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.13.0",
+    "@open-multi-agent/core": "1.14.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/create-oma-app/templates/security/package.json
+++ b/packages/create-oma-app/templates/security/package.json
@@ -11,7 +11,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.13.0",
+    "@open-multi-agent/core": "1.14.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/otel/package.json
+++ b/packages/otel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/otel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Optional OpenTelemetry adapter for @open-multi-agent/core TraceRecord v2.",
   "files": [
     "dist",

--- a/packages/otel/src/version.ts
+++ b/packages/otel/src/version.ts
@@ -3,4 +3,4 @@
  * instrumentationVersion. A guard test asserts it matches package.json, so
  * bumping the package without bumping this constant fails CI.
  */
-export const PACKAGE_VERSION = '0.1.0'
+export const PACKAGE_VERSION = '0.1.1'


### PR DESCRIPTION
## Summary

- bump `@open-multi-agent/core` from `1.13.0` to `1.14.0`
- bump `@open-multi-agent/otel` from `0.1.0` to `0.1.1` so the published package carries the Node 20 `engines` floor; its core dependency range stays `^1.11.0`
- bump `create-oma-app` from `0.6.0` to `0.7.0` and pin all generated starters to core `1.14.0`
- finalize the `1.14.0` changelog for the adaptive recovery, hybrid semantic routing, DeepSeek reasoning, task-requirement, and dependency changes already merged to `main`

## Motivation

Prepare the coordinated npm release for changes merged after `v1.13.0`. The scaffolder must be published with an exact core `1.14.0` pin so the post-release registry smoke validates one coherent release. Unlike the previous release, otel is part of this one: #453 moved its `engines` floor from Node 18 to Node 20, and the published `0.1.0` still declares the old floor.

## Scope and impact

Affected workspaces: `@open-multi-agent/core`, `@open-multi-agent/otel`, `create-oma-app`, root release metadata, and starter manifests.

The underlying public APIs and behavior were introduced by previously merged PRs. This release metadata documents adaptive plan recovery, opt-in hybrid semantic execution routing, DeepSeek V4 Flash reasoning controls, globally enforced task requirements, and fail-closed validation for task DAGs and coordinator plans.

The public export surface was diffed against `v1.13.0`: nothing was removed, so `^1.x` consumers keep every symbol they had. Compatibility notes are recorded in `CHANGELOG.md`: automatic routing stays deterministic, adaptive recovery is opt-in, version 1 task-queue snapshots remain restorable, and runs that previously succeeded with an invalid DAG or an unsatisfiable task requirement now fail at validation time.

The one user-visible break is the Node 18 to Node 20 `engines` floor. Node 18 reached end of life on 2025-04-30.

Security/privacy impact: none from this release-only diff. A clean consumer install of the packed core `1.14.0` resolves 4 packages and reports zero vulnerabilities. The root `npm audit --omit=dev` reports one high advisory in `fast-xml-builder`, reachable only through the optional peer `@aws-sdk/client-bedrock-runtime` in this repository's own tree; it is not installed by consumers.

Intentional non-goals: no npm publication, tag, or GitHub Release in this PR.

## Validation

All commands run on Node 22.23.1 unless noted.

- `npm ci` — passed
- `npm run lint` — all three workspaces passed
- `npm test` — passed: core 1,824; create-oma-app 31; OTel 15 tests
- `npm run build` — all three workspaces passed
- `npm run typecheck:template -w create-oma-app` — all three templates passed
- `npm run test:scaffold` — packed CLI, all template/runtime combinations, no-key demos, Cloud gate, and Ollama gate passed
- `npm run test:example-catalog` — 9 checks passed, 59 catalog entries validated
- CI-equivalent `npm run test:observability-pack` with `OMA_OBSERVABILITY_MIN_CORE_TARBALL` set to core `1.11.0` packed from npm — core-only, core + OTel, and minimum-core scenarios passed against otel `0.1.1`
- `npm run test:observability-examples` — 7 examples passed
- `npm run test:eval-examples` — passed
- `npm run bench:observability:ci` — passed
- dry-run packs — core `1.14.0` (523 files), otel `0.1.1` (19 files), create-oma-app `0.7.0` (28 files)
- clean-consumer install of the packed core `1.14.0` tarball — resolves 4 packages, `npm audit` reports zero vulnerabilities
- `git diff --check` — passed
