### PR TITLE
feat(core): accept structured agent input

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -185,6 +185,10 @@ all use the same evaluator owned by the `OpenMultiAgent` instance. Its
 `evalRunId` therefore remains stable for that instance lifetime. Each sampled
 run produces one `EvalRecord` per scorer with `source: 'online'`, no EvalSet or
 case ID, and a `runRef` containing the exact logical run and attempt.
+For structured `runAgent()` input, the evaluator receives a defensive copy of
+the caller's `LLMMessage[]`; string calls retain their existing string input.
+Payload omission, bounding, redaction, and persistence still follow
+`storePayloads` below.
 
 Numeric sampling uses `Math.random() < sample`. A rule can select by normalized
 status and validated run metadata without implementing tail sampling:

--- a/docs/external-agents.md
+++ b/docs/external-agents.md
@@ -101,6 +101,15 @@ still shapes the external agent because OMA — lacking any ACP system-prompt fi
 prepends it to the agent's first prompt (once per session), on top of seeding the
 coordinator's routing as it does for every agent.
 
+External backends have a text transport boundary. Their public Agent APIs accept
+the existing string form, but reject structured `LLMMessage[]` / `ContentBlock[]`
+arguments with `InvalidMessageError` before spawning a process or opening an ACP
+session. This avoids silently dropping image blocks or caller-owned history.
+`beforeRun.prompt` remains supported; changing `beforeRun.messages` is rejected
+for the same reason. `AgentConfig.history` does not seed a process or ACP
+session; it restores messages only for LLM-backed `prompt()` conversations. See
+[Structured Agent Input](structured-input.md).
+
 For `process`, OMA starts a fresh subprocess per run. Use `input: 'stdin'` for
 commands that read a prompt from stdin, `input: 'argument'` when the command
 expects the prompt as the final argument, and `input: 'none'` for fixed adapters

--- a/docs/structured-input.md
+++ b/docs/structured-input.md
@@ -1,0 +1,118 @@
+# Structured Agent Input
+
+`Agent.run()`, `Agent.stream()`, and `OpenMultiAgent.runAgent()` accept either a
+string or a complete `LLMMessage[]`. The string form is unchanged shorthand for
+one user text message. Use the message form when the application owns prior
+conversation turns or needs content blocks such as images:
+
+```ts
+import {
+  OpenMultiAgent,
+  type LLMMessage,
+} from '@open-multi-agent/core'
+
+const messages: LLMMessage[] = [
+  { role: 'user', content: [{ type: 'text', text: 'Keep answers concise.' }] },
+  { role: 'assistant', content: [{ type: 'text', text: 'Understood.' }] },
+  {
+    role: 'user',
+    content: [
+      { type: 'text', text: 'What is shown here?' },
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/png',
+          data: imageBytes.toString('base64'),
+        },
+      },
+    ],
+  },
+]
+
+const result = await new OpenMultiAgent().runAgent(
+  { name: 'vision', model: 'claude-sonnet-4-6' },
+  messages,
+)
+```
+
+The selected model/provider must support every supplied content block. OMA does
+not infer a vision-capability flag or silently remove unsupported blocks;
+provider errors follow the normal agent failure path.
+
+## API boundaries
+
+| API | String form | Structured form | Conversation behavior |
+|---|---|---|---|
+| `Agent.run(input)` | One user text message | Complete `readonly LLMMessage[]` | Fresh; does not read or update persistent history |
+| `Agent.stream(input)` | One user text message | Complete `readonly LLMMessage[]` | Fresh; same input semantics as `run()` |
+| `OpenMultiAgent.runAgent(config, input)` | One user text message | Complete `readonly LLMMessage[]` | Fresh one-off Agent with orchestration, tracing, progress, budgets, and evaluation |
+| `Agent.prompt(input)` | One user text message | One user turn as `readonly ContentBlock[]` | Appends that turn and the response to persistent history |
+
+`AgentConfig.history` restores earlier persistent turns for `prompt()`. Passing a
+content-block list to `prompt()` does not replace that history and cannot insert
+assistant turns; use `run(messages)` for a caller-owned complete conversation.
+`runTeam()` goals and `runTasks()` task descriptions remain text-only.
+
+## Copying and validation
+
+Structured inputs are runtime-validated with the same `LLMMessage` shape guard
+used at adapter boundaries, then defensively deep-copied before hooks, runners,
+progress callbacks, evaluation, or persistent history retain them. Mutating the
+caller's arrays, content blocks, image source, or tool input after calling an API
+does not change that run. `Agent.getHistory()` also returns a deep copy.
+
+Invalid message/content shapes or data that cannot be cloned throw
+`InvalidMessageError` before `beforeRun`, provider/backend execution, progress,
+or online evaluation. Invalid `prompt()` input is not appended to history.
+For `stream()`, this validation happens when `stream()` is called, before the
+returned iterator starts.
+
+## `beforeRun` semantics
+
+`beforeRun` receives both views of the effective input:
+
+```ts
+beforeRun(ctx) {
+  return {
+    ...ctx,
+    messages: ctx.messages, // complete defensive message copy
+    prompt: ctx.prompt,     // text blocks from the latest user message
+  }
+}
+```
+
+`ctx.prompt` remains the backwards-compatible concatenation of text blocks from
+the latest user message. An image-only turn therefore has an empty `prompt` but
+is fully available in `ctx.messages`.
+
+Returning `messages` replaces the complete input. If the hook also changes
+`prompt`, OMA applies the message replacement first, then replaces the latest
+user message's text blocks with one text block. Non-text blocks keep their
+relative order. Hook inputs and execution messages are copies, so a hook rewrite
+does not mutate caller-owned data or the original user turn stored by
+`Agent.prompt()`.
+
+## Progress and online evaluation
+
+String `runAgent()` calls retain the existing `agent_start` payload
+`{ prompt: string }` and string evaluation input. Structured calls emit
+`{ messages: LLMMessage[] }` and submit a separate message copy to online
+evaluation. Progress callback mutations cannot affect execution or evaluation.
+The evaluator's existing `storePayloads` policy still applies: `none` omits the
+content, while `redacted` or `full` serializes a bounded payload according to the
+documented privacy contract.
+
+## External process and ACP backends
+
+Process and ACP backends expose text prompt transports, not OMA's structured
+message protocol. Supplying `LLMMessage[]` to `run()` / `stream()` / `runAgent()`,
+or `ContentBlock[]` to `prompt()`, throws `InvalidMessageError` before a process
+is spawned or an ACP session is opened. This fail-fast boundary prevents images
+or caller-owned history from being silently discarded. Pass a string instead.
+
+For the same reason, an external agent's `beforeRun` may rewrite `prompt` but may
+not change `messages`. Existing string execution, including the process backend's
+fresh-per-run behavior and ACP's protocol session behavior, is unchanged.
+`AgentConfig.history` does not seed either external transport; it restores
+messages only for LLM-backed `prompt()` conversations.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -110,6 +110,42 @@ Set `OPENAI_API_KEY` for this example. For other hosted or local models, see [Pr
 
 Use `planOnly` to inspect a generated task graph before execution, then `createPlanArtifact()` and `runFromPlan()` to replay it. `runConsensus()` adds a proposer→judge verification loop when one answer needs extra scrutiny.
 
+### Structured single-agent input
+
+`Agent.run()`, `Agent.stream()`, and `OpenMultiAgent.runAgent()` keep the string
+form above and also accept a complete `LLMMessage[]`. Use the message form for
+caller-owned conversation history or blocks such as base64 images:
+
+```typescript
+import { OpenMultiAgent, type LLMMessage } from '@open-multi-agent/core'
+
+const messages: LLMMessage[] = [{
+  role: 'user',
+  content: [
+    { type: 'text', text: 'Describe this image.' },
+    {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: imageBase64 },
+    },
+  ],
+}]
+
+const result = await new OpenMultiAgent().runAgent(
+  { name: 'vision', model: 'claude-sonnet-4-6' },
+  messages,
+)
+```
+
+For a persistent `Agent.prompt()` conversation, pass a string or one
+`ContentBlock[]` user turn; restore earlier turns through `AgentConfig.history`.
+Structured input is validated and defensively copied. `beforeRun` receives both
+the complete `messages` and its backwards-compatible latest-user `prompt` view.
+Process and ACP backends remain string-only and reject structured arguments
+instead of discarding history or images. See [Structured Agent
+Input](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/structured-input.md) for copy, hook, progress/evaluation, and
+external-backend semantics, or run
+[`basics/structured-input`](examples/basics/structured-input.ts).
+
 Automatic `runTeam()` uses the deterministic router by default: no extra model
 call is made. Opt into Hybrid Semantic Routing with
 `executionRouting: { strategy: 'hybrid' }`; it keeps deterministic Team
@@ -192,7 +228,7 @@ are covered in
 | **Dynamic orchestration** | Runtime goal decomposition, dependency-aware scheduling, parallel branches, configurable assignment, task-scoped results and handoffs, opt-in team context for workers (`revealCoordinator`), and final synthesis. |
 | **Models and reasoning** | Mix built-in, OpenAI-compatible, AI SDK, or local models; map one `thinking` config to each provider's reasoning setting, route phases separately, and preserve reasoning only when explicitly enabled. |
 | **Tools and handoffs** | Built-in tools are default-deny; custom tools, MCP, and guarded `delegate_to_agent` handoffs are opt-in, and consequential tools on undeclared runs are flagged for confirmation. |
-| **Controlled outputs** | Stream per agent, validate results with Zod, approve or durably suspend plans, task rounds, dispatches, and tool calls, rewrite prompts or post-process results with `beforeRun` / `afterRun`, and cancel with `AbortSignal`. |
+| **Controlled outputs** | Send text or structured single-agent input, stream per agent, validate results with Zod, approve or durably suspend plans, task rounds, dispatches, and tool calls, rewrite messages/prompts or post-process results with `beforeRun` / `afterRun`, and cancel with `AbortSignal`. |
 | **Evaluation** | Version EvalSets, run reference scorers, gate CI with offline reports, persist results, or sample production runs on a best-effort path. |
 | **Memory and recovery** | Shared memory is pluggable; checkpoints resume interrupted runs without repeating completed tasks. |
 | **Observability** | Stable run identity, traces, execution receipts, redaction, TraceStore, and the offline DAG/Waterfall Viewer are available without a hosted service. |
@@ -221,6 +257,7 @@ Start with one example that matches the behavior you need:
 
 | Goal | Example |
 |---|---|
+| Send image blocks and caller-owned history | [`basics/structured-input`](examples/basics/structured-input.ts) |
 | See coordinator planning | [`basics/team-collaboration`](examples/basics/team-collaboration.ts) |
 | Build an explicit DAG | [`cookbook/contract-review-dag`](examples/cookbook/contract-review-dag.ts) |
 | Observe event-driven DAG dispatch | [`patterns/event-driven-dag`](examples/patterns/event-driven-dag.ts) |
@@ -275,7 +312,7 @@ See the [observability guide](https://github.com/open-multi-agent/open-multi-age
 
 | Area | Guides |
 |---|---|
-| Build agents | [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md), [tools](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md), [context](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) |
+| Build agents | [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md), [structured input](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/structured-input.md), [tools](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md), [context](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) |
 | Run reliably | [Evaluation](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/evaluation.md), [checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md), [durable approvals](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/durable-approvals.md), [adaptive recovery](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/adaptive-recovery.md), [execution routing](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/execution-routing.md), [model routing](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/model-routing.md), [consensus](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/consensus.md) |
 | Control workflows | [Plan preview & replay](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/plan-replay.md), [shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md), [external agents](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/external-agents.md) |
 | Operate | [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md), [CLI](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/cli.md), [production examples](examples/production/README.md) |

--- a/packages/core/examples/README.md
+++ b/packages/core/examples/README.md
@@ -14,11 +14,12 @@ standalone example or top-level example directory is not registered.
 
 ## basics — start here
 
-The four core execution modes. Read these first.
+Core execution modes and input shapes. Read these first.
 
 | Example | What it shows |
 |---------|---------------|
 | [`basics/single-agent`](basics/single-agent.ts) | One agent with bash + file tools, then streaming via the `Agent` class. |
+| [`basics/structured-input`](basics/structured-input.ts) | Caller-owned message history and image blocks through `runAgent()`. |
 | [`basics/team-collaboration`](basics/team-collaboration.ts) | `runTeam()` coordinator pattern — goal in, results out. |
 | [`basics/task-pipeline`](basics/task-pipeline.ts) | `runTasks()` with explicit task DAG and dependencies. |
 | [`basics/multi-model-team`](basics/multi-model-team.ts) | Different models per agent in one team. |

--- a/packages/core/examples/basics/structured-input.ts
+++ b/packages/core/examples/basics/structured-input.ts
@@ -1,0 +1,70 @@
+/**
+ * Structured Multimodal Input
+ *
+ * Send an image and caller-owned message history through runAgent() without
+ * bypassing OMA's hooks, tracing, budgets, progress, or evaluation path.
+ *
+ * Run:
+ *   npx tsx packages/core/examples/basics/structured-input.ts ./photo.png
+ *
+ * Prerequisites:
+ *   ANTHROPIC_API_KEY env var must be set.
+ *   The image must be PNG, JPEG, GIF, or WebP.
+ */
+
+import { readFile } from 'node:fs/promises'
+import { extname } from 'node:path'
+
+import { OpenMultiAgent, type LLMMessage } from '../../src/index.js'
+
+const imagePath = process.argv[2]
+if (!imagePath) {
+  throw new Error('Pass an image path: npx tsx packages/core/examples/basics/structured-input.ts ./photo.png')
+}
+
+const mediaTypes: Readonly<Record<string, string>> = {
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+}
+const mediaType = mediaTypes[extname(imagePath).toLowerCase()]
+if (!mediaType) {
+  throw new Error('Unsupported image extension. Use PNG, JPEG, GIF, or WebP.')
+}
+
+const imageData = (await readFile(imagePath)).toString('base64')
+const messages: LLMMessage[] = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: 'When I share an image, describe only visible facts.' }],
+  },
+  {
+    role: 'assistant',
+    content: [{ type: 'text', text: 'Understood.' }],
+  },
+  {
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Describe this image in three concise bullet points.' },
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: mediaType,
+          data: imageData,
+        },
+      },
+    ],
+  },
+]
+
+const oma = new OpenMultiAgent({
+  defaultProvider: 'anthropic',
+  defaultModel: process.env.OMA_MODEL ?? 'claude-sonnet-4-6',
+})
+const result = await oma.runAgent({ name: 'vision-assistant' }, messages)
+
+if (!result.success) throw new Error(result.output)
+console.log(result.output)

--- a/packages/core/examples/catalog.json
+++ b/packages/core/examples/catalog.json
@@ -15,6 +15,17 @@
       "featuredOrder": 1
     },
     {
+      "id": "structured-input",
+      "path": "basics/structured-input.ts",
+      "title": "Structured Multimodal Input",
+      "description": "Send caller-owned message history and an image through runAgent() as structured input.",
+      "section": "goal",
+      "goal": "start-here",
+      "capabilities": ["run-agent", "multi-turn"],
+      "format": "script",
+      "level": "beginner"
+    },
+    {
       "id": "team-collaboration",
       "path": "basics/team-collaboration.ts",
       "title": "Team Collaboration",

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -36,12 +36,18 @@
  * ```
  */
 
+import { isDeepStrictEqual } from 'node:util'
+
 import type {
   ExternalAgentBackendConfig,
   AgentConfig,
+  AgentPromptInput,
+  AgentRunInput,
   AgentState,
   AgentRunResult,
   BeforeRunHookContext,
+  BeforeRunHookResult,
+  ContentBlock,
   LLMMessage,
   StreamEvent,
   TokenUsage,
@@ -56,7 +62,8 @@ import { createRunIdentity } from '../observability/identity.js'
 import { classifyRunFailure, statusOnly } from '../observability/status.js'
 import { DurableApprovalError } from '../approval/durable.js'
 import { createTraceRuntime } from '../observability/runtime.js'
-import { TokenBudgetExceededError } from '../errors.js'
+import { InvalidMessageError, TokenBudgetExceededError } from '../errors.js'
+import { assertValidMessages } from '../llm/validate.js'
 import type { ToolDefinition as FrameworkToolDefinition, ToolRegistry } from '../tool/framework.js'
 import type { ToolExecutor } from '../tool/executor.js'
 import { defaultWorkspaceDir } from '../tool/built-in/path-safety.js'
@@ -67,6 +74,11 @@ import {
   extractJSON,
   validateOutput,
 } from './structured-output.js'
+import {
+  copyMessages,
+  prepareAgentPromptInput,
+  prepareAgentRunInput,
+} from './input.js'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -126,7 +138,8 @@ export class Agent {
     this.config = config
     this._toolRegistry = toolRegistry
     this._toolExecutor = toolExecutor
-    this.messageHistory = config.history ? [...config.history] : []
+    if (config.history) assertValidMessages(config.history)
+    this.messageHistory = config.history ? copyMessages(config.history) : []
 
     this.state = {
       status: 'idle',
@@ -265,42 +278,38 @@ export class Agent {
   // -------------------------------------------------------------------------
 
   /**
-   * Run `prompt` in a fresh conversation (history is NOT used).
+   * Run a string prompt or complete message list in a fresh conversation
+   * (persistent history is NOT used).
    *
-   * Equivalent to constructing a brand-new messages array `[{ role:'user', … }]`
-   * and calling the runner once. The agent's persistent history is not modified.
+   * A string is shorthand for `[{ role:'user', content:[{ type:'text', … }] }]`.
+   * A structured list is defensively copied before execution. The agent's
+   * persistent history is not modified.
    *
    * Use this for one-shot queries where past context is irrelevant.
    */
-  async run(prompt: string, runOptions?: Partial<RunOptions>): Promise<AgentRunResult> {
-    const messages: LLMMessage[] = [
-      { role: 'user', content: [{ type: 'text', text: prompt }] },
-    ]
-
+  async run(input: AgentRunInput, runOptions?: Partial<RunOptions>): Promise<AgentRunResult> {
+    const { messages } = prepareAgentRunInput(input, this.config.backend)
     return this.executeRun(messages, runOptions)
   }
 
   /**
-   * Run `prompt` as part of the ongoing conversation.
+   * Run a string or structured user turn as part of the ongoing conversation.
    *
-   * Appends the user message to the persistent history, runs the agent, then
-   * appends the resulting messages to the history for the next call.
+   * A `ContentBlock[]` is appended as exactly one user message. The input and
+   * resulting messages are defensively copied into persistent history for the
+   * next call.
    *
    * Use this for multi-turn interactions.
    */
   // TODO(#18): accept optional RunOptions to forward trace context
-  async prompt(message: string): Promise<AgentRunResult> {
-    const userMessage: LLMMessage = {
-      role: 'user',
-      content: [{ type: 'text', text: message }],
-    }
-
+  async prompt(input: AgentPromptInput): Promise<AgentRunResult> {
+    const { message: userMessage } = prepareAgentPromptInput(input, this.config.backend)
     this.messageHistory.push(userMessage)
 
-    const result = await this.executeRun([...this.messageHistory])
+    const result = await this.executeRun(copyMessages(this.messageHistory))
 
     // Persist the new messages into history so the next `prompt` sees them.
-    for (const msg of result.messages) {
+    for (const msg of copyMessages(result.messages)) {
       this.messageHistory.push(msg)
     }
 
@@ -308,16 +317,14 @@ export class Agent {
   }
 
   /**
-   * Stream a fresh-conversation response, yielding {@link StreamEvent}s.
+   * Stream a fresh-conversation response from a string or complete message list,
+   * yielding {@link StreamEvent}s.
    *
    * Like {@link run}, this does not use or update the persistent history.
    */
-  async *stream(prompt: string, runOptions?: Partial<RunOptions>): AsyncGenerator<StreamEvent> {
-    const messages: LLMMessage[] = [
-      { role: 'user', content: [{ type: 'text', text: prompt }] },
-    ]
-
-    yield* this.executeStream(messages, runOptions)
+  stream(input: AgentRunInput, runOptions?: Partial<RunOptions>): AsyncGenerator<StreamEvent> {
+    const { messages } = prepareAgentRunInput(input, this.config.backend)
+    return this.executeStream(messages, runOptions)
   }
 
   // -------------------------------------------------------------------------
@@ -331,7 +338,7 @@ export class Agent {
 
   /** Return a copy of the persistent message history. */
   getHistory(): LLMMessage[] {
-    return [...this.messageHistory]
+    return copyMessages(this.messageHistory)
   }
 
   /**
@@ -417,9 +424,7 @@ export class Agent {
       // --- beforeRun hook ---
       if (this.config.beforeRun && callerOptions?.resumeState === undefined) {
         failureKind = 'callback'
-        const hookCtx = this.buildBeforeRunHookContext(messages)
-        const modified = await this.config.beforeRun(hookCtx)
-        this.applyHookContext(messages, modified, hookCtx.prompt)
+        await this.applyBeforeRunHook(messages)
         failureKind = undefined
       }
 
@@ -766,9 +771,7 @@ export class Agent {
       // --- beforeRun hook ---
       if (this.config.beforeRun && callerOptions?.resumeState === undefined) {
         failureKind = 'callback'
-        const hookCtx = this.buildBeforeRunHookContext(messages)
-        const modified = await this.config.beforeRun(hookCtx)
-        this.applyHookContext(messages, modified, hookCtx.prompt)
+        await this.applyBeforeRunHook(messages)
         failureKind = undefined
       }
 
@@ -890,6 +893,28 @@ export class Agent {
   // Hook helpers
   // -------------------------------------------------------------------------
 
+  private async applyBeforeRunHook(messages: LLMMessage[]): Promise<void> {
+    const hook = this.config.beforeRun
+    if (!hook) return
+
+    const hookCtx = this.buildBeforeRunHookContext(messages)
+    const originalHookMessages = copyMessages(hookCtx.messages)
+    const modified = await hook(hookCtx)
+
+    if (
+      this.config.backend !== undefined &&
+      modified.messages !== undefined &&
+      !isDeepStrictEqual(modified.messages, originalHookMessages)
+    ) {
+      throw new InvalidMessageError(
+        `The ${this.config.backend.kind} external backend accepts beforeRun.prompt rewrites only; ` +
+          'beforeRun.messages cannot be forwarded without loss.',
+      )
+    }
+
+    this.applyHookContext(messages, modified, hookCtx)
+  }
+
   /** Extract the prompt text from the last user message to build hook context. */
   private buildBeforeRunHookContext(messages: LLMMessage[]): BeforeRunHookContext {
     let prompt = ''
@@ -904,26 +929,52 @@ export class Agent {
     }
     // Strip hook functions to avoid circular self-references in the context
     const { beforeRun, afterRun, ...agentInfo } = this.config
-    return { prompt, agent: agentInfo as AgentConfig }
+    return {
+      prompt,
+      messages: copyMessages(messages),
+      agent: agentInfo as AgentConfig,
+    }
   }
 
   /**
    * Apply a (possibly modified) hook context back to the messages array.
    *
-   * Only text blocks in the last user message are replaced; non-text content
-   * (images, tool results) is preserved. The array element is replaced (not
-   * mutated in place) so that shallow copies of the original array (e.g. from
-   * `prompt()`) are not affected.
+   * A returned `messages` list replaces the complete run input first. A changed
+   * `prompt` then replaces text blocks in the last user message; non-text blocks
+   * retain their relative order. The caller's input and persistent prompt
+   * history are separate defensive copies.
    */
-  private applyHookContext(messages: LLMMessage[], ctx: BeforeRunHookContext, originalPrompt: string): void {
-    if (ctx.prompt === originalPrompt) return
+  private applyHookContext(
+    messages: LLMMessage[],
+    ctx: BeforeRunHookResult,
+    original: BeforeRunHookContext,
+  ): void {
+    if (typeof ctx.prompt !== 'string') {
+      throw new InvalidMessageError('beforeRun.prompt must be a string')
+    }
+
+    if (ctx.messages !== undefined) {
+      assertValidMessages(ctx.messages)
+      messages.splice(0, messages.length, ...copyMessages(ctx.messages))
+    }
+
+    if (ctx.prompt === original.prompt) return
 
     for (let i = messages.length - 1; i >= 0; i--) {
       if (messages[i]!.role === 'user') {
-        const nonTextBlocks = messages[i]!.content.filter(b => b.type !== 'text')
+        const content = messages[i]!.content
+        const firstTextIndex = content.findIndex((block) => block.type === 'text')
+        const replacement = { type: 'text' as const, text: ctx.prompt }
+        const rewritten = firstTextIndex === -1
+          ? [replacement, ...content]
+          : content.reduce<ContentBlock[]>((blocks, block, index) => {
+              if (block.type !== 'text') blocks.push(block)
+              else if (index === firstTextIndex) blocks.push(replacement)
+              return blocks
+            }, [])
         messages[i] = {
           role: 'user',
-          content: [{ type: 'text', text: ctx.prompt }, ...nonTextBlocks],
+          content: rewritten,
         }
         break
       }

--- a/packages/core/src/agent/input.ts
+++ b/packages/core/src/agent/input.ts
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview Normalisation and defensive copying for public Agent inputs.
+ */
+
+import { InvalidMessageError } from '../errors.js'
+import { assertValidMessages } from '../llm/validate.js'
+import type {
+  AgentPromptInput,
+  AgentRunInput,
+  ContentBlock,
+  ExternalAgentBackendConfig,
+  LLMMessage,
+} from '../types.js'
+
+export interface PreparedAgentRunInput {
+  readonly messages: LLMMessage[]
+  readonly structured: boolean
+}
+
+function cloneMessages(messages: readonly LLMMessage[]): LLMMessage[] {
+  try {
+    return structuredClone(messages) as LLMMessage[]
+  } catch {
+    throw new InvalidMessageError(
+      'messages must contain cloneable structured data (strings, arrays, and plain data objects)',
+    )
+  }
+}
+
+function assertStructuredInputSupported(
+  structured: boolean,
+  backend: ExternalAgentBackendConfig | undefined,
+): void {
+  if (!structured || backend === undefined) return
+  throw new InvalidMessageError(
+    `The ${backend.kind} external backend accepts string prompts only; ` +
+      'structured messages or content blocks cannot be forwarded without loss.',
+  )
+}
+
+/** Validate, copy, and normalise a one-shot public run input. */
+export function prepareAgentRunInput(
+  input: AgentRunInput,
+  backend?: ExternalAgentBackendConfig,
+): PreparedAgentRunInput {
+  if (typeof input === 'string') {
+    return {
+      structured: false,
+      messages: [{ role: 'user', content: [{ type: 'text', text: input }] }],
+    }
+  }
+
+  assertValidMessages(input)
+  assertStructuredInputSupported(true, backend)
+  return { structured: true, messages: cloneMessages(input) }
+}
+
+/** Validate, copy, and normalise one persistent prompt turn. */
+export function prepareAgentPromptInput(
+  input: AgentPromptInput,
+  backend?: ExternalAgentBackendConfig,
+): { readonly message: LLMMessage } {
+  if (typeof input === 'string') {
+    return {
+      message: { role: 'user', content: [{ type: 'text', text: input }] },
+    }
+  }
+
+  const messages: LLMMessage[] = [{
+    role: 'user',
+    content: input as unknown as ContentBlock[],
+  }]
+  assertValidMessages(messages)
+  assertStructuredInputSupported(true, backend)
+  return {
+    message: cloneMessages(messages)[0]!,
+  }
+}
+
+/** Copy a validated message list before exposing or retaining it. */
+export function copyMessages(messages: readonly LLMMessage[]): LLMMessage[] {
+  return cloneMessages(messages)
+}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -126,10 +126,10 @@ export class RoutingDeclarationRequiredError extends Error {
 }
 
 /**
- * Raised when a message list passed to an adapter violates the
- * {@link LLMMessage}[] contract (e.g. a `content` that isn't a `ContentBlock[]`).
- * Surfaced at the adapter entry so the violation fails loudly instead of
- * crashing deep in provider-specific message conversion.
+ * Raised when structured input passed to a public Agent API or adapter violates
+ * the {@link LLMMessage}[] contract (e.g. a `content` that isn't a
+ * `ContentBlock[]`), cannot be copied safely, or crosses a text-only backend
+ * boundary. Surfaced before provider-specific conversion or external execution.
  */
 export class InvalidMessageError extends Error {
   readonly code = 'INVALID_MESSAGE'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -332,6 +332,8 @@ export type {
 
   // Agent
   AgentConfig,
+  AgentPromptInput,
+  AgentRunInput,
   AgentState,
   AgentRunResult,
   RunAgentOptions,
@@ -364,6 +366,7 @@ export type {
   AcpPermissionPolicy,
   AcpPermissionRequest,
   BeforeRunHookContext,
+  BeforeRunHookResult,
   ToolCallRecord,
   LoopDetectionConfig,
   LoopDetectionInfo,

--- a/packages/core/src/llm/validate.ts
+++ b/packages/core/src/llm/validate.ts
@@ -1,14 +1,14 @@
 /**
- * @fileoverview Entry-point validation for adapter message lists.
+ * @fileoverview Entry-point validation for public and adapter message lists.
  *
  * `LLMMessage.content` is typed as `ContentBlock[]`, but JS callers, deserialized
  * history, or custom integrations can break that contract at runtime. Without a
  * guard a non-array `content` fails deep in provider-specific conversion with a
  * cryptic `TypeError: <x>.content.some is not a function`.
  *
- * {@link assertValidMessages} is called at the entry of every adapter's
- * `chat()`/`stream()` so a broken contract surfaces as a clear
- * {@link InvalidMessageError} at the boundary instead.
+ * {@link assertValidMessages} is called by public structured Agent inputs and
+ * at every adapter's `chat()`/`stream()` entry so a broken contract surfaces as
+ * a clear {@link InvalidMessageError} at the boundary instead.
  */
 
 import type { LLMMessage } from '../types.js'
@@ -31,7 +31,7 @@ function describeType(value: unknown): string {
  * fields. It rejects invalid input rather than coercing it, so the caller's bug
  * stays visible instead of being silently reshaped.
  */
-export function assertValidMessages(messages: LLMMessage[]): void {
+export function assertValidMessages(messages: readonly LLMMessage[]): void {
   if (!Array.isArray(messages)) {
     throw new InvalidMessageError(`messages must be an array, got ${describeType(messages)}`)
   }

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -43,6 +43,7 @@
 
 import type {
   AgentConfig,
+  AgentRunInput,
   AgentRunResult,
   ApprovalDecisionRecord,
   ApprovalGateDecision,
@@ -82,6 +83,7 @@ import type {
 } from '../types.js'
 import type { RunOptions } from '../agent/runner.js'
 import { Agent } from '../agent/agent.js'
+import { copyMessages, prepareAgentRunInput } from '../agent/input.js'
 import { AgentPool } from '../agent/pool.js'
 import { createAdapter } from '../llm/adapter.js'
 import { emitTrace, generateSpanId } from '../utils/trace.js'
@@ -776,22 +778,25 @@ export class OpenMultiAgent {
   // -------------------------------------------------------------------------
 
   /**
-   * Run a single prompt with a one-off agent.
+   * Run a string prompt or structured message history with a one-off agent.
    *
-   * Constructs a fresh agent from `config`, runs `prompt` in a single turn,
+   * Constructs a fresh agent from `config`, runs `input` in a fresh conversation,
    * and returns the result. The agent is not registered with any pool or team.
    *
    * Useful for simple one-shot queries that do not need team orchestration.
    *
    * @param config - Agent configuration.
-   * @param prompt - The user prompt to send.
+   * @param input - A string shorthand or complete caller-owned message list.
    */
   async runAgent(
     config: AgentConfig,
-    prompt: string,
+    input: AgentRunInput,
     options?: RunAgentOptions,
   ): Promise<AgentRunResult> {
-    const pendingEvaluation = this.beginOnlineEvaluation(prompt)
+    const preparedInput = prepareAgentRunInput(input, config.backend)
+    const pendingEvaluation = this.beginOnlineEvaluation(
+      preparedInput.structured ? copyMessages(preparedInput.messages) : input,
+    )
     const { identity, metadata } = createRunFacts(options)
     const traceRuntime = this.startTrace(identity, metadata)
     const effectiveBudget = resolveBudgetCeiling(config.maxTokenBudget, this.config.maxTokenBudget)
@@ -808,7 +813,9 @@ export class OpenMultiAgent {
     this.config.onProgress?.({
       type: 'agent_start',
       agent: config.name,
-      data: { prompt },
+      data: preparedInput.structured
+        ? { messages: copyMessages(preparedInput.messages) }
+        : { prompt: input },
     })
 
     // Build run-time options: trace + optional abort signal. RunOptions has
@@ -837,7 +844,10 @@ export class OpenMultiAgent {
             tracePhase: 'agent',
           }
 
-    const result = await agent.run(prompt, runOptions)
+    const result = await agent.run(
+      preparedInput.structured ? preparedInput.messages : input,
+      runOptions,
+    )
     let finalResult = result
 
     if (result.budgetExceeded) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -125,6 +125,23 @@ export interface LLMMessage {
   readonly content: ContentBlock[]
 }
 
+/**
+ * Input accepted by one-shot agent entry points.
+ *
+ * A string is shorthand for one user text message. A message list starts a
+ * fresh run with caller-owned conversation history and may include structured
+ * content such as {@link ImageBlock}s.
+ */
+export type AgentRunInput = string | readonly LLMMessage[]
+
+/**
+ * Input accepted by {@link Agent.prompt} for one persistent user turn.
+ *
+ * Use {@link AgentConfig.history} to restore earlier turns; the content-block
+ * form here is appended as exactly one new user message.
+ */
+export type AgentPromptInput = string | readonly ContentBlock[]
+
 /** Context management strategy for long-running agent conversations. */
 export type ContextStrategy =
   | { type: 'sliding-window'; maxTurns: number }
@@ -691,9 +708,34 @@ export interface ThinkingConfig {
 
 /** Context passed to the {@link AgentConfig.beforeRun} hook. */
 export interface BeforeRunHookContext {
-  /** The user prompt text. */
+  /**
+   * Text blocks from the latest user message, concatenated in block order.
+   * Kept for backwards-compatible text-only rewrites.
+   */
   readonly prompt: string
+  /**
+   * A defensive copy of the complete effective message list.
+   * Return a replacement list to rewrite structured input or caller history.
+   */
+  readonly messages: readonly LLMMessage[]
   /** The agent's static configuration. */
+  readonly agent: AgentConfig
+}
+
+/** Value returned by {@link AgentConfig.beforeRun}. */
+export interface BeforeRunHookResult {
+  /**
+   * Backwards-compatible text rewrite for the latest user message. When both
+   * `messages` and `prompt` change, `messages` is applied first and `prompt`
+   * then replaces that message's text blocks while preserving non-text order.
+   */
+  readonly prompt: string
+  /**
+   * Optional replacement for the complete message list. Omission preserves
+   * compatibility with hooks that predate structured run input.
+   */
+  readonly messages?: readonly LLMMessage[]
+  /** Read-only informational agent configuration. */
   readonly agent: AgentConfig
 }
 
@@ -794,10 +836,10 @@ export interface AgentConfig {
   /**
    * Previously persisted conversation messages to restore for prompt() calls.
    *
-   * The messages are copied when the Agent is constructed, so a caller can
-   * safely reuse or replace the serialized history after passing it in. The
-   * history should contain the same valid message sequence returned by
-   * Agent.getHistory().
+   * The messages are validated and defensively deep-copied when the Agent is
+   * constructed, so a caller can safely reuse or mutate the serialized history
+   * after passing it in. The history should contain the same valid message
+   * sequence returned by Agent.getHistory().
    */
   readonly history?: readonly LLMMessage[]
   /** One-sentence role description for bounded, structured agent manifests. */
@@ -1096,11 +1138,13 @@ export interface AgentConfig {
    */
   readonly outputSchema?: ZodSchema
   /**
-   * Called before each agent run. Receives the prompt and agent config.
+   * Called before each agent run. Receives a defensive copy of the complete
+   * messages plus the backwards-compatible text `prompt` view and agent config.
    * Return a (possibly modified) context to continue, or throw to abort the run.
-   * Only `prompt` from the returned context is applied; `agent` is read-only informational.
+   * `messages` is applied first, then a changed `prompt`; `agent` is read-only
+   * informational. External process/ACP backends support `prompt` rewrites only.
    */
-  readonly beforeRun?: (context: BeforeRunHookContext) => Promise<BeforeRunHookContext> | BeforeRunHookContext
+  readonly beforeRun?: (context: BeforeRunHookContext) => Promise<BeforeRunHookResult> | BeforeRunHookResult
   /**
    * Called after each agent run completes successfully. Receives the run result.
    * Return a (possibly modified) result, or throw to mark the run as failed.

--- a/packages/core/tests/agent-structured-input.test.ts
+++ b/packages/core/tests/agent-structured-input.test.ts
@@ -1,0 +1,366 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { Agent } from '../src/agent/agent.js'
+import { InvalidMessageError } from '../src/errors.js'
+import type { Scorer } from '../src/eval/scorer.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { ToolExecutor } from '../src/tool/executor.js'
+import { ToolRegistry } from '../src/tool/framework.js'
+import type {
+  AgentConfig,
+  ContentBlock,
+  ExternalAgentBackendConfig,
+  ImageBlock,
+  LLMAdapter,
+  LLMMessage,
+  LLMResponse,
+  OrchestratorEvent,
+} from '../src/types.js'
+
+const IMAGE: ImageBlock = {
+  type: 'image',
+  source: {
+    type: 'base64',
+    media_type: 'image/png',
+    data: 'aW1hZ2U=',
+  },
+}
+
+function response(text = 'ok'): LLMResponse {
+  return {
+    id: 'structured-input-response',
+    content: [{ type: 'text', text }],
+    model: 'test-model',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 2, output_tokens: 1 },
+  }
+}
+
+function recordingAdapter(calls: LLMMessage[][], text = 'ok'): LLMAdapter {
+  return {
+    name: 'structured-input-test',
+    async chat(messages) {
+      calls.push(structuredClone(messages))
+      return response(text)
+    },
+    async *stream() { /* AgentRunner streams through chat(). */ },
+  }
+}
+
+function createAgent(
+  config: Partial<AgentConfig> = {},
+  calls: LLMMessage[][] = [],
+): Agent {
+  const registry = new ToolRegistry()
+  return new Agent({
+    name: 'structured-agent',
+    model: 'test-model',
+    adapter: recordingAdapter(calls),
+    ...config,
+  }, registry, new ToolExecutor(registry))
+}
+
+function callerHistory(): LLMMessage[] {
+  return [
+    { role: 'user', content: [{ type: 'text', text: 'Earlier question' }] },
+    { role: 'assistant', content: [{ type: 'text', text: 'Earlier answer' }] },
+    {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'What is in this image?' },
+        structuredClone(IMAGE),
+      ],
+    },
+  ]
+}
+
+describe('public structured Agent input', () => {
+  it('run() and stream() accept caller history with images and copy it at call time', async () => {
+    const calls: LLMMessage[][] = []
+    const agent = createAgent({}, calls)
+
+    const runInput = callerHistory()
+    const expectedRunInput = structuredClone(runInput)
+    const run = agent.run(runInput)
+    ;(runInput[2]!.content[0] as { text: string }).text = 'caller mutation'
+    runInput.splice(0, runInput.length)
+
+    await expect(run).resolves.toMatchObject({ success: true, output: 'ok' })
+    expect(calls[0]).toEqual(expectedRunInput)
+
+    const streamInput = callerHistory()
+    const expectedStreamInput = structuredClone(streamInput)
+    const stream = agent.stream(streamInput)
+    ;(streamInput[2]!.content[1] as { source: { data: string } }).source.data = 'mutated'
+    streamInput.splice(0, 1)
+
+    const events = []
+    for await (const event of stream) events.push(event)
+
+    expect(events.some((event) => event.type === 'done')).toBe(true)
+    expect(calls[1]).toEqual(expectedStreamInput)
+  })
+
+  it('prompt() appends one structured user turn and keeps defensive persistent history', async () => {
+    const calls: LLMMessage[][] = []
+    const restoredHistory: LLMMessage[] = [
+      { role: 'user', content: [{ type: 'text', text: 'Stored question' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'Stored answer' }] },
+    ]
+    const expectedRestoredHistory = structuredClone(restoredHistory)
+    const blocks: ContentBlock[] = [
+      structuredClone(IMAGE),
+      { type: 'text', text: 'Continue from the stored conversation.' },
+    ]
+    const expectedBlocks = structuredClone(blocks)
+    const agent = createAgent({
+      history: restoredHistory,
+      beforeRun: (ctx) => ({ ...ctx, prompt: 'hook-rewritten turn' }),
+    }, calls)
+
+    const prompt = agent.prompt(blocks)
+    ;(restoredHistory[0]!.content[0] as { text: string }).text = 'mutated history'
+    ;(blocks[0] as { source: { data: string } }).source.data = 'mutated image'
+    blocks.splice(0, blocks.length)
+    const result = await prompt
+    expect(result).toMatchObject({ success: true })
+
+    expect(calls[0]).toEqual([
+      ...expectedRestoredHistory,
+      {
+        role: 'user',
+        content: [expectedBlocks[0]!, { type: 'text', text: 'hook-rewritten turn' }],
+      },
+    ])
+
+    const history = agent.getHistory()
+    expect(history).toEqual([
+      ...expectedRestoredHistory,
+      { role: 'user', content: expectedBlocks },
+      { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+    ])
+
+    ;(history[0]!.content[0] as { text: string }).text = 'mutated snapshot'
+    ;(result.messages[0]!.content[0] as { text: string }).text = 'mutated result'
+    expect((agent.getHistory()[0]!.content[0] as { text: string }).text).toBe('Stored question')
+    expect((agent.getHistory().at(-1)!.content[0] as { text: string }).text).toBe('ok')
+  })
+
+  it('beforeRun exposes full messages and applies messages before the prompt rewrite', async () => {
+    const calls: LLMMessage[][] = []
+    let receivedMessages: readonly LLMMessage[] | undefined
+    let receivedPrompt: string | undefined
+    const beforeImage = { ...structuredClone(IMAGE), source: { ...IMAGE.source, data: 'before' } }
+    const afterImage = { ...structuredClone(IMAGE), source: { ...IMAGE.source, data: 'after' } }
+    const agent = createAgent({
+      beforeRun(ctx) {
+        receivedMessages = ctx.messages
+        receivedPrompt = ctx.prompt
+        return {
+          ...ctx,
+          prompt: 'prompt replacement',
+          messages: [
+            { role: 'assistant', content: [{ type: 'text', text: 'caller history' }] },
+            {
+              role: 'user',
+              content: [
+                beforeImage,
+                { type: 'text', text: 'message replacement one' },
+                afterImage,
+                { type: 'text', text: 'message replacement two' },
+              ],
+            },
+          ],
+        }
+      },
+    }, calls)
+    const input: LLMMessage[] = [{
+      role: 'user',
+      content: [
+        { type: 'text', text: 'first' },
+        structuredClone(IMAGE),
+        { type: 'text', text: 'second' },
+      ],
+    }]
+
+    await agent.run(input)
+
+    expect(receivedPrompt).toBe('firstsecond')
+    expect(receivedMessages).toEqual(input)
+    expect(calls[0]).toEqual([
+      { role: 'assistant', content: [{ type: 'text', text: 'caller history' }] },
+      {
+        role: 'user',
+        content: [
+          beforeImage,
+          { type: 'text', text: 'prompt replacement' },
+          afterImage,
+        ],
+      },
+    ])
+    expect(input[0]!.content).toHaveLength(3)
+  })
+
+  it('rejects malformed input before hooks or state/history mutation', async () => {
+    const calls: LLMMessage[][] = []
+    const beforeRun = vi.fn((ctx) => ctx)
+    const agent = createAgent({ beforeRun }, calls)
+    const invalidMessages = [
+      { role: 'user', content: 'not-blocks' },
+    ] as unknown as LLMMessage[]
+
+    await expect(agent.run(invalidMessages)).rejects.toBeInstanceOf(InvalidMessageError)
+    expect(() => agent.stream(invalidMessages)).toThrow(InvalidMessageError)
+    await expect(agent.prompt([null] as unknown as ContentBlock[]))
+      .rejects.toBeInstanceOf(InvalidMessageError)
+    await expect(agent.prompt(null as unknown as ContentBlock[]))
+      .rejects.toBeInstanceOf(InvalidMessageError)
+
+    const uncloneableMessages: LLMMessage[] = [{
+      role: 'user',
+      content: [{
+        type: 'tool_use',
+        id: 'uncloneable',
+        name: 'test',
+        input: { callback: () => undefined },
+      }],
+    }]
+    await expect(agent.run(uncloneableMessages)).rejects.toThrow(/cloneable structured data/)
+
+    expect(beforeRun).not.toHaveBeenCalled()
+    expect(calls).toHaveLength(0)
+    expect(agent.getState().status).toBe('idle')
+    expect(agent.getHistory()).toEqual([])
+  })
+
+  it('validates and copies AgentConfig.history when the Agent is constructed', () => {
+    const history = callerHistory()
+    const agent = createAgent({ history })
+    ;(history[0]!.content[0] as { text: string }).text = 'mutated after construction'
+    expect((agent.getHistory()[0]!.content[0] as { text: string }).text).toBe('Earlier question')
+
+    const invalidHistory = [
+      { role: 'user', content: 'not-blocks' },
+    ] as unknown as LLMMessage[]
+    expect(() => createAgent({ history: invalidHistory })).toThrow(InvalidMessageError)
+  })
+})
+
+describe('structured input with text-only external backends', () => {
+  const backends: ExternalAgentBackendConfig[] = [
+    { kind: 'process', command: process.execPath },
+    { kind: 'acp', command: 'unused-acp-command' },
+  ]
+
+  for (const backend of backends) {
+    it(`${backend.kind} rejects structured arguments before hooks, spawn, or history mutation`, async () => {
+      const beforeRun = vi.fn((ctx) => ctx)
+      const registry = new ToolRegistry()
+      const agent = new Agent({ name: backend.kind, backend, beforeRun }, registry, new ToolExecutor(registry))
+
+      await expect(agent.run(callerHistory())).rejects.toThrow(/accepts string prompts only/)
+      expect(() => agent.stream(callerHistory())).toThrow(/accepts string prompts only/)
+      await expect(agent.prompt([{ type: 'text', text: 'structured text' }]))
+        .rejects.toThrow(/accepts string prompts only/)
+
+      expect(beforeRun).not.toHaveBeenCalled()
+      expect(agent.getHistory()).toEqual([])
+    })
+  }
+
+  it('retains beforeRun.prompt rewrites for string process runs', async () => {
+    const registry = new ToolRegistry()
+    const agent = new Agent({
+      name: 'external-prompt-hook',
+      backend: { kind: 'process', command: process.execPath },
+      beforeRun: (ctx) => ({ ...ctx, prompt: 'console.log("rewritten")' }),
+    }, registry, new ToolExecutor(registry))
+
+    const result = await agent.run('console.log("original")')
+    expect(result.success).toBe(true)
+    expect(result.output.trim()).toBe('rewritten')
+  })
+
+  it('rejects beforeRun.messages changes before starting an external backend', async () => {
+    const registry = new ToolRegistry()
+    const agent = new Agent({
+      name: 'external-hook',
+      backend: { kind: 'process', command: process.execPath },
+      beforeRun(ctx) {
+        return {
+          ...ctx,
+          messages: [{ role: 'user', content: [structuredClone(IMAGE)] }],
+        }
+      },
+    }, registry, new ToolExecutor(registry))
+
+    const result = await agent.run('plain text')
+    expect(result).toMatchObject({ success: false, status: { code: 'error' } })
+    expect(result.output).toContain('beforeRun.messages cannot be forwarded without loss')
+  })
+})
+
+describe('OpenMultiAgent structured run lifecycle', () => {
+  it('preserves string progress data and isolates structured progress, evaluation, and execution copies', async () => {
+    const calls: LLMMessage[][] = []
+    const progressSnapshots: unknown[] = []
+    const scoredInputs: unknown[] = []
+    const scorer: Scorer = {
+      name: 'capture-input',
+      score({ evalCase }) {
+        scoredInputs.push(evalCase.input)
+        return { score: 1 }
+      },
+    }
+    const oma = new OpenMultiAgent({
+      defaultModel: 'test-model',
+      onProgress(event: OrchestratorEvent) {
+        if (event.type !== 'agent_start') return
+        progressSnapshots.push(structuredClone(event.data))
+        const messages = (event.data as { messages?: LLMMessage[] })?.messages
+        const text = messages?.[0]?.content[0]
+        if (text?.type === 'text') (text as { text: string }).text = 'progress mutation'
+      },
+      evaluation: {
+        scorers: [scorer],
+        sample: 1,
+        storePayloads: 'full',
+      },
+    })
+    const config: AgentConfig = {
+      name: 'lifecycle-agent',
+      model: 'test-model',
+      adapter: recordingAdapter(calls),
+    }
+
+    await oma.runAgent(config, 'plain string')
+    expect(progressSnapshots[0]).toEqual({ prompt: 'plain string' })
+
+    const messages = callerHistory()
+    const expected = structuredClone(messages)
+    await oma.runAgent(config, messages)
+    ;(messages[0]!.content[0] as { text: string }).text = 'post-run caller mutation'
+    await oma.evaluation.forceFlush({ timeoutMs: 1_000 })
+
+    expect(progressSnapshots[1]).toEqual({ messages: expected })
+    expect(calls[1]).toEqual(expected)
+    expect(JSON.parse(String(scoredInputs[1]))).toEqual(expected)
+  })
+
+  it('rejects invalid external structured input before progress or online evaluation', async () => {
+    const onProgress = vi.fn()
+    const scorer: Scorer = { name: 'unused', score: () => ({ score: 1 }) }
+    const oma = new OpenMultiAgent({
+      onProgress,
+      evaluation: { scorers: [scorer], sample: 1 },
+    })
+
+    await expect(oma.runAgent({
+      name: 'external',
+      backend: { kind: 'process', command: process.execPath },
+    }, callerHistory())).rejects.toBeInstanceOf(InvalidMessageError)
+
+    expect(onProgress).not.toHaveBeenCalled()
+    expect(oma.evaluation.getStats().sampled).toBe(0)
+  })
+})

--- a/scripts/example-catalog.test.mjs
+++ b/scripts/example-catalog.test.mjs
@@ -26,7 +26,7 @@ function copyCatalog() {
 }
 
 test('the checked-in catalog covers every discovered example unit', () => {
-  assert.equal(catalog.examples.length, 60)
+  assert.equal(catalog.examples.length, 61)
   assert.deepEqual(validateExampleCatalog(catalog, examplesRoot), [])
 })
 
@@ -43,7 +43,7 @@ test('the public schema and runtime validator use the same controlled vocabulary
 
 test('discovery uses standalone scripts and immediate example directories as units', () => {
   const discovered = discoverExampleUnits(examplesRoot)
-  assert.equal(discovered.length, 60)
+  assert.equal(discovered.length, 61)
   assert.ok(discovered.includes('basics/single-agent.ts'))
   assert.ok(discovered.includes('patterns/event-driven-dag.ts'))
   assert.ok(discovered.includes('patterns/durable-approval.ts'))


### PR DESCRIPTION
## Summary

- accept complete structured message histories in `Agent.run()`, `Agent.stream()`, and `OpenMultiAgent.runAgent()` while preserving every string call form
- accept one structured user turn in persistent `Agent.prompt()` conversations, with runtime validation and defensive deep copies
- expose full messages to `beforeRun`, preserve string progress/evaluation behavior, and isolate structured lifecycle copies
- fail fast when structured input crosses the text-only process or ACP backend boundary
- document the contract and add a runnable image-input example

## Scope

- keeps `runTeam()` and `runTasks()` text-only
- does not add rich tool outputs or provider capability inference

## Validation

- `npm run lint -w @open-multi-agent/core`
- `npm run test -w @open-multi-agent/core` (125 files, 1836 tests)
- `npm run build -w @open-multi-agent/core`
- focused structured-input, hook, validation, process, and ACP tests (5 files, 64 tests)
- `npm run test:example-catalog`
- strict standalone TypeScript compile of the new example
- `git diff --check`

Closes #465
