### PR TITLE
feat(core): add pluggable shell executor

### DIFF
--- a/docs/tool-configuration.md
+++ b/docs/tool-configuration.md
@@ -388,6 +388,109 @@ Compound commands are segmented on shell separators (`&&`, `||`, `;`, `|`, subst
 
 The classifier is a **shallow heuristic, not a parser**; it can be fooled by obfuscation (variable indirection, base64-decode-then-exec, exotic quoting). It is convenience only: extend the tables, wrap it, or replace it entirely. See [`examples/patterns/risk-gated-bash.ts`](../packages/core/examples/patterns/risk-gated-bash.ts) for an end-to-end demo.
 
+## Shell Executors
+
+The granted `bash` built-in delegates command execution through a
+`ShellExecutor`. With no executor configured, OMA uses `LocalShellExecutor`,
+which preserves the existing `bash -c` behavior on the host:
+
+```typescript
+import { OpenMultiAgent } from '@open-multi-agent/core'
+import type { AgentConfig } from '@open-multi-agent/core'
+import type { ShellExecutor } from '@open-multi-agent/core/shell'
+
+declare const sharedRemoteExecutor: ShellExecutor
+declare const specialistExecutor: ShellExecutor
+
+const orchestrator = new OpenMultiAgent({
+  // Inherited by agents that do not set shellExecutor.
+  defaultShellExecutor: sharedRemoteExecutor,
+})
+
+const agent: AgentConfig = {
+  name: 'builder',
+  model: 'claude-sonnet-4-6',
+  tools: ['bash'],
+  // Per-agent value wins over the orchestrator default.
+  shellExecutor: specialistExecutor,
+}
+```
+
+The executor changes **where an already-granted command runs**. It does not
+grant `bash` or bypass `disallowedTools`; command execution still happens only
+after `onToolCall` allows it. The existing default-deny and per-call gate rules
+are unchanged. The tool wrapper also keeps the model-facing behavior uniform
+across executors: input validation, the 30-second default timeout,
+stdout/stderr formatting, output redaction, and
+`isError` on a nonzero exit code.
+
+The public type contract is available from `@open-multi-agent/core/shell` and
+has no runtime imports:
+
+```typescript
+interface ShellExecutor {
+  start?(): Promise<void>
+  exec(command: string, options: ShellExecOptions): Promise<ShellExecResult>
+  dispose?(): Promise<void>
+}
+```
+
+`ShellExecOptions` contains `cwd`, `timeoutMs`, and `abortSignal`.
+`ShellExecResult` contains `stdout`, `stderr`, and `exitCode`. Executors must
+use exit code `124` for timeout, `130` for abort, and `127` when the process or
+remote command could not be started. The tool wrapper adds a short deadline
+backstop so an executor that ignores timeout or abort cannot stall the tool
+loop indefinitely, but implementations still own prompt cancellation and
+termination of the process, job, or remote session they control.
+
+### Lifecycle and concurrent use
+
+One executor instance represents one reusable session:
+
+- OMA calls `start()` lazily, immediately before the first allowed `bash`
+  execution in a run. A granted tool that is never called (or is denied by
+  `onToolCall`) creates no session. Later shell calls in that run reuse it.
+- OMA always attempts `dispose()` when the run succeeds, fails, is aborted, or
+  a streaming consumer stops early. If `start()` partially allocates resources
+  and then rejects, OMA attempts `dispose()` too.
+- If overlapping runs share the same executor instance (as agents inheriting
+  one `defaultShellExecutor` do), OMA reference-counts them: one `start()`, then
+  one `dispose()` after the final run finishes. `exec()` may be called
+  concurrently, including when one model turn requests multiple shell calls.
+  An executor that cannot run commands concurrently must serialize internally;
+  use distinct per-agent instances when each agent needs its own session.
+- A process crash cannot execute JavaScript cleanup. Remote adapters should
+  also configure a provider-side TTL, lease expiry, or out-of-band reaper for
+  crash recovery.
+
+These lifecycle calls belong to Agent/Orchestrator runs. If application code
+invokes the low-level exported `bashTool.execute()` directly, that caller owns
+`start()` / `dispose()` around its tool calls.
+
+`LocalShellExecutor` is stateless. It keeps the existing safe environment
+allowlist, captures stdout/stderr, runs the command in a separate process group
+on POSIX, and kills the process tree on timeout or abort. It executes with the
+host Node.js process's permissions: **it is not a sandbox or security
+boundary**. A custom executor is only as isolated as the environment and
+adapter implementation behind it; OMA does not ship Docker, VM, or hosted
+sandbox adapters in core.
+
+### Host and remote filesystems diverge
+
+> **A remote shell executor does not move the built-in filesystem tools.**
+> `file_read`, `file_write`, `file_edit`, `grep`, and `glob` still operate on
+> the host inside `AgentConfig.cwd` / `defaultCwd`. The `cwd` passed to `bash`
+> is interpreted inside the executor's environment. For example, `file_write`
+> may create `report.md` in the host `.agent-workspace`, while a following
+> remote `bash` call to `wc -l report.md` sees no such file. Unless the
+> application provides its own synchronization layer, do not co-grant the
+> host filesystem tools to a remote-shell agent, or explicitly design around
+> the two separate filesystems.
+
+Shell executors apply only inside the normal LLM runner tool loop. Process and
+ACP agent backends replace that loop and continue to manage their own command
+execution and `cwd`; `shellExecutor` does not affect them.
+
 ## Filesystem Working Directory
 
 Built-in filesystem tools (`file_read`, `file_write`, `file_edit`, `grep`, `glob`) are sandboxed to a per-agent working directory. Paths must be absolute and resolve inside that directory; symlinks are resolved before the check so they cannot escape the configured root.
@@ -438,7 +541,10 @@ const agent: AgentConfig = {
 
 **Auto-creation.** The sandbox root is `mkdir -p`'d on first write, so callers do not need to pre-create `.agent-workspace` (or any custom path).
 
-The `bash` tool runs in its own process group on POSIX, so timeouts and abort signals kill any backgrounded children rather than letting them outlive the parent.
+The default `LocalShellExecutor` runs `bash` in its own process group on POSIX,
+so timeouts and abort signals kill any backgrounded children rather than
+letting them outlive the parent. Custom executors own equivalent cleanup in
+their execution environment.
 
 ## Custom Tools
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -303,9 +303,12 @@ your model provider, so grant read and exec access deliberately. Tools may keep
 application-owned data separate while returning text, image, or file content
 through `modelOutput`; see the [tool configuration guide](../../docs/tool-configuration.md#rich-image-and-file-results).
 Filesystem tools stay within the configured `cwd`; granted `bash` is not
-sandboxed. Secrets are redacted from traces, shell output, and Viewer payloads
-by default, but result messages and checkpoints have their own persistence
-boundary.
+sandboxed. Its execution target can be replaced through a
+[`ShellExecutor`](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md#shell-executors),
+while the default `LocalShellExecutor` preserves host execution and is not a
+security boundary. Secrets are redacted from traces, shell output, and Viewer
+payloads by default, but result messages and checkpoints have their own
+persistence boundary.
 
 ### Observability
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,10 @@
       "types": "./dist/classifiers.d.ts",
       "import": "./dist/classifiers.js"
     },
+    "./shell": {
+      "types": "./dist/shell.d.ts",
+      "import": "./dist/shell.js"
+    },
     "./eval": {
       "types": "./dist/eval/index.d.ts",
       "import": "./dist/eval/index.js"

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -207,6 +207,9 @@ export class Agent {
       allowedTools: this.config.tools,
       disallowedTools: this.config.disallowedTools,
       ...(this.config.onToolCall !== undefined ? { onToolCall: this.config.onToolCall } : {}),
+      ...(this.config.shellExecutor !== undefined
+        ? { shellExecutor: this.config.shellExecutor }
+        : {}),
       cwd: this.config.cwd,
       agentName: this.name,
       agentRole: this.config.systemPrompt?.slice(0, 50) ?? 'assistant',
@@ -1066,6 +1069,9 @@ export class Agent {
         model: this.config.model!,
       },
       abortSignal,
+      ...(this.config.shellExecutor !== undefined
+        ? { shellExecutor: this.config.shellExecutor }
+        : {}),
       cwd: this.config.cwd === undefined ? defaultWorkspaceDir() : this.config.cwd,
       ...(this.config.credentials !== undefined ? { credentials: this.config.credentials } : {}),
     }

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -52,6 +52,8 @@ import type { TraceRuntime, TraceSpan } from '../observability/runtime.js'
 import { classifyRunFailure } from '../observability/status.js'
 import type { ToolRegistry } from '../tool/framework.js'
 import type { ToolExecutor } from '../tool/executor.js'
+import type { ShellExecutor } from '../tool/shell/types.js'
+import { RunScopedShellExecutor } from '../tool/shell/lifecycle.js'
 import { defaultWorkspaceDir } from '../tool/built-in/path-safety.js'
 import {
   AGENT_FRAMEWORK_DISALLOWED,
@@ -147,6 +149,8 @@ export interface RunnerOptions {
   readonly disallowedTools?: readonly string[]
   /** Optional per-call tool gate inherited from agent or orchestrator config. */
   readonly onToolCall?: ToolCallGate
+  /** Effective execution target for the granted `bash` built-in. */
+  readonly shellExecutor?: ShellExecutor
   /**
    * Root directory passed to built-in filesystem tools via `ToolUseContext.cwd`.
    * `null` disables the sandbox; `undefined` falls back to
@@ -982,6 +986,10 @@ export class AgentRunner implements AgentBackend {
       }
     }
     const loopAction = this.options.loopDetection?.onLoopDetected ?? 'warn'
+    const runShellExecutor = this.options.shellExecutor === undefined
+      ? undefined
+      : new RunScopedShellExecutor(this.options.shellExecutor)
+    let streamError: Error | undefined
 
     try {
       // -----------------------------------------------------------------
@@ -991,7 +999,10 @@ export class AgentRunner implements AgentBackend {
         if (phase === 'completed') break
 
         if (phase === 'executing_tools') {
-          const toolContext: ToolUseContext = this.buildToolContext(options)
+          const toolContext: ToolUseContext = this.buildToolContext(
+            options,
+            runShellExecutor,
+          )
           const executions = await Promise.all(pendingToolCalls.map(async (pending, index) => {
             if (pending.commit) {
               return { commit: pending.commit, shouldCommit: true } satisfies ToolExecution
@@ -1319,8 +1330,24 @@ export class AgentRunner implements AgentBackend {
         await persistCheckpoint()
       }
     } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err))
-      yield { type: 'error', data: error } satisfies StreamEvent
+      streamError = err instanceof Error ? err : new Error(String(err))
+    } finally {
+      try {
+        await runShellExecutor?.release()
+      } catch (err) {
+        const cleanupError = err instanceof Error ? err : new Error(String(err))
+        if (streamError !== undefined) {
+          throw new AggregateError(
+            [streamError, cleanupError],
+            'Agent run failed and shell executor cleanup also failed.',
+          )
+        }
+        throw cleanupError
+      }
+    }
+
+    if (streamError !== undefined) {
+      yield { type: 'error', data: streamError } satisfies StreamEvent
       return
     }
 
@@ -1793,7 +1820,10 @@ export class AgentRunner implements AgentBackend {
    * Build the {@link ToolUseContext} passed to every tool execution.
    * Identifies this runner as the invoking agent.
    */
-  private buildToolContext(options: RunOptions = {}): ToolUseContext {
+  private buildToolContext(
+    options: RunOptions = {},
+    shellExecutor?: ShellExecutor,
+  ): ToolUseContext {
     return {
       agent: {
         name: this.options.agentName ?? 'runner',
@@ -1801,6 +1831,9 @@ export class AgentRunner implements AgentBackend {
         model: this.options.model,
       },
       abortSignal: options.abortSignal ?? this.options.abortSignal,
+      ...(shellExecutor !== undefined
+        ? { shellExecutor }
+        : {}),
       cwd: this.options.cwd === undefined ? defaultWorkspaceDir() : this.options.cwd,
       ...(options.runId !== undefined ? { runId: options.runId } : {}),
       ...(options.taskId !== undefined ? { taskId: options.taskId } : {}),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -165,6 +165,12 @@ export type { TaskQueueEvent } from './task/queue.js'
 export { defineTool, ToolRegistry, zodToJsonSchema } from './tool/framework.js'
 export { ToolExecutor, truncateToolOutput } from './tool/executor.js'
 export type { ToolExecutorExecutionOptions, ToolExecutorOptions, BatchToolCall } from './tool/executor.js'
+export { LocalShellExecutor } from './tool/shell/local.js'
+export type {
+  ShellExecOptions,
+  ShellExecResult,
+  ShellExecutor,
+} from './tool/shell/types.js'
 export {
   registerBuiltInTools,
   BUILT_IN_TOOLS,

--- a/packages/core/src/orchestrator/agent-config.ts
+++ b/packages/core/src/orchestrator/agent-config.ts
@@ -25,6 +25,7 @@ export interface AgentDefaultsSource {
   readonly defaultBaseURL?: OrchestratorConfig['defaultBaseURL']
   readonly defaultApiKey?: OrchestratorConfig['defaultApiKey']
   readonly defaultCwd?: OrchestratorConfig['defaultCwd']
+  readonly defaultShellExecutor?: OrchestratorConfig['defaultShellExecutor']
   readonly onToolCall?: OrchestratorConfig['onToolCall']
 }
 
@@ -37,6 +38,7 @@ export function applyAgentDefaults(config: AgentConfig, src: AgentDefaultsSource
     baseURL: config.baseURL ?? src.defaultBaseURL,
     apiKey: config.apiKey ?? src.defaultApiKey,
     cwd: config.cwd === undefined ? src.defaultCwd : config.cwd,
+    shellExecutor: config.shellExecutor ?? src.defaultShellExecutor,
     onToolCall: config.onToolCall ?? src.onToolCall,
   }
 }

--- a/packages/core/src/orchestrator/consensus.ts
+++ b/packages/core/src/orchestrator/consensus.ts
@@ -41,6 +41,7 @@ export interface ConsensusAgentDefaults {
   readonly defaultBaseURL: OrchestratorConfig['defaultBaseURL']
   readonly defaultApiKey: OrchestratorConfig['defaultApiKey']
   readonly defaultCwd: OrchestratorConfig['defaultCwd']
+  readonly defaultShellExecutor: OrchestratorConfig['defaultShellExecutor']
   readonly onToolCall: OrchestratorConfig['onToolCall']
   readonly maxConcurrency: number
 }
@@ -370,6 +371,7 @@ export async function runTaskVerify(
       defaultBaseURL: config.defaultBaseURL,
       defaultApiKey: config.defaultApiKey,
       defaultCwd: config.defaultCwd,
+      defaultShellExecutor: config.defaultShellExecutor,
       onToolCall: config.onToolCall,
       maxConcurrency: config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,
     },

--- a/packages/core/src/orchestrator/coordinator.ts
+++ b/packages/core/src/orchestrator/coordinator.ts
@@ -526,6 +526,8 @@ export function buildCoordinatorBaseConfig(
     tools: coordinatorOverrides?.tools,
     disallowedTools: coordinatorOverrides?.disallowedTools,
     onToolCall: coordinatorOverrides?.onToolCall ?? config.onToolCall,
+    shellExecutor:
+      coordinatorOverrides?.shellExecutor ?? config.defaultShellExecutor,
     cwd: coordinatorOverrides?.cwd === undefined
       ? config.defaultCwd
       : coordinatorOverrides.cwd,

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -344,8 +344,8 @@ function resolveRunBudgets(
  */
 export class OpenMultiAgent {
   private readonly config: Required<
-    Omit<OrchestratorConfig, 'onApproval' | 'onTaskDispatch' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'evaluation' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint' | 'recovery'>
-  > & Pick<OrchestratorConfig, 'onApproval' | 'onTaskDispatch' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'evaluation' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint' | 'recovery'>
+    Omit<OrchestratorConfig, 'onApproval' | 'onTaskDispatch' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'evaluation' | 'defaultBaseURL' | 'defaultApiKey' | 'defaultShellExecutor' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint' | 'recovery'>
+  > & Pick<OrchestratorConfig, 'onApproval' | 'onTaskDispatch' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'evaluation' | 'defaultBaseURL' | 'defaultApiKey' | 'defaultShellExecutor' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint' | 'recovery'>
 
   private readonly teams: Map<string, Team> = new Map()
   private readonly hasConfiguredCustomExecutionRouter: boolean
@@ -426,6 +426,7 @@ export class OpenMultiAgent {
       // <cwd>/.agent-workspace". An explicit `null` propagates through to
       // disable the filesystem sandbox; a string sets a custom sandbox root.
       defaultCwd: config.defaultCwd === undefined ? defaultWorkspaceDir() : config.defaultCwd,
+      defaultShellExecutor: config.defaultShellExecutor,
       maxTokenBudget: config.maxTokenBudget,
       maxCostBudget: config.maxCostBudget,
       estimateCost: config.estimateCost,
@@ -2525,6 +2526,7 @@ export class OpenMultiAgent {
       defaultBaseURL: this.config.defaultBaseURL,
       defaultApiKey: this.config.defaultApiKey,
       defaultCwd: this.config.defaultCwd,
+      defaultShellExecutor: this.config.defaultShellExecutor,
       onToolCall: this.config.onToolCall,
       maxConcurrency: this.config.maxConcurrency,
     }

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -1,0 +1,8 @@
+/** Public shell-execution seam for the `bash` built-in. */
+
+export { LocalShellExecutor } from './tool/shell/local.js'
+export type {
+  ShellExecOptions,
+  ShellExecResult,
+  ShellExecutor,
+} from './tool/shell/types.js'

--- a/packages/core/src/tool/built-in/bash.ts
+++ b/packages/core/src/tool/built-in/bash.ts
@@ -5,30 +5,22 @@
  * optional timeout and a custom working directory.
  */
 
-import { spawn } from 'child_process'
 import { z } from 'zod'
 import { defineTool } from '../framework.js'
-import { isSensitiveName, redactSensitiveText } from '../../utils/redaction.js'
-import { killProcessTree } from '../../utils/process-tree.js'
+import { redactSensitiveText } from '../../utils/redaction.js'
+import { LocalShellExecutor } from '../shell/local.js'
+import type {
+  ShellExecResult,
+  ShellExecutor,
+} from '../shell/types.js'
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 const DEFAULT_TIMEOUT_MS = 30_000
-const SAFE_ENV_ALLOWLIST = new Set([
-  'HOME',
-  'LANG',
-  'LC_ALL',
-  'LOGNAME',
-  'PATH',
-  'SHELL',
-  'TEMP',
-  'TERM',
-  'TMP',
-  'TMPDIR',
-  'USER',
-])
+const EXECUTOR_BACKSTOP_GRACE_MS = 100
+const DEFAULT_SHELL_EXECUTOR = new LocalShellExecutor()
 
 // ---------------------------------------------------------------------------
 // Tool definition
@@ -62,12 +54,23 @@ export const bashTool = defineTool({
   execute: async (input, context) => {
     const timeoutMs = input.timeout ?? DEFAULT_TIMEOUT_MS
 
-    const { stdout, stderr, exitCode } = await runCommand(
-      input.command,
-      { cwd: input.cwd, timeoutMs },
-      context.abortSignal,
-    )
+    let execution: ShellExecResult
+    try {
+      execution = await executeWithBackstop(
+        context.shellExecutor ?? DEFAULT_SHELL_EXECUTOR,
+        input.command,
+        { cwd: input.cwd, timeoutMs },
+        context.abortSignal,
+      )
+    } catch (error) {
+      execution = {
+        stdout: '',
+        stderr: error instanceof Error ? error.message : String(error),
+        exitCode: 127,
+      }
+    }
 
+    const { stdout, stderr, exitCode } = execution
     const combined = redactSensitiveText(buildOutput(stdout, stderr, exitCode))
     const isError = exitCode !== 0
 
@@ -82,128 +85,126 @@ export const bashTool = defineTool({
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-interface RunResult {
-  stdout: string
-  stderr: string
-  exitCode: number
-}
-
-interface RunOptions {
+interface BashRunOptions {
   cwd: string | undefined
   timeoutMs: number
 }
 
 /**
- * Spawn a bash subprocess, capture its output, and resolve when it exits or
- * the abort signal fires.
+ * Bound an executor even when an adapter fails to honour its own timeout or
+ * abort contract. The executor receives the cancellation immediately; the
+ * short grace period lets a cooperative implementation return captured output
+ * before the wrapper falls back to an empty conventional result.
  */
-function runCommand(
+async function executeWithBackstop(
+  executor: ShellExecutor,
   command: string,
-  options: RunOptions,
+  options: BashRunOptions,
   signal: AbortSignal | undefined,
-): Promise<RunResult> {
-  return new Promise<RunResult>((resolve) => {
-    const stdoutChunks: Buffer[] = []
-    const stderrChunks: Buffer[] = []
-
-    const child = spawn('bash', ['-c', command], {
+): Promise<ShellExecResult> {
+  // The local implementation already owns a process-tree-aware deadline and
+  // abort path. Calling it directly preserves the historical timing and
+  // captured-output behavior exactly; the wrapper backstop is for pluggable
+  // executors whose cooperation OMA cannot assume.
+  if (executor instanceof LocalShellExecutor) {
+    return executor.exec(command, {
       cwd: options.cwd,
-      detached: process.platform !== 'win32',
-      env: buildSafeShellEnv(process.env),
-      stdio: ['ignore', 'pipe', 'pipe'],
+      timeoutMs: options.timeoutMs,
+      abortSignal: signal,
     })
-
-    child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk))
-    child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
-
-    let timedOut = false
-    let aborted = false
-    let settled = false
-
-    const done = (exitCode: number): void => {
-      if (settled) return
-      settled = true
-      clearTimeout(timer)
-      if (signal !== undefined) {
-        signal.removeEventListener('abort', onAbort)
-      }
-
-      const stdout = Buffer.concat(stdoutChunks).toString('utf8')
-      const stderr = Buffer.concat(stderrChunks).toString('utf8')
-
-      resolve({ stdout, stderr, exitCode })
-    }
-
-    // Timeout handler — kill the whole process group so backgrounded
-    // children (`(sleep 5; ...) &`) do not outlive the parent.
-    const timer = setTimeout(() => {
-      timedOut = true
-      killProcessTree(child)
-    }, options.timeoutMs)
-
-    // Abort-signal handler — same process-group cleanup as the timeout.
-    const onAbort = (): void => {
-      aborted = true
-      killProcessTree(child)
-    }
-
-    if (signal !== undefined) {
-      signal.addEventListener('abort', onAbort, { once: true })
-    }
-
-    // `close` (process exited AND stdio drained) is the normal completion
-    // path. After a forced kill we settle on `exit` instead: on Windows,
-    // MSYS bash's fork emulation can leave descendants that taskkill cannot
-    // reach (their recorded parent PID is a dead intermediate process), and
-    // any such straggler would hold the stdio pipes open and delay `close`
-    // until it exits naturally.
-    //
-    // When we killed the process ourselves, report the conventional exit
-    // codes (124 timeout / 130 abort) authoritatively: the code the OS
-    // reports for a forced termination is platform-dependent (`null` after
-    // SIGKILL on POSIX, `1` after taskkill on Windows).
-    const resolveExitCode = (code: number | null): number => {
-      if (timedOut) return 124
-      if (aborted) return 130
-      return code ?? 1
-    }
-
-    child.on('close', (code: number | null) => {
-      done(resolveExitCode(code))
-    })
-
-    child.on('exit', (code: number | null) => {
-      if (timedOut || aborted) {
-        done(resolveExitCode(code))
-      }
-    })
-
-    child.on('error', (err: Error) => {
-      if (!settled) {
-        settled = true
-        clearTimeout(timer)
-        if (signal !== undefined) {
-          signal.removeEventListener('abort', onAbort)
-        }
-        resolve({
-          stdout: '',
-          stderr: err.message,
-          exitCode: 127,
-        })
-      }
-    })
-  })
-}
-
-function buildSafeShellEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
-  const safeEnv: NodeJS.ProcessEnv = {}
-  for (const [name, value] of Object.entries(env)) {
-    if (value === undefined) continue
-    if (!SAFE_ENV_ALLOWLIST.has(name)) continue
-    if (isSensitiveName(name)) continue
-    safeEnv[name] = value
   }
-  return safeEnv
+
+  if (signal?.aborted) {
+    return { stdout: '', stderr: '', exitCode: 130 }
+  }
+
+  type TerminationReason = 'timeout' | 'abort'
+  type Outcome =
+    | { readonly kind: 'result'; readonly result: ShellExecResult }
+    | { readonly kind: 'backstop'; readonly reason: TerminationReason }
+
+  const commandAbort = new AbortController()
+  let termination: TerminationReason | undefined
+  let graceTimer: ReturnType<typeof setTimeout> | undefined
+  let resolveBackstop!: (outcome: Outcome) => void
+  const backstop = new Promise<Outcome>((resolve) => {
+    resolveBackstop = resolve
+  })
+
+  const terminate = (reason: TerminationReason): void => {
+    if (termination !== undefined) return
+    termination = reason
+    commandAbort.abort()
+    graceTimer = setTimeout(() => {
+      resolveBackstop({ kind: 'backstop', reason })
+    }, EXECUTOR_BACKSTOP_GRACE_MS)
+  }
+
+  const onAbort = (): void => terminate('abort')
+  signal?.addEventListener('abort', onAbort, { once: true })
+  let timeoutTimer: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    // Invoke first so LocalShellExecutor's own deadline is registered before
+    // the wrapper backstop. That preserves its captured-output behavior while
+    // still bounding a non-cooperative custom executor.
+    const execution = executor.exec(command, {
+      cwd: options.cwd,
+      timeoutMs: options.timeoutMs,
+      abortSignal: commandAbort.signal,
+    })
+      .then((result): Outcome => ({ kind: 'result', result }))
+      .catch((error: unknown): Outcome => {
+        // Cancellation-triggered adapter rejections still use the cross-adapter
+        // 124/130 result contract. Unrelated executor failures propagate to the
+        // ToolExecutor, which converts thrown tool errors into ToolResult values.
+        if (termination !== undefined) {
+          return {
+            kind: 'result',
+            result: {
+              stdout: '',
+              stderr: '',
+              exitCode: termination === 'timeout' ? 124 : 130,
+            },
+          }
+        }
+        throw error
+      })
+
+    if (signal?.aborted) terminate('abort')
+    timeoutTimer = setTimeout(() => terminate('timeout'), options.timeoutMs)
+
+    const outcome = await Promise.race([execution, backstop])
+    if (outcome.kind === 'backstop') {
+      return {
+        stdout: '',
+        stderr: '',
+        exitCode: outcome.reason === 'timeout' ? 124 : 130,
+      }
+    }
+    if (termination !== undefined) {
+      return {
+        ...outcome.result,
+        exitCode: termination === 'timeout' ? 124 : 130,
+      }
+    }
+    return outcome.result
+  } catch (error) {
+    // An executor is allowed by JavaScript to throw before returning its
+    // promise. Cancellation remains authoritative in that race too.
+    if (termination !== undefined) {
+      return {
+        stdout: '',
+        stderr: '',
+        exitCode: termination === 'timeout' ? 124 : 130,
+      }
+    }
+    throw error
+  } finally {
+    if (timeoutTimer !== undefined) clearTimeout(timeoutTimer)
+    if (graceTimer !== undefined) clearTimeout(graceTimer)
+    signal?.removeEventListener('abort', onAbort)
+  }
 }
 
 /**

--- a/packages/core/src/tool/shell/lifecycle.ts
+++ b/packages/core/src/tool/shell/lifecycle.ts
@@ -1,0 +1,130 @@
+/** Shared lifecycle coordination for configured shell-executor instances. */
+
+import type {
+  ShellExecOptions,
+  ShellExecResult,
+  ShellExecutor,
+} from './types.js'
+
+export interface ShellExecutorLease {
+  /** Release this run's ownership. Safe to call more than once. */
+  release(): Promise<void>
+}
+
+class ExecutorLifecycle {
+  private leases = 0
+  private started = false
+  private transition: Promise<void> = Promise.resolve()
+
+  constructor(private readonly executor: ShellExecutor) {}
+
+  async acquire(): Promise<ShellExecutorLease> {
+    this.leases++
+
+    if (this.leases === 1) {
+      // A new run that arrives while the previous dispose is still settling
+      // waits for that transition before starting a fresh session.
+      this.transition = this.transition.then(async () => {
+        await this.executor.start?.()
+        this.started = true
+      })
+    }
+
+    try {
+      await this.transition
+    } catch (startError) {
+      try {
+        await this.releaseLease(true)
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [startError, cleanupError],
+          'Shell executor start failed and cleanup also failed.',
+        )
+      }
+      throw startError
+    }
+
+    let released = false
+    return {
+      release: async () => {
+        if (released) return
+        released = true
+        await this.releaseLease(false)
+      },
+    }
+  }
+
+  private async releaseLease(startFailed: boolean): Promise<void> {
+    this.leases--
+    if (this.leases > 0) return
+
+    // `dispose()` is attempted after a failed `start()` too: a remote adapter
+    // may have allocated a session before its start promise rejected.
+    const shouldDispose = this.started || startFailed
+    this.transition = this.transition
+      .catch(() => undefined)
+      .then(async () => {
+        if (shouldDispose) {
+          await this.executor.dispose?.()
+        }
+        this.started = false
+      })
+
+    await this.transition
+  }
+}
+
+const lifecycles = new WeakMap<ShellExecutor, ExecutorLifecycle>()
+
+/**
+ * Acquire one run lease for an executor. Overlapping leases share a single
+ * start/dispose window; the final release owns disposal.
+ */
+export function acquireShellExecutor(executor: ShellExecutor): Promise<ShellExecutorLease> {
+  let lifecycle = lifecycles.get(executor)
+  if (lifecycle === undefined) {
+    lifecycle = new ExecutorLifecycle(executor)
+    lifecycles.set(executor, lifecycle)
+  }
+  return lifecycle.acquire()
+}
+
+/**
+ * Per-run proxy that acquires the shared executor lazily on the first command.
+ * This keeps `start()` below grant and onToolCall checks and avoids creating a
+ * remote session for runs that are allowed to use bash but never request it.
+ */
+export class RunScopedShellExecutor implements ShellExecutor {
+  private leasePromise: Promise<ShellExecutorLease> | undefined
+
+  constructor(private readonly executor: ShellExecutor) {}
+
+  async exec(command: string, options: ShellExecOptions): Promise<ShellExecResult> {
+    if (options.abortSignal?.aborted) {
+      return { stdout: '', stderr: '', exitCode: 130 }
+    }
+    this.leasePromise ??= acquireShellExecutor(this.executor)
+    await this.leasePromise
+    // A timeout or caller abort may have fired while start() was acquiring a
+    // remote session. Never dispatch the command after cancellation.
+    if (options.abortSignal?.aborted) {
+      return { stdout: '', stderr: '', exitCode: 130 }
+    }
+    return this.executor.exec(command, options)
+  }
+
+  /** Release this run's lease if any command acquired one. */
+  async release(): Promise<void> {
+    if (this.leasePromise === undefined) return
+    let lease: ShellExecutorLease
+    try {
+      lease = await this.leasePromise
+    } catch {
+      // acquire() already attempted cleanup and surfaced the start failure to
+      // the bash ToolResult. Do not turn that handled tool error into a second
+      // run-level failure while closing the run.
+      return
+    }
+    await lease.release()
+  }
+}

--- a/packages/core/src/tool/shell/local.ts
+++ b/packages/core/src/tool/shell/local.ts
@@ -1,0 +1,128 @@
+/** Local host implementation of the shell-executor contract. */
+
+import { spawn } from 'node:child_process'
+import { isSensitiveName } from '../../utils/redaction.js'
+import { killProcessTree } from '../../utils/process-tree.js'
+import type {
+  ShellExecOptions,
+  ShellExecResult,
+  ShellExecutor,
+} from './types.js'
+
+const SAFE_ENV_ALLOWLIST = new Set([
+  'HOME',
+  'LANG',
+  'LC_ALL',
+  'LOGNAME',
+  'PATH',
+  'SHELL',
+  'TEMP',
+  'TERM',
+  'TMP',
+  'TMPDIR',
+  'USER',
+])
+
+/**
+ * Execute `bash -c` on the host using the built-in's historical environment,
+ * timeout, abort, and process-tree cleanup behavior.
+ *
+ * This class is not a sandbox or security boundary. It executes with the
+ * permissions of the current Node.js process.
+ */
+export class LocalShellExecutor implements ShellExecutor {
+  exec(command: string, options: ShellExecOptions): Promise<ShellExecResult> {
+    if (options.abortSignal?.aborted) {
+      return Promise.resolve({ stdout: '', stderr: '', exitCode: 130 })
+    }
+    return new Promise<ShellExecResult>((resolve) => {
+      const stdoutChunks: Buffer[] = []
+      const stderrChunks: Buffer[] = []
+
+      const child = spawn('bash', ['-c', command], {
+        cwd: options.cwd,
+        detached: process.platform !== 'win32',
+        env: buildSafeShellEnv(process.env),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+
+      child.stdout.on('data', (chunk: Buffer) => stdoutChunks.push(chunk))
+      child.stderr.on('data', (chunk: Buffer) => stderrChunks.push(chunk))
+
+      let timedOut = false
+      let aborted = false
+      let settled = false
+
+      const done = (exitCode: number): void => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        options.abortSignal?.removeEventListener('abort', onAbort)
+
+        const stdout = Buffer.concat(stdoutChunks).toString('utf8')
+        const stderr = Buffer.concat(stderrChunks).toString('utf8')
+
+        resolve({ stdout, stderr, exitCode })
+      }
+
+      // Kill the whole process group so backgrounded children do not outlive
+      // the command on either timeout or caller cancellation.
+      const timer = setTimeout(() => {
+        timedOut = true
+        killProcessTree(child)
+      }, options.timeoutMs)
+
+      const onAbort = (): void => {
+        aborted = true
+        killProcessTree(child)
+      }
+
+      if (options.abortSignal !== undefined) {
+        options.abortSignal.addEventListener('abort', onAbort, { once: true })
+      }
+
+      // `close` (process exited AND stdio drained) is the normal completion
+      // path. After a forced kill we settle on `exit` instead: on Windows,
+      // MSYS bash descendants may otherwise keep the stdio pipes open.
+      const resolveExitCode = (code: number | null): number => {
+        if (timedOut) return 124
+        if (aborted) return 130
+        return code ?? 1
+      }
+
+      child.on('close', (code: number | null) => {
+        done(resolveExitCode(code))
+      })
+
+      child.on('exit', (code: number | null) => {
+        if (timedOut || aborted) {
+          done(resolveExitCode(code))
+        }
+      })
+
+      child.on('error', (err: Error) => {
+        if (!settled) {
+          settled = true
+          clearTimeout(timer)
+          options.abortSignal?.removeEventListener('abort', onAbort)
+          resolve({
+            stdout: '',
+            stderr: err.message,
+            exitCode: 127,
+          })
+        }
+      })
+    })
+  }
+}
+
+function buildSafeShellEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const safeEnv: NodeJS.ProcessEnv = {}
+  for (const [name, value] of Object.entries(env)) {
+    if (value === undefined) continue
+    if (!SAFE_ENV_ALLOWLIST.has(name)) continue
+    if (isSensitiveName(name)) continue
+    safeEnv[name] = value
+  }
+  return safeEnv
+}

--- a/packages/core/src/tool/shell/types.ts
+++ b/packages/core/src/tool/shell/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Dependency-light contract for executing commands requested by the `bash`
+ * built-in. Implementations may execute locally or dispatch to an external
+ * environment; the contract itself has no runtime imports.
+ */
+
+/** Options supplied for one shell command. */
+export interface ShellExecOptions {
+  /** Working directory interpreted inside the executor's environment. */
+  readonly cwd?: string
+  /** Deadline the executor must enforce for the command it controls. */
+  readonly timeoutMs: number
+  /** Cancellation signal; aborting it must terminate the controlled command. */
+  readonly abortSignal?: AbortSignal
+}
+
+/** Captured result of one shell command. */
+export interface ShellExecResult {
+  readonly stdout: string
+  readonly stderr: string
+  /** `124` on timeout, `130` on abort, and `127` when startup fails. */
+  readonly exitCode: number
+}
+
+/**
+ * Execution seam behind the granted `bash` built-in.
+ *
+ * One instance represents a reusable session. OMA calls `start()` before a
+ * run may use it, may call `exec()` concurrently, and calls `dispose()` after
+ * the last overlapping run using that instance finishes. Implementations that
+ * cannot execute concurrently must serialize calls internally.
+ */
+export interface ShellExecutor {
+  /** Acquire reusable resources such as a remote session. */
+  start?(): Promise<void>
+  /** Execute one bash command to completion. */
+  exec(command: string, options: ShellExecOptions): Promise<ShellExecResult>
+  /**
+   * Release all resources owned by this instance, terminating any outstanding
+   * command that a tool-level timeout or abort backstop left unsettled.
+   */
+  dispose?(): Promise<void>
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,6 +11,7 @@ import type {
   SchedulingStrategy,
   SchedulingWeights,
 } from './orchestrator/scheduler.js'
+import type { ShellExecutor } from './tool/shell/types.js'
 
 // ---------------------------------------------------------------------------
 // Content blocks
@@ -545,6 +546,13 @@ export interface ToolUseContext {
    */
   readonly abortController?: AbortController
   /**
+   * Effective executor for the built-in `bash` tool. Framework callers inject
+   * this from {@link AgentConfig.shellExecutor}; low-level tool callers may
+   * omit it to use `LocalShellExecutor`. A caller that invokes
+   * `bashTool.execute()` directly owns the executor lifecycle.
+   */
+  readonly shellExecutor?: ShellExecutor
+  /**
    * Working directory for filesystem-tool sandboxing.
    *
    * - `string` — built-in filesystem tools (`file_read`, `file_write`,
@@ -997,6 +1005,17 @@ export interface AgentConfig {
    * key is auto-redacted from traces and dashboards.
    */
   readonly credentials?: Readonly<Record<string, string>>
+  /**
+   * Where a granted `bash` tool executes. Overrides
+   * {@link OrchestratorConfig.defaultShellExecutor} for this agent. The
+   * executor does not grant `bash`; `tools` / `toolPreset` still control
+   * availability.
+   *
+   * One instance is reused across bash calls within a run. If the same
+   * instance is shared by multiple agents, its `exec()` may be called
+   * concurrently and its lifecycle is reference-counted across those runs.
+   */
+  readonly shellExecutor?: ShellExecutor
   /**
    * Root directory used by built-in filesystem tools (`file_read`,
    * `file_write`, `file_edit`, `grep`, `glob`). Paths must be absolute and
@@ -2250,6 +2269,14 @@ export interface OrchestratorConfig {
    * then accept arbitrary absolute or relative paths).
    */
   readonly defaultCwd?: string | null
+  /**
+   * Default executor inherited by agents that do not set
+   * {@link AgentConfig.shellExecutor}. This changes where a granted `bash`
+   * command runs; it does not grant the tool. One shared instance may serve
+   * concurrent agents, so non-concurrent implementations must serialize
+   * `exec()` internally or be supplied as distinct per-agent instances.
+   */
+  readonly defaultShellExecutor?: ShellExecutor
   readonly onProgress?: (event: OrchestratorEvent) => void
   /** Best-effort online scoring of settled top-level runs. Disabled unless configured. */
   readonly evaluation?: import('./eval/online.js').OnlineEvaluationConfig
@@ -2652,6 +2679,8 @@ export interface CoordinatorConfig {
   readonly disallowedTools?: readonly string[]
   /** See {@link AgentConfig.onToolCall}. */
   readonly onToolCall?: ToolCallGate
+  /** See {@link AgentConfig.shellExecutor}. */
+  readonly shellExecutor?: ShellExecutor
   /**
    * Root directory used by the coordinator's filesystem tools.
    * Defaults to {@link OrchestratorConfig.defaultCwd}. Pass `null` to

--- a/packages/core/tests/shell-executor.test.ts
+++ b/packages/core/tests/shell-executor.test.ts
@@ -1,0 +1,601 @@
+import { describe, expect, it, vi } from 'vitest'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { Agent } from '../src/agent/agent.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { bashTool, registerBuiltInTools } from '../src/tool/built-in/index.js'
+import { ToolExecutor } from '../src/tool/executor.js'
+import { ToolRegistry } from '../src/tool/framework.js'
+import { LocalShellExecutor } from '../src/shell.js'
+import type {
+  ShellExecOptions,
+  ShellExecResult,
+  ShellExecutor,
+} from '../src/shell.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMChatOptions,
+  LLMMessage,
+  LLMResponse,
+  ToolUseContext,
+} from '../src/types.js'
+
+function toolUse(
+  id: string,
+  command: string,
+  options: { readonly timeout?: number; readonly cwd?: string } = {},
+): LLMResponse {
+  return {
+    id: `response-${id}`,
+    content: [{ type: 'tool_use', id, name: 'bash', input: { command, ...options } }],
+    model: 'mock-model',
+    stop_reason: 'tool_use',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function parallelToolUse(commands: readonly string[]): LLMResponse {
+  return {
+    id: 'response-parallel',
+    content: commands.map((command, index) => ({
+      type: 'tool_use' as const,
+      id: `parallel-${index}`,
+      name: 'bash',
+      input: { command },
+    })),
+    model: 'mock-model',
+    stop_reason: 'tool_use',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function text(value: string): LLMResponse {
+  return {
+    id: 'response-text',
+    content: [{ type: 'text', text: value }],
+    model: 'mock-model',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function scriptedAdapter(steps: LLMResponse[]): LLMAdapter {
+  let index = 0
+  return {
+    name: 'mock',
+    async chat(_messages: LLMMessage[], _options: LLMChatOptions): Promise<LLMResponse> {
+      return steps[Math.min(index++, steps.length - 1)]!
+    },
+    async *stream() {
+      /* unused */
+    },
+  }
+}
+
+function failingAdapter(error: Error): LLMAdapter {
+  return {
+    name: 'mock',
+    async chat(): Promise<LLMResponse> {
+      throw error
+    },
+    async *stream() {
+      /* unused */
+    },
+  }
+}
+
+function toolThenFailure(first: LLMResponse, error: Error): LLMAdapter {
+  let called = false
+  return {
+    name: 'mock',
+    async chat(): Promise<LLMResponse> {
+      if (!called) {
+        called = true
+        return first
+      }
+      throw error
+    },
+    async *stream() {
+      /* unused */
+    },
+  }
+}
+
+function buildAgent(config: AgentConfig): Agent {
+  const registry = new ToolRegistry()
+  registerBuiltInTools(registry)
+  return new Agent(config, registry, new ToolExecutor(registry))
+}
+
+function toolContext(overrides: Partial<ToolUseContext> = {}): ToolUseContext {
+  return {
+    agent: { name: 'test', role: 'test', model: 'mock-model' },
+    ...overrides,
+  }
+}
+
+function successfulExecutor(events: string[] = []): ShellExecutor {
+  return {
+    async start() {
+      events.push('start')
+    },
+    async exec(command: string): Promise<ShellExecResult> {
+      events.push(`exec:${command}`)
+      return { stdout: command, stderr: '', exitCode: 0 }
+    },
+    async dispose() {
+      events.push('dispose')
+    },
+  }
+}
+
+describe('ShellExecutor tool seam', () => {
+  it('delegates command execution while preserving formatting and redaction', async () => {
+    const exec = vi.fn(async (
+      _command: string,
+      _options: ShellExecOptions,
+    ): Promise<ShellExecResult> => ({
+      stdout: 'hello\nOPENAI_API_KEY=sk-outputsecretvalue1234567890',
+      stderr: 'remote warning',
+      exitCode: 7,
+    }))
+    const executor: ShellExecutor = { exec }
+
+    const result = await bashTool.execute(
+      { command: 'remote-command', cwd: '/remote/work', timeout: 234 },
+      toolContext({ shellExecutor: executor }),
+    )
+
+    expect(exec).toHaveBeenCalledWith(
+      'remote-command',
+      expect.objectContaining({
+        cwd: '/remote/work',
+        timeoutMs: 234,
+        abortSignal: expect.any(AbortSignal),
+      }),
+    )
+    expect(result.isError).toBe(true)
+    expect(result.data).toContain('hello')
+    expect(result.data).toContain('--- stderr ---\nremote warning')
+    expect(result.data).toContain('(exit code: 7)')
+    expect(result.data).toContain('[redacted]')
+    expect(result.data).not.toContain('sk-outputsecretvalue1234567890')
+  })
+
+  it('bounds an executor that ignores timeout and normalizes exit code 124', async () => {
+    let receivedSignal: AbortSignal | undefined
+    const executor: ShellExecutor = {
+      exec: async (_command, options) => {
+        receivedSignal = options.abortSignal
+        return new Promise<ShellExecResult>(() => {})
+      },
+    }
+
+    const result = await bashTool.execute(
+      { command: 'hang', timeout: 5 },
+      toolContext({ shellExecutor: executor }),
+    )
+
+    expect(receivedSignal?.aborted).toBe(true)
+    expect(result.isError).toBe(true)
+    expect(result.data).toContain('124')
+  })
+
+  it('bounds an executor that ignores abort and normalizes exit code 130', async () => {
+    const controller = new AbortController()
+    const executor: ShellExecutor = {
+      exec: async () => new Promise<ShellExecResult>(() => {}),
+    }
+    setTimeout(() => controller.abort(), 5)
+
+    const result = await bashTool.execute(
+      { command: 'hang', timeout: 5_000 },
+      toolContext({ shellExecutor: executor, abortSignal: controller.signal }),
+    )
+
+    expect(result.isError).toBe(true)
+    expect(result.data).toContain('130')
+  })
+
+  it('maps executor rejection to redacted startup failure code 127', async () => {
+    const executor: ShellExecutor = {
+      async exec() {
+        throw new Error('OPENAI_API_KEY=sk-rejectedsecretvalue1234567890')
+      },
+    }
+
+    const result = await bashTool.execute(
+      { command: 'cannot-start' },
+      toolContext({ shellExecutor: executor }),
+    )
+
+    expect(result.isError).toBe(true)
+    expect(result.data).toContain('127')
+    expect(result.data).toContain('[redacted]')
+    expect(result.data).not.toContain('sk-rejectedsecretvalue1234567890')
+  })
+})
+
+describe('LocalShellExecutor compatibility', () => {
+  it('executes on the host and reports startup failure as 127', async () => {
+    const executor = new LocalShellExecutor()
+    const success = await executor.exec('printf local-ok', { timeoutMs: 1_000 })
+    const startupFailure = await executor.exec('true', {
+      cwd: join(tmpdir(), 'oma-shell-executor-directory-that-does-not-exist'),
+      timeoutMs: 1_000,
+    })
+
+    expect(success).toEqual({ stdout: 'local-ok', stderr: '', exitCode: 0 })
+    expect(startupFailure.exitCode).toBe(127)
+  })
+
+  it('preserves abort exit code 130', async () => {
+    const controller = new AbortController()
+    setTimeout(() => controller.abort(), 20)
+
+    const result = await bashTool.execute(
+      { command: 'sleep 5', timeout: 5_000 },
+      toolContext({ abortSignal: controller.signal }),
+    )
+
+    expect(result.isError).toBe(true)
+    expect(result.data).toContain('130')
+  })
+})
+
+describe('ShellExecutor lifecycle', () => {
+  it('starts once, reuses the session across calls, and disposes on success', async () => {
+    const events: string[] = []
+    const agent = buildAgent({
+      name: 'shell-agent',
+      model: 'mock-model',
+      adapter: scriptedAdapter([
+        toolUse('tool-1', 'first'),
+        toolUse('tool-2', 'second'),
+        text('done'),
+      ]),
+      tools: ['bash'],
+      shellExecutor: successfulExecutor(events),
+    })
+
+    const result = await agent.run('run both commands')
+
+    expect(result.success).toBe(true)
+    expect(events).toEqual(['start', 'exec:first', 'exec:second', 'dispose'])
+  })
+
+  it('disposes after provider failure', async () => {
+    const events: string[] = []
+    const agent = buildAgent({
+      name: 'shell-agent',
+      model: 'mock-model',
+      adapter: toolThenFailure(
+        toolUse('before-failure', 'started'),
+        new Error('provider failed'),
+      ),
+      tools: ['bash'],
+      shellExecutor: successfulExecutor(events),
+    })
+
+    const result = await agent.run('fail after start')
+
+    expect(result.success).toBe(false)
+    expect(result.output).toContain('provider failed')
+    expect(events).toEqual(['start', 'exec:started', 'dispose'])
+  })
+
+  it('does not start a granted executor until bash is actually called', async () => {
+    const events: string[] = []
+    const agent = buildAgent({
+      name: 'shell-agent',
+      model: 'mock-model',
+      adapter: failingAdapter(new Error('provider failed before tools')),
+      tools: ['bash'],
+      shellExecutor: successfulExecutor(events),
+    })
+
+    const result = await agent.run('fail before any tool call')
+
+    expect(result.success).toBe(false)
+    expect(events).toEqual([])
+  })
+
+  it('attempts disposal when start partially fails', async () => {
+    const events: string[] = []
+    const executor: ShellExecutor = {
+      async start() {
+        events.push('start')
+        throw new Error('start failed')
+      },
+      async exec() {
+        throw new Error('must not execute')
+      },
+      async dispose() {
+        events.push('dispose')
+      },
+    }
+    const agent = buildAgent({
+      name: 'shell-agent',
+      model: 'mock-model',
+      adapter: scriptedAdapter([
+        toolUse('start-failure', 'must-not-run'),
+        text('handled'),
+      ]),
+      tools: ['bash'],
+      shellExecutor: executor,
+    })
+
+    const result = await agent.run('fail during start')
+
+    expect(result.success).toBe(true)
+    expect(result.toolCalls[0]!.output).toContain('start failed')
+    expect(events).toEqual(['start', 'dispose'])
+  })
+
+  it('surfaces disposal failure instead of reporting a clean run', async () => {
+    const executor: ShellExecutor = {
+      async start() {},
+      async exec() {
+        return { stdout: '', stderr: '', exitCode: 0 }
+      },
+      async dispose() {
+        throw new Error('dispose failed')
+      },
+    }
+    const agent = buildAgent({
+      name: 'shell-agent',
+      model: 'mock-model',
+      adapter: scriptedAdapter([
+        toolUse('before-dispose', 'run'),
+        text('would have succeeded'),
+      ]),
+      tools: ['bash'],
+      shellExecutor: executor,
+    })
+
+    const result = await agent.run('cleanup must count')
+
+    expect(result.success).toBe(false)
+    expect(result.output).toContain('dispose failed')
+  })
+
+  it('disposes the session after the tool-level timeout backstop fires', async () => {
+    const events: string[] = []
+    const executor: ShellExecutor = {
+      async start() {
+        events.push('start')
+      },
+      async exec() {
+        events.push('exec')
+        return new Promise<ShellExecResult>(() => {})
+      },
+      async dispose() {
+        events.push('dispose')
+      },
+    }
+    const agent = buildAgent({
+      name: 'shell-agent',
+      model: 'mock-model',
+      adapter: scriptedAdapter([
+        toolUse('timeout-tool', 'hang', { timeout: 5 }),
+        text('recovered'),
+      ]),
+      tools: ['bash'],
+      shellExecutor: executor,
+    })
+
+    const result = await agent.run('bound and clean up')
+
+    expect(result.success).toBe(true)
+    expect(result.toolCalls[0]!.output).toContain('124')
+    expect(events).toEqual(['start', 'exec', 'dispose'])
+  })
+
+  it('does not dispatch a command when timeout fires during start', async () => {
+    const events: string[] = []
+    const executor: ShellExecutor = {
+      async start() {
+        events.push('start')
+        await new Promise((resolve) => setTimeout(resolve, 20))
+      },
+      async exec() {
+        events.push('exec')
+        return { stdout: 'must not run', stderr: '', exitCode: 0 }
+      },
+      async dispose() {
+        events.push('dispose')
+      },
+    }
+    const agent = buildAgent({
+      name: 'shell-agent',
+      model: 'mock-model',
+      adapter: scriptedAdapter([
+        toolUse('start-timeout', 'late-command', { timeout: 5 }),
+        text('recovered'),
+      ]),
+      tools: ['bash'],
+      shellExecutor: executor,
+    })
+
+    const result = await agent.run('timeout while starting')
+
+    expect(result.success).toBe(true)
+    expect(result.toolCalls[0]!.output).toContain('124')
+    expect(events).toEqual(['start', 'dispose'])
+  })
+
+  it('disposes when a streaming consumer stops early', async () => {
+    const events: string[] = []
+    const agent = buildAgent({
+      name: 'shell-agent',
+      model: 'mock-model',
+      adapter: scriptedAdapter([
+        toolUse('stream-tool', 'first'),
+        text('streamed'),
+      ]),
+      tools: ['bash'],
+      shellExecutor: successfulExecutor(events),
+    })
+
+    for await (const event of agent.stream('stop after the command')) {
+      if (event.type === 'tool_result') break
+    }
+
+    expect(events).toEqual(['start', 'exec:first', 'dispose'])
+  })
+
+  it('shares one lifecycle window and permits concurrent exec calls', async () => {
+    const start = vi.fn(async () => undefined)
+    const dispose = vi.fn(async () => undefined)
+    let entered = 0
+    let release!: () => void
+    const bothEntered = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const executor: ShellExecutor = {
+      start,
+      async exec(command) {
+        entered++
+        if (entered === 2) release()
+        await bothEntered
+        return { stdout: command, stderr: '', exitCode: 0 }
+      },
+      dispose,
+    }
+    const first = buildAgent({
+      name: 'first',
+      model: 'mock-model',
+      adapter: scriptedAdapter([toolUse('first-tool', 'first'), text('done')]),
+      tools: ['bash'],
+      shellExecutor: executor,
+    })
+    const second = buildAgent({
+      name: 'second',
+      model: 'mock-model',
+      adapter: scriptedAdapter([toolUse('second-tool', 'second'), text('done')]),
+      tools: ['bash'],
+      shellExecutor: executor,
+    })
+
+    const [firstResult, secondResult] = await Promise.all([
+      first.run('first'),
+      second.run('second'),
+    ])
+
+    expect(firstResult.success).toBe(true)
+    expect(secondResult.success).toBe(true)
+    expect(entered).toBe(2)
+    expect(start).toHaveBeenCalledTimes(1)
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('permits concurrent bash calls within one model turn', async () => {
+    const events: string[] = []
+    let entered = 0
+    let release!: () => void
+    const bothEntered = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const executor: ShellExecutor = {
+      async start() {
+        events.push('start')
+      },
+      async exec(command) {
+        events.push(`exec:${command}`)
+        entered++
+        if (entered === 2) release()
+        await bothEntered
+        return { stdout: command, stderr: '', exitCode: 0 }
+      },
+      async dispose() {
+        events.push('dispose')
+      },
+    }
+    const agent = buildAgent({
+      name: 'parallel-shell',
+      model: 'mock-model',
+      adapter: scriptedAdapter([
+        parallelToolUse(['first', 'second']),
+        text('done'),
+      ]),
+      tools: ['bash'],
+      shellExecutor: executor,
+    })
+
+    const result = await agent.run('run in parallel')
+
+    expect(result.success).toBe(true)
+    expect(result.toolCalls).toHaveLength(2)
+    expect(events[0]).toBe('start')
+    expect(new Set(events.slice(1, 3))).toEqual(new Set(['exec:first', 'exec:second']))
+    expect(events[3]).toBe('dispose')
+  })
+})
+
+describe('ShellExecutor configuration precedence and grants', () => {
+  it('uses an agent override before the orchestrator default', async () => {
+    const defaultEvents: string[] = []
+    const overrideEvents: string[] = []
+    const oma = new OpenMultiAgent({
+      defaultShellExecutor: successfulExecutor(defaultEvents),
+    })
+
+    const overridden = await oma.runAgent({
+      name: 'overridden',
+      model: 'mock-model',
+      adapter: scriptedAdapter([toolUse('override-tool', 'override'), text('done')]),
+      tools: ['bash'],
+      shellExecutor: successfulExecutor(overrideEvents),
+    }, 'use override')
+
+    expect(overridden.success).toBe(true)
+    expect(overrideEvents).toEqual(['start', 'exec:override', 'dispose'])
+    expect(defaultEvents).toEqual([])
+
+    const inherited = await oma.runAgent({
+      name: 'inherited',
+      model: 'mock-model',
+      adapter: scriptedAdapter([toolUse('default-tool', 'default'), text('done')]),
+      tools: ['bash'],
+    }, 'use default')
+
+    expect(inherited.success).toBe(true)
+    expect(defaultEvents).toEqual(['start', 'exec:default', 'dispose'])
+  })
+
+  it('does not start the default executor when bash is not granted', async () => {
+    const events: string[] = []
+    const oma = new OpenMultiAgent({
+      defaultShellExecutor: successfulExecutor(events),
+    })
+
+    const result = await oma.runAgent({
+      name: 'no-shell',
+      model: 'mock-model',
+      adapter: scriptedAdapter([toolUse('ungranted-tool', 'must-not-run'), text('done')]),
+    }, 'do not grant bash')
+
+    expect(result.success).toBe(true)
+    expect(result.toolCalls[0]!.output).toContain('not granted')
+    expect(events).toEqual([])
+  })
+
+  it('does not start the executor when onToolCall denies bash', async () => {
+    const events: string[] = []
+    const agent = buildAgent({
+      name: 'denied-shell',
+      model: 'mock-model',
+      adapter: scriptedAdapter([toolUse('denied-tool', 'must-not-run'), text('done')]),
+      tools: ['bash'],
+      onToolCall: async () => ({ action: 'deny', reason: 'blocked' }),
+      shellExecutor: successfulExecutor(events),
+    })
+
+    const result = await agent.run('deny bash')
+
+    expect(result.success).toBe(true)
+    expect(result.toolCalls[0]!.output).toContain('blocked')
+    expect(events).toEqual([])
+  })
+})

--- a/packages/core/tests/subpath-exports.test.ts
+++ b/packages/core/tests/subpath-exports.test.ts
@@ -23,6 +23,12 @@ describe('subpath export barrels', () => {
     expect(typeof mod.AISdkAdapter).toBe('function')
   })
 
+  it('/shell exposes LocalShellExecutor', async () => {
+    const mod = await import('../src/shell.js')
+    expect(typeof mod.LocalShellExecutor).toBe('function')
+    expect(typeof new mod.LocalShellExecutor().exec).toBe('function')
+  })
+
   it('/eval exposes EvalSet and offline runner entry points', async () => {
     const mod = await import('../src/eval/index.js')
     expect(typeof mod.defineEvalSet).toBe('function')


### PR DESCRIPTION
## Summary

- add a public, dependency-light `ShellExecutor` contract and a `LocalShellExecutor` that preserves the built-in's host execution behavior
- support per-agent overrides and an orchestrator default with lazy, reference-counted lifecycle cleanup plus timeout and abort backstops
- preserve bash grants, gates, output formatting, redaction, safe environment filtering, exit codes, and local process-tree cleanup while documenting remote filesystem divergence
- keep concrete Docker/E2B adapters and new workspace packages out of scope; this PR establishes the public contract they can implement

## Validation

- `npm run lint`
- `npm test`
- `npm run build`
- package subpath import smoke test

Closes #472

