### PR TITLE
feat(core): add framework-owned LLM egress policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Need to embed agent capabilities in an existing product or business system? We h
 | Goal | Start here |
 |---|---|
 | Install and run | [Core package guide](packages/core/README.md) · [Examples](packages/core/examples/README.md) · [CLI](docs/cli.md) |
-| Configure models and tools | [Providers](docs/providers.md) · [Tools and sandbox](docs/tool-configuration.md) · [External agents](docs/external-agents.md) |
+| Configure models and tools | [Providers](docs/providers.md) · [LLM egress policy](docs/egress-policy.md) · [Tools and sandbox](docs/tool-configuration.md) · [External agents](docs/external-agents.md) |
 | Operate reliably | [Observability](docs/observability.md) · [Evaluation](docs/evaluation.md) · [Checkpoint and resume](docs/checkpoint.md) · [Adaptive recovery](docs/adaptive-recovery.md) · [Context management](docs/context-management.md) |
 | Control orchestration | [Consensus](docs/consensus.md) · [Execution routing](docs/execution-routing.md) · [Model routing](docs/model-routing.md) · [Task scheduling](docs/task-scheduling.md) · [Plan replay](docs/plan-replay.md) · [Shared memory](docs/shared-memory.md) |
 

--- a/docs/egress-policy.md
+++ b/docs/egress-policy.md
@@ -1,0 +1,126 @@
+# Framework-owned LLM egress policy
+
+`egressPolicy` restricts network requests that OMA can identify and guard
+before a built-in LLM adapter opens them. It is an application configuration
+control, not a process sandbox or host firewall.
+
+Omitting the policy preserves existing behavior. Once a policy is configured,
+OMA fails closed on a built-in adapter surface only when this document says the
+surface is enforced.
+
+## Configuration and precedence
+
+The same `EgressPolicy` type is accepted by `OpenMultiAgent`, `AgentConfig`, and
+the options for each top-level run:
+
+```typescript
+import { OpenMultiAgent } from '@open-multi-agent/core'
+
+const oma = new OpenMultiAgent({
+  egressPolicy: {
+    mode: 'allowlist',
+    allowedOrigins: [
+      'https://api.anthropic.com',
+      'http://localhost:11434',
+    ],
+  },
+})
+
+const result = await oma.runAgent(
+  {
+    name: 'local',
+    model: 'llama3.1',
+    provider: 'openai',
+    baseURL: 'http://localhost:11434/v1',
+    apiKey: 'ollama',
+  },
+  'Summarize this text.',
+  { egressPolicy: { mode: 'offline' } },
+)
+```
+
+Orchestrator, run, and agent policies are intersected. Omitted scopes do not
+change the result; a more specific scope can narrow access but cannot widen a
+parent scope. An empty intersection denies every framework-owned LLM origin.
+The same effective policy reaches workers, the coordinator, synthesis,
+delegated agents, model-route fallbacks, consensus agents, and the built-in LLM
+semantic profiler.
+
+The modes are:
+
+- `offline`: allow only URL hostnames `localhost`, `*.localhost`, IPv4
+  `127.0.0.0/8`, and IPv6 `::1`. Private LAN, link-local, and arbitrary names
+  that happen to resolve to loopback are not allowed.
+- `allowlist`: allow only the listed HTTP(S) origins. Entries are normalized
+  with standard URL origin semantics and must not include credentials, a path,
+  a query string, or a fragment. A non-default port is part of the origin.
+
+The provider request may include any path under an allowed origin. Every
+guarded fetch uses `redirect: 'error'`, so a permitted endpoint cannot silently
+redirect a credential-bearing SDK request to another origin.
+
+For built-in provider target selection, `AgentConfig.baseURL` takes precedence
+over `OpenMultiAgent.defaultBaseURL`; the effective explicit value then takes
+precedence over the provider endpoint environment variable, which takes
+precedence over the built-in default. Relevant endpoint variables are
+`ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `AZURE_OPENAI_ENDPOINT`,
+`MINIMAX_BASE_URL`, `MIMO_BASE_URL`, and `HUNYUAN_BASE_URL`. Copilot uses fixed
+origins and ignores `baseURL`. Azure OpenAI requires an explicit/default
+endpoint or `AZURE_OPENAI_ENDPOINT` when a policy is active.
+
+## Enforcement matrix
+
+| Surface | Behavior while `egressPolicy` is configured |
+|---|---|
+| Anthropic, OpenAI, Azure OpenAI, DeepSeek, Doubao, Grok, Hunyuan, MiniMax, MiMo, and Qiniu built-in adapters | Enforced. OMA resolves and checks the effective provider origin before loading the optional SDK, injects a guarded fetch transport, checks every request again, and rejects redirects. |
+| Gemini built-in adapter | Unsupported and fail-closed before import or connection. The current Google GenAI SDK path uses module-global fetch and exposes no per-client transport hook to this adapter. |
+| AWS Bedrock built-in adapter | Unsupported and fail-closed before import or connection. The current adapter cannot bound all request and AWS credential-provider endpoints, including identity/metadata paths. |
+| AI SDK bridge or another custom `LLMAdapter` | Unsupported and fail-closed before adapter invocation. The model object does not expose a reliable target and transport contract to OMA. This also applies when a custom adapter is supplied to the built-in semantic profiler or coordinator. |
+| GitHub Copilot auth and API | Enforced. A pre-supplied GitHub token requires `https://api.github.com` and `https://api.githubcopilot.com`. Interactive device login additionally requires `https://github.com`. OMA checks all required origins before the first auth request and guards both token exchange and model API fetches. |
+| Custom `TaskProfiler`, execution router, hooks, and other application callbacks | Not covered. They are application-owned in-process code. |
+| MCP stdio child | Not covered. OMA starts the configured child and exchanges stdio messages; it cannot constrain connections opened inside the MCP server. |
+| `process` and ACP backends | Not covered. OMA starts a child process and uses stdio; the child owns its network behavior. ACP permission callbacks are not a network sandbox. |
+| Built-in `bash` tool | Not covered. The shell process can use its host permissions and network stack. |
+| Custom tools, including tools that call `fetch` | Not covered. Tool code and its clients are supplied by the application. |
+| `@open-multi-agent/otel` and application-owned trace/OTel exporters | Not covered. OMA invokes the supplied tracer, provider, sink, or exporter; the application owns its transport and lifecycle. |
+
+Any adapter instance supplied through `AgentConfig.adapter` is a custom adapter
+for this policy, even if the application constructed it from an OMA adapter
+class. Select an enforceable built-in provider through `provider` and `baseURL`
+so OMA owns construction and can inject the guarded transport.
+
+The MCP, backend, shell, and custom-tool rows stay outside the policy even when
+they are launched by a policy-configured agent. Use process/container network
+namespaces, an egress proxy, or an OS firewall when those surfaces must be
+contained. Do not treat `offline` as evidence that the whole Node.js process or
+its descendants are offline.
+
+## Errors and audit behavior
+
+Invalid policy shapes and allowlist entries throw `EgressPolicyError` with
+`code: 'INVALID_EGRESS_POLICY'`; invalid entries are never ignored. Direct
+`createAdapter()` calls reject with the same error class. During an agent LLM
+run, denial or an unsupported adapter follows the existing LLM-failure path:
+the agent result is unsuccessful with `status.code: 'rejected'`,
+`errorInfo.kind: 'validation'`, and a non-retryable stable code. It is not
+converted into a tool `ToolResult`.
+
+The remaining stable codes are:
+
+| Code | Meaning |
+|---|---|
+| `EGRESS_POLICY_DENIED` | A concrete resolved origin is outside the effective policy. |
+| `EGRESS_POLICY_TARGET_UNRESOLVED` | The built-in adapter needs an endpoint that configuration and environment did not provide. |
+| `EGRESS_POLICY_UNSUPPORTED` | OMA cannot truthfully enforce the selected adapter transport surface. |
+
+Existing team/task failure and dependency-cascade behavior remains unchanged.
+No policy outcome is retried because another attempt cannot widen policy.
+
+## Security boundary
+
+The guard evaluates the configured/request URL before the fetch implementation
+runs. It is not DNS resolution pinning, proxy enforcement, socket interception,
+or protection against a compromised provider SDK. An allowed hostname can
+resolve according to the process's DNS environment. For a hard containment
+boundary, pair this declarative audit control with infrastructure-level egress
+enforcement.

--- a/docs/external-agents.md
+++ b/docs/external-agents.md
@@ -133,6 +133,9 @@ The callback receives a minimal, SDK-agnostic `{ title, kind, optionKinds }` and
 > to a project you trust the backend with. ACP backends can use `permission` to
 > gate protocol permission prompts; process backends do not have protocol-level
 > permission prompts, so constrain the configured command, args, env, and cwd.
+> `egressPolicy` governs enforceable framework-owned LLM requests only; it does
+> not constrain network calls made by process or ACP children. See the
+> [egress enforcement matrix](egress-policy.md#enforcement-matrix).
 
 ## How it works
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -482,6 +482,10 @@ when available: set `shutdownOnShutdown: true` only when the adapter owns that
 provider's lifecycle. Rejection/timeout maps to the OBS-2 exporter result and
 diagnostics, never to an Agent/Task/Run failure.
 
+`egressPolicy` does not wrap the application-owned provider or its exporters.
+Use the provider/exporter transport configuration or infrastructure controls
+for telemetry egress; see the [egress enforcement matrix](egress-policy.md#enforcement-matrix).
+
 OMA run/agent/task/LLM/tool/consensus/checkpoint records become spans;
 retry, verdict, first-chunk, and stream records become `oma.*` events. DAG,
 delegation, consumed-synthesis, and restore-continuation relations become OTel

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -2,6 +2,11 @@
 
 `open-multi-agent` keeps the agent config shape stable across hosted, cloud, and local providers. Change `provider`, `model`, and the relevant credential; the rest of your team definition stays the same.
 
+To restrict connections opened by enforceable built-in LLM adapters, see the
+[framework-owned LLM egress policy](egress-policy.md). That policy deliberately
+does not claim to sandbox tools, subprocesses, MCP servers, or application-owned
+exporters.
+
 The supported runtime is Node.js 20 or newer; Node.js 22 or 24 is recommended.
 Node.js 20 is upstream-EOL and retained only as a migration compatibility
 window. OMA will remove Node.js 20 support in its next major release, no earlier
@@ -109,6 +114,12 @@ one model turn. `preferredUnderBudget: 'degrade'` is an application-declared
 policy choice, not a prediction that a particular plan would exceed budget.
 
 ## Vercel AI SDK (optional)
+
+The AI SDK model is an opaque application-supplied transport. When
+`egressPolicy` is configured, OMA rejects `AISdkAdapter` before invocation
+rather than claiming it can constrain the model's requests. Use the provider's
+own transport controls or an infrastructure firewall when the bridge needs an
+egress boundary; see [framework-owned LLM egress policy](egress-policy.md).
 
 The AI SDK bridge routes an agent through [any AI SDK provider](https://ai-sdk.dev/providers) instead of the built-in `provider` factory. Install the optional peers with `npm i ai @ai-sdk/<provider>`; the peer range accepts AI SDK 5, 6, and 7, and AI SDK 7 requires Node.js >= 22.
 

--- a/docs/tool-configuration.md
+++ b/docs/tool-configuration.md
@@ -582,5 +582,6 @@ Notes:
 - Current transport support is stdio.
 - MCP input validation is delegated to the MCP server (`inputSchema` is `z.any()`).
 - Prefer locally installed or pinned MCP server binaries and pass only the environment variables that server needs. Avoid spreading `process.env` into MCP subprocesses.
+- `egressPolicy` does not constrain connections opened inside the MCP child, by `bash`, or by custom tools. See the [egress enforcement matrix](egress-policy.md#enforcement-matrix).
 
 See [`integrations/mcp-github`](../packages/core/examples/integrations/mcp-github.ts) for a full runnable setup.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -245,7 +245,7 @@ Change `provider`, `model`, and credentials; the agent shape stays the same.
 
 Optional integrations load only when used: core directly installs only `@anthropic-ai/sdk`, `openai`, and `zod`; other SDKs are lazy-loading opt-in peers, and OpenTelemetry lives entirely in `@open-multi-agent/otel`. Dependency changes are weighed on demonstrated value plus security, size, maintenance, and compatibility cost, not a fixed count.
 
-See [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md) and [Tool configuration](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) for credentials, models, the AI SDK bridge, reasoning settings, MCP, and local endpoints.
+See [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md), [framework-owned LLM egress policy](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/egress-policy.md), and [Tool configuration](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md) for credentials, models, the AI SDK bridge, reasoning settings, MCP, local endpoints, and the exact network-enforcement boundary.
 
 ## Production
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -60,6 +60,7 @@ import type { ToolDefinition as FrameworkToolDefinition, ToolRegistry } from '..
 import type { ToolExecutor } from '../tool/executor.js'
 import { defaultWorkspaceDir } from '../tool/built-in/path-safety.js'
 import { createAdapter } from '../llm/adapter.js'
+import { normalizeEgressPolicy, rejectUnsupportedEgress } from '../llm/egress.js'
 import { AgentRunner, type AgentBackend, type RunnerOptions, type RunOptions, type RunResult } from './runner.js'
 import {
   buildStructuredOutputInstruction,
@@ -122,7 +123,10 @@ export class Agent {
           `or run it through OpenMultiAgent to inherit 'defaultModel'.`,
       )
     }
-    this.config = config
+    const egressPolicy = normalizeEgressPolicy(config.egressPolicy)
+    this.config = egressPolicy === undefined
+      ? config
+      : { ...config, egressPolicy }
     this._toolRegistry = toolRegistry
     this._toolExecutor = toolExecutor
     this.messageHistory = config.history ? [...config.history] : []
@@ -160,9 +164,29 @@ export class Agent {
     }
 
     const provider = this.config.provider ?? 'anthropic'
-    const adapter =
-      this.config.adapter ??
-      (await createAdapter(provider, this.config.apiKey, this.config.baseURL, this.config.region))
+    let adapter = this.config.adapter
+    if (adapter !== undefined) {
+      rejectUnsupportedEgress(
+        this.config.egressPolicy,
+        adapter.name,
+        'custom and AI SDK adapters do not expose an enforceable request transport or target contract to OMA.',
+      )
+    } else {
+      adapter = this.config.egressPolicy === undefined
+        ? await createAdapter(
+            provider,
+            this.config.apiKey,
+            this.config.baseURL,
+            this.config.region,
+          )
+        : await createAdapter(
+            provider,
+            this.config.apiKey,
+            this.config.baseURL,
+            this.config.region,
+            this.config.egressPolicy,
+          )
+    }
 
     // Append structured-output instructions when an outputSchema is configured.
     let effectiveSystemPrompt = this.config.systemPrompt

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -158,6 +158,37 @@ export class UnsupportedToolCallError extends Error {
   }
 }
 
+export type EgressPolicyErrorReason =
+  | 'invalid-policy'
+  | 'denied'
+  | 'unsupported'
+  | 'unresolved-target'
+
+/**
+ * Raised before a framework-owned LLM transport opens a disallowed or
+ * unenforceable network request.
+ */
+export class EgressPolicyError extends Error {
+  readonly code: string
+
+  constructor(
+    readonly reason: EgressPolicyErrorReason,
+    message: string,
+    readonly provider?: string,
+    readonly origin?: string,
+  ) {
+    super(message)
+    this.name = 'EgressPolicyError'
+    this.code = reason === 'invalid-policy'
+      ? 'INVALID_EGRESS_POLICY'
+      : reason === 'denied'
+        ? 'EGRESS_POLICY_DENIED'
+        : reason === 'unresolved-target'
+          ? 'EGRESS_POLICY_TARGET_UNRESOLVED'
+          : 'EGRESS_POLICY_UNSUPPORTED'
+  }
+}
+
 /**
  * Read an HTTP-style status code off an unknown error, if present. Provider
  * SDK errors (`Anthropic.APIError`, `OpenAI.APIError`) expose it as `.status`;
@@ -203,6 +234,7 @@ export function isRetryableError(error: unknown): boolean {
   if (error instanceof CostBudgetExceededError) return false
   if (error instanceof InvalidMessageError) return false
   if (error instanceof UnsupportedToolCallError) return false
+  if (error instanceof EgressPolicyError) return false
   if (error instanceof LLMCallTimeoutError) return true
   if (error instanceof RoutingTimeoutError) return true
   if (error instanceof RoutingProfilerFailedError) return false

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -195,6 +195,7 @@ export {
   RoutingDeclarationRequiredError,
   RoutingProfilerFailedError,
   RoutingTimeoutError,
+  EgressPolicyError,
   isRetryableError,
 } from './errors.js'
 export { createRunIdentity, createRestoreIdentity, validateRunId } from './observability/identity.js'
@@ -302,6 +303,7 @@ export type {
   LLMToolDef,
   TokenUsage,
   StreamEvent,
+  EgressPolicy,
 
   // Tools
   ToolDefinition,

--- a/packages/core/src/llm/adapter.ts
+++ b/packages/core/src/llm/adapter.ts
@@ -31,7 +31,13 @@ export type {
   ImageBlock,
 } from '../types.js'
 
-import type { LLMAdapter } from '../types.js'
+import type { EgressPolicy, LLMAdapter } from '../types.js'
+import {
+  assertEgressAllowed,
+  normalizeEgressPolicy,
+  rejectUnresolvedEgressTarget,
+  rejectUnsupportedEgress,
+} from './egress.js'
 
 /**
  * The set of LLM providers supported out of the box.
@@ -40,6 +46,86 @@ import type { LLMAdapter } from '../types.js'
  * `@open-multi-agent/core/ai-sdk` (optional peer `ai`).
  */
 export type SupportedProvider = 'anthropic' | 'azure-openai' | 'bedrock' | 'copilot' | 'deepseek' | 'doubao' | 'grok' | 'hunyuan' | 'minimax' | 'mimo' | 'openai' | 'gemini' | 'qiniu'
+
+const PROVIDER_DEFAULT_BASE_URLS: Partial<Record<SupportedProvider, string>> = {
+  anthropic: 'https://api.anthropic.com',
+  deepseek: 'https://api.deepseek.com/v1',
+  doubao: 'https://ark.cn-beijing.volces.com/api/v3',
+  grok: 'https://api.x.ai/v1',
+  hunyuan: 'https://tokenhub.tencentmaas.com/v1',
+  minimax: 'https://api.minimax.io/v1',
+  mimo: 'https://api.xiaomimimo.com/v1',
+  openai: 'https://api.openai.com/v1',
+  qiniu: 'https://api.qnaigc.com/v1',
+}
+
+function configuredProviderBaseURL(
+  provider: Exclude<SupportedProvider, 'bedrock' | 'copilot' | 'gemini'>,
+  baseURL: string | undefined,
+): string {
+  if (baseURL !== undefined) return baseURL
+  const envURL = provider === 'anthropic'
+    ? process.env['ANTHROPIC_BASE_URL']
+    : provider === 'openai'
+      ? process.env['OPENAI_BASE_URL']
+      : provider === 'azure-openai'
+        ? process.env['AZURE_OPENAI_ENDPOINT']
+        : provider === 'minimax'
+          ? process.env['MINIMAX_BASE_URL']
+          : provider === 'mimo'
+            ? process.env['MIMO_BASE_URL']
+            : provider === 'hunyuan'
+              ? process.env['HUNYUAN_BASE_URL']
+              : undefined
+  if (envURL !== undefined) return envURL
+  const fallback = PROVIDER_DEFAULT_BASE_URLS[provider]
+  if (fallback === undefined) {
+    rejectUnresolvedEgressTarget(
+      provider,
+      'set AgentConfig.baseURL or the provider-specific endpoint environment variable.',
+    )
+  }
+  return fallback
+}
+
+function prepareProviderBaseURL(
+  provider: SupportedProvider,
+  baseURL: string | undefined,
+  policy: EgressPolicy | undefined,
+  apiKey: string | undefined,
+): string | undefined {
+  if (policy === undefined) return baseURL
+  if (provider === 'bedrock') {
+    rejectUnsupportedEgress(
+      policy,
+      provider,
+      'the AWS SDK credential chain and request handler can open endpoints not exposed by the current OMA adapter config.',
+    )
+    return undefined
+  }
+  if (provider === 'gemini') {
+    rejectUnsupportedEgress(
+      policy,
+      provider,
+      'the current Google GenAI SDK path uses module-global fetch and does not expose a request transport hook to OMA.',
+    )
+    return undefined
+  }
+  if (provider === 'copilot') {
+    assertEgressAllowed(policy, 'https://api.githubcopilot.com', provider)
+    assertEgressAllowed(policy, 'https://api.github.com', provider)
+    const hasGithubToken = apiKey !== undefined
+      || process.env['GITHUB_COPILOT_TOKEN'] !== undefined
+      || process.env['GITHUB_TOKEN'] !== undefined
+    if (!hasGithubToken) {
+      assertEgressAllowed(policy, 'https://github.com', provider)
+    }
+    return undefined
+  }
+  const target = configuredProviderBaseURL(provider, baseURL)
+  assertEgressAllowed(policy, target, provider)
+  return target
+}
 
 /**
  * Instantiate the appropriate {@link LLMAdapter} for the given provider.
@@ -71,6 +157,7 @@ export type SupportedProvider = 'anthropic' | 'azure-openai' | 'bedrock' | 'copi
  * @param apiKey   - Optional API key override; falls back to env var. Not used for `bedrock`.
  * @param baseURL  - Optional base URL for OpenAI-compatible APIs (Ollama, vLLM, etc.). Not used for `bedrock`.
  * @param region   - Optional AWS region for `bedrock`; falls back to `AWS_REGION` env var, then `'us-east-1'`. Ignored by all other providers.
+ * @param egressPolicy - Optional framework-owned LLM egress restriction.
  * @throws {Error} When the provider string is not recognised.
  */
 export async function createAdapter(
@@ -78,18 +165,21 @@ export async function createAdapter(
   apiKey?: string,
   baseURL?: string,
   region?: string,
+  egressPolicy?: EgressPolicy,
 ): Promise<LLMAdapter> {
+  const policy = normalizeEgressPolicy(egressPolicy)
+  const policyBaseURL = prepareProviderBaseURL(provider, baseURL, policy, apiKey)
   switch (provider) {
     case 'anthropic': {
       const { AnthropicAdapter } = await import('./anthropic.js')
-      return new AnthropicAdapter(apiKey, baseURL)
+      return new AnthropicAdapter(apiKey, policyBaseURL, policy)
     }
     case 'copilot': {
       if (baseURL) {
         console.warn('[open-multi-agent] baseURL is not supported for the copilot provider and will be ignored.')
       }
       const { CopilotAdapter } = await import('./copilot.js')
-      return new CopilotAdapter(apiKey)
+      return new CopilotAdapter({ apiKey, egressPolicy: policy })
     }
     case 'gemini': {
       const { GeminiAdapter } = await import('./gemini.js')
@@ -97,41 +187,41 @@ export async function createAdapter(
     }
     case 'openai': {
       const { OpenAIAdapter } = await import('./openai.js')
-      return new OpenAIAdapter(apiKey, baseURL)
+      return new OpenAIAdapter(apiKey, policyBaseURL, policy, provider)
     }
     case 'grok': {
       const { GrokAdapter } = await import('./grok.js')
-      return new GrokAdapter(apiKey, baseURL)
+      return new GrokAdapter(apiKey, policyBaseURL, policy)
     }
     case 'minimax': {
       const { MiniMaxAdapter } = await import('./minimax.js')
-      return new MiniMaxAdapter(apiKey, baseURL)
+      return new MiniMaxAdapter(apiKey, policyBaseURL, policy)
     }
     case 'mimo': {
       const { MiMoAdapter } = await import('./mimo.js')
-      return new MiMoAdapter(apiKey, baseURL)
+      return new MiMoAdapter(apiKey, policyBaseURL, policy)
     }
     case 'deepseek': {
       const { DeepSeekAdapter } = await import('./deepseek.js')
-      return new DeepSeekAdapter(apiKey, baseURL)
+      return new DeepSeekAdapter(apiKey, policyBaseURL, policy)
     }
     case 'doubao': {
       const { DoubaoAdapter } = await import('./doubao.js')
-      return new DoubaoAdapter(apiKey, baseURL)
+      return new DoubaoAdapter(apiKey, policyBaseURL, policy)
     }
     case 'hunyuan': {
       const { HunyuanAdapter } = await import('./hunyuan.js')
-      return new HunyuanAdapter(apiKey, baseURL)
+      return new HunyuanAdapter(apiKey, policyBaseURL, policy)
     }
     case 'qiniu': {
       const { QiniuAdapter } = await import('./qiniu.js')
-      return new QiniuAdapter(apiKey, baseURL)
+      return new QiniuAdapter(apiKey, policyBaseURL, policy)
     }
     case 'azure-openai': {
       // For azure-openai, the `baseURL` parameter serves as the Azure endpoint URL.
       // To override the API version, set AZURE_OPENAI_API_VERSION env var.
       const { AzureOpenAIAdapter } = await import('./azure-openai.js')
-      return new AzureOpenAIAdapter(apiKey, baseURL)
+      return new AzureOpenAIAdapter(apiKey, policyBaseURL, undefined, policy)
     }
     case 'bedrock': {
       if (baseURL) console.warn('[open-multi-agent] baseURL is ignored for bedrock; pass region as the fourth arg or set AWS_REGION.')

--- a/packages/core/src/llm/anthropic.ts
+++ b/packages/core/src/llm/anthropic.ts
@@ -52,6 +52,7 @@ import type {
   ThinkingConfig,
   ToolResultBlock,
   ToolUseBlock,
+  EgressPolicy,
 } from '../types.js'
 import {
   reasoningBlockToInlineText,
@@ -59,6 +60,7 @@ import {
   type ReasoningOutboundOptions,
 } from './reasoning-fallback.js'
 import { assertValidMessages } from './validate.js'
+import { createEgressFetch } from './egress.js'
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -326,10 +328,13 @@ export class AnthropicAdapter implements LLMAdapter {
 
   readonly #client: Anthropic
 
-  constructor(apiKey?: string, baseURL?: string) {
+  constructor(apiKey?: string, baseURL?: string, egressPolicy?: EgressPolicy) {
     this.#client = new Anthropic({
       apiKey: apiKey ?? process.env['ANTHROPIC_API_KEY'],
       baseURL,
+      ...(egressPolicy !== undefined
+        ? { fetch: createEgressFetch(egressPolicy, this.name) }
+        : {}),
     })
   }
 

--- a/packages/core/src/llm/azure-openai.ts
+++ b/packages/core/src/llm/azure-openai.ts
@@ -53,6 +53,7 @@ import type {
   StreamEvent,
   TextBlock,
   ToolUseBlock,
+  EgressPolicy,
 } from '../types.js'
 
 import {
@@ -64,6 +65,7 @@ import {
 } from './openai-common.js'
 import { assertValidMessages } from './validate.js'
 import { extractToolCallsFromText } from '../tool/text-tool-extractor.js'
+import { createEgressFetch } from './egress.js'
 
 // ---------------------------------------------------------------------------
 // Adapter implementation
@@ -106,11 +108,24 @@ export class AzureOpenAIAdapter implements LLMAdapter {
    * @param endpoint - Azure endpoint URL (falls back to AZURE_OPENAI_ENDPOINT env var)
    * @param apiVersion - API version string (falls back to AZURE_OPENAI_API_VERSION, defaults to '2024-10-21')
    */
-  constructor(apiKey?: string, endpoint?: string, apiVersion?: string) {
+  constructor(
+    apiKey?: string,
+    endpoint?: string,
+    apiVersion?: string,
+    egressPolicy?: EgressPolicy,
+  ) {
     this.#client = new AzureOpenAI({
       apiKey: apiKey ?? process.env['AZURE_OPENAI_API_KEY'],
       endpoint: endpoint ?? process.env['AZURE_OPENAI_ENDPOINT'],
       apiVersion: apiVersion ?? process.env['AZURE_OPENAI_API_VERSION'] ?? DEFAULT_AZURE_OPENAI_API_VERSION,
+      ...(egressPolicy !== undefined
+        ? {
+            // Explicit null suppresses OpenAI SDK's unrelated
+            // OPENAI_BASE_URL fallback so the checked Azure endpoint wins.
+            baseURL: null,
+            fetch: createEgressFetch(egressPolicy, this.name),
+          }
+        : {}),
     })
   }
 
@@ -338,4 +353,3 @@ export class AzureOpenAIAdapter implements LLMAdapter {
     }
   }
 }
-

--- a/packages/core/src/llm/copilot.ts
+++ b/packages/core/src/llm/copilot.ts
@@ -40,6 +40,7 @@ import type {
   StreamEvent,
   TextBlock,
   ToolUseBlock,
+  EgressPolicy,
 } from '../types.js'
 
 import {
@@ -50,6 +51,7 @@ import {
   toOpenAISdkReasoningEffort,
 } from './openai-common.js'
 import { assertValidMessages } from './validate.js'
+import { assertEgressAllowed, createEgressFetch, normalizeEgressPolicy } from './egress.js'
 
 // ---------------------------------------------------------------------------
 // Copilot auth — OAuth2 device flow + token exchange
@@ -108,9 +110,12 @@ const defaultDeviceCodeCallback: DeviceCodeCallback = (uri, code) => {
  * until the user completes authorization. Returns a GitHub OAuth token
  * scoped for Copilot access.
  */
-async function deviceCodeLogin(onDeviceCode: DeviceCodeCallback): Promise<string> {
+async function deviceCodeLogin(
+  onDeviceCode: DeviceCodeCallback,
+  fetchImpl: typeof globalThis.fetch,
+): Promise<string> {
   // Step 1: Request a device code
-  const codeRes = await fetch(DEVICE_CODE_URL, {
+  const codeRes = await fetchImpl(DEVICE_CODE_URL, {
     method: 'POST',
     headers: {
       Accept: 'application/json',
@@ -136,7 +141,7 @@ async function deviceCodeLogin(onDeviceCode: DeviceCodeCallback): Promise<string
   while (Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, interval))
 
-    const pollRes = await fetch(POLL_URL, {
+    const pollRes = await fetchImpl(POLL_URL, {
       method: 'POST',
       headers: {
         Accept: 'application/json',
@@ -177,8 +182,11 @@ async function deviceCodeLogin(onDeviceCode: DeviceCodeCallback): Promise<string
  * Note: the token exchange endpoint does NOT require the Copilot-specific
  * headers (Editor-Version etc.) — only the chat completions endpoint does.
  */
-async function fetchCopilotToken(githubToken: string): Promise<CopilotTokenResponse> {
-  const res = await fetch(COPILOT_TOKEN_URL, {
+async function fetchCopilotToken(
+  githubToken: string,
+  fetchImpl: typeof globalThis.fetch,
+): Promise<CopilotTokenResponse> {
+  const res = await fetchImpl(COPILOT_TOKEN_URL, {
     method: 'GET',
     headers: {
       Authorization: `token ${githubToken}`,
@@ -210,6 +218,8 @@ export interface CopilotAdapterOptions {
    * Defaults to printing the verification URI and user code to stdout.
    */
   onDeviceCode?: DeviceCodeCallback
+  /** Framework-owned Copilot authentication/API egress restriction. */
+  egressPolicy?: EgressPolicy
 }
 
 /**
@@ -241,6 +251,8 @@ export class CopilotAdapter implements LLMAdapter {
   #tokenExpiresAt = 0
   #refreshPromise: Promise<string> | null = null
   readonly #onDeviceCode: DeviceCodeCallback
+  readonly #egressPolicy?: EgressPolicy
+  readonly #egressFetch?: typeof globalThis.fetch
 
   constructor(apiKeyOrOptions?: string | CopilotAdapterOptions) {
     const opts = typeof apiKeyOrOptions === 'string'
@@ -252,6 +264,10 @@ export class CopilotAdapter implements LLMAdapter {
       ?? process.env['GITHUB_TOKEN']
       ?? null
     this.#onDeviceCode = opts.onDeviceCode ?? defaultDeviceCodeCallback
+    this.#egressPolicy = normalizeEgressPolicy(opts.egressPolicy)
+    this.#egressFetch = this.#egressPolicy !== undefined
+      ? createEgressFetch(this.#egressPolicy, this.name)
+      : undefined
   }
 
   /**
@@ -280,10 +296,16 @@ export class CopilotAdapter implements LLMAdapter {
 
   async #doRefresh(): Promise<string> {
     if (!this.#githubToken) {
-      this.#githubToken = await deviceCodeLogin(this.#onDeviceCode)
+      this.#githubToken = await deviceCodeLogin(
+        this.#onDeviceCode,
+        this.#egressFetch ?? globalThis.fetch,
+      )
     }
 
-    const resp = await fetchCopilotToken(this.#githubToken)
+    const resp = await fetchCopilotToken(
+      this.#githubToken,
+      this.#egressFetch ?? globalThis.fetch,
+    )
     this.#cachedToken = resp.token
     this.#tokenExpiresAt = resp.expires_at
     return resp.token
@@ -291,11 +313,22 @@ export class CopilotAdapter implements LLMAdapter {
 
   /** Build a short-lived OpenAI client pointed at the Copilot endpoint. */
   async #createClient(): Promise<OpenAI> {
+    if (this.#egressPolicy !== undefined) {
+      // Validate every endpoint needed for this adapter before opening the
+      // first one. Device-flow endpoints are needed only without a GitHub token.
+      assertEgressAllowed(this.#egressPolicy, 'https://api.githubcopilot.com', this.name)
+      assertEgressAllowed(this.#egressPolicy, COPILOT_TOKEN_URL, this.name)
+      if (!this.#githubToken) {
+        assertEgressAllowed(this.#egressPolicy, DEVICE_CODE_URL, this.name)
+        assertEgressAllowed(this.#egressPolicy, POLL_URL, this.name)
+      }
+    }
     const sessionToken = await this.#getSessionToken()
     return new OpenAI({
       apiKey: sessionToken,
       baseURL: 'https://api.githubcopilot.com',
       defaultHeaders: COPILOT_HEADERS,
+      ...(this.#egressFetch !== undefined ? { fetch: this.#egressFetch } : {}),
     })
   }
 

--- a/packages/core/src/llm/deepseek.ts
+++ b/packages/core/src/llm/deepseek.ts
@@ -5,7 +5,7 @@
  * OpenAI-compatible endpoint and DEEPSEEK_API_KEY environment variable fallback.
  */
 
-import type { LLMChatOptions, ThinkingConfig } from '../types.js'
+import type { EgressPolicy, LLMChatOptions, ThinkingConfig } from '../types.js'
 import { OpenAIAdapter } from './openai.js'
 
 /**
@@ -63,11 +63,13 @@ export class DeepSeekAdapter extends OpenAIAdapter {
     return options.thinking?.effort
   }
 
-  constructor(apiKey?: string, baseURL?: string) {
+  constructor(apiKey?: string, baseURL?: string, egressPolicy?: EgressPolicy) {
     // Allow override of baseURL (for proxies or future changes) but default to official DeepSeek endpoint.
     super(
       apiKey ?? process.env['DEEPSEEK_API_KEY'],
-      baseURL ?? 'https://api.deepseek.com/v1'
+      baseURL ?? 'https://api.deepseek.com/v1',
+      egressPolicy,
+      'deepseek',
     )
   }
 }

--- a/packages/core/src/llm/doubao.ts
+++ b/packages/core/src/llm/doubao.ts
@@ -5,6 +5,7 @@
  * Ark OpenAI-compatible endpoint and ARK_API_KEY environment variable fallback.
  */
 
+import type { EgressPolicy } from '../types.js'
 import { OpenAIAdapter } from './openai.js'
 
 /**
@@ -19,11 +20,13 @@ import { OpenAIAdapter } from './openai.js'
 export class DoubaoAdapter extends OpenAIAdapter {
   readonly name = 'doubao'
 
-  constructor(apiKey?: string, baseURL?: string) {
+  constructor(apiKey?: string, baseURL?: string, egressPolicy?: EgressPolicy) {
     // Allow override of baseURL (for proxies or future changes) but default to official Volcengine Ark endpoint.
     super(
       apiKey ?? process.env['ARK_API_KEY'],
-      baseURL ?? 'https://ark.cn-beijing.volces.com/api/v3'
+      baseURL ?? 'https://ark.cn-beijing.volces.com/api/v3',
+      egressPolicy,
+      'doubao',
     )
   }
 }

--- a/packages/core/src/llm/egress.ts
+++ b/packages/core/src/llm/egress.ts
@@ -1,0 +1,211 @@
+import { EgressPolicyError } from '../errors.js'
+import type { EgressPolicy } from '../types.js'
+
+type FetchLike = typeof globalThis.fetch
+
+function invalidPolicy(message: string): never {
+  throw new EgressPolicyError(
+    'invalid-policy',
+    `Invalid egress policy: ${message}`,
+  )
+}
+
+function parseHttpUrl(value: string, label: string): URL {
+  let parsed: URL
+  try {
+    parsed = new URL(value)
+  } catch {
+    invalidPolicy(`${label} must be an absolute HTTP(S) URL.`)
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    invalidPolicy(`${label} must use http: or https:.`)
+  }
+  if (parsed.username !== '' || parsed.password !== '') {
+    invalidPolicy(`${label} must not contain credentials.`)
+  }
+  return parsed
+}
+
+function normalizedOrigin(value: string, label: string): string {
+  const parsed = parseHttpUrl(value, label)
+  if (parsed.pathname !== '/' || parsed.search !== '' || parsed.hash !== '') {
+    invalidPolicy(`${label} must be an origin without a path, query string, or fragment.`)
+  }
+  return parsed.origin
+}
+
+function assertOnlyKeys(
+  value: object,
+  allowed: readonly string[],
+  label: string,
+): void {
+  const unexpected = Object.keys(value).filter(key => !allowed.includes(key))
+  if (unexpected.length > 0) {
+    invalidPolicy(`${label} contains unsupported field${unexpected.length === 1 ? '' : 's'}: ${unexpected.join(', ')}.`)
+  }
+}
+
+/** Validate and defensively copy a public policy object. */
+export function normalizeEgressPolicy(
+  policy: EgressPolicy | undefined,
+): EgressPolicy | undefined {
+  if (policy === undefined) return undefined
+  if (policy === null || typeof policy !== 'object' || Array.isArray(policy)) {
+    invalidPolicy('expected an object.')
+  }
+  if (policy.mode === 'offline') {
+    assertOnlyKeys(policy, ['mode'], 'offline policy')
+    return Object.freeze({ mode: 'offline' as const })
+  }
+  if (policy.mode !== 'allowlist') {
+    invalidPolicy('mode must be "offline" or "allowlist".')
+  }
+  if (!Array.isArray(policy.allowedOrigins)) {
+    invalidPolicy('allowedOrigins must be an array of exact origins.')
+  }
+  assertOnlyKeys(policy, ['mode', 'allowedOrigins'], 'allowlist policy')
+  const origins = policy.allowedOrigins.map((value, index) => {
+    if (typeof value !== 'string' || value.trim() === '') {
+      invalidPolicy(`allowedOrigins[${index}] must be a non-empty string.`)
+    }
+    return normalizedOrigin(value, `allowedOrigins[${index}]`)
+  })
+  return Object.freeze({
+    mode: 'allowlist' as const,
+    allowedOrigins: Object.freeze([...new Set(origins)].sort()),
+  })
+}
+
+function normalizedHostname(hostname: string): string {
+  const lower = hostname.toLowerCase()
+  return lower.endsWith('.') ? lower.slice(0, -1) : lower
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = normalizedHostname(hostname)
+  if (normalized === 'localhost' || normalized.endsWith('.localhost')) return true
+  if (normalized === '[::1]' || normalized === '::1') return true
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(normalized)
+  if (!match) return false
+  const octets = match.slice(1).map(Number)
+  return octets.every(octet => octet >= 0 && octet <= 255) && octets[0] === 127
+}
+
+function originIsLoopback(origin: string): boolean {
+  return isLoopbackHostname(new URL(origin).hostname)
+}
+
+/**
+ * Intersect policy scopes. Omitted scopes have no effect; any denial wins.
+ */
+export function intersectEgressPolicies(
+  ...policies: readonly (EgressPolicy | undefined)[]
+): EgressPolicy | undefined {
+  const normalized = policies
+    .map(normalizeEgressPolicy)
+    .filter((policy): policy is EgressPolicy => policy !== undefined)
+  if (normalized.length === 0) return undefined
+
+  let effective = normalized[0]!
+  for (const next of normalized.slice(1)) {
+    if (effective.mode === 'offline' && next.mode === 'offline') continue
+    if (effective.mode === 'offline' && next.mode === 'allowlist') {
+      effective = {
+        mode: 'allowlist',
+        allowedOrigins: next.allowedOrigins.filter(originIsLoopback),
+      }
+      continue
+    }
+    if (effective.mode === 'allowlist' && next.mode === 'offline') {
+      effective = {
+        mode: 'allowlist',
+        allowedOrigins: effective.allowedOrigins.filter(originIsLoopback),
+      }
+      continue
+    }
+    if (effective.mode === 'allowlist' && next.mode === 'allowlist') {
+      const nextOrigins = new Set(next.allowedOrigins)
+      effective = {
+        mode: 'allowlist',
+        allowedOrigins: effective.allowedOrigins.filter(origin => nextOrigins.has(origin)),
+      }
+    }
+  }
+  return normalizeEgressPolicy(effective)
+}
+
+function requestUrl(input: Parameters<FetchLike>[0]): URL {
+  if (typeof input === 'string' || input instanceof URL) {
+    return parseHttpUrl(String(input), 'request URL')
+  }
+  return parseHttpUrl(input.url, 'request URL')
+}
+
+/** Assert one concrete framework-owned request target before I/O starts. */
+export function assertEgressAllowed(
+  policy: EgressPolicy,
+  target: string | URL,
+  provider: string,
+): void {
+  const effective = normalizeEgressPolicy(policy)!
+  const parsed = parseHttpUrl(String(target), 'request URL')
+  const origin = parsed.origin
+  const allowed = effective.mode === 'offline'
+    ? isLoopbackHostname(parsed.hostname)
+    : effective.allowedOrigins.includes(origin)
+  if (!allowed) {
+    throw new EgressPolicyError(
+      'denied',
+      `Egress policy denied framework-owned provider "${provider}" request to ${origin}.`,
+      provider,
+      origin,
+    )
+  }
+}
+
+/**
+ * Build a fetch implementation that re-checks every request and rejects all
+ * redirects. Redirect rejection avoids an allowed origin silently forwarding
+ * a credential-bearing SDK request to a different origin.
+ */
+export function createEgressFetch(
+  policy: EgressPolicy,
+  provider: string,
+  implementation: FetchLike = globalThis.fetch,
+): FetchLike {
+  const effective = normalizeEgressPolicy(policy)!
+  return (async (input, init) => {
+    const url = requestUrl(input)
+    assertEgressAllowed(effective, url, provider)
+    return implementation(input, {
+      ...init,
+      redirect: 'error',
+    })
+  }) as FetchLike
+}
+
+/** Reject an opaque or SDK-unenforceable adapter while a policy is active. */
+export function rejectUnsupportedEgress(
+  policy: EgressPolicy | undefined,
+  provider: string,
+  detail: string,
+): void {
+  if (policy === undefined) return
+  throw new EgressPolicyError(
+    'unsupported',
+    `Egress policy cannot enforce provider "${provider}": ${detail}`,
+    provider,
+  )
+}
+
+/** Reject a provider whose actual target cannot be resolved before use. */
+export function rejectUnresolvedEgressTarget(
+  provider: string,
+  detail: string,
+): never {
+  throw new EgressPolicyError(
+    'unresolved-target',
+    `Egress policy cannot resolve provider "${provider}" target: ${detail}`,
+    provider,
+  )
+}

--- a/packages/core/src/llm/grok.ts
+++ b/packages/core/src/llm/grok.ts
@@ -5,6 +5,7 @@
  * and XAI_API_KEY environment variable fallback.
  */
 
+import type { EgressPolicy } from '../types.js'
 import { OpenAIAdapter } from './openai.js'
 
 /**
@@ -19,11 +20,13 @@ import { OpenAIAdapter } from './openai.js'
 export class GrokAdapter extends OpenAIAdapter {
   readonly name = 'grok'
 
-  constructor(apiKey?: string, baseURL?: string) {
+  constructor(apiKey?: string, baseURL?: string, egressPolicy?: EgressPolicy) {
     // Allow override of baseURL (for proxies or future changes) but default to official xAI endpoint.
     super(
       apiKey ?? process.env['XAI_API_KEY'],
-      baseURL ?? 'https://api.x.ai/v1'
+      baseURL ?? 'https://api.x.ai/v1',
+      egressPolicy,
+      'grok',
     )
   }
 }

--- a/packages/core/src/llm/hunyuan.ts
+++ b/packages/core/src/llm/hunyuan.ts
@@ -6,6 +6,7 @@
  * environment variable fallback.
  */
 
+import type { EgressPolicy } from '../types.js'
 import { OpenAIAdapter } from './openai.js'
 
 /**
@@ -54,12 +55,14 @@ export class HunyuanAdapter extends OpenAIAdapter {
     echoesReasoning: 'tool-use-only' as const,
   }
 
-  constructor(apiKey?: string, baseURL?: string) {
+  constructor(apiKey?: string, baseURL?: string, egressPolicy?: EgressPolicy) {
     // Default to the current Tencent MaaS / TokenHub endpoint; allow override
     // of baseURL (legacy Tencent Cloud endpoint, proxies, or future clusters).
     super(
       apiKey ?? process.env['HUNYUAN_API_KEY'],
-      baseURL ?? process.env['HUNYUAN_BASE_URL'] ?? 'https://tokenhub.tencentmaas.com/v1'
+      baseURL ?? process.env['HUNYUAN_BASE_URL'] ?? 'https://tokenhub.tencentmaas.com/v1',
+      egressPolicy,
+      'hunyuan',
     )
   }
 }

--- a/packages/core/src/llm/mimo.ts
+++ b/packages/core/src/llm/mimo.ts
@@ -5,6 +5,7 @@
  * OpenAI-compatible endpoint and MIMO_API_KEY environment variable fallback.
  */
 
+import type { EgressPolicy } from '../types.js'
 import { OpenAIAdapter } from './openai.js'
 
 /**
@@ -25,12 +26,14 @@ export class MiMoAdapter extends OpenAIAdapter {
     echoesReasoning: 'tool-use-only' as const,
   }
 
-  constructor(apiKey?: string, baseURL?: string) {
+  constructor(apiKey?: string, baseURL?: string, egressPolicy?: EgressPolicy) {
     // Allow override of baseURL (Token Plan clusters, proxies, or future changes)
     // but default to the official pay-as-you-go MiMo endpoint.
     super(
       apiKey ?? process.env['MIMO_API_KEY'],
-      baseURL ?? process.env['MIMO_BASE_URL'] ?? 'https://api.xiaomimimo.com/v1'
+      baseURL ?? process.env['MIMO_BASE_URL'] ?? 'https://api.xiaomimimo.com/v1',
+      egressPolicy,
+      'mimo',
     )
   }
 }

--- a/packages/core/src/llm/minimax.ts
+++ b/packages/core/src/llm/minimax.ts
@@ -5,6 +5,7 @@
  * OpenAI-compatible endpoint and MINIMAX_API_KEY environment variable fallback.
  */
 
+import type { EgressPolicy } from '../types.js'
 import { OpenAIAdapter } from './openai.js'
 
 /**
@@ -19,11 +20,13 @@ import { OpenAIAdapter } from './openai.js'
 export class MiniMaxAdapter extends OpenAIAdapter {
   readonly name = 'minimax'
 
-  constructor(apiKey?: string, baseURL?: string) {
+  constructor(apiKey?: string, baseURL?: string, egressPolicy?: EgressPolicy) {
     // Allow override of baseURL (for proxies or future changes) but default to official MiniMax endpoint.
     super(
       apiKey ?? process.env['MINIMAX_API_KEY'],
-      baseURL ?? process.env['MINIMAX_BASE_URL'] ?? 'https://api.minimax.io/v1'
+      baseURL ?? process.env['MINIMAX_BASE_URL'] ?? 'https://api.minimax.io/v1',
+      egressPolicy,
+      'minimax',
     )
   }
 }

--- a/packages/core/src/llm/openai.ts
+++ b/packages/core/src/llm/openai.ts
@@ -49,6 +49,7 @@ import type {
   TextBlock,
   ThinkingConfig,
   ToolUseBlock,
+  EgressPolicy,
 } from '../types.js'
 
 import {
@@ -63,6 +64,7 @@ import {
 import { assertValidMessages } from './validate.js'
 import type { ReasoningOutboundOptions } from './reasoning-fallback.js'
 import { extractToolCallsFromText } from '../tool/text-tool-extractor.js'
+import { createEgressFetch } from './egress.js'
 
 // ---------------------------------------------------------------------------
 // Adapter implementation
@@ -94,10 +96,18 @@ export class OpenAIAdapter implements LLMAdapter {
 
   readonly #client: OpenAI
 
-  constructor(apiKey?: string, baseURL?: string) {
+  constructor(
+    apiKey?: string,
+    baseURL?: string,
+    egressPolicy?: EgressPolicy,
+    egressProvider = 'openai',
+  ) {
     this.#client = new OpenAI({
       apiKey: apiKey ?? process.env['OPENAI_API_KEY'],
       baseURL,
+      ...(egressPolicy !== undefined
+        ? { fetch: createEgressFetch(egressPolicy, egressProvider) }
+        : {}),
     })
   }
 

--- a/packages/core/src/llm/qiniu.ts
+++ b/packages/core/src/llm/qiniu.ts
@@ -5,6 +5,7 @@
  * OpenAI-compatible endpoint and QINIU_API_KEY environment variable fallback.
  */
 
+import type { EgressPolicy } from '../types.js'
 import { OpenAIAdapter } from './openai.js'
 
 /**
@@ -19,11 +20,13 @@ import { OpenAIAdapter } from './openai.js'
 export class QiniuAdapter extends OpenAIAdapter {
   readonly name = 'qiniu'
 
-  constructor(apiKey?: string, baseURL?: string) {
+  constructor(apiKey?: string, baseURL?: string, egressPolicy?: EgressPolicy) {
     // Allow override of baseURL (for proxies or future changes) but default to official Qiniu endpoint.
     super(
       apiKey ?? process.env['QINIU_API_KEY'],
-      baseURL ?? 'https://api.qnaigc.com/v1'
+      baseURL ?? 'https://api.qnaigc.com/v1',
+      egressPolicy,
+      'qiniu',
     )
   }
 }

--- a/packages/core/src/observability/status.ts
+++ b/packages/core/src/observability/status.ts
@@ -1,5 +1,6 @@
 import {
   CostBudgetExceededError,
+  EgressPolicyError,
   LLMCallTimeoutError,
   RoutingTimeoutError,
   TokenBudgetExceededError,
@@ -56,6 +57,9 @@ export function classifyRunFailure(
   } else if (error instanceof LLMCallTimeoutError || error instanceof RoutingTimeoutError) {
     statusCode = 'timeout'
     kind = 'timeout'
+  } else if (error instanceof EgressPolicyError) {
+    statusCode = 'rejected'
+    kind = 'validation'
   } else if (isCancellationError(error)) {
     statusCode = 'cancelled'
     kind = 'cancellation'

--- a/packages/core/src/orchestrator/agent-config.ts
+++ b/packages/core/src/orchestrator/agent-config.ts
@@ -18,12 +18,14 @@ import { ToolRegistry } from '../tool/framework.js'
 import { ToolExecutor } from '../tool/executor.js'
 import { registerBuiltInTools } from '../tool/built-in/index.js'
 import { resolveGrantedToolDefinitions } from '../tool/grants.js'
+import { intersectEgressPolicies } from '../llm/egress.js'
 
 export interface AgentDefaultsSource {
   readonly defaultModel?: OrchestratorConfig['defaultModel']
   readonly defaultProvider?: OrchestratorConfig['defaultProvider']
   readonly defaultBaseURL?: OrchestratorConfig['defaultBaseURL']
   readonly defaultApiKey?: OrchestratorConfig['defaultApiKey']
+  readonly egressPolicy?: OrchestratorConfig['egressPolicy']
   readonly defaultCwd?: OrchestratorConfig['defaultCwd']
   readonly onToolCall?: OrchestratorConfig['onToolCall']
 }
@@ -36,6 +38,7 @@ export function applyAgentDefaults(config: AgentConfig, src: AgentDefaultsSource
     provider: config.provider ?? src.defaultProvider,
     baseURL: config.baseURL ?? src.defaultBaseURL,
     apiKey: config.apiKey ?? src.defaultApiKey,
+    egressPolicy: intersectEgressPolicies(src.egressPolicy, config.egressPolicy),
     cwd: config.cwd === undefined ? src.defaultCwd : config.cwd,
     onToolCall: config.onToolCall ?? src.onToolCall,
   }

--- a/packages/core/src/orchestrator/consensus.ts
+++ b/packages/core/src/orchestrator/consensus.ts
@@ -40,6 +40,7 @@ export interface ConsensusAgentDefaults {
   readonly defaultProvider: OrchestratorConfig['defaultProvider']
   readonly defaultBaseURL: OrchestratorConfig['defaultBaseURL']
   readonly defaultApiKey: OrchestratorConfig['defaultApiKey']
+  readonly egressPolicy: OrchestratorConfig['egressPolicy']
   readonly defaultCwd: OrchestratorConfig['defaultCwd']
   readonly onToolCall: OrchestratorConfig['onToolCall']
   readonly maxConcurrency: number
@@ -369,6 +370,7 @@ export async function runTaskVerify(
       defaultProvider: config.defaultProvider,
       defaultBaseURL: config.defaultBaseURL,
       defaultApiKey: config.defaultApiKey,
+      egressPolicy: config.egressPolicy,
       defaultCwd: config.defaultCwd,
       onToolCall: config.onToolCall,
       maxConcurrency: config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY,

--- a/packages/core/src/orchestrator/coordinator.ts
+++ b/packages/core/src/orchestrator/coordinator.ts
@@ -503,6 +503,7 @@ export function buildCoordinatorBaseConfig(
     provider: coordinatorOverrides?.provider ?? config.defaultProvider,
     baseURL: coordinatorOverrides?.baseURL ?? config.defaultBaseURL,
     apiKey: coordinatorOverrides?.apiKey ?? config.defaultApiKey,
+    egressPolicy: config.egressPolicy,
     systemPrompt: buildCoordinatorPrompt(
       agentConfigs,
       coordinatorOverrides,

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -49,6 +49,7 @@ import type {
   ConsensusOptions,
   ConsensusResult,
   CoordinatorConfig,
+  EgressPolicy,
   ExecutionRoutingConfig,
   ModelRoutingPolicy,
   PlanArtifact,
@@ -79,6 +80,10 @@ import type { RunOptions } from '../agent/runner.js'
 import { Agent } from '../agent/agent.js'
 import { AgentPool } from '../agent/pool.js'
 import { createAdapter } from '../llm/adapter.js'
+import {
+  intersectEgressPolicies,
+  rejectUnsupportedEgress,
+} from '../llm/egress.js'
 import { emitTrace, generateSpanId } from '../utils/trace.js'
 import { mergeAbortSignals } from '../utils/abort.js'
 import { defaultWorkspaceDir } from '../tool/built-in/path-safety.js'
@@ -228,6 +233,50 @@ interface EffectiveRunBudgets {
   readonly maxCostBudget?: number
 }
 
+type EffectiveOrchestratorConfig = Required<
+  Omit<
+    OrchestratorConfig,
+    | 'onApproval'
+    | 'onTaskDispatch'
+    | 'onAgentStream'
+    | 'onPlanReady'
+    | 'onProgress'
+    | 'onTrace'
+    | 'onToolCall'
+    | 'observability'
+    | 'evaluation'
+    | 'defaultBaseURL'
+    | 'defaultApiKey'
+    | 'egressPolicy'
+    | 'maxTokenBudget'
+    | 'maxCostBudget'
+    | 'estimateCost'
+    | 'defaultToolPreset'
+    | 'checkpoint'
+    | 'recovery'
+  >
+> & Pick<
+  OrchestratorConfig,
+  | 'onApproval'
+  | 'onTaskDispatch'
+  | 'onAgentStream'
+  | 'onPlanReady'
+  | 'onProgress'
+  | 'onTrace'
+  | 'onToolCall'
+  | 'observability'
+  | 'evaluation'
+  | 'defaultBaseURL'
+  | 'defaultApiKey'
+  | 'egressPolicy'
+  | 'maxTokenBudget'
+  | 'maxCostBudget'
+  | 'estimateCost'
+  | 'defaultToolPreset'
+  | 'checkpoint'
+  | 'recovery'
+>
+
 interface SemanticProfileRun {
   readonly assessment: SemanticRoutingAssessment
   readonly usage?: TokenUsage
@@ -305,9 +354,7 @@ function resolveRunBudgets(
  * Most users will interact with this class exclusively.
  */
 export class OpenMultiAgent {
-  private readonly config: Required<
-    Omit<OrchestratorConfig, 'onApproval' | 'onTaskDispatch' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'evaluation' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint' | 'recovery'>
-  > & Pick<OrchestratorConfig, 'onApproval' | 'onTaskDispatch' | 'onAgentStream' | 'onPlanReady' | 'onProgress' | 'onTrace' | 'onToolCall' | 'observability' | 'evaluation' | 'defaultBaseURL' | 'defaultApiKey' | 'maxTokenBudget' | 'maxCostBudget' | 'estimateCost' | 'defaultToolPreset' | 'checkpoint' | 'recovery'>
+  private readonly config: EffectiveOrchestratorConfig
 
   private readonly teams: Map<string, Team> = new Map()
   private readonly hasConfiguredCustomExecutionRouter: boolean
@@ -384,6 +431,7 @@ export class OpenMultiAgent {
       defaultProvider: config.defaultProvider ?? 'anthropic',
       defaultBaseURL: config.defaultBaseURL,
       defaultApiKey: config.defaultApiKey,
+      egressPolicy: intersectEgressPolicies(config.egressPolicy),
       // `defaultCwd === undefined` means "use the default sandbox rooted at
       // <cwd>/.agent-workspace". An explicit `null` propagates through to
       // disable the filesystem sandbox; a string sets a custom sandbox root.
@@ -404,6 +452,14 @@ export class OpenMultiAgent {
       onTrace: config.onTrace ?? (hasExplicitLegacyBridge ? LEGACY_TRACE_METADATA_ONLY : undefined),
       onToolCall: config.onToolCall,
       requireConsequentialConfirmation: config.requireConsequentialConfirmation ?? false,
+    }
+  }
+
+  private configForRun(egressPolicy?: EgressPolicy): EffectiveOrchestratorConfig {
+    const effectivePolicy = intersectEgressPolicies(this.config.egressPolicy, egressPolicy)
+    return {
+      ...this.config,
+      egressPolicy: effectivePolicy,
     }
   }
 
@@ -490,18 +546,35 @@ export class OpenMultiAgent {
   private async resolveTaskProfiler(
     routingConfig: ExecutionRoutingConfig,
     coordinator?: CoordinatorConfig,
+    config: EffectiveOrchestratorConfig = this.config,
   ): Promise<TaskProfiler> {
     if (routingConfig.profiler !== undefined) return routingConfig.profiler
-    const adapter = routingConfig.adapter
-      ?? coordinator?.adapter
-      ?? await createAdapter(
-        this.config.defaultProvider,
-        this.config.defaultApiKey,
-        this.config.defaultBaseURL,
+    const configuredAdapter = routingConfig.adapter ?? coordinator?.adapter
+    if (configuredAdapter !== undefined) {
+      rejectUnsupportedEgress(
+        config.egressPolicy,
+        configuredAdapter.name,
+        'custom and AI SDK adapters do not expose an enforceable request transport or target contract to OMA.',
       )
+    }
+    const adapter = configuredAdapter ?? (
+      config.egressPolicy === undefined
+        ? await createAdapter(
+            config.defaultProvider,
+            config.defaultApiKey,
+            config.defaultBaseURL,
+          )
+        : await createAdapter(
+            config.defaultProvider,
+            config.defaultApiKey,
+            config.defaultBaseURL,
+            undefined,
+            config.egressPolicy,
+          )
+    )
     return new LLMTaskProfiler({
       adapter,
-      model: routingConfig.model ?? coordinator?.model ?? this.config.defaultModel,
+      model: routingConfig.model ?? coordinator?.model ?? config.defaultModel,
     })
   }
 
@@ -509,6 +582,7 @@ export class OpenMultiAgent {
     context: ReturnType<typeof buildRoutingContext>,
     routingConfig: ReturnType<OpenMultiAgent['resolveExecutionRoutingConfig']>,
     coordinator: CoordinatorConfig | undefined,
+    config: EffectiveOrchestratorConfig,
     traceRuntime: TraceRuntime | undefined,
     facts: {
       readonly hasConsequentialTools: boolean
@@ -527,7 +601,7 @@ export class OpenMultiAgent {
       },
     })
     try {
-      profiler = await this.resolveTaskProfiler(routingConfig, coordinator)
+      profiler = await this.resolveTaskProfiler(routingConfig, coordinator, config)
       if (typeof profiler.version !== 'string' || profiler.version.length === 0) {
         throw new TaskProfileValidationError(
           'Task profiler version must be a non-empty string.',
@@ -755,14 +829,15 @@ export class OpenMultiAgent {
     prompt: string,
     options?: RunAgentOptions,
   ): Promise<AgentRunResult> {
+    const runConfig = this.configForRun(options?.egressPolicy)
     const pendingEvaluation = this.beginOnlineEvaluation(prompt)
     const { identity, metadata } = createRunFacts(options)
     const traceRuntime = this.startTrace(identity, metadata)
     const effectiveBudget = resolveBudgetCeiling(config.maxTokenBudget, this.config.maxTokenBudget)
     const effective: AgentConfig = applyDefaultToolPreset({
-      ...applyAgentDefaults(config, this.config),
+      ...applyAgentDefaults(config, runConfig),
       maxTokenBudget: effectiveBudget,
-    }, this.config.defaultToolPreset)
+    }, runConfig.defaultToolPreset)
     const consequential = hasGrantedConsequentialTool(effective)
     const confirmationState = createConsequentialConfirmationState()
     const guardedEffective = consequential && this.config.requireConsequentialConfirmation
@@ -896,9 +971,10 @@ export class OpenMultiAgent {
     goal: string,
     options?: RunTeamOptions,
   ): Promise<TeamRunResult> {
+    const runConfig = this.configForRun(options?.egressPolicy)
     const pendingEvaluation = this.beginOnlineEvaluation(goal)
     const agentConfigs = team.getAgents()
-    const budgets = resolveRunBudgets(this.config, options)
+    const budgets = resolveRunBudgets(runConfig, options)
     const explicitMode = options?.mode
     if (explicitMode === 'single' && options?.planOnly) {
       throw new Error("runTeam mode 'single' cannot be combined with planOnly.")
@@ -1004,14 +1080,15 @@ export class OpenMultiAgent {
       const deterministicSingleDecision = routerDecision!
       const effectiveAgents = agentConfigs.map((agentConfig) =>
         applyDefaultToolPreset(
-          applyAgentDefaults(agentConfig, this.config),
-          this.config.defaultToolPreset,
+          applyAgentDefaults(agentConfig, runConfig),
+          runConfig.defaultToolPreset,
         ))
       try {
         semanticProfileRun = await this.runSemanticProfiler(
           routingContext,
           executionRouting,
           options?.coordinator,
+          runConfig,
           traceRuntime,
           {
             hasConsequentialTools: effectiveAgents.some((agentConfig) =>
@@ -1152,8 +1229,8 @@ export class OpenMultiAgent {
     const confirmationState = createConsequentialConfirmationState()
     let consequentialUndeclared = undeclared && agentConfigs.some((agentConfig) => {
       const effective = applyDefaultToolPreset(
-        applyAgentDefaults(agentConfig, this.config),
-        this.config.defaultToolPreset,
+        applyAgentDefaults(agentConfig, runConfig),
+        runConfig.defaultToolPreset,
       )
       return hasGrantedConsequentialTool(effective, { includeDelegateTool: true })
     })
@@ -1242,9 +1319,9 @@ export class OpenMultiAgent {
         budgets.maxTokenBudget,
       )
       const effective: AgentConfig = withModelRoute(applyDefaultToolPreset({
-        ...applyAgentDefaults(bestAgent, this.config),
+        ...applyAgentDefaults(bestAgent, runConfig),
         maxTokenBudget: effectiveBudget,
-      }, this.config.defaultToolPreset), routeMatches(options?.modelRouting, { phase: 'short-circuit', agent: bestAgent.name }))
+      }, runConfig.defaultToolPreset), routeMatches(options?.modelRouting, { phase: 'short-circuit', agent: bestAgent.name }))
       const selectedConsequential = undeclared
         && hasGrantedConsequentialTool(effective)
       const guardedEffective = selectedConsequential
@@ -1365,7 +1442,7 @@ export class OpenMultiAgent {
     // Step 1: Coordinator decomposes goal into tasks
     // ------------------------------------------------------------------
     const unguardedCoordinatorBaseConfig = buildCoordinatorBaseConfig(
-      this.config,
+      runConfig,
       coordinatorOverrides,
       agentConfigs,
       (options?.verifyJudges?.length ?? 0) > 0,
@@ -1622,6 +1699,7 @@ export class OpenMultiAgent {
       undeclared && this.config.requireConsequentialConfirmation
         ? confirmationState
         : undefined,
+      runConfig,
     )
     const activeCheckpoint = this.createActiveCheckpoint(
       team,
@@ -1634,7 +1712,7 @@ export class OpenMultiAgent {
       pool,
       scheduler,
       agentResults,
-      config: this.config,
+      config: runConfig,
       ...(activeCheckpoint ? { checkpoint: activeCheckpoint } : {}),
       runId,
       identity,
@@ -1773,7 +1851,7 @@ export class OpenMultiAgent {
     // ------------------------------------------------------------------
     // Step 5: Coordinator synthesises final result
     // ------------------------------------------------------------------
-    const synthesis = await runCoordinatorSynthesis(this.config, team, queue, goal, coordinatorBaseConfig, {
+    const synthesis = await runCoordinatorSynthesis(runConfig, team, queue, goal, coordinatorBaseConfig, {
       identity,
       modelRouting: options?.modelRouting,
       runId,
@@ -2178,6 +2256,7 @@ export class OpenMultiAgent {
     prompt: string,
     options: ConsensusOptions,
   ): Promise<ConsensusResult> {
+    const runConfig = this.configForRun(options.egressPolicy)
     const pendingEvaluation = this.beginOnlineEvaluation(prompt)
     const { identity, metadata } = createRunFacts(options)
     const proposers = Array.isArray(options.proposer) ? options.proposer : [options.proposer]
@@ -2230,6 +2309,7 @@ export class OpenMultiAgent {
       defaultProvider: this.config.defaultProvider,
       defaultBaseURL: this.config.defaultBaseURL,
       defaultApiKey: this.config.defaultApiKey,
+      egressPolicy: runConfig.egressPolicy,
       defaultCwd: this.config.defaultCwd,
       onToolCall: this.config.onToolCall,
       maxConcurrency: this.config.maxConcurrency,
@@ -2439,6 +2519,7 @@ export class OpenMultiAgent {
     governanceDeclaration?: GovernanceDeclaration,
     routingDecisionInput?: RoutingDecisionRecordInput,
   ): Promise<TeamRunResult> {
+    const runConfig = this.configForRun(options?.egressPolicy)
     const agentConfigs = team.getAgents()
     const requirementIssues = validateTaskRequirements(
       queue.list(),
@@ -2471,9 +2552,9 @@ export class OpenMultiAgent {
     if (this.config.onApproval) {
       scheduler.autoAssign(queue, agentConfigs)
     }
-    const budgets = resolveRunBudgets(this.config, options)
+    const budgets = resolveRunBudgets(runConfig, options)
 
-    const pool = this.buildPool(agentConfigs)
+    const pool = this.buildPool(agentConfigs, undefined, runConfig)
     const agentResults = initialAgentResults ?? new Map<string, AgentRunResult>()
     const checkpoint = activeCheckpoint ?? this.createActiveCheckpoint(
       team,
@@ -2486,7 +2567,7 @@ export class OpenMultiAgent {
       pool,
       scheduler,
       agentResults,
-      config: this.config,
+      config: runConfig,
       ...(checkpoint ? { checkpoint } : {}),
       identity: runIdentity,
       ...(metadata !== undefined ? { metadata } : {}),
@@ -2521,8 +2602,8 @@ export class OpenMultiAgent {
     // we surface `synthesis_failed` and fall back to raw outputs.
     if (checkpoint?.mode === 'runTeam' && goal !== undefined) {
       try {
-        const coordinatorBaseConfig = buildCoordinatorBaseConfig(this.config, coordinatorForSynthesis, agentConfigs, false)
-        const synthesis = await runCoordinatorSynthesis(this.config, team, queue, goal, coordinatorBaseConfig, {
+        const coordinatorBaseConfig = buildCoordinatorBaseConfig(runConfig, coordinatorForSynthesis, agentConfigs, false)
+        const synthesis = await runCoordinatorSynthesis(runConfig, team, queue, goal, coordinatorBaseConfig, {
           identity: runIdentity,
           modelRouting: options?.modelRouting,
           runId: ctx.runId,
@@ -2688,12 +2769,13 @@ export class OpenMultiAgent {
   private buildPool(
     agentConfigs: AgentConfig[],
     confirmationState?: ConsequentialConfirmationState,
+    config: EffectiveOrchestratorConfig = this.config,
   ): AgentPool {
-    const pool = new AgentPool(this.config.maxConcurrency)
-    for (const config of agentConfigs) {
+    const pool = new AgentPool(config.maxConcurrency)
+    for (const agentConfig of agentConfigs) {
       const effective: AgentConfig = applyDefaultToolPreset(
-        applyAgentDefaults(config, this.config),
-        this.config.defaultToolPreset,
+        applyAgentDefaults(agentConfig, config),
+        config.defaultToolPreset,
       )
       const guardedEffective = confirmationState
         && hasGrantedConsequentialTool(effective, { includeDelegateTool: true })

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -161,6 +161,28 @@ export interface TokenUsage {
   readonly output_tokens: number
 }
 
+/**
+ * Declarative policy for network requests opened by framework-owned LLM
+ * transports.
+ *
+ * - `'offline'` permits only loopback HTTP(S) origins (`localhost`,
+ *   `*.localhost`, `127.0.0.0/8`, and `[::1]`).
+ * - `'allowlist'` permits only the listed exact HTTP(S) origins. Entries must
+ *   be origins such as `https://api.openai.com` or
+ *   `http://127.0.0.1:11434`, without credentials, paths, query strings, or
+ *   fragments.
+ *
+ * This is deliberately narrower than a process firewall. It does not govern
+ * application callbacks, tools, subprocesses, MCP-server internals, or
+ * application-owned telemetry exporters.
+ */
+export type EgressPolicy =
+  | { readonly mode: 'offline' }
+  | {
+      readonly mode: 'allowlist'
+      readonly allowedOrigins: readonly string[]
+    }
+
 // ---------------------------------------------------------------------------
 // Run identity and outcome
 // ---------------------------------------------------------------------------
@@ -209,6 +231,12 @@ export interface RunIdentityOptions {
    * and echoed on the run result.
    */
   readonly metadata?: Readonly<Record<string, TraceAttributeValue>>
+  /**
+   * Per-run framework-owned LLM egress restriction. When agent- or
+   * orchestrator-level policies are also configured, all scopes are
+   * intersected: a more specific scope may narrow but never widen another.
+   */
+  readonly egressPolicy?: EgressPolicy
 }
 
 /** Per-call options for {@link OpenMultiAgent.runAgent}. */
@@ -738,6 +766,13 @@ export interface AgentConfig {
    * non-empty placeholder (e.g. `'ollama'`) because the OpenAI SDK validates it.
    */
   readonly baseURL?: string
+  /**
+   * Agent-level restriction for framework-owned LLM requests. It intersects
+   * with run- and orchestrator-level policies, so it can narrow inherited
+   * access but cannot widen it. External backends and tool code are outside
+   * this policy's scope.
+   */
+  readonly egressPolicy?: EgressPolicy
   /** API key override; falls back to the provider's standard env var. */
   readonly apiKey?: string
   /** AWS region override for the `bedrock` provider; falls back to `AWS_REGION` env var, then `'us-east-1'`. Ignored by all other providers. */
@@ -2000,6 +2035,12 @@ export interface OrchestratorConfig {
   readonly defaultProvider?: SupportedProvider
   readonly defaultBaseURL?: string
   readonly defaultApiKey?: string
+  /**
+   * Default restriction for framework-owned LLM network requests. Per-run and
+   * per-agent policies intersect with this default; omission preserves legacy
+   * unrestricted behavior.
+   */
+  readonly egressPolicy?: EgressPolicy
   /**
    * Default checkpoint configuration for `runTeam`, `runTasks`, `runFromPlan`,
    * and `restore`. Per-call options override this value. Defaults to off.

--- a/packages/core/tests/anthropic-adapter.test.ts
+++ b/packages/core/tests/anthropic-adapter.test.ts
@@ -8,16 +8,16 @@ import type { LLMMessage, LLMResponse, ReasoningBlock, StreamEvent, ToolUseBlock
 
 const mockCreate = vi.hoisted(() => vi.fn())
 const mockStream = vi.hoisted(() => vi.fn())
-
-vi.mock('@anthropic-ai/sdk', () => {
-  const AnthropicMock = vi.fn(() => ({
+const AnthropicMock = vi.hoisted(() =>
+  vi.fn(() => ({
     messages: {
       create: mockCreate,
       stream: mockStream,
     },
-  }))
-  return { default: AnthropicMock, Anthropic: AnthropicMock }
-})
+  })),
+)
+
+vi.mock('@anthropic-ai/sdk', () => ({ default: AnthropicMock, Anthropic: AnthropicMock }))
 
 import { AnthropicAdapter } from '../src/llm/anthropic.js'
 
@@ -55,6 +55,20 @@ describe('AnthropicAdapter', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     adapter = new AnthropicAdapter('test-key')
+  })
+
+  it('injects a guarded fetch when an egress policy is configured', async () => {
+    new AnthropicAdapter('test-key', 'https://api.anthropic.com', {
+      mode: 'allowlist',
+      allowedOrigins: ['https://api.anthropic.com'],
+    })
+    const init = AnthropicMock.mock.calls.at(-1)?.[0] as { fetch?: typeof globalThis.fetch }
+
+    expect(init.fetch).toEqual(expect.any(Function))
+    await expect(init.fetch!('https://other.example/v1')).rejects.toMatchObject({
+      code: 'EGRESS_POLICY_DENIED',
+      origin: 'https://other.example',
+    })
   })
 
   // =========================================================================

--- a/packages/core/tests/azure-openai-adapter.test.ts
+++ b/packages/core/tests/azure-openai-adapter.test.ts
@@ -100,6 +100,29 @@ describe('AzureOpenAIAdapter', () => {
     expect(adapter.name).toBe('azure-openai')
   })
 
+  it('injects a guarded fetch and suppresses OPENAI_BASE_URL under policy', async () => {
+    new AzureOpenAIAdapter(
+      'test-key',
+      'https://resource.openai.azure.com',
+      undefined,
+      {
+        mode: 'allowlist',
+        allowedOrigins: ['https://resource.openai.azure.com'],
+      },
+    )
+    const init = AzureOpenAIMock.mock.calls.at(-1)?.[0] as {
+      baseURL?: string | null
+      fetch?: typeof globalThis.fetch
+    }
+
+    expect(init.baseURL).toBeNull()
+    expect(init.fetch).toEqual(expect.any(Function))
+    await expect(init.fetch!('https://other.example/v1')).rejects.toMatchObject({
+      code: 'EGRESS_POLICY_DENIED',
+      origin: 'https://other.example',
+    })
+  })
+
   it('uses AZURE_OPENAI_API_KEY by default', () => {
     const originalKey = process.env['AZURE_OPENAI_API_KEY']
     const originalEndpoint = process.env['AZURE_OPENAI_ENDPOINT']

--- a/packages/core/tests/copilot-adapter.test.ts
+++ b/packages/core/tests/copilot-adapter.test.ts
@@ -110,6 +110,54 @@ describe('CopilotAdapter', () => {
     })
   })
 
+  describe('egress policy', () => {
+    it('checks every required origin before opening the first auth connection', async () => {
+      const fetchMock = vi.fn()
+      globalThis.fetch = fetchMock
+      const adapter = new CopilotAdapter({
+        apiKey: 'gh_token',
+        egressPolicy: {
+          mode: 'allowlist',
+          allowedOrigins: ['https://api.githubcopilot.com'],
+        },
+      })
+
+      await expect(adapter.chat([textMsg('user', 'Hi')], chatOpts())).rejects.toMatchObject({
+        code: 'EGRESS_POLICY_DENIED',
+        origin: 'https://api.github.com',
+      })
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(OpenAIMock).not.toHaveBeenCalled()
+    })
+
+    it('guards the token exchange and Copilot API transport when both origins are allowed', async () => {
+      const fetchMock = mockFetchForToken('session_guarded')
+      globalThis.fetch = fetchMock
+      mockCreate.mockResolvedValue(makeCompletion())
+      const adapter = new CopilotAdapter({
+        apiKey: 'gh_token',
+        egressPolicy: {
+          mode: 'allowlist',
+          allowedOrigins: [
+            'https://api.github.com',
+            'https://api.githubcopilot.com',
+          ],
+        },
+      })
+
+      await adapter.chat([textMsg('user', 'Hi')], chatOpts())
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.github.com/copilot_internal/v2/token',
+        expect.objectContaining({ redirect: 'error' }),
+      )
+      expect(OpenAIMock).toHaveBeenCalledWith(expect.objectContaining({
+        baseURL: 'https://api.githubcopilot.com',
+        fetch: expect.any(Function),
+      }))
+    })
+  })
+
   // =========================================================================
   // Token management
   // =========================================================================

--- a/packages/core/tests/egress-policy.test.ts
+++ b/packages/core/tests/egress-policy.test.ts
@@ -1,0 +1,462 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { LanguageModel } from 'ai'
+import { Agent } from '../src/agent/agent.js'
+import { AISdkAdapter } from '../src/llm/ai-sdk.js'
+import { createAdapter } from '../src/llm/adapter.js'
+import {
+  createEgressFetch,
+  intersectEgressPolicies,
+  normalizeEgressPolicy,
+} from '../src/llm/egress.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { ToolExecutor } from '../src/tool/executor.js'
+import { ToolRegistry } from '../src/tool/framework.js'
+import type { EgressPolicy, LLMAdapter, StreamEvent } from '../src/types.js'
+
+const originalOpenAIBaseURL = process.env['OPENAI_BASE_URL']
+const originalAzureEndpoint = process.env['AZURE_OPENAI_ENDPOINT']
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name]
+  else process.env[name] = value
+}
+
+function makeAgent(adapter: LLMAdapter, policy: EgressPolicy): Agent {
+  const registry = new ToolRegistry()
+  return new Agent(
+    {
+      name: 'policy-agent',
+      model: 'test-model',
+      adapter,
+      egressPolicy: policy,
+    },
+    registry,
+    new ToolExecutor(registry),
+  )
+}
+
+afterEach(() => {
+  restoreEnv('OPENAI_BASE_URL', originalOpenAIBaseURL)
+  restoreEnv('AZURE_OPENAI_ENDPOINT', originalAzureEndpoint)
+  vi.restoreAllMocks()
+})
+
+describe('egress policy validation and matching', () => {
+  it('rejects malformed allowlist entries instead of silently broadening them', () => {
+    expect(() => normalizeEgressPolicy({
+      mode: 'allowlist',
+      allowedOrigins: ['https://api.example.test/v1'],
+    })).toThrowError(expect.objectContaining({
+      code: 'INVALID_EGRESS_POLICY',
+      reason: 'invalid-policy',
+    }))
+
+    expect(() => normalizeEgressPolicy({
+      mode: 'allowlist',
+      allowedOrigins: ['https://user:secret@api.example.test'],
+    })).toThrowError(expect.objectContaining({ code: 'INVALID_EGRESS_POLICY' }))
+
+    expect(() => normalizeEgressPolicy({
+      mode: 'offline',
+      allowedOrigins: ['https://api.example.test'],
+    } as unknown as EgressPolicy)).toThrowError(expect.objectContaining({
+      code: 'INVALID_EGRESS_POLICY',
+    }))
+  })
+
+  it('allows loopback HTTP in offline mode and never calls fetch for a remote target', async () => {
+    const implementation = vi.fn(async () => new Response('ok')) as typeof globalThis.fetch
+    const guarded = createEgressFetch({ mode: 'offline' }, 'openai', implementation)
+
+    await guarded('http://127.42.0.9:11434/v1/chat/completions', {
+      method: 'POST',
+      redirect: 'follow',
+    })
+    await guarded('http://worker.localhost:8080/v1/models')
+    await guarded('http://[::1]:8000/v1/models')
+
+    expect(implementation).toHaveBeenCalledTimes(3)
+    expect(implementation).toHaveBeenNthCalledWith(
+      1,
+      'http://127.42.0.9:11434/v1/chat/completions',
+      expect.objectContaining({ redirect: 'error' }),
+    )
+
+    await expect(guarded('https://api.openai.com/v1/chat/completions')).rejects.toMatchObject({
+      code: 'EGRESS_POLICY_DENIED',
+      reason: 'denied',
+      provider: 'openai',
+      origin: 'https://api.openai.com',
+    })
+    expect(implementation).toHaveBeenCalledTimes(3)
+  })
+
+  it('matches allowlist entries by exact origin, including the port', async () => {
+    const implementation = vi.fn(async () => new Response('ok')) as typeof globalThis.fetch
+    const guarded = createEgressFetch({
+      mode: 'allowlist',
+      allowedOrigins: ['https://api.example.test:8443'],
+    }, 'test-provider', implementation)
+
+    await guarded('https://api.example.test:8443/v1/chat')
+    await expect(guarded('https://api.example.test/v1/chat')).rejects.toMatchObject({
+      code: 'EGRESS_POLICY_DENIED',
+      origin: 'https://api.example.test',
+    })
+    expect(implementation).toHaveBeenCalledTimes(1)
+  })
+
+  it('intersects scopes so a narrower run or agent policy cannot widen a parent', () => {
+    expect(intersectEgressPolicies(
+      {
+        mode: 'allowlist',
+        allowedOrigins: ['https://api.openai.com', 'http://localhost:11434'],
+      },
+      { mode: 'offline' },
+    )).toEqual({
+      mode: 'allowlist',
+      allowedOrigins: ['http://localhost:11434'],
+    })
+
+    expect(intersectEgressPolicies(
+      { mode: 'allowlist', allowedOrigins: ['https://one.example'] },
+      { mode: 'allowlist', allowedOrigins: ['https://two.example'] },
+    )).toEqual({ mode: 'allowlist', allowedOrigins: [] })
+  })
+})
+
+describe('built-in adapter enforcement', () => {
+  it('preserves legacy adapter construction when no policy is configured', async () => {
+    const adapter = await createAdapter('openai', 'test-key')
+    expect(adapter.name).toBe('openai')
+  })
+
+  it('allows an explicit local OpenAI-compatible baseURL in offline mode', async () => {
+    const adapter = await createAdapter(
+      'openai',
+      'local-placeholder',
+      'http://127.0.0.1:11434/v1',
+      undefined,
+      { mode: 'offline' },
+    )
+    expect(adapter.name).toBe('openai')
+  })
+
+  it('constructs every enforceable built-in adapter only for its allowed origin', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new Error('test must not open a network connection'),
+    )
+    const cases = [
+      ['anthropic', 'https://api.anthropic.com'],
+      ['openai', 'https://api.openai.com/v1'],
+      ['azure-openai', 'https://resource.openai.azure.com'],
+      ['deepseek', 'https://api.deepseek.com/v1'],
+      ['doubao', 'https://ark.cn-beijing.volces.com/api/v3'],
+      ['grok', 'https://api.x.ai/v1'],
+      ['hunyuan', 'https://tokenhub.tencentmaas.com/v1'],
+      ['minimax', 'https://api.minimax.io/v1'],
+      ['mimo', 'https://api.xiaomimimo.com/v1'],
+      ['qiniu', 'https://api.qnaigc.com/v1'],
+    ] as const
+
+    for (const [provider, baseURL] of cases) {
+      const adapter = await createAdapter(
+        provider,
+        'test-key',
+        baseURL,
+        undefined,
+        { mode: 'allowlist', allowedOrigins: [new URL(baseURL).origin] },
+      )
+      expect(adapter.name).toBe(provider)
+    }
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('denies every enforceable hosted adapter before SDK I/O', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new Error('test must not open a network connection'),
+    )
+    const cases = [
+      ['anthropic', 'https://api.anthropic.com'],
+      ['openai', 'https://api.openai.com/v1'],
+      ['azure-openai', 'https://resource.openai.azure.com'],
+      ['deepseek', 'https://api.deepseek.com/v1'],
+      ['doubao', 'https://ark.cn-beijing.volces.com/api/v3'],
+      ['grok', 'https://api.x.ai/v1'],
+      ['hunyuan', 'https://tokenhub.tencentmaas.com/v1'],
+      ['minimax', 'https://api.minimax.io/v1'],
+      ['mimo', 'https://api.xiaomimimo.com/v1'],
+      ['qiniu', 'https://api.qnaigc.com/v1'],
+    ] as const
+
+    for (const [provider, baseURL] of cases) {
+      await expect(createAdapter(
+        provider,
+        'test-key',
+        baseURL,
+        undefined,
+        { mode: 'offline' },
+      )).rejects.toMatchObject({
+        code: 'EGRESS_POLICY_DENIED',
+        provider,
+        origin: new URL(baseURL).origin,
+      })
+    }
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('uses explicit baseURL before environment configuration and denies before SDK construction', async () => {
+    process.env['OPENAI_BASE_URL'] = 'http://localhost:11434/v1'
+
+    await expect(createAdapter(
+      'openai',
+      'test-key',
+      'https://api.openai.com/v1',
+      undefined,
+      { mode: 'offline' },
+    )).rejects.toMatchObject({
+      code: 'EGRESS_POLICY_DENIED',
+      origin: 'https://api.openai.com',
+    })
+  })
+
+  it('uses a provider endpoint environment variable when baseURL is omitted', async () => {
+    process.env['OPENAI_BASE_URL'] = 'http://localhost:11434/v1'
+
+    const adapter = await createAdapter(
+      'openai',
+      'local-placeholder',
+      undefined,
+      undefined,
+      { mode: 'offline' },
+    )
+    expect(adapter.name).toBe('openai')
+  })
+
+  it('requires a resolvable Azure endpoint before loading the SDK', async () => {
+    delete process.env['AZURE_OPENAI_ENDPOINT']
+
+    await expect(createAdapter(
+      'azure-openai',
+      'test-key',
+      undefined,
+      undefined,
+      { mode: 'allowlist', allowedOrigins: ['https://resource.openai.azure.com'] },
+    )).rejects.toMatchObject({
+      code: 'EGRESS_POLICY_TARGET_UNRESOLVED',
+      reason: 'unresolved-target',
+      provider: 'azure-openai',
+    })
+  })
+
+  it('uses the checked Azure endpoint even when OPENAI_BASE_URL is set', async () => {
+    process.env['OPENAI_BASE_URL'] = 'https://unrelated.example/v1'
+
+    const adapter = await createAdapter(
+      'azure-openai',
+      'test-key',
+      'https://resource.openai.azure.com',
+      undefined,
+      { mode: 'allowlist', allowedOrigins: ['https://resource.openai.azure.com'] },
+    )
+    expect(adapter.name).toBe('azure-openai')
+  })
+
+  it('fails closed for SDKs whose complete transport surface is not enforceable', async () => {
+    for (const provider of ['gemini', 'bedrock'] as const) {
+      await expect(createAdapter(
+        provider,
+        'test-key',
+        undefined,
+        undefined,
+        { mode: 'offline' },
+      )).rejects.toMatchObject({
+        code: 'EGRESS_POLICY_UNSUPPORTED',
+        reason: 'unsupported',
+        provider,
+      })
+    }
+  })
+})
+
+describe('run-level precedence and error contracts', () => {
+  it('returns a rejected non-retryable LLM result when policy scopes have no common origin', async () => {
+    const oma = new OpenMultiAgent({
+      defaultModel: 'test-model',
+      defaultProvider: 'openai',
+      defaultApiKey: 'test-key',
+      egressPolicy: {
+        mode: 'allowlist',
+        allowedOrigins: ['https://api.openai.com'],
+      },
+    })
+
+    const result = await oma.runAgent({
+      name: 'restricted',
+      baseURL: 'https://api.openai.com/v1',
+    }, 'hello', {
+      egressPolicy: { mode: 'offline' },
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.status).toMatchObject({ code: 'rejected' })
+    expect(result.errorInfo).toMatchObject({
+      kind: 'validation',
+      code: 'EGRESS_POLICY_DENIED',
+      retryable: false,
+    })
+    expect(result.toolCalls).toEqual([])
+  })
+
+  it('lets an agent policy narrow an orchestrator allowlist', async () => {
+    const oma = new OpenMultiAgent({
+      defaultModel: 'test-model',
+      defaultProvider: 'openai',
+      defaultApiKey: 'test-key',
+      egressPolicy: {
+        mode: 'allowlist',
+        allowedOrigins: ['https://api.openai.com'],
+      },
+    })
+
+    const result = await oma.runAgent({
+      name: 'agent-narrowed',
+      baseURL: 'https://api.openai.com/v1',
+      egressPolicy: { mode: 'offline' },
+    }, 'hello')
+
+    expect(result).toMatchObject({
+      success: false,
+      errorInfo: { code: 'EGRESS_POLICY_DENIED' },
+    })
+  })
+
+  it('propagates the run policy through top-level consensus agents', async () => {
+    const oma = new OpenMultiAgent({
+      defaultModel: 'test-model',
+      defaultProvider: 'openai',
+      defaultApiKey: 'test-key',
+      defaultBaseURL: 'https://api.openai.com/v1',
+    })
+    const team = oma.createTeam('consensus-egress', {
+      name: 'consensus-egress',
+      agents: [],
+    })
+
+    const result = await oma.runConsensus(team, 'hello', {
+      proposer: { name: 'proposer' },
+      judges: [{ name: 'judge' }],
+      egressPolicy: { mode: 'offline' },
+    })
+
+    expect(result).toMatchObject({
+      verdict: 'rejected',
+      status: { code: 'rejected' },
+      errorInfo: { code: 'EGRESS_POLICY_DENIED', retryable: false },
+    })
+  })
+
+  it('rejects a custom adapter before invoking it when a policy is active', async () => {
+    const chat = vi.fn()
+    const customAdapter: LLMAdapter = {
+      name: 'custom-http-adapter',
+      chat,
+      async *stream(): AsyncGenerator<StreamEvent> {
+        throw new Error('must not run')
+      },
+    }
+
+    const result = await makeAgent(customAdapter, { mode: 'offline' }).run('hello')
+
+    expect(chat).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      success: false,
+      status: { code: 'rejected' },
+      errorInfo: {
+        kind: 'validation',
+        code: 'EGRESS_POLICY_UNSUPPORTED',
+        retryable: false,
+      },
+    })
+  })
+
+  it('rejects the opaque AI SDK bridge before it can call the model', async () => {
+    const dummyModel = { _brand: 'test' } as unknown as LanguageModel
+    const result = await makeAgent(
+      new AISdkAdapter(dummyModel),
+      { mode: 'offline' },
+    ).run('hello')
+
+    expect(result).toMatchObject({
+      success: false,
+      status: { code: 'rejected' },
+      errorInfo: { code: 'EGRESS_POLICY_UNSUPPORTED' },
+    })
+  })
+
+  it('does not claim to constrain an external process backend', async () => {
+    const registry = new ToolRegistry()
+    const agent = new Agent({
+      name: 'local-process',
+      egressPolicy: { mode: 'offline' },
+      backend: {
+        kind: 'process',
+        command: process.execPath,
+        args: [
+          '-e',
+          "process.stdin.resume(); process.stdin.on('end', () => process.stdout.write('process-owned'))",
+        ],
+      },
+    }, registry, new ToolExecutor(registry))
+
+    const result = await agent.run('hello')
+
+    expect(result.success).toBe(true)
+    expect(result.output).toBe('process-owned')
+  })
+
+  it('leaves a custom semantic profiler application-owned and uncovered', async () => {
+    const profile = vi.fn(async () => ({
+      profile: {
+        evidenceSources: 'single' as const,
+        independentReview: 'none' as const,
+        conflictingObjectives: false,
+        sideEffectIntent: 'none' as const,
+        permissionIsolation: 'none' as const,
+        decomposable: false,
+        parallelizable: false,
+        complexity: 'low' as const,
+        confidence: 0.95,
+        reasons: ['Application-owned fixture.'],
+        source: 'inferred' as const,
+      },
+    }))
+    const oma = new OpenMultiAgent({
+      defaultModel: 'test-model',
+      egressPolicy: { mode: 'offline' },
+      executionRouting: {
+        strategy: 'hybrid',
+        profiler: { version: 'application-profiler-v1', profile },
+      },
+    })
+    const team = oma.createTeam('custom-profiler-egress', {
+      name: 'custom-profiler-egress',
+      agents: [{
+        name: 'process-worker',
+        backend: {
+          kind: 'process',
+          command: process.execPath,
+          args: [
+            '-e',
+            "process.stdin.resume(); process.stdin.on('end', () => process.stdout.write('done'))",
+          ],
+        },
+      }],
+    })
+
+    const result = await oma.runTeam(team, 'Say hello')
+
+    expect(profile).toHaveBeenCalledTimes(1)
+    expect(result.success).toBe(true)
+  })
+})

--- a/packages/core/tests/openai-adapter.test.ts
+++ b/packages/core/tests/openai-adapter.test.ts
@@ -7,17 +7,17 @@ import type { LLMResponse, StreamEvent, ToolUseBlock } from '../src/types.js'
 // ---------------------------------------------------------------------------
 
 const mockCreate = vi.hoisted(() => vi.fn())
-
-vi.mock('openai', () => {
-  const OpenAIMock = vi.fn(() => ({
+const OpenAIMock = vi.hoisted(() =>
+  vi.fn(() => ({
     chat: {
       completions: {
         create: mockCreate,
       },
     },
-  }))
-  return { default: OpenAIMock, OpenAI: OpenAIMock }
-})
+  })),
+)
+
+vi.mock('openai', () => ({ default: OpenAIMock, OpenAI: OpenAIMock }))
 
 import { OpenAIAdapter } from '../src/llm/openai.js'
 
@@ -105,6 +105,20 @@ describe('OpenAIAdapter', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     adapter = new OpenAIAdapter('test-key')
+  })
+
+  it('injects a guarded fetch when an egress policy is configured', async () => {
+    new OpenAIAdapter('test-key', 'https://api.openai.com/v1', {
+      mode: 'allowlist',
+      allowedOrigins: ['https://api.openai.com'],
+    })
+    const init = OpenAIMock.mock.calls.at(-1)?.[0] as { fetch?: typeof globalThis.fetch }
+
+    expect(init.fetch).toEqual(expect.any(Function))
+    await expect(init.fetch!('https://other.example/v1')).rejects.toMatchObject({
+      code: 'EGRESS_POLICY_DENIED',
+      origin: 'https://other.example',
+    })
   })
 
   // =========================================================================

--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -37,6 +37,11 @@ Pass exactly one of `tracer` or `tracerProvider`. Passing neither is a clear
 configuration error: this package does not fall back to `trace.getTracer()` or
 any global provider.
 
+Core `egressPolicy` does not wrap this application-owned provider or any
+exporter attached to it. Configure telemetry egress in the provider/exporter or
+at the infrastructure boundary; see the core
+[egress enforcement matrix](../../docs/egress-policy.md#enforcement-matrix).
+
 ## Lifecycle and ownership
 
 The caller owns the tracer/provider in every mode.


### PR DESCRIPTION
## Summary

- add an auditable `egressPolicy` with intersecting orchestrator, run, and agent scopes
- preflight and guard framework-owned requests for enforceable built-in LLM adapters and Copilot authentication/API calls
- fail closed for Gemini, Bedrock, AI SDK, and custom LLM adapters when OMA cannot truthfully enforce their transport surface
- document exact provider/base URL precedence, offline behavior, errors, and uncovered process/tool/exporter boundaries

## Security boundary

This policy covers only connections OMA can resolve and guard before a built-in LLM transport opens them. It deliberately does not claim to constrain MCP server internals, process or ACP backends, `bash`, custom tools/callbacks, or application-owned OpenTelemetry exporters. Those surfaces still require process or infrastructure-level egress controls.

## Validation

- `npm run lint -w @open-multi-agent/core`
- `npm run test -w @open-multi-agent/core` (125 files, 1850 tests)
- `npm run build -w @open-multi-agent/core`
- `git diff --check origin/main...HEAD`

Closes #473
