### PR TITLE
docs(readme): lead with the quickstart and fix the root snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,8 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@open-multi-agent/core"><img src="https://img.shields.io/npm/v/@open-multi-agent/core" alt="npm version"></a>
   <a href="https://github.com/open-multi-agent/open-multi-agent/actions/workflows/ci.yml"><img src="https://github.com/open-multi-agent/open-multi-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License"></a>
-  <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-5.6-blue" alt="TypeScript"></a>
   <a href="https://codecov.io/gh/open-multi-agent/open-multi-agent"><img src="https://codecov.io/gh/open-multi-agent/open-multi-agent/graph/badge.svg" alt="codecov"></a>
-  <a href="https://github.com/open-multi-agent/open-multi-agent/stargazers"><img src="https://img.shields.io/github/stars/open-multi-agent/open-multi-agent" alt="GitHub stars"></a>
-  <a href="https://github.com/open-multi-agent/open-multi-agent/network/members"><img src="https://img.shields.io/github/forks/open-multi-agent/open-multi-agent" alt="GitHub forks"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License"></a>
 </p>
 
 <p align="center">
@@ -48,29 +45,6 @@
 
 `open-multi-agent` is an AI agent orchestration framework for TypeScript backends that drops into any Node.js app. It runs **dynamic workflows**: a coordinator turns one goal into a task DAG at runtime, a deterministic scheduler executes it across the team, and the whole run stays data you can inspect, approve, and replay. The dashboard above is the built-in offline Run Viewer replaying a real run.
 
-## Why OMA
-
-OMA combines dynamic orchestration with the control, evidence, and recovery paths needed to move multi-agent systems from prototype to production.
-
-- **Dynamic orchestration.** Describe the goal and let the coordinator build the task DAG, assign work, and synthesize the result at runtime. There is no hand-wired graph to maintain.
-- **Controlled execution.** Keep dynamic plans within explicit boundaries.
-
-  - **Approve:** Preview and approve plans or individual dispatches, then freeze approved plans for replay.
-  - **Constrain:** Declare required roles and order when topology cannot drift, and verify outputs with multi-agent consensus.
-
-- **Production essentials.** Run reliably, diagnose failures, and prevent quality regressions.
-
-  - **Reliability:** Resume interrupted runs from checkpoints or opt into append-only plan repair at task outcome barriers. Retries, timeouts, loop detection, and token and cost budgets keep execution bounded.
-  - **Observability:** Follow each run through stable identity, execution receipts, and traces; query them in TraceStore, replay the task DAG and span waterfall in the offline Run Viewer, or export through the optional OpenTelemetry adapter.
-  - **Evaluation:** Use the same run records for versioned EvalSets, reference scorers, offline reports, CI gates, regression baselines, and production sampling.
-  - **Safety and privacy:** Keep tools default-deny, gate individual calls, and apply explicit privacy controls to telemetry and persisted state.
-
-- **Open runtime.** Bring OMA into your stack without giving up control of agents, models, infrastructure, or credentials.
-
-  - **Agents:** Process and ACP backends let Claude Code, Gemini CLI, and Codex join LLM agents on the same task DAG, shared memory, and budgets.
-  - **Models:** Mix cloud and local models, natively integrated Chinese providers, OpenAI-compatible endpoints, and AI SDK providers. A fallback parser covers local models that emit tool calls as text.
-  - **Deployment:** Run on your own infrastructure and credentials, locally, offline, or air-gapped. A minimal runtime footprint fits locked-down environments.
-
 ## Get started
 
 Requires Node.js 20 or newer. For production, use a currently maintained
@@ -82,7 +56,7 @@ Scaffold a PR review agent, security analysis agent, or teaching DAG:
 npm create oma-app@latest my-oma
 ```
 
-In an interactive terminal, that one command selects a starter and runtime, installs dependencies, and runs a deterministic local demo. The demo needs no API key and makes no model request: scripted model responses drive the real OMA scheduler, result aggregation, and offline dashboard. Use `--no-install` to generate files only, or `--no-run` to install without starting the demo.
+In an interactive terminal, that one command selects a starter and runtime, installs dependencies, and runs a deterministic local demo. The demo needs no API key and makes no model request: scripted model responses drive the real OMA scheduler, result aggregation, and offline dashboard. The [Core package guide](packages/core/README.md#quick-start) covers the flags and runtime choices.
 
 Or add OMA to an existing backend:
 
@@ -93,7 +67,9 @@ npm install @open-multi-agent/core
 ```typescript
 import { OpenMultiAgent } from '@open-multi-agent/core'
 
-const oma = new OpenMultiAgent({ defaultProvider: 'openai', defaultModel: 'gpt-5.4' })
+const model = process.env.OMA_MODEL ?? 'gpt-5.4'
+
+const oma = new OpenMultiAgent({ defaultProvider: 'openai', defaultModel: model })
 
 const team = oma.createTeam('research-team', {
   name: 'research-team',
@@ -105,20 +81,41 @@ const team = oma.createTeam('research-team', {
 })
 
 const result = await oma.runTeam(team, 'Compare three approaches and recommend one.')
+
+// Nothing above declares a task graph. The coordinator planned one at runtime,
+// and the finished run is data you can read back.
+for (const task of result.tasks ?? []) {
+  console.log(`[${task.status}] ${task.title} → ${task.assignee ?? 'unassigned'}`, task.dependsOn)
+}
+
 console.log(result.agentResults.get('coordinator')?.output)
+console.log(result.totalTokenUsage)
 ```
 
+Set `OPENAI_API_KEY` to run this example. [Providers](docs/providers.md) covers other hosted models, local servers, OpenAI-compatible endpoints, and AI SDK providers.
+
 `runTeam()` plans from a goal, `runAgent()` runs a single agent, and `runTasks()` executes an explicit pipeline. The [Core package guide](packages/core/README.md) walks through all three modes, provider and credential setup, and the production checklist. The [example index](packages/core/examples/README.md) lists 50+ runnable examples across basics, cookbook workflows, patterns, providers, and integrations.
+
+## Why OMA
+
+OMA combines dynamic orchestration with the control, evidence, and recovery paths needed to move multi-agent systems from prototype to production.
+
+- **Dynamic orchestration.** Describe the goal and let the coordinator build the task DAG, assign work, and synthesize the result at runtime. There is no hand-wired graph to maintain.
+- **Controlled execution.** Preview and approve plans or individual dispatches and freeze approved plans for replay. Declare required roles and order when topology cannot drift, and verify outputs with multi-agent consensus.
+- **Reliability.** Resume interrupted runs from checkpoints, or opt into append-only plan repair at task outcome barriers. Retries, timeouts, loop detection, and token and cost budgets keep execution bounded.
+- **Observability and evaluation.** Follow each run through stable identity, execution receipts, and traces. Replay the task DAG and span waterfall in the offline Run Viewer, or export through the optional OpenTelemetry adapter. The same records feed versioned EvalSets, offline reports, CI gates, and production sampling.
+- **Safety and privacy.** Tools are default-deny, individual calls are gated, and explicit privacy controls apply to telemetry and persisted state.
+- **Open runtime.** Process and ACP backends put Claude Code, Gemini CLI, and Codex on the same task DAG, shared memory, and budgets as LLM agents. Mix cloud and local models, natively integrated Chinese providers, OpenAI-compatible endpoints, and AI SDK providers, with a fallback parser for local models that emit tool calls as text. Run on your own infrastructure and credentials, locally, offline, or air-gapped.
 
 ## Built with OMA
 
 `open-multi-agent` launched 2026-04-01 under MIT. Known users and integrations to date:
 
-- **[temodar-agent](https://github.com/xeloxa/temodar-agent)**. WordPress security analysis platform by [Ali Sünbül](https://github.com/xeloxa). Uses our built-in tools (`bash`, `file_*`, `grep`) directly inside a Docker runtime. Confirmed production use.
-- **[Mark Galyan](https://github.com/apollo-mg)** runs OMA fully offline on local quantized models, using the Coordinator and context compaction to keep autonomous agent loops alive under tight VRAM limits. Contributor since the framework's first month, across compaction, sampling, and tool-call parsing.
-- **[PR-Copilot](https://github.com/kidoom/PR-Copilot)**. AI pull-request review assistant by [kidoom](https://github.com/kidoom). Runs an OMA review team (coordinator + scoped reviewer agents), defines repo-context tools with `defineTool`, and adds a custom `ContextStrategy` for token-aware PR-diff compression. Public code on `@open-multi-agent/core`.
-- **[StuFlow](https://github.com/znc15/StuFlow)** by [znc15](https://github.com/znc15). Terminal AI coding assistant on OMA's orchestration core: builds a team and drives it through `runAgent` / `runTasks` / `runTeam` with a custom `RunTeamOptions` coordinator, paired with DeepSeek. Public code on `@open-multi-agent/core`.
-- **[Reports to Charts Studio](https://github.com/NARNIX0/Evident-Project)**. Turns documents and research tables into slide-ready charts. Uses OMA to run a five-role extraction council with structured outputs and deterministic validation. Public code on `@open-multi-agent/core`.
+- **[temodar-agent](https://github.com/xeloxa/temodar-agent)** by [Ali Sünbül](https://github.com/xeloxa). WordPress security analysis platform running OMA's built-in tools (`bash`, `file_*`, `grep`) inside a Docker runtime. Confirmed production use.
+- **[Mark Galyan](https://github.com/apollo-mg)** runs OMA fully offline on local quantized models, using the coordinator and context compaction to keep autonomous agent loops alive under tight VRAM limits. Contributor since the framework's first month.
+- **[PR-Copilot](https://github.com/kidoom/PR-Copilot)** by [kidoom](https://github.com/kidoom). AI pull-request review assistant running an OMA review team, with `defineTool` repo-context tools and a custom `ContextStrategy` for token-aware diff compression.
+- **[StuFlow](https://github.com/znc15/StuFlow)** by [znc15](https://github.com/znc15). Terminal AI coding assistant on OMA's orchestration core, driving `runAgent` / `runTasks` / `runTeam` with a custom coordinator, paired with DeepSeek.
+- **[Reports to Charts Studio](https://github.com/NARNIX0/Evident-Project)**. Turns documents and research tables into slide-ready charts, using a five-role extraction council with structured outputs and deterministic validation.
 
 **Integrations**
 
@@ -148,7 +145,7 @@ Core users can store traces locally and inspect them with the offline Run Viewer
 
 ## Commercial support
 
-Need to embed agent capabilities in an existing product or business system? Email [jack@yuanasi.com](mailto:jack@yuanasi.com) for discovery and delivery support.
+Need to embed agent capabilities in an existing product or business system? We help teams scope AI use cases, embed agent capabilities, and support delivery. Email [jack@yuanasi.com](mailto:jack@yuanasi.com).
 
 ## Documentation
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -20,11 +20,8 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/@open-multi-agent/core"><img src="https://img.shields.io/npm/v/@open-multi-agent/core" alt="npm version"></a>
   <a href="https://github.com/open-multi-agent/open-multi-agent/actions/workflows/ci.yml"><img src="https://github.com/open-multi-agent/open-multi-agent/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License"></a>
-  <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-5.6-blue" alt="TypeScript"></a>
   <a href="https://codecov.io/gh/open-multi-agent/open-multi-agent"><img src="https://codecov.io/gh/open-multi-agent/open-multi-agent/graph/badge.svg" alt="codecov"></a>
-  <a href="https://github.com/open-multi-agent/open-multi-agent/stargazers"><img src="https://img.shields.io/github/stars/open-multi-agent/open-multi-agent" alt="GitHub stars"></a>
-  <a href="https://github.com/open-multi-agent/open-multi-agent/network/members"><img src="https://img.shields.io/github/forks/open-multi-agent/open-multi-agent" alt="GitHub forks"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="MIT License"></a>
 </p>
 
 <p align="center">
@@ -48,29 +45,6 @@
 
 `open-multi-agent` 是面向 TypeScript 后端的多智能体编排框架，可直接嵌入任意 Node.js 应用。它运行的是**动态工作流（dynamic workflows）**：Coordinator 在运行时将一个目标分解为任务 DAG，由确定性调度器分派给团队执行，整个运行过程始终是可审查、可审批、可回放的数据。上方动图就是内置的离线 Run Viewer 在回放一次真实运行。
 
-## 为什么选择 OMA
-
-OMA 将动态编排与生产所需的控制、证据和恢复能力结合起来，帮助多智能体系统从原型走向生产环境。
-
-- **动态编排。** 只需描述目标，Coordinator 就会在运行时生成任务 DAG、分配工作并合成结果，无需手工维护工作流图。
-- **受控执行。** 让动态计划始终处于显式边界内。
-
-  - **审批：** 预览和审批计划或单任务派发，并固化已审批计划以供重放。
-  - **约束：** 当拓扑不容漂移时声明必需的角色与执行顺序，并通过多 Agent 共识验证结果。
-
-- **生产必备。** 让运行可恢复、故障可诊断，并及时发现质量退化。
-
-  - **可靠性：** 通过 Checkpoint 从断点恢复中断的运行，或选择在任务结果屏障处启用仅追加式计划修复；重试、超时、循环检测与 token、成本双预算让执行始终有明确边界。
-  - **可观测性：** 通过稳定的运行标识、执行回执与 Trace 跟踪每次运行；使用 TraceStore 查询记录，在离线 Run Viewer 中回放任务 DAG 与 span 瀑布，或通过可选的 OpenTelemetry 适配器导出。
-  - **评测：** 使用同一套运行记录支撑版本化 EvalSet、参考 scorer 打分、离线报告、CI gate、回归基线与线上采样。
-  - **安全与隐私：** 内置工具默认拒绝，支持逐次调用 gate，并对遥测与持久化状态应用显式的隐私控制。
-
-- **开放运行时。** 将 OMA 嵌入现有技术栈，同时保留对 Agent、模型、基础设施与凭证的控制权。
-
-  - **Agent：** Process 与 ACP backend 让 Claude Code、Gemini CLI、Codex 和 LLM Agent 同处一个任务 DAG，并共享记忆与预算。
-  - **模型：** 在同一团队混用云端模型、本地开源模型、原生接入的国产模型、OpenAI 兼容端点与 AI SDK provider，并通过容错解析支持以文本形式返回工具调用的本地模型。
-  - **部署：** 使用自己的基础设施与凭证，支持本地、离线或气隙部署；极小的运行时占用可适配受限内网环境。
-
 ## 快速开始
 
 要求 Node.js 20 或更高版本。生产环境请使用仍处于维护期的 Node.js LTS 版本。
@@ -81,7 +55,7 @@ OMA 将动态编排与生产所需的控制、证据和恢复能力结合起来�
 npm create oma-app@latest my-oma
 ```
 
-在交互式终端中，这一条命令会完成 starter 与 runtime 选择、依赖安装，并运行确定性的本地 Demo。Demo 不需要 API Key，也不会发起模型请求：预置模型响应负责模拟生成边界，OMA 的调度、结果聚合与离线 Dashboard 均真实运行。使用 `--no-install` 可仅生成文件，使用 `--no-run` 可安装但不启动 Demo。
+在交互式终端中，这一条命令会完成 starter 与 runtime 选择、依赖安装，并运行确定性的本地 Demo。Demo 不需要 API Key，也不会发起模型请求：预置模型响应负责模拟生成边界，OMA 的调度、结果聚合与离线 Dashboard 均真实运行。命令行参数与 runtime 选项见[核心包使用指南](packages/core/README_zh.md#快速开始)。
 
 也可以把 OMA 直接加入现有后端：
 
@@ -92,7 +66,9 @@ npm install @open-multi-agent/core
 ```typescript
 import { OpenMultiAgent } from '@open-multi-agent/core'
 
-const oma = new OpenMultiAgent({ defaultProvider: 'openai', defaultModel: 'gpt-5.4' })
+const model = process.env.OMA_MODEL ?? 'gpt-5.4'
+
+const oma = new OpenMultiAgent({ defaultProvider: 'openai', defaultModel: model })
 
 const team = oma.createTeam('research-team', {
   name: 'research-team',
@@ -104,20 +80,41 @@ const team = oma.createTeam('research-team', {
 })
 
 const result = await oma.runTeam(team, 'Compare three approaches and recommend one.')
+
+// 以上代码没有声明任何任务图，任务 DAG 由 Coordinator 在运行时生成，
+// 运行结束后整个过程都是可以读回的数据。
+for (const task of result.tasks ?? []) {
+  console.log(`[${task.status}] ${task.title} → ${task.assignee ?? 'unassigned'}`, task.dependsOn)
+}
+
 console.log(result.agentResults.get('coordinator')?.output)
+console.log(result.totalTokenUsage)
 ```
 
+运行这段示例需要设置 `OPENAI_API_KEY`。其他云端模型、本地服务、OpenAI 兼容端点与 AI SDK provider 的配置见 [Provider 文档](docs/providers.md)。
+
 `runTeam()` 从目标自动规划，`runAgent()` 运行单个 Agent，`runTasks()` 执行显式流水线。三种模式、Provider 与凭证配置、生产检查清单见[核心包使用指南](packages/core/README_zh.md)。[示例索引](packages/core/examples/README.md)收录 50+ 个可运行示例，覆盖基础、cookbook 流程、模式、Provider 与集成。
+
+## 为什么选择 OMA
+
+OMA 将动态编排与生产所需的控制、证据和恢复能力结合起来，帮助多智能体系统从原型走向生产环境。
+
+- **动态编排。** 只需描述目标，Coordinator 就会在运行时生成任务 DAG、分配工作并合成结果，无需手工维护工作流图。
+- **受控执行。** 可预览和审批计划或单任务派发，并固化已审批计划以供重放；当拓扑不容漂移时可声明必需的角色与执行顺序，并通过多 Agent 共识验证结果。
+- **可靠性。** 通过 Checkpoint 从断点恢复中断的运行，或选择在任务结果屏障处启用仅追加式计划修复；重试、超时、循环检测与 token、成本双预算让执行始终有明确边界。
+- **可观测与评测。** 通过稳定的运行标识、执行回执与 Trace 跟踪每次运行，在离线 Run Viewer 中回放任务 DAG 与 span 瀑布，或通过可选的 OpenTelemetry 适配器导出；同一套运行记录可直接支撑版本化 EvalSet、离线报告、CI gate 与线上采样。
+- **安全与隐私。** 内置工具默认拒绝，支持逐次调用 gate，并对遥测与持久化状态应用显式的隐私控制。
+- **开放运行时。** Process 与 ACP backend 让 Claude Code、Gemini CLI、Codex 和 LLM Agent 同处一个任务 DAG，并共享记忆与预算；可混用云端模型、本地开源模型、原生接入的国产模型、OpenAI 兼容端点与 AI SDK provider，并通过容错解析支持以文本形式返回工具调用的本地模型；支持使用自有基础设施与凭证，本地、离线或气隙部署。
 
 ## 基于 OMA 构建
 
 `open-multi-agent` 2026-04-01 发布，MIT 协议。当前公开在用与集成的项目：
 
-- **[temodar-agent](https://github.com/xeloxa/temodar-agent)**。WordPress 安全分析平台，作者 [Ali Sünbül](https://github.com/xeloxa)。在 Docker runtime 里直接用我们的内置工具（`bash`、`file_*`、`grep`）。已确认生产环境使用。
-- **[Mark Galyan](https://github.com/apollo-mg)** 在本地量化模型上完全离线运行 OMA，借助 coordinator 与上下文压缩，在显存受限的条件下维持自治 agent 循环持续运行。自框架发布首月起持续贡献，涵盖上下文压缩、采样与工具调用解析。
-- **[PR-Copilot](https://github.com/kidoom/PR-Copilot)**。AI pull request 审查助手，作者 [kidoom](https://github.com/kidoom)。运行一个 OMA 审查 team（coordinator + 限定范围的 reviewer agent），用 `defineTool` 定义仓库上下文工具，并加入自定义 `ContextStrategy` 做 token-aware 的 PR diff 压缩。公开代码，基于 `@open-multi-agent/core`。
-- **[StuFlow](https://github.com/znc15/StuFlow)**。终端 AI 编码助手，作者 [znc15](https://github.com/znc15)。以 OMA 为编排内核：构建 team 并通过 `runAgent` / `runTasks` / `runTeam` 驱动，配自定义 `RunTeamOptions` coordinator，搭配 DeepSeek。公开代码，基于 `@open-multi-agent/core`。
-- **[Reports to Charts Studio](https://github.com/NARNIX0/Evident-Project)**。把文档和研究表格转换成可直接用于幻灯片的图表。使用 OMA 运行由五个角色组成的数据提取评审组，结合结构化输出与确定性校验。公开代码，基于 `@open-multi-agent/core`。
+- **[temodar-agent](https://github.com/xeloxa/temodar-agent)**，作者 [Ali Sünbül](https://github.com/xeloxa)。WordPress 安全分析平台，在 Docker runtime 里直接使用 OMA 内置工具（`bash`、`file_*`、`grep`）。已确认生产环境使用。
+- **[Mark Galyan](https://github.com/apollo-mg)** 在本地量化模型上完全离线运行 OMA，借助 Coordinator 与上下文压缩，在显存受限的条件下维持自治 Agent 循环持续运行。自框架发布首月起持续贡献。
+- **[PR-Copilot](https://github.com/kidoom/PR-Copilot)**，作者 [kidoom](https://github.com/kidoom)。AI pull request 审查助手，运行 OMA 审查 team，用 `defineTool` 定义仓库上下文工具，并加入自定义 `ContextStrategy` 做 token-aware 的 diff 压缩。
+- **[StuFlow](https://github.com/znc15/StuFlow)**，作者 [znc15](https://github.com/znc15)。终端 AI 编码助手，以 OMA 为编排内核，通过 `runAgent` / `runTasks` / `runTeam` 驱动自定义 coordinator，搭配 DeepSeek。
+- **[Reports to Charts Studio](https://github.com/NARNIX0/Evident-Project)**。把文档和研究表格转换成可直接用于幻灯片的图表，使用由五个角色组成的数据提取评审组，结合结构化输出与确定性校验。
 
 **集成**
 


### PR DESCRIPTION
## Why

Two problems with the root README, both measured on the live page rather than guessed at.

**The snippet a new reader lands on could not be run as written.** It set `defaultProvider: 'openai'` but never said which credential to set, so copying it produces an auth error with no hint. It also pinned a bare `defaultModel: 'gpt-5.4'`, while the core README, the scaffolder templates, and the examples all read `process.env.OMA_MODEL ?? 'gpt-5.4'`. The most-read copy was the only one teaching the wrong pattern, and the one most likely to go stale.

**The first line of code rendered about four screens down.** Measured on github.com at a 720px viewport: the README body starts at 979px, and the first code block sat at 3041px, roughly screen 4.2 of a 7.2 screen page. A 298 word Why OMA section sat between the intro and the quickstart.

## What changed

Lower the cost of the first run:

- Say that `OPENAI_API_KEY` is required, and link to the provider docs for everything else.
- Read the model from `process.env.OMA_MODEL ?? 'gpt-5.4'`.
- Print the task graph the coordinator generated at runtime. The tagline is "describe the goal, not the graph", but the snippet previously showed neither the graph nor any output, so the claim had no evidence where readers actually look.

Reduce the distance to that snippet:

- Move Get started above Why OMA.
- Flatten Why OMA from three bullet levels to two, 298 to 241 words.
- Tighten the Built with OMA entries, 295 to 259 words. Order is unchanged.
- Drop the stars, forks, and hardcoded TypeScript 5.6 badges, 7 down to 4. GitHub renders stars and forks natively just above the README, and the TypeScript badge needed a manual bump on every upgrade (declared `^5.6.0`, installed 5.9.3).
- Align the English commercial support section with the Chinese one, which already listed the same three items.
- Stop duplicating the scaffolder flags that the core guide owns, and link to it instead.

Total 1302 to 1274 words. Both `README.md` and `README_zh.md` are updated together.

## Measured result

Both branches measured on their rendered GitHub page in the same session, same 1280x800 viewport, same 838px content width, with `main` as the control:

| | main | this branch | delta |
|---|---|---|---|
| First code block, relative to README body | 1569px | 730px | -839px |
| Badges | 7 | 4 | -3 |
| README body height | 4692px | 4565px | -127px |

In absolute page terms the first code block moves from 3041px to 2202px, which is screen 4.2 to screen 3.1 at a 720px viewport.

## Verification

- Extracted the TypeScript block from both files and ran `tsc --noEmit` against the built `packages/core/dist` types. Both clean. This confirms the optional handling on `result.tasks`, the `TaskExecutionRecord` fields used, and the `createTeam` call shape.
- English and Chinese code blocks are line-for-line identical aside from comment language.
- Both files carry the same 9 sections in the same order.
- Every relative link target resolves; the new `#quick-start` and `#快速开始` anchors exist in the core READMEs.
- `git diff --check` clean.

## Not included

The Integrations list links `Agentscreator/engram-memory`, which is archived (last push 2026-05-23). Left as is deliberately; out of scope for this PR.
