### PR TITLE
docs: flag the 1.14.0 breaking changes and fix release note wrapping

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -25,6 +25,35 @@ needed at publish time.
 - [`CHANGELOG.md`](../CHANGELOG.md) is a single root file keyed by core version,
   with an `## Unreleased` section at the top.
 
+## Breaking changes
+
+Decide whether a release contains one before the release commit, not while
+writing release notes. A change is breaking when it can stop working for a
+caller who did nothing but upgrade:
+
+- the `engines` floor rises
+- a published direct dependency crosses a major version
+- input that an earlier release accepted is now rejected
+- a public export is removed, renamed, or has its signature narrowed
+
+A conventional-commits `!` marker on a merged commit signals that one landed,
+but it is not a substitute for the steps below, because nothing carries it
+through to a reader of the release.
+
+When a release contains a breaking change:
+
+- [`CHANGELOG.md`](../CHANGELOG.md) opens that version with a
+  `### Breaking changes` section above `### Added`, naming what breaks and what
+  the caller has to do.
+- The GitHub Release repeats it as its first section, not as a note near the
+  end.
+- Weigh the version number against how far the change reaches. 1.14.0 raised the
+  `engines` floor to Node 20 and moved `openai` from v4 to v6 while shipping as
+  a minor, so every `^1.x` caller on Node 18 received it automatically. npm
+  treats an `engines` mismatch as an `EBADENGINE` warning rather than an install
+  failure, which means those projects install successfully and fail later at run
+  time.
+
 ## The release commit
 
 Version bumps land on `main` through a normal pull request before anything is
@@ -72,6 +101,24 @@ none is triggered by pushing a tag.
    live on npm. Publishing it triggers `release-smoke.yml`, which resolves the
    published packages from the real registry. Releasing before they are live
    makes that run fail.
+
+## Release notes are not a copy of the changelog
+
+The two are rendered under different rules. [`CHANGELOG.md`](../CHANGELOG.md) is
+hard-wrapped at 80 columns, which is correct for a repository file because GitHub
+joins a single newline into a space there. A release body is rendered with GFM
+hard line breaks, where every newline becomes a `<br>`, so pasted wrapped text
+turns into a column of lines that look truncated at 80 characters.
+
+Unwrap each paragraph and list item onto a single line before publishing, and
+check the draft first:
+
+```bash
+jq -Rs '{text: ., mode: "gfm"}' < notes.md | gh api /markdown --input - | grep -c '<br>'
+```
+
+That endpoint matches what the release page renders. A correct release body
+returns `0`.
 
 ## What CI proves
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@
 
 ## 1.14.0 - 2026-08-01
 
+### Breaking changes
+
+This release shipped as a minor version, so a caller on a `^1.x` range receives
+it without an explicit upgrade step. npm reports an `engines` mismatch as an
+`EBADENGINE` warning rather than an install failure, so a Node 18 project
+installs 1.14.0 successfully and then fails at run time.
+
+- **Node.js 20 or newer is now required.** The `engines` floor moved from 18 to
+  20 across `@open-multi-agent/core`, `@open-multi-agent/otel`, and
+  `create-oma-app`. Node 18 reached end of life on 2025-04-30.
+- **The bundled `openai` dependency moved from v4 to v6.** A project that also
+  depends on `openai` directly resolves a nested second copy until it moves to
+  v6 as well.
+- **Plans that were previously accepted can now fail at validation time.**
+  Invalid task dependency graphs, unsatisfiable task requirements, and invalid
+  coordinator plans are rejected before execution instead of running partially.
+  Each of these surfaces a defect that was previously silent, so correct graphs
+  and rosters are unaffected. The individual entries are under Changed and
+  Fixed below.
+
 ### Added
 
 - Adaptive plan recovery lets a run revise the not-yet-executed part of its task
@@ -33,13 +53,9 @@
 
 ### Changed
 
-- **Node.js 20 or newer is now required.** The `engines` floor moved from 18 to
-  20 across `@open-multi-agent/core`, `@open-multi-agent/otel`, and
-  `create-oma-app`. Node 18 reached end of life on 2025-04-30.
-- The bundled `openai` dependency moved from v4 to v6. OpenAI user aborts are
-  now classified as cancellation rather than as a retryable failure, and
-  unsupported custom tool calls are rejected explicitly instead of being passed
-  through.
+- On the OpenAI v6 SDK, user aborts are now classified as cancellation rather
+  than as a retryable failure, and unsupported custom tool calls are rejected
+  explicitly instead of being passed through.
 - Task requirements are enforced as global hard constraints. A task whose
   requirements no agent satisfies is now rejected rather than assigned to an
   ineligible agent.
@@ -58,9 +74,6 @@
   runs.
 - Adaptive plan recovery is opt-in. Task graphs stay fixed unless
   `recovery.mode` selects `'repairable'`.
-- Runs that previously succeeded with an invalid task DAG or an unsatisfiable
-  task requirement now fail at validation time. This surfaces a defect that was
-  previously silent; correct graphs and rosters are unaffected.
 - Adaptive recovery adds a version 2 task-queue snapshot carrying plan-revision
   history. `TaskQueue.fromSnapshot()` still accepts version 1 snapshots, so
   checkpoints written by earlier releases remain restorable.


### PR DESCRIPTION
## Why

1.14.0 raised the `engines` floor to Node 20 and moved `openai` from v4 to v6, but shipped as a minor with no breaking-change notice. The conventional-commits `!` marker on #453 never reached the changelog or the GitHub Release, so a `^1.x` caller on Node 18 received the upgrade automatically. npm treats an `engines` mismatch as an `EBADENGINE` warning rather than an install failure, which means those projects installed successfully and failed later at run time with no obvious cause.

## What changed

`CHANGELOG.md` opens 1.14.0 with a `Breaking changes` section above `Added`, collecting three items that were scattered across the entry: the Node floor and the `openai` major move (previously under Changed), and the plans that are now rejected at validation time (previously under Compatibility, which is meant to describe what did not change).

`.github/RELEASING.md` gains two sections:

- A breaking-change decision step that runs before the release commit, listing the four criteria that make a change breaking and requiring both the changelog and the release body to lead with it. It also records what the 1.14.0 version choice cost, so the next number is weighed against reach rather than defaulted.
- The release-note wrapping rule. A release body is rendered with GFM hard line breaks, so every newline in the source becomes a `<br>`, and changelog text pasted at 80 columns renders as a column of lines that look truncated. Repository `.md` files do not use that rule, which is why the identical text is correct in `CHANGELOG.md`. The section includes a one-line check to run against a draft before publishing.

## Applied outside this diff

The published release bodies were rewritten to match, since merging cannot do that:

- v1.14.0 now leads with Breaking changes. Its rendered `<br>` count went from 33 to 0.
- v1.13.0 was unwrapped as well, 22 to 0. Wording and code blocks are unchanged there.

v1.12.1 and earlier were already correct.

## Verification

`git diff --check` is clean. Documentation only, so no commands, generated artifacts, or executable examples changed. Both release bodies were confirmed against the live rendered HTML after editing.
