### PR TITLE
docs(tool-configuration): correct the runTeam routing default

### DIFF
--- a/docs/tool-configuration.md
+++ b/docs/tool-configuration.md
@@ -29,11 +29,11 @@ result reports `governanceConclusion: 'not-applicable'` until that plan is
 executed, for example through `runFromPlan()`.
 
 Use `governanceIntent: 'none'` to opt into automatic `runTeam()` routing
-explicitly. Omitting `governanceIntent` does the same. This route is Hybrid by
-default: a deterministic Single candidate may be upgraded after one semantic
-profile call. Set
-`executionRouting: { strategy: 'deterministic' }` for the previous no-profiler
-behavior.
+explicitly. Omitting `governanceIntent` does the same. This route is
+deterministic by default and makes no semantic profile call. Hybrid semantic
+routing is opt-in: set `executionRouting: { strategy: 'hybrid' }` to let a
+deterministic Single candidate be upgraded after one semantic profile call. See
+[execution routing](execution-routing.md).
 
 After execution, required declarations are checked against the execution
 receipt. The `governanceConclusion` value is `satisfied`, `unsatisfied`, or


### PR DESCRIPTION
## Summary

`docs/tool-configuration.md` described the automatic `runTeam()` route as Hybrid
by default, and told readers to set `executionRouting: { strategy: 'deterministic' }`
for "the previous no-profiler behavior". Both halves are inverted: deterministic
is the default and Hybrid is opt-in.

## Motivation

The claim contradicted three places that were already correct:

- `docs/execution-routing.md`: "Hybrid is opt-in."
- The 1.14.0 Compatibility note in `CHANGELOG.md`, which states that Hybrid
  semantic routing is opt-in through `executionRouting.strategy` and does not
  change existing runs.
- `packages/core/README.md`, which documents opting in with
  `executionRouting: { strategy: 'hybrid' }`.

It is a leftover from before e0e4cf6 ("fix(core): make hybrid routing opt-in").
That commit updated `docs/execution-routing.md`, `packages/core/README.md`, and
`docs/evaluation.md` alongside the source change, but did not touch this file.

The implementation agrees that Hybrid is opt-in:

- `types.ts` documents `deterministic` as the `strategy` default.
- The orchestrator resolves `strategy ?? 'deterministic'` for both the
  constructor config and the per-run override.
- Semantic profiling is gated on `strategy === 'hybrid'`, so the default path
  makes no profiler call.
- `semantic-routing.test.ts` asserts that an orchestrator configured with no
  `executionRouting` produces no `semanticRoutingAssessment`.

This was the costlier direction to leave in place. A reader following it would
budget for a profiler call per Single-candidate run that never happens, and
would set `strategy: 'deterministic'` believing it changes behavior.

## Scope and impact

Documentation only: one paragraph in one file. No source, test, template, or CI
change, and no public API or behavior change, since the code was already
correct. A repository-wide scan found no other occurrence of the inverted claim,
including the root and package READMEs and their Chinese translations.

## Validation

- `git diff --check`: clean.
- `npm run test -w @open-multi-agent/core -- semantic-routing.test.ts`: 36
  passed. Not required for a docs-only change; run to check the corrected claim
  against the implementation rather than to validate the diff.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING
