### PR TITLE
feat(agent): restore persisted conversation history

### DIFF
--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -125,6 +125,7 @@ export class Agent {
     this.config = config
     this._toolRegistry = toolRegistry
     this._toolExecutor = toolExecutor
+    this.messageHistory = config.history ? [...config.history] : []
 
     this.state = {
       status: 'idle',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -670,6 +670,15 @@ export type ExternalAgentBackendConfig = AgentBackendConfig | ProcessAgentBacken
 /** Static configuration for a single agent. */
 export interface AgentConfig {
   readonly name: string
+  /**
+   * Previously persisted conversation messages to restore for prompt() calls.
+   *
+   * The messages are copied when the Agent is constructed, so a caller can
+   * safely reuse or replace the serialized history after passing it in. The
+   * history should contain the same valid message sequence returned by
+   * Agent.getHistory().
+   */
+  readonly history?: readonly LLMMessage[]
   /** One-sentence role description for bounded, structured agent manifests. */
   readonly description?: string
   /**

--- a/packages/core/tests/agent-hooks.test.ts
+++ b/packages/core/tests/agent-hooks.test.ts
@@ -379,6 +379,41 @@ describe('Agent hooks — beforeRun / afterRun', () => {
     expect((firstUserInHistory!.content[0] as any).text).toBe('original message')
   })
 
+  it('restores constructor history for stateless prompt conversations', async () => {
+    const history: LLMMessage[] = [
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'previous question' }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'previous answer' }],
+      },
+    ]
+    const { agent, calls } = buildMockAgent({ ...baseConfig, history }, 'new answer')
+
+    await agent.prompt('follow-up question')
+
+    expect(calls[0]).toEqual([
+      ...history,
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'follow-up question' }],
+      },
+    ])
+    expect(agent.getHistory()).toEqual([
+      ...history,
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'follow-up question' }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'new answer' }],
+      },
+    ])
+  })
+
   // -----------------------------------------------------------------------
   // afterRun NOT called on error
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add an optional history field to AgentConfig
- copy restored messages into the Agent for subsequent prompt calls
- cover stateless multi-turn restoration with a focused test

Closes #467

## Validation
- npm test -- --run tests/agent-hooks.test.ts
- npm run lint