### PR TITLE
feat(approval): add durable suspend and resume gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Set `OPENAI_API_KEY` to run this example. [Providers](docs/providers.md) covers 
 OMA combines dynamic orchestration with the control, evidence, and recovery paths needed to move multi-agent systems from prototype to production.
 
 - **Dynamic orchestration.** Describe the goal and let the coordinator build the task DAG, assign work, and synthesize the result at runtime. There is no hand-wired graph to maintain.
-- **Controlled execution.** Preview and approve plans or individual dispatches and freeze approved plans for replay. Declare required roles and order when topology cannot drift, and verify outputs with multi-agent consensus.
+- **Controlled execution.** Preview, approve, or durably suspend plans, task dispatches, and tool calls; freeze approved plans for replay. Declare required roles and order when topology cannot drift, and verify outputs with multi-agent consensus.
 - **Reliability.** Resume interrupted runs from checkpoints, or opt into append-only plan repair at task outcome barriers. Retries, timeouts, loop detection, and token and cost budgets keep execution bounded.
 - **Observability and evaluation.** Follow each run through stable identity, execution receipts, and traces. Replay the task DAG and span waterfall in the offline Run Viewer, or export through the optional OpenTelemetry adapter. The same records feed versioned EvalSets, offline reports, CI gates, and production sampling.
 - **Safety and privacy.** Tools are default-deny, individual calls are gated, and explicit privacy controls apply to telemetry and persisted state.
@@ -153,7 +153,7 @@ Need to embed agent capabilities in an existing product or business system? We h
 |---|---|
 | Install and run | [Core package guide](packages/core/README.md) · [Examples](packages/core/examples/README.md) · [CLI](docs/cli.md) |
 | Configure models and tools | [Providers](docs/providers.md) · [Tools and sandbox](docs/tool-configuration.md) · [External agents](docs/external-agents.md) |
-| Operate reliably | [Observability](docs/observability.md) · [Evaluation](docs/evaluation.md) · [Checkpoint and resume](docs/checkpoint.md) · [Adaptive recovery](docs/adaptive-recovery.md) · [Context management](docs/context-management.md) |
+| Operate reliably | [Observability](docs/observability.md) · [Evaluation](docs/evaluation.md) · [Checkpoint and resume](docs/checkpoint.md) · [Durable approvals](docs/durable-approvals.md) · [Adaptive recovery](docs/adaptive-recovery.md) · [Context management](docs/context-management.md) |
 | Control orchestration | [Consensus](docs/consensus.md) · [Execution routing](docs/execution-routing.md) · [Model routing](docs/model-routing.md) · [Task scheduling](docs/task-scheduling.md) · [Plan replay](docs/plan-replay.md) · [Shared memory](docs/shared-memory.md) |
 
 ## Contributing

--- a/docs/checkpoint.md
+++ b/docs/checkpoint.md
@@ -4,6 +4,10 @@ Long-running task workflows can persist their progress and resume after a crash,
 
 It covers the orchestration paths (`runTeam`, `runTasks`, `runFromPlan`, and `restore`). A single `runAgent` call has nothing to resume and is not checkpointed.
 
+Checkpoint schema v4 also carries suspended continuation state for
+[durable approval gates](durable-approvals.md). Approval decisions live in
+separate primary records in the same store; they are not telemetry.
+
 ## Enable it
 
 Pass `checkpoint` per call, or set a default for every run via `OrchestratorConfig.checkpoint`. Per-call options override the config default.
@@ -106,7 +110,7 @@ await orchestrator.restore(team,        { checkpoint: { store } })  // resume-on
 
 At each safe in-flight runner boundary and after each successfully completed task, the orchestrator writes the latest `CheckpointSnapshot`:
 
-- **Execution identity (schema v3)** — `runId`, current `attempt`,
+- **Execution identity (schema v4)** — `runId`, current `attempt`,
   `lastTraceId`, and `lastRootSpanId`. Restore preserves the logical `runId`,
   increments `attempt`, creates fresh trace/root IDs, and returns a
   `continued_from` link to the prior attempt.
@@ -125,15 +129,20 @@ At each safe in-flight runner boundary and after each successfully completed tas
   calls. Tool results are committed independently by model-issued tool-call ID,
   so a parallel turn may contain both replayable results and calls that still
   need execution.
+- **Approval continuation state** — exact pending approval requests plus the
+  decisions already consumed by this logical run. The authoritative request /
+  decision row is stored separately under `__oma_approval__/<requestId>` and is
+  checked against the checkpoint during restore.
 - **Task handoff/provenance config** — `dependencyPayload`, logical `role`, and
   validated task `metadata` remain on the queue snapshot, so resumed consumers
   use the same data-flow and trace references as the original run.
 
-Snapshots are stored as JSON under a reserved namespace: `__oma_checkpoint__/<runId>/latest` (or `__oma_checkpoint__/latest` when no `runId` is set). Keys under `__oma_checkpoint__/` are reserved — shared-memory snapshot/restore deliberately skips them so one store can hold both agent memory and checkpoints.
+Snapshots are stored as JSON under a reserved namespace: `__oma_checkpoint__/<runId>/latest` (or `__oma_checkpoint__/latest` when no `runId` is set). Keys under `__oma_checkpoint__/` and `__oma_approval__/` are reserved — shared-memory snapshot/restore deliberately skips them so one store can hold agent memory, checkpoints, and primary approval records.
 
-New writes use checkpoint schema v3. Schema v1 and v2 remain readable; because
-they contain no in-flight runner state, their active tasks resume from the task
-boundary. A v1 checkpoint's optional top-level `runId` is preserved, and
+New writes use checkpoint schema v4. Schemas v1, v2, and v3 remain readable;
+v1 and v2 contain no in-flight runner state, so their active tasks resume from
+the task boundary. Schema v3 retains mid-task tool recovery but has no durable
+approval continuation. A v1 checkpoint's optional top-level `runId` is preserved, and
 restore treats the saved execution as attempt 1. A v1 checkpoint without
 `runId` receives a new logical run ID. If a caller-supplied restore `runId`
 conflicts with the snapshot, restore throws a validation error instead of
@@ -141,7 +150,11 @@ joining unrelated runs.
 
 ### Saves are best-effort
 
-A checkpoint write must never take down the run it protects. If the store rejects (a transient Redis/SQLite error), the failure is surfaced via `onProgress` and the run continues; the next safe runner boundary or completed task retries the write.
+An ordinary checkpoint write must never take down the run it protects. If the store rejects (a transient Redis/SQLite error), the failure is surfaced via `onProgress` and the run continues; the next safe runner boundary or completed task retries the write.
+
+Suspension is the exception: OMA cannot return a resumable approval request
+until the exact pending boundary has been saved. That save is strict and fails
+closed. See [durable approvals](durable-approvals.md#rejection-and-recovery-semantics).
 
 ```typescript
 const orchestrator = new OpenMultiAgent({
@@ -180,6 +193,12 @@ await orchestrator.runTasks(team, tasks, {
 Wrap **every durable store you persist to**: in a split setup — wrapped shared store, separate *unwrapped* checkpoint store — the checkpoint's `completedTaskResults` (sourced from the queue, not the store) would still be raw. Add custom value patterns (e.g. PII) via `new RedactingStore(store, { patterns: [/…/] })`.
 
 Redaction is opt-in by construction and lossy on purpose: a **resumed** run sees `[redacted]` in place of the masked values. Don't enable it if a downstream agent legitimately needs a persisted secret on resume.
+
+The same lossiness makes `RedactingStore` unsuitable for durable approvals,
+whose hash must bind verbatim reviewed content. It deliberately does not expose
+`compareAndSet`, so a suspend decision fails closed before OMA reports a pending
+request. Use a protected, non-redacting checkpoint/approval store for those
+runs.
 
 ## Mid-task tool recovery
 
@@ -252,6 +271,9 @@ Per-run snapshot/restore over `MemoryStore`. What it does *not* yet do:
 - **External agent backends remain task-grained.** Process and ACP backends own
   their own loops, so OMA cannot persist their private mid-task conversation or
   tool state.
+- **Suspendable tool gates require the built-in LLM runner.** Standalone agents,
+  the simple-goal short circuit, and external backends fail closed on a tool
+  `suspend` decision because they have no resumable private tool-loop state.
 - **Only runner tool results have per-call commit records.** Application hooks,
   custom context-strategy callbacks, and an LLM request interrupted before a
   response may run again from the last safe boundary.

--- a/docs/durable-approvals.md
+++ b/docs/durable-approvals.md
@@ -1,0 +1,191 @@
+# Durable approval gates
+
+OMA can stop a checkpointed task run at an approval boundary, return a durable
+request to the application, and continue from the same reviewed content after a
+process restart. Existing synchronous decisions are unchanged: `true` and
+`{ action: 'allow' }` continue, while `false` and `{ action: 'deny' }` reject.
+Return `{ action: 'suspend' }` only when the decision must happen outside the
+current callback lifetime.
+
+Durable approval is an execution-state feature, not a telemetry feature. The
+checkpoint owns the suspended continuation. A separate primary approval row in
+the same `MemoryStore` owns the immutable request and first-wins decision.
+Traces and execution receipts may derive approval facts, but losing telemetry
+does not lose or change a decision.
+
+## Supported boundaries
+
+| Gate | Reviewed content | Resume behavior |
+|---|---|---|
+| `onPlanReady` | The checkpoint-resumable coordinator task snapshots and whether the caller requested execution or `planOnly` | Runs exactly those snapshots, or returns them for `planOnly` |
+| `onApproval` | The completed tasks and next pending tasks at a legacy round barrier | Starts the reviewed next round without calling the gate again for that boundary |
+| `onTaskDispatch` | One fully assigned task snapshot immediately before dispatch | Dispatches that exact task without calling the gate again for that boundary |
+| `onToolCall` | Tool name, model-issued input, Zod-validated input, agent, task, tool-call ID, and `consequential` flag | Applies the durable decision instead of re-running the gate; approval executes the validated invocation, rejection returns a denied `ToolResult` without calling the tool |
+
+Plan, round, and dispatch gates accept `ApprovalGateDecision`. Tool gates accept
+`ToolCallDecision`; both include the same `allow`, `deny`, and `suspend` object
+forms. The boolean forms remain supported on the three existing orchestration
+gates for backward compatibility.
+
+## Suspend, decide, and restore
+
+Suspension requires checkpoint configuration and a checkpoint `MemoryStore`
+that implements atomic `compareAndSet`. The store must remain available to the
+reviewer and the resumed process.
+
+```typescript
+import {
+  decideApproval,
+  FileStore,
+  OpenMultiAgent,
+} from '@open-multi-agent/core'
+
+const store = new FileStore('./.oma/release-run.json')
+const orchestrator = new OpenMultiAgent({
+  onTaskDispatch: async (task) => {
+    if (task.priority === 'critical') {
+      return { action: 'suspend', reason: 'Critical release review' }
+    }
+    return true
+  },
+})
+
+const suspended = await orchestrator.runTasks(team, tasks, {
+  checkpoint: { store },
+})
+
+if (suspended.status?.code === 'suspended') {
+  for (const request of suspended.pendingApprovals ?? []) {
+    // Present request.content and request.requestHash to the reviewer.
+    await decideApproval(store, {
+      requestId: request.id,
+      requestHash: request.requestHash,
+      decision: 'approve', // or 'reject'
+      reviewer: { id: currentUser.id, displayName: currentUser.name },
+    })
+  }
+}
+
+// A fresh process rebuilds the same team/backend wiring and uses the same store.
+const result = await new OpenMultiAgent({
+  onTaskDispatch: applicationDispatchPolicy,
+}).restore(resumedTeam, { checkpoint: { store } })
+```
+
+A suspended result has `success: false`, `status.code === 'suspended'`, and one
+or more `pendingApprovals`. Do not call `restore()` to force progress while a
+request is undecided: it returns `suspended` again and performs no reviewed
+work.
+
+The public reviewer helpers are:
+
+- `getApprovalRecord(store, requestId)` — read the primary request and any
+  decision;
+- `decideApproval(store, input)` — atomically approve or reject an exact
+  `requestHash`;
+- `DurableApprovalLedger` — the lower-level equivalent for applications that
+  want a long-lived ledger object.
+
+`decideApproval` records the reviewer's required `id`, optional `displayName`,
+the normalized decision, and the decision-writer's current time. Decisions are
+immutable: the first successful compare-and-set wins; concurrent or repeated
+decisions fail with `APPROVAL_CONFLICT`.
+
+## Exact-content binding
+
+Every request has a deterministic ID and a SHA-256 `requestHash`. The hash is
+computed over canonical JSON containing the approval scope, boundary, and
+review content. Object-key ordering cannot change it. The explanatory `reason`
+and `requestedAt` are metadata and are not part of the reviewed-content hash.
+
+The binding covers the serialized `request.content`, not live application
+wiring. Agent adapters, prompts, tool implementations, schemas, and callbacks
+must be rebuilt by the application and remain inside its deployment trust
+boundary. Task-level suspension fails closed when a pending task has `verify`
+configuration because that object can contain live judges, schemas, and prompt
+callbacks that the current checkpoint schema cannot reconstruct.
+
+The reviewer must submit both `requestId` and the hash it inspected. A changed
+hash fails with `APPROVAL_STALE_DECISION`. During restore, OMA independently
+compares the request with the checkpointed plan, task state, or pending tool
+call. It also compares checkpointed decision history with the primary ledger.
+A mismatch fails before the approved task or tool can execute.
+
+For tool calls, restore validates the raw input again with the current Zod
+schema and compares the resulting validated value with the reviewed content.
+This prevents a changed input or changed validation result from inheriting an
+old approval. The reviewed content must be JSON-compatible: finite numbers,
+strings, booleans, nulls, arrays, and plain objects only.
+
+This is integrity checking across OMA's independent records, not a
+cryptographic signature against the storage administrator. A principal that
+can rewrite both the checkpoint and primary ledger remains inside the trust
+boundary. Protect and audit the store accordingly.
+
+## Rejection and recovery semantics
+
+- Rejecting a plan, round, or task dispatch produces a top-level `rejected`
+  result and skips remaining work. The terminal rejection survives repeated
+  restores.
+- Rejecting a tool call produces the same kind of error `ToolResult` as an
+  inline gate denial. The tool is not invoked; the model may adapt on its next
+  turn.
+- Approving a tool call executes it once, then the mid-task checkpoint records
+  its returned result before the model continues. The ordinary
+  [external-side-effect idempotency window](checkpoint.md#mid-task-tool-recovery)
+  still applies if a process dies after an external system commits but before
+  the tool returns.
+- An ordinary checkpoint write remains best-effort. The write that makes a
+  pending approval resumable is strict: OMA does not report suspension unless
+  the exact continuation was saved and the primary request was created.
+- A missing checkpoint, missing CAS capability, malformed record, or stale
+  content fails closed. The protected task or tool is not executed.
+
+`approvalDecisions` on the final result contains decisions consumed by the
+logical run. `buildExecutionReceipt()` copies a bounded approval summary from
+that result. The receipt is derived evidence; the primary row under
+`__oma_approval__/<requestId>` remains authoritative.
+
+## Store requirements
+
+`InMemoryStore` provides process-local CAS and is useful for tests. `FileStore`
+provides CAS for concurrent callers sharing one `FileStore` instance. It is
+still a single-writer file store with no cross-process lock: an out-of-process
+reviewer should decide after the suspended writer exits, or use a database
+store whose `compareAndSet` is atomic across all writers.
+
+Approval requests can contain complete task descriptions and raw/validated
+tool arguments. They are persisted verbatim so the approved operation remains
+exact. Use access controls and encryption appropriate for that data.
+`RedactingStore` is intentionally unsupported for durable approvals because it
+is lossy and would change the content hash; it remains available for ordinary
+checkpoint and shared-memory redaction.
+
+## Explicit limits
+
+- Tool-call suspension is supported only inside checkpointed built-in LLM
+  workers reached through `runTeam`, `runTasks`, or `runFromPlan`. Standalone
+  `runAgent`, the automatic `runTeam` simple-goal short circuit, process
+  backends, and ACP backends do not expose resumable private tool-loop state; a
+  `suspend` tool decision fails closed there. Orchestration-level plan, round,
+  and dispatch gates still apply around eligible external-backend tasks.
+- An approval binds the serialized request data, not deployed code or live
+  agent configuration. Changing an adapter, prompt, tool implementation, or
+  schema is an application deployment boundary. Pin a deployment while a run
+  is suspended, or include an application-owned version in reviewed task/tool
+  data when that distinction matters.
+- A task with `verify` may still use existing inline boolean approval, but its
+  plan/round/dispatch gate cannot return `suspend`. Model verification as an
+  explicit task when it must be part of a durable approval boundary.
+- Adaptive recovery's `onPlanPatch` callback is not suspendable in this
+  contract. It remains an inline boolean decision.
+- There is no built-in expiry, reassignment, revocation, quorum, or replacement
+  of a recorded decision. Applications can decline to resume and start a new
+  logical run when policy requires a new request.
+- Checkpoints remain latest-snapshot state. Append-only event sourcing and
+  transition replay are separate work tracked in
+  [#313](https://github.com/open-multi-agent/open-multi-agent/issues/313).
+
+See the no-key runnable
+[`durable-approval`](../packages/core/examples/patterns/durable-approval.ts)
+example for the complete suspend/decide/fresh-orchestrator flow.

--- a/docs/observability-release-readiness.md
+++ b/docs/observability-release-readiness.md
@@ -29,7 +29,7 @@ Baseline: `6339ee50515e149eb1fb5a073f44024d3ab821a3`, including PR #384.
 | `@open-multi-agent/otel` | separate package root | `packages/otel/src` | official in-memory exporter suites |
 | `forceFlush` / `shutdown` | `TraceSink`; OTel sink | batching/composite/legacy/OTel implementations | concurrency, timeout, reentry suites |
 | diagnostics / stats | sink and file-store types | `sink.ts`, `file-store.ts` | payload-free diagnostic and counter tests |
-| checkpoint/restore identity | top-level run results and checkpoint v3 | `memory/checkpoint.ts`, `identity.ts`, orchestrator | v1/v2 read, v3 continuation, runId-conflict tests |
+| checkpoint/restore identity | top-level run results and checkpoint v4 | `memory/checkpoint.ts`, `identity.ts`, orchestrator | v1/v2/v3 read, v4 continuation, runId-conflict tests |
 
 The public contract is the exported type plus the implementation and its tests.
 The private design RFC is historical rationale, not a substitute for current
@@ -171,7 +171,8 @@ does not claim it is browser-safe or attempt an unrelated root-export redesign.
   derives from `status.code === 'ok'`.
 - Identity-aware checkpoint schemas preserve logical identity across restore,
   increment the attempt, start a new trace, and link to the prior root. Schema
-  v1 and v2 remain readable; current v3 writes also carry in-flight runner state.
+  v1, v2, and v3 remain readable; current v4 writes also carry in-flight runner
+  and durable-approval continuation state.
 - TraceRecord schema v2 adds start/event/end records, W3C-compatible IDs,
   structured errors, and DAG/delegation/synthesis/restore links.
 - `TraceSink`, `TraceExporter`, and `BatchingTraceSink` add bounded queueing,

--- a/docs/tool-configuration.md
+++ b/docs/tool-configuration.md
@@ -199,8 +199,10 @@ const orchestrator = new OpenMultiAgent({
 ```
 
 The guard composes with the existing per-call `onToolCall` gateway, after input
-validation and before `execute`. An `allow` continues; a `deny` does not call
-the tool and returns a rejected run outcome. For a dynamically planned
+validation and before `execute`. An `allow` continues; a `deny` returns an error
+`ToolResult` without calling the tool. Inside a checkpointed task, `suspend` can persist the exact invocation
+for an out-of-process decision and later `restore()`; see
+[durable approvals](durable-approvals.md). For a dynamically planned
 `runTeam()`, an approved `onPlanReady` callback can supply the approval when no
 per-call gate is configured. If neither approval path exists, the tool is not
 executed and the result returns `confirmationRequired: true` with
@@ -346,7 +348,8 @@ const orchestrator = new OpenMultiAgent({
 Key semantics:
 
 - **`deny` returns a structured error `ToolResult`; it never throws.** The model sees the `reason` as a normal tool error and can adapt (try a safer command, ask the user, stop) rather than crashing the run. A gate that throws or returns an invalid decision is turned into an error result too (fail closed).
-- **Human-in-the-loop lives inside your callback.** `await` your own CLI prompt, Slack button, or web dialog, then return `allow` or `deny`. The framework prescribes no review channel, keeping the surface small.
+- **`suspend` is durable and returns control.** In a checkpointed built-in LLM task, `{ action: 'suspend' }` saves the exact invocation and returns a top-level `suspended` result. Record a decision with `decideApproval()`, then call `restore()`. Without a resumable checkpoint and atomic store, the call fails closed and the tool does not run. See [durable approvals](durable-approvals.md).
+- **Inline human-in-the-loop still works.** `await` your own CLI prompt, Slack button, or web dialog, then return `allow` or `deny` in the same callback lifetime. The framework prescribes no review channel.
 - **Agent overrides orchestrator.** `AgentConfig.onToolCall` beats `OrchestratorConfig.onToolCall` for that agent, so a team can set a default policy while one specialist tightens or relaxes it. A standalone `new Agent({ ..., onToolCall })` wires the gate straight into its executor.
 - **Runs after the name-based grant.** Default-deny / allowlist / denylist resolution runs **first**; a tool that is not granted is refused before the gate is reached, so the gate only ever sees calls to already-reachable tools. Custom tools and MCP tools route through the same executor, so they are gated too.
 - **The model-issued call ID is stable across recovery.** `toolCallId` identifies
@@ -354,7 +357,7 @@ Key semantics:
   restore, it keeps the same ID; a committed result is replayed without running
   the gate or tool again. See [checkpoint recovery](checkpoint.md#mid-task-tool-recovery).
 - **Orthogonal to task dispatch approval.** `OrchestratorConfig.onApproval` gates legacy task rounds and `onTaskDispatch` gates one ready task before dispatch; `onToolCall` gates a single tool invocation during execution. They operate at different layers and compose. The two task-level approval modes are mutually exclusive with each other.
-- **Observability.** When a gate runs, the `tool_call` trace event carries `gated: true`, `gateAction: 'allow' | 'deny'`, and (on deny) a `gateReason` that is redacted like other sensitive trace text, so `onTrace` consumers can audit every decision.
+- **Observability.** When a gate runs, the `tool_call` trace event carries `gated: true`, `gateAction: 'allow' | 'deny' | 'suspend'`, and an optional redacted `gateReason`. Durable decisions come from the approval ledger and may be summarized in an execution receipt; telemetry is not their source of truth.
 
 > **Not a security boundary.** A gate that returns `deny` still relies on cooperating code; it is a coordination layer, not containment. `bash` remains un-sandboxed (see the callout below). For an actually-untrusted shell, use process-level isolation (a container / VM / seccomp); the gate is for *policy*, not *isolation*.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -192,7 +192,7 @@ are covered in
 | **Dynamic orchestration** | Runtime goal decomposition, dependency-aware scheduling, parallel branches, configurable assignment, task-scoped results and handoffs, opt-in team context for workers (`revealCoordinator`), and final synthesis. |
 | **Models and reasoning** | Mix built-in, OpenAI-compatible, AI SDK, or local models; map one `thinking` config to each provider's reasoning setting, route phases separately, and preserve reasoning only when explicitly enabled. |
 | **Tools and handoffs** | Built-in tools are default-deny; custom tools, MCP, and guarded `delegate_to_agent` handoffs are opt-in, and consequential tools on undeclared runs are flagged for confirmation. |
-| **Controlled outputs** | Stream per agent, validate results with Zod, approve plans, legacy task rounds (`onApproval`), or individual dispatches (`onTaskDispatch`), rewrite prompts or post-process results with `beforeRun` / `afterRun`, and cancel with `AbortSignal`. |
+| **Controlled outputs** | Stream per agent, validate results with Zod, approve or durably suspend plans, task rounds, dispatches, and tool calls, rewrite prompts or post-process results with `beforeRun` / `afterRun`, and cancel with `AbortSignal`. |
 | **Evaluation** | Version EvalSets, run reference scorers, gate CI with offline reports, persist results, or sample production runs on a best-effort path. |
 | **Memory and recovery** | Shared memory is pluggable; checkpoints resume interrupted runs without repeating completed tasks. |
 | **Observability** | Stable run identity, traces, execution receipts, redaction, TraceStore, and the offline DAG/Waterfall Viewer are available without a hosted service. |
@@ -227,6 +227,7 @@ Start with one example that matches the behavior you need:
 | Validate structured output | [`patterns/structured-output`](examples/patterns/structured-output.ts) |
 | Delegate between agents | [`patterns/agent-handoff`](examples/patterns/agent-handoff.ts) |
 | Replay a frozen plan | [`patterns/plan-replay`](examples/patterns/plan-replay.ts) |
+| Suspend and resume an approval | [`patterns/durable-approval`](examples/patterns/durable-approval.ts) |
 | Embed OMA in a backend | [`integrations/express-customer-support`](examples/integrations/express-customer-support/) |
 | Export an offline trace viewer | [`integrations/observability-v2/run-viewer`](examples/integrations/observability-v2/run-viewer.ts) |
 
@@ -255,7 +256,7 @@ See [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/d
 | Control spend | `maxTokenBudget`; `maxCostBudget` + application-owned `estimateCost` |
 | Limit tools | `tools` / `toolPreset`, `cwd` / `defaultCwd`, tool-output caps |
 | Recover | Task retries, checkpointing, `restore()`, and opt-in adaptive plan repair |
-| Review work | `planOnly`, `onPlanReady`, and approval callbacks |
+| Review work | `planOnly`, inline approval callbacks, or [durable approval gates](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/durable-approvals.md) |
 | Observe | Trace sinks, TraceStore, execution receipts, Run Viewer, or the optional OTel adapter |
 
 Budget checks run at turn and task boundaries, so a run can overshoot by up to one model turn; they are not a cent-exact stop. `estimateCost` receives each call's token usage plus the agent, effective `model`, `provider`, phase, and `taskId`, and your application owns the price table.
@@ -275,7 +276,7 @@ See the [observability guide](https://github.com/open-multi-agent/open-multi-age
 | Area | Guides |
 |---|---|
 | Build agents | [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md), [tools](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md), [context](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/context-management.md) |
-| Run reliably | [Evaluation](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/evaluation.md), [checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md), [adaptive recovery](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/adaptive-recovery.md), [execution routing](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/execution-routing.md), [model routing](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/model-routing.md), [consensus](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/consensus.md) |
+| Run reliably | [Evaluation](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/evaluation.md), [checkpoint & resume](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/checkpoint.md), [durable approvals](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/durable-approvals.md), [adaptive recovery](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/adaptive-recovery.md), [execution routing](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/execution-routing.md), [model routing](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/model-routing.md), [consensus](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/consensus.md) |
 | Control workflows | [Plan preview & replay](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/plan-replay.md), [shared memory](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/shared-memory.md), [external agents](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/external-agents.md) |
 | Operate | [Observability](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/observability.md), [CLI](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/cli.md), [production examples](examples/production/README.md) |
 

--- a/packages/core/examples/README.md
+++ b/packages/core/examples/README.md
@@ -65,6 +65,7 @@ Reusable shapes for common multi-agent problems.
 | [`patterns/cost-tiered-pipeline`](patterns/cost-tiered-pipeline.ts) | Run the same four-stage pipeline twice to compare flagship vs tiered model cost. |
 | [`patterns/agent-handoff`](patterns/agent-handoff.ts) | Synchronous sub-agent delegation via `delegate_to_agent`. |
 | [`patterns/risk-gated-bash`](patterns/risk-gated-bash.ts) | Per-call `onToolCall` gate + `classifyBashCommand`: auto-pass read-only bash, human-review ambiguous, block destructive. |
+| [`patterns/durable-approval`](patterns/durable-approval.ts) | No-key suspend → atomic reviewer decision → fresh-orchestrator restore of the exact approved task. |
 | [`patterns/plan-replay`](patterns/plan-replay.ts) | Pin a coordinator plan with `createPlanArtifact`, then replay it with `runFromPlan`, no coordinator re-run. |
 | [`patterns/consensus`](patterns/consensus.ts) | Proposer→judge refutation loop via `runConsensus()`: default judge prompt and per-judge `judgePrompt` function. |
 | [`patterns/cross-provider-reasoning`](patterns/cross-provider-reasoning.ts) | Preserve a reasoning model's thought stream across providers via `preserveReasoningAsText`. |

--- a/packages/core/examples/catalog.json
+++ b/packages/core/examples/catalog.json
@@ -284,6 +284,17 @@
       "featuredOrder": 3
     },
     {
+      "id": "durable-approval",
+      "path": "patterns/durable-approval.ts",
+      "title": "Durable Approval",
+      "description": "Suspend a task dispatch, record one atomic reviewer decision, and restore the exact approved task with a fresh orchestrator.",
+      "section": "goal",
+      "goal": "production-controls",
+      "capabilities": ["run-tasks"],
+      "format": "script",
+      "level": "advanced"
+    },
+    {
       "id": "plan-replay",
       "path": "patterns/plan-replay.ts",
       "title": "Plan Replay",

--- a/packages/core/examples/patterns/durable-approval.ts
+++ b/packages/core/examples/patterns/durable-approval.ts
@@ -1,0 +1,104 @@
+/**
+ * Durable Approval: Suspend, Decide, Restore
+ *
+ * Demonstrates a task-dispatch gate that returns `suspend`, an atomic reviewer
+ * decision, and a fresh orchestrator that resumes the exact approved task. The
+ * in-memory store keeps this example no-key and deterministic; replace it with
+ * FileStore or a database MemoryStore to survive a real process restart.
+ *
+ * Run:
+ *   npx tsx packages/core/examples/patterns/durable-approval.ts
+ *
+ * Prerequisites:
+ *   None. This example makes no model or network request.
+ */
+
+import {
+  decideApproval,
+  InMemoryStore,
+  OpenMultiAgent,
+} from '../../src/index.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMChatOptions,
+  LLMResponse,
+} from '../../src/types.js'
+
+function adapter(output: string): LLMAdapter {
+  return {
+    name: 'durable-approval-example',
+    async chat(_messages, options: LLMChatOptions): Promise<LLMResponse> {
+      return {
+        id: 'approved-task-result',
+        content: [{ type: 'text', text: output }],
+        model: options.model,
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 1, output_tokens: 1 },
+      }
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: {} }
+    },
+  }
+}
+
+function releaseAgent(output: string): AgentConfig {
+  return {
+    name: 'release-operator',
+    model: 'local-demo',
+    adapter: adapter(output),
+  }
+}
+
+const store = new InMemoryStore()
+const first = new OpenMultiAgent({
+  onTaskDispatch: async () => ({
+    action: 'suspend',
+    reason: 'Production release requires a named reviewer.',
+  }),
+})
+const firstTeam = first.createTeam('durable-approval', {
+  name: 'durable-approval',
+  agents: [releaseAgent('This must not run before approval.')],
+  sharedMemory: false,
+})
+
+const suspended = await first.runTasks(firstTeam, [{
+  title: 'Release build 42',
+  description: 'Release the already-tested build to production.',
+  assignee: 'release-operator',
+  priority: 'critical',
+}], { checkpoint: { store } })
+
+if (suspended.status?.code !== 'suspended' || suspended.pendingApprovals?.length !== 1) {
+  throw new Error('Expected one durable approval request.')
+}
+
+const request = suspended.pendingApprovals[0]!
+console.log(`Suspended: ${request.scope} ${request.id}`)
+console.log(`Reviewed task: ${request.content.kind === 'task_dispatch' ? request.content.task.title : 'unexpected'}`)
+
+await decideApproval(store, {
+  requestId: request.id,
+  requestHash: request.requestHash,
+  decision: 'approve',
+  reviewer: { id: 'release-manager-7', displayName: 'Release Manager' },
+})
+
+// Rebuild live dependencies as a restarted process would. This callback would
+// reject a new boundary; the exact approved boundary bypasses it once.
+const resumed = new OpenMultiAgent({ onTaskDispatch: async () => false })
+const resumedTeam = resumed.createTeam('durable-approval', {
+  name: 'durable-approval',
+  agents: [releaseAgent('Build 42 released.')],
+  sharedMemory: false,
+})
+const result = await resumed.restore(resumedTeam, { checkpoint: { store } })
+
+if (!result.success || result.tasks?.[0]?.status !== 'completed') {
+  throw new Error(`Restore failed: ${result.status?.code ?? 'unknown'}`)
+}
+
+console.log(`Resumed: ${result.agentResults.get('release-operator')?.output ?? 'missing output'}`)
+console.log(`Reviewer: ${result.approvalDecisions?.[0]?.reviewer.id ?? 'missing'}`)

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -54,6 +54,7 @@ import { emitTrace, generateSpanId } from '../utils/trace.js'
 import { mergeAbortSignals } from '../utils/abort.js'
 import { createRunIdentity } from '../observability/identity.js'
 import { classifyRunFailure, statusOnly } from '../observability/status.js'
+import { DurableApprovalError } from '../approval/durable.js'
 import { createTraceRuntime } from '../observability/runtime.js'
 import { TokenBudgetExceededError } from '../errors.js'
 import type { ToolDefinition as FrameworkToolDefinition, ToolRegistry } from '../tool/framework.js'
@@ -459,6 +460,19 @@ export class Agent {
       const result = await backend.run(messages, runOptions)
       this.state.tokenUsage = addUsage(this.state.tokenUsage, result.tokenUsage)
 
+      if (result.suspended) {
+        const suspendedResult = this.toAgentRunResult(
+          result,
+          false,
+          undefined,
+          identity,
+          statusOnly('suspended', 'Durable approval required before execution can continue.'),
+        )
+        this.transitionTo('completed')
+        this.emitAgentTrace(runOptions, agentStartMs, suspendedResult)
+        return suspendedResult
+      }
+
       if (result.budgetExceeded) {
         const budgetError = new TokenBudgetExceededError(
           this.name,
@@ -550,6 +564,8 @@ export class Agent {
         ? classifyRunFailure(error, { kind: 'timeout', statusCode: 'timeout' })
         : callerAbort?.aborted
           ? classifyRunFailure(error, { kind: 'cancellation', statusCode: 'cancelled' })
+          : error instanceof DurableApprovalError
+            ? classifyRunFailure(error, { kind: 'validation' })
           : classifyRunFailure(error, {
               ...(failureKind !== undefined ? { kind: failureKind } : {}),
               provider: this.config.provider,
@@ -788,15 +804,17 @@ export class Agent {
 
           const status = result.budgetExceeded
             ? statusOnly('budget_exhausted')
+            : result.suspended
+              ? statusOnly('suspended', 'Durable approval required before execution can continue.')
             : timeoutSignal?.aborted
               ? statusOnly('timeout')
               : callerAbort?.aborted && result.aborted
                 ? statusOnly('cancelled')
                 : statusOnly('ok')
           let agentResult = this.toAgentRunResult(
-            result, !result.budgetExceeded, undefined, identity, status,
+            result, !result.budgetExceeded && !result.suspended, undefined, identity, status,
           )
-          if (this.config.afterRun) {
+          if (this.config.afterRun && !result.suspended) {
             failureKind = 'callback'
             agentResult = await this.config.afterRun(agentResult)
             failureKind = undefined
@@ -814,7 +832,9 @@ export class Agent {
           // Backend stream errors originate from the configured provider. Keep
           // the source classification on the event so task retry can make an
           // explicit failover decision without reclassifying a raw Error.
-          const classified = classifyRunFailure(error, { provider: this.config.provider })
+          const classified = error instanceof DurableApprovalError
+            ? classifyRunFailure(error, { kind: 'validation' })
+            : classifyRunFailure(error, { provider: this.config.provider })
           this.transitionToError(error)
           this.emitAgentTrace(runOptions, agentStartMs, {
             success: false,
@@ -842,6 +862,8 @@ export class Agent {
         ? classifyRunFailure(error, { kind: 'timeout', statusCode: 'timeout' })
         : callerAbort?.aborted
           ? classifyRunFailure(error, { kind: 'cancellation', statusCode: 'cancelled' })
+          : error instanceof DurableApprovalError
+            ? classifyRunFailure(error, { kind: 'validation' })
           : classifyRunFailure(error, {
               ...(failureKind !== undefined ? { kind: failureKind } : {}),
               provider: this.config.provider,
@@ -944,6 +966,7 @@ export class Agent {
       structured,
       ...(result.loopDetected ? { loopDetected: true } : {}),
       ...(result.budgetExceeded ? { budgetExceeded: true } : {}),
+      ...(result.pendingApprovals ? { pendingApprovals: result.pendingApprovals } : {}),
     }
   }
 

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -38,6 +38,9 @@ import type {
   InFlightTaskCheckpoint,
   PendingToolCallCheckpoint,
   ToolCallCommitCheckpoint,
+  ApprovalDecisionRecord,
+  ApprovalRequest,
+  ToolCallApprovalContent,
 } from '../types.js'
 import { LLMCallTimeoutError, TokenBudgetExceededError } from '../errors.js'
 import { LoopDetector } from './loop-detector.js'
@@ -55,6 +58,7 @@ import {
   resolveGrantedToolDefinitions,
   TOOL_PRESETS,
 } from '../tool/grants.js'
+import { createApprovalRequest, DurableApprovalError } from '../approval/durable.js'
 
 // ---------------------------------------------------------------------------
 // Tool presets
@@ -199,6 +203,12 @@ export interface RunOptions {
    * recoverable message/tool boundary; failures must be isolated by the caller.
    */
   readonly onCheckpoint?: (state: InFlightTaskCheckpoint) => void | Promise<void>
+  /** Internal primary-ledger write after the pending runner state is durable. */
+  readonly onApprovalRequest?: (request: ApprovalRequest) => void | Promise<void>
+  /** Internal fail-fast check run before a pending approval enters the checkpoint. */
+  readonly onApprovalPrepare?: () => void | Promise<void>
+  /** Internal notification used to remove a reviewed request after commit. */
+  readonly onApprovalConsumed?: (requestId: string) => void | Promise<void>
   /**
    * Fired when the runner detects a potential configuration issue.
    * For example, when a model appears to ignore tool definitions.
@@ -248,6 +258,10 @@ export interface RunResult {
   readonly budgetExceeded?: boolean
   /** True when the runner stopped before its next LLM call because the signal was aborted. */
   readonly aborted?: boolean
+  /** True when one or more tool invocations await durable approval. */
+  readonly suspended?: boolean
+  /** Exact requests that stopped this runner before tool execution. */
+  readonly pendingApprovals?: readonly ApprovalRequest[]
 }
 
 /**
@@ -417,6 +431,13 @@ interface ToolExecution {
   readonly result?: ToolResult
   /** False only when cancellation interrupted the call before a durable result. */
   readonly shouldCommit: boolean
+  /** Present only when the gate requested a durable suspension. */
+  readonly suspension?: {
+    readonly content: ToolCallApprovalContent
+    readonly reason?: string
+  }
+  /** Filled after the pending runner state and primary record are durable. */
+  readonly approvalRequest?: ApprovalRequest
 }
 
 // ---------------------------------------------------------------------------
@@ -859,6 +880,7 @@ export class AgentRunner implements AgentBackend {
     let turns = restored?.turns ?? 0
     let budgetExceeded = restored?.budgetExceeded ?? false
     let aborted = false
+    let suspended = false
     let loopDetected = restored?.loopDetected ?? false
     let phase: InFlightTaskCheckpoint['phase'] = restored?.phase ?? 'awaiting_model'
     let pendingToolCalls: PendingToolCallCheckpoint[] = restored?.pendingToolCalls
@@ -879,7 +901,7 @@ export class AgentRunner implements AgentBackend {
     // Per-call abortSignal takes precedence over the static one.
     const effectiveAbortSignal = options.abortSignal ?? this.options.abortSignal
 
-    const persistCheckpoint = async (): Promise<void> => {
+    const persistCheckpoint = async (strict = false): Promise<void> => {
       if (!options.onCheckpoint || !options.taskId) return
       const assignee = options.traceAgent ?? this.options.agentName
       if (!assignee) return
@@ -905,7 +927,8 @@ export class AgentRunner implements AgentBackend {
       }
       try {
         await options.onCheckpoint(state)
-      } catch {
+      } catch (error) {
+        if (strict) throw error
         // Checkpoint delivery is best-effort and must never fail the agent run.
       }
     }
@@ -962,14 +985,56 @@ export class AgentRunner implements AgentBackend {
               return { commit: pending.commit, shouldCommit: true } satisfies ToolExecution
             }
 
+            if (pending.approvalRequest && !pending.approvalDecision) {
+              return {
+                commit: this.suspendedToolCommit(pending.call),
+                shouldCommit: false,
+                approvalRequest: pending.approvalRequest,
+                suspension: {
+                  content: pending.approvalRequest.content as ToolCallApprovalContent,
+                  ...(pending.approvalRequest.reason !== undefined
+                    ? { reason: pending.approvalRequest.reason }
+                    : {}),
+                },
+              } satisfies ToolExecution
+            }
+
             const execution = await this.executeToolCall(
               pending.call,
               grantedToolNames,
               toolContext,
               options,
+              pending.approvalRequest && pending.approvalDecision
+                ? {
+                    request: pending.approvalRequest,
+                    decision: pending.approvalDecision,
+                  }
+                : undefined,
             )
+            if (execution.suspension) {
+              const request = createApprovalRequest({
+                runId: options.runId!,
+                scope: 'tool_call',
+                boundary: `${options.taskId!}:${pending.call.id}`,
+                content: execution.suspension.content,
+                ...(execution.suspension.reason !== undefined
+                  ? { reason: execution.suspension.reason }
+                  : {}),
+              })
+              await options.onApprovalPrepare!()
+              pendingToolCalls[index] = { ...pending, approvalRequest: request }
+              // A suspension is not reported until its exact in-flight state
+              // is durable. Unlike ordinary recovery snapshots, failure here
+              // must fail closed rather than pretending the run can resume.
+              await persistCheckpoint(true)
+              await options.onApprovalRequest!(request)
+              return { ...execution, shouldCommit: false, approvalRequest: request }
+            }
             if (execution.shouldCommit) {
-              pendingToolCalls[index] = { ...pending, commit: execution.commit }
+              if (pending.approvalRequest) {
+                await options.onApprovalConsumed?.(pending.approvalRequest.id)
+              }
+              pendingToolCalls[index] = { call: pending.call, commit: execution.commit }
               // Await the checkpoint before any fallible result callback so a
               // callback failure cannot turn a returned side effect into a
               // missing commit that restore would execute again.
@@ -980,6 +1045,16 @@ export class AgentRunner implements AgentBackend {
             }
             return execution
           }))
+
+          const suspendedExecutions = executions.filter(
+            (execution): execution is ToolExecution & { readonly approvalRequest: ApprovalRequest } =>
+              execution.approvalRequest !== undefined,
+          )
+          if (suspendedExecutions.length > 0) {
+            suspended = true
+            await persistCheckpoint(true)
+            break
+          }
 
           let delegationTurnUsage: TokenUsage | undefined
           for (const execution of executions) {
@@ -1257,6 +1332,14 @@ export class AgentRunner implements AgentBackend {
       ...(loopDetected ? { loopDetected: true } : {}),
       ...(budgetExceeded ? { budgetExceeded: true } : {}),
       ...(aborted ? { aborted: true } : {}),
+      ...(suspended ? { suspended: true } : {}),
+      ...(suspended
+        ? {
+            pendingApprovals: pendingToolCalls
+              .map((pending) => pending.approvalRequest)
+              .filter((request): request is ApprovalRequest => request !== undefined),
+          }
+        : {}),
     }
 
     yield { type: 'done', data: runResult } satisfies StreamEvent
@@ -1271,6 +1354,10 @@ export class AgentRunner implements AgentBackend {
     grantedToolNames: ReadonlySet<string>,
     toolContext: ToolUseContext,
     options: RunOptions,
+    durableApproval?: {
+      readonly request: ApprovalRequest
+      readonly decision: ApprovalDecisionRecord
+    },
   ): Promise<ToolExecution> {
     options.onToolCall?.(block.name, block.input)
 
@@ -1298,6 +1385,9 @@ export class AgentRunner implements AgentBackend {
           'Built-in tools are opt-in: grant it via the agent\'s "tools" allowlist or ' +
           '"toolPreset" (or set the orchestrator\'s "defaultToolPreset").',
         isError: true,
+        ...(durableApproval
+          ? { metadata: { approvalError: 'The reviewed tool is no longer granted.' } }
+          : {}),
       }
     } else {
       try {
@@ -1319,13 +1409,37 @@ export class AgentRunner implements AgentBackend {
           block.name,
           block.input,
           executionContext,
-          { onToolCall: this.options.onToolCall },
+          {
+            onToolCall: this.options.onToolCall,
+            ...(durableApproval ? { durableApproval } : {}),
+          },
         )
       } catch (err) {
         // Tool executor errors become error results — the loop continues.
         const message = err instanceof Error ? err.message : String(err)
         result = { data: message, isError: true }
       }
+    }
+
+    const approvalContent = result.metadata?.approvalRequestContent
+    const canSuspend = approvalContent !== undefined
+      && options.onCheckpoint !== undefined
+      && options.onApprovalPrepare !== undefined
+      && options.onApprovalRequest !== undefined
+      && options.taskId !== undefined
+      && options.runId !== undefined
+    if (approvalContent !== undefined && !canSuspend) {
+      const { approvalRequestContent: _approvalRequestContent, ...metadata } = result.metadata ?? {}
+      result = {
+        data:
+          `Tool "${block.name}" requested suspension, but durable tool approval requires ` +
+          'an orchestrated task with checkpoint persistence and MemoryStore.compareAndSet.',
+        isError: true,
+        metadata,
+      }
+    }
+    if (result.metadata?.approvalError) {
+      throw new DurableApprovalError('APPROVAL_STALE_DECISION', result.data)
     }
 
     const endTime = Date.now()
@@ -1396,6 +1510,34 @@ export class AgentRunner implements AgentBackend {
       // a cancellation that became visible during this call: it represents the
       // conservative "no commit record" path and must run again after restore.
       shouldCommit: !(result.isError === true && toolContext.abortSignal?.aborted === true),
+      ...(canSuspend
+        ? {
+            suspension: {
+              content: approvalContent,
+              ...(result.metadata?.toolCallGate?.reason !== undefined
+                ? { reason: result.metadata.toolCallGate.reason }
+                : {}),
+            },
+          }
+        : {}),
+    }
+  }
+
+  private suspendedToolCommit(block: ToolUseBlock): ToolCallCommitCheckpoint {
+    const output = `Tool "${block.name}" is awaiting durable approval.`
+    return {
+      result: {
+        type: 'tool_result',
+        tool_use_id: block.id,
+        content: output,
+        is_error: true,
+      },
+      record: {
+        toolName: block.name,
+        input: block.input,
+        output,
+        duration: 0,
+      },
     }
   }
 

--- a/packages/core/src/approval/durable.ts
+++ b/packages/core/src/approval/durable.ts
@@ -1,0 +1,578 @@
+/**
+ * @fileoverview Content-bound durable approval requests and atomic decisions.
+ *
+ * Approval rows are primary execution facts stored beside (not inside
+ * telemetry or receipts) the checkpoint that owns the pending continuation.
+ */
+
+import { createHash } from 'node:crypto'
+import type {
+  ApprovalDecisionInput,
+  ApprovalDecisionRecord,
+  ApprovalRecord,
+  ApprovalRequest,
+  ApprovalRequestContent,
+  ApprovalReviewer,
+  ApprovalScope,
+  MemoryStore,
+  Task,
+} from '../types.js'
+
+export const APPROVAL_KEY_PREFIX = '__oma_approval__/'
+
+export type DurableApprovalErrorCode =
+  | 'APPROVAL_ATOMIC_STORE_REQUIRED'
+  | 'APPROVAL_CONFLICT'
+  | 'APPROVAL_INTEGRITY_ERROR'
+  | 'APPROVAL_NOT_FOUND'
+  | 'APPROVAL_STALE_DECISION'
+  | 'APPROVAL_VALIDATION_ERROR'
+
+/** Stable public error for approval persistence, integrity, and concurrency failures. */
+export class DurableApprovalError extends Error {
+  readonly code: DurableApprovalErrorCode
+
+  constructor(code: DurableApprovalErrorCode, message: string) {
+    super(message)
+    this.name = 'DurableApprovalError'
+    this.code = code
+  }
+}
+
+export function approvalKey(requestId: string): string {
+  return `${APPROVAL_KEY_PREFIX}${requestId}`
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value).digest('hex')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stableJson(value: unknown, seen = new Set<object>()): string {
+  if (value === null) return 'null'
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+      return JSON.stringify(value)
+    case 'number':
+      if (!Number.isFinite(value)) {
+        throw new DurableApprovalError(
+          'APPROVAL_VALIDATION_ERROR',
+          'Approval content contains a non-finite number.',
+        )
+      }
+      return JSON.stringify(value)
+    case 'object': {
+      const object = value as object
+      if (seen.has(object)) {
+        throw new DurableApprovalError(
+          'APPROVAL_VALIDATION_ERROR',
+          'Approval content contains a cycle.',
+        )
+      }
+      seen.add(object)
+      try {
+        if (Array.isArray(value)) {
+          return `[${value.map((item) => stableJson(item, seen)).join(',')}]`
+        }
+        const prototype = Object.getPrototypeOf(value)
+        if (prototype !== Object.prototype && prototype !== null) {
+          throw new DurableApprovalError(
+            'APPROVAL_VALIDATION_ERROR',
+            'Approval content must contain only JSON-compatible plain objects.',
+          )
+        }
+        const record = value as Record<string, unknown>
+        const keys = Object.keys(record).sort()
+        const fields = keys.map((key) => {
+          const item = record[key]
+          if (item === undefined) {
+            throw new DurableApprovalError(
+              'APPROVAL_VALIDATION_ERROR',
+              `Approval content field "${key}" is undefined.`,
+            )
+          }
+          return `${JSON.stringify(key)}:${stableJson(item, seen)}`
+        })
+        return `{${fields.join(',')}}`
+      } finally {
+        seen.delete(object)
+      }
+    }
+    default:
+      throw new DurableApprovalError(
+        'APPROVAL_VALIDATION_ERROR',
+        `Approval content contains unsupported ${typeof value} data.`,
+      )
+  }
+}
+
+function requestPayload(
+  scope: ApprovalScope,
+  boundary: string,
+  content: ApprovalRequestContent,
+): Record<string, unknown> {
+  return {
+    scope,
+    boundary,
+    content,
+  }
+}
+
+export function hashApprovalRequest(
+  scope: ApprovalScope,
+  boundary: string,
+  content: ApprovalRequestContent,
+): string {
+  return sha256(stableJson(requestPayload(scope, boundary, content)))
+}
+
+/**
+ * Fail closed when a task boundary contains live verification wiring that the
+ * checkpoint schema cannot reconstruct after a process restart.
+ */
+export function assertDurableTaskApprovalSupport(tasks: readonly Task[]): void {
+  const unsupported = tasks.find((task) => task.verify !== undefined)
+  if (!unsupported) return
+  throw new DurableApprovalError(
+    'APPROVAL_VALIDATION_ERROR',
+    `Task "${unsupported.title}" cannot use durable suspension because its verify config ` +
+      'contains live judge/schema/callback wiring that checkpoints do not persist.',
+  )
+}
+
+export interface CreateApprovalRequestInput {
+  readonly runId: string
+  readonly scope: ApprovalScope
+  readonly boundary: string
+  readonly content: ApprovalRequestContent
+  readonly reason?: string
+  /** Internal deterministic-time seam used by tests. */
+  readonly requestedAt?: Date
+}
+
+/** Create a deterministic identity for one exact reviewed boundary. */
+export function createApprovalRequest(input: CreateApprovalRequestInput): ApprovalRequest {
+  const runId = input.runId.trim()
+  const boundary = input.boundary.trim()
+  if (!runId || !boundary) {
+    throw new DurableApprovalError(
+      'APPROVAL_VALIDATION_ERROR',
+      'Approval runId and boundary must be non-empty strings.',
+    )
+  }
+  if (input.content.kind !== input.scope) {
+    throw new DurableApprovalError(
+      'APPROVAL_VALIDATION_ERROR',
+      `Approval scope "${input.scope}" does not match content kind "${input.content.kind}".`,
+    )
+  }
+  if (input.reason !== undefined && typeof input.reason !== 'string') {
+    throw new DurableApprovalError(
+      'APPROVAL_VALIDATION_ERROR',
+      'Approval reason must be a string when provided.',
+    )
+  }
+  const requestHash = hashApprovalRequest(
+    input.scope,
+    boundary,
+    input.content,
+  )
+  const id = `apr_${sha256(`${runId}\n${input.scope}\n${boundary}\n${requestHash}`).slice(0, 32)}`
+  return {
+    version: 1,
+    id,
+    runId,
+    scope: input.scope,
+    boundary,
+    requestHash,
+    requestedAt: (input.requestedAt ?? new Date()).toISOString(),
+    ...(input.reason !== undefined ? { reason: input.reason } : {}),
+    content: input.content,
+  }
+}
+
+function assertIsoDate(value: unknown, field: string): asserts value is string {
+  if (typeof value !== 'string' || !Number.isFinite(Date.parse(value))) {
+    throw new DurableApprovalError(
+      'APPROVAL_INTEGRITY_ERROR',
+      `Approval ${field} must be an ISO-compatible timestamp.`,
+    )
+  }
+}
+
+function assertReviewer(value: unknown): asserts value is ApprovalReviewer {
+  if (!isRecord(value) || typeof value['id'] !== 'string' || value['id'].trim().length === 0) {
+    throw new DurableApprovalError(
+      'APPROVAL_VALIDATION_ERROR',
+      'Approval reviewer.id must be a non-empty string.',
+    )
+  }
+  if (value['displayName'] !== undefined && typeof value['displayName'] !== 'string') {
+    throw new DurableApprovalError(
+      'APPROVAL_VALIDATION_ERROR',
+      'Approval reviewer.displayName must be a string when provided.',
+    )
+  }
+}
+
+function assertTaskSnapshot(value: unknown): void {
+  if (
+    !isRecord(value)
+    || typeof value['id'] !== 'string'
+    || typeof value['title'] !== 'string'
+    || typeof value['description'] !== 'string'
+    || typeof value['status'] !== 'string'
+    || typeof value['createdAt'] !== 'string'
+    || typeof value['updatedAt'] !== 'string'
+  ) {
+    throw new DurableApprovalError(
+      'APPROVAL_INTEGRITY_ERROR',
+      'Approval content contains an invalid task snapshot.',
+    )
+  }
+  stableJson(value)
+}
+
+function assertContent(value: unknown): asserts value is ApprovalRequestContent {
+  if (!isRecord(value) || typeof value['kind'] !== 'string') {
+    throw new DurableApprovalError(
+      'APPROVAL_INTEGRITY_ERROR',
+      'Approval request content is not an object with a kind.',
+    )
+  }
+  switch (value['kind']) {
+    case 'plan': {
+      if (
+        value['continuation'] !== 'execute'
+        && value['continuation'] !== 'plan_only'
+      ) {
+        throw new DurableApprovalError(
+          'APPROVAL_INTEGRITY_ERROR',
+          'Plan approval has an invalid continuation.',
+        )
+      }
+      if (!Array.isArray(value['tasks'])) {
+        throw new DurableApprovalError('APPROVAL_INTEGRITY_ERROR', 'Plan approval has no tasks array.')
+      }
+      value['tasks'].forEach(assertTaskSnapshot)
+      break
+    }
+    case 'task_round': {
+      if (!Array.isArray(value['completedTasks']) || !Array.isArray(value['nextTasks'])) {
+        throw new DurableApprovalError(
+          'APPROVAL_INTEGRITY_ERROR',
+          'Round approval has invalid completedTasks/nextTasks arrays.',
+        )
+      }
+      value['completedTasks'].forEach(assertTaskSnapshot)
+      value['nextTasks'].forEach(assertTaskSnapshot)
+      break
+    }
+    case 'task_dispatch':
+      assertTaskSnapshot(value['task'])
+      break
+    case 'tool_call':
+      if (
+        typeof value['toolName'] !== 'string'
+        || !isRecord(value['rawInput'])
+        || !isRecord(value['input'])
+        || typeof value['agentName'] !== 'string'
+        || typeof value['taskId'] !== 'string'
+        || typeof value['toolCallId'] !== 'string'
+        || typeof value['consequential'] !== 'boolean'
+      ) {
+        throw new DurableApprovalError(
+          'APPROVAL_INTEGRITY_ERROR',
+          'Tool-call approval content is malformed.',
+        )
+      }
+      stableJson(value['rawInput'])
+      stableJson(value['input'])
+      break
+    default:
+      throw new DurableApprovalError(
+        'APPROVAL_INTEGRITY_ERROR',
+        `Unsupported approval content kind "${String(value['kind'])}".`,
+      )
+  }
+}
+
+/** Throw when a stored/checkpointed request is malformed or content-tampered. */
+export function assertApprovalRequest(value: unknown): asserts value is ApprovalRequest {
+  if (!isRecord(value) || value['version'] !== 1) {
+    throw new DurableApprovalError('APPROVAL_INTEGRITY_ERROR', 'Approval request version is invalid.')
+  }
+  const scope = value['scope']
+  if (
+    typeof value['id'] !== 'string'
+    || !/^apr_[0-9a-f]{32}$/.test(value['id'])
+    || typeof value['runId'] !== 'string'
+    || (scope !== 'plan' && scope !== 'task_round' && scope !== 'task_dispatch' && scope !== 'tool_call')
+    || typeof value['boundary'] !== 'string'
+    || typeof value['requestHash'] !== 'string'
+    || !/^[0-9a-f]{64}$/.test(value['requestHash'])
+    || (value['reason'] !== undefined && typeof value['reason'] !== 'string')
+  ) {
+    throw new DurableApprovalError('APPROVAL_INTEGRITY_ERROR', 'Approval request fields are invalid.')
+  }
+  assertIsoDate(value['requestedAt'], 'requestedAt')
+  assertContent(value['content'])
+  if (value['content'].kind !== scope) {
+    throw new DurableApprovalError(
+      'APPROVAL_INTEGRITY_ERROR',
+      'Approval request scope does not match its content kind.',
+    )
+  }
+  const expectedHash = hashApprovalRequest(
+    scope,
+    value['boundary'],
+    value['content'],
+  )
+  if (expectedHash !== value['requestHash']) {
+    throw new DurableApprovalError(
+      'APPROVAL_INTEGRITY_ERROR',
+      `Approval request "${value['id']}" does not match its content hash.`,
+    )
+  }
+  const expectedId = createApprovalRequest({
+    runId: value['runId'],
+    scope,
+    boundary: value['boundary'],
+    content: value['content'],
+    ...(value['reason'] !== undefined ? { reason: value['reason'] } : {}),
+    requestedAt: new Date(value['requestedAt']),
+  }).id
+  if (expectedId !== value['id']) {
+    throw new DurableApprovalError(
+      'APPROVAL_INTEGRITY_ERROR',
+      `Approval request "${value['id']}" has an invalid identity.`,
+    )
+  }
+}
+
+export function isApprovalRequest(value: unknown): value is ApprovalRequest {
+  try {
+    assertApprovalRequest(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Throw when a durable decision is malformed or does not bind its request. */
+export function assertApprovalDecision(
+  value: unknown,
+  request?: ApprovalRequest,
+): asserts value is ApprovalDecisionRecord {
+  if (!isRecord(value) || value['version'] !== 1) {
+    throw new DurableApprovalError('APPROVAL_INTEGRITY_ERROR', 'Approval decision version is invalid.')
+  }
+  if (
+    typeof value['requestId'] !== 'string'
+    || !/^apr_[0-9a-f]{32}$/.test(value['requestId'])
+    || typeof value['runId'] !== 'string'
+    || value['runId'].trim().length === 0
+    || (value['scope'] !== 'plan'
+      && value['scope'] !== 'task_round'
+      && value['scope'] !== 'task_dispatch'
+      && value['scope'] !== 'tool_call')
+    || typeof value['requestHash'] !== 'string'
+    || !/^[0-9a-f]{64}$/.test(value['requestHash'])
+    || (value['decision'] !== 'approved' && value['decision'] !== 'rejected')
+  ) {
+    throw new DurableApprovalError('APPROVAL_INTEGRITY_ERROR', 'Approval decision fields are invalid.')
+  }
+  assertReviewer(value['reviewer'])
+  assertIsoDate(value['decidedAt'], 'decidedAt')
+  if (request && (
+    value['requestId'] !== request.id
+    || value['runId'] !== request.runId
+    || value['scope'] !== request.scope
+    || value['requestHash'] !== request.requestHash
+  )) {
+    throw new DurableApprovalError(
+      'APPROVAL_INTEGRITY_ERROR',
+      `Approval decision for "${value['requestId']}" does not bind the pending request.`,
+    )
+  }
+}
+
+function assertApprovalRecord(value: unknown): asserts value is ApprovalRecord {
+  if (!isRecord(value) || value['version'] !== 1) {
+    throw new DurableApprovalError('APPROVAL_INTEGRITY_ERROR', 'Approval record version is invalid.')
+  }
+  assertApprovalRequest(value['request'])
+  if (value['decision'] !== undefined) {
+    assertApprovalDecision(value['decision'], value['request'])
+  }
+}
+
+/** Primary-ledger access over a MemoryStore with atomic decision writes. */
+export class DurableApprovalLedger {
+  constructor(private readonly store: MemoryStore) {}
+
+  /** Fail before writing a pending checkpoint when the store cannot decide atomically. */
+  assertAtomicSupport(): void {
+    if (!this.store.compareAndSet) {
+      throw new DurableApprovalError(
+        'APPROVAL_ATOMIC_STORE_REQUIRED',
+        'Suspendable approvals require MemoryStore.compareAndSet for atomic decisions.',
+      )
+    }
+  }
+
+  private compareAndSet(
+    key: string,
+    expectedValue: string | null,
+    value: string,
+    metadata: Record<string, unknown>,
+  ): Promise<boolean> {
+    this.assertAtomicSupport()
+    return this.store.compareAndSet!(key, expectedValue, value, metadata)
+  }
+
+  async ensureRequest(request: ApprovalRequest): Promise<ApprovalRecord> {
+    assertApprovalRequest(request)
+    const record: ApprovalRecord = { version: 1, request }
+    const key = approvalKey(request.id)
+    const value = JSON.stringify(record)
+    const created = await this.compareAndSet(key, null, value, {
+      namespace: 'approval',
+      version: 1,
+      runId: request.runId,
+      scope: request.scope,
+      requestHash: request.requestHash,
+      requestedAt: request.requestedAt,
+    })
+    if (created) return record
+
+    const existing = await this.get(request.id)
+    if (existing && stableJson(existing.request) === stableJson(request)) return existing
+    throw new DurableApprovalError(
+      'APPROVAL_CONFLICT',
+      `Approval request "${request.id}" already exists with different content.`,
+    )
+  }
+
+  async get(requestId: string): Promise<ApprovalRecord | null> {
+    const entry = await this.store.get(approvalKey(requestId))
+    if (!entry) return null
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(entry.value)
+    } catch {
+      throw new DurableApprovalError(
+        'APPROVAL_INTEGRITY_ERROR',
+        `Approval record "${requestId}" is not valid JSON.`,
+      )
+    }
+    assertApprovalRecord(parsed)
+    if (parsed.request.id !== requestId) {
+      throw new DurableApprovalError(
+        'APPROVAL_INTEGRITY_ERROR',
+        `Approval record key does not match request "${parsed.request.id}".`,
+      )
+    }
+    return parsed
+  }
+
+  async decide(input: ApprovalDecisionInput): Promise<ApprovalDecisionRecord> {
+    assertReviewer(input.reviewer)
+    if (input.decision !== 'approve' && input.decision !== 'reject') {
+      throw new DurableApprovalError(
+        'APPROVAL_VALIDATION_ERROR',
+        'Approval decision must be "approve" or "reject".',
+      )
+    }
+    const key = approvalKey(input.requestId)
+    const entry = await this.store.get(key)
+    if (!entry) {
+      throw new DurableApprovalError(
+        'APPROVAL_NOT_FOUND',
+        `Approval request "${input.requestId}" was not found.`,
+      )
+    }
+    let record: unknown
+    try {
+      record = JSON.parse(entry.value)
+    } catch {
+      throw new DurableApprovalError(
+        'APPROVAL_INTEGRITY_ERROR',
+        `Approval record "${input.requestId}" is not valid JSON.`,
+      )
+    }
+    assertApprovalRecord(record)
+    if (record.request.id !== input.requestId) {
+      throw new DurableApprovalError(
+        'APPROVAL_INTEGRITY_ERROR',
+        `Approval record key does not match request "${record.request.id}".`,
+      )
+    }
+    if (record.request.requestHash !== input.requestHash) {
+      throw new DurableApprovalError(
+        'APPROVAL_STALE_DECISION',
+        `Approval request "${input.requestId}" changed after review; decision rejected.`,
+      )
+    }
+    if (record.decision) {
+      throw new DurableApprovalError(
+        'APPROVAL_CONFLICT',
+        `Approval request "${input.requestId}" already has a decision.`,
+      )
+    }
+
+    const decision: ApprovalDecisionRecord = {
+      version: 1,
+      requestId: record.request.id,
+      runId: record.request.runId,
+      scope: record.request.scope,
+      requestHash: record.request.requestHash,
+      decision: input.decision === 'approve' ? 'approved' : 'rejected',
+      reviewer: {
+        id: input.reviewer.id.trim(),
+        ...(input.reviewer.displayName !== undefined
+          ? { displayName: input.reviewer.displayName }
+          : {}),
+      },
+      decidedAt: new Date().toISOString(),
+    }
+    const updated: ApprovalRecord = { ...record, decision }
+    const swapped = await this.compareAndSet(key, entry.value, JSON.stringify(updated), {
+      namespace: 'approval',
+      version: 1,
+      runId: record.request.runId,
+      scope: record.request.scope,
+      requestHash: record.request.requestHash,
+      decision: decision.decision,
+      reviewerId: decision.reviewer.id,
+      decidedAt: decision.decidedAt,
+    })
+    if (!swapped) {
+      throw new DurableApprovalError(
+        'APPROVAL_CONFLICT',
+        `Approval request "${input.requestId}" was decided concurrently.`,
+      )
+    }
+    return decision
+  }
+}
+
+/** Read one primary approval ledger row. */
+export async function getApprovalRecord(
+  store: MemoryStore,
+  requestId: string,
+): Promise<ApprovalRecord | null> {
+  return new DurableApprovalLedger(store).get(requestId)
+}
+
+/** Atomically approve or reject an exact durable request. First decision wins. */
+export async function decideApproval(
+  store: MemoryStore,
+  input: ApprovalDecisionInput,
+): Promise<ApprovalDecisionRecord> {
+  return new DurableApprovalLedger(store).decide(input)
+}

--- a/packages/core/src/dashboard/render-run-viewer.ts
+++ b/packages/core/src/dashboard/render-run-viewer.ts
@@ -223,6 +223,7 @@ export function renderRunViewer(input: RunViewerInput, options: RunViewerOptions
     .source-chip { color: var(--mint); }
     .status-ok, .status-completed { color: var(--mint); }
     .status-error, .status-failed, .status-timeout, .status-budget_exhausted, .status-rejected { color: var(--coral); }
+    .status-suspended { color: var(--amber); }
     .status-in_progress, .status-pending { color: var(--amber); }
     .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
     @media (max-width: 940px) {

--- a/packages/core/src/dashboard/run-viewer-model.ts
+++ b/packages/core/src/dashboard/run-viewer-model.ts
@@ -310,6 +310,7 @@ function taskStatusFromSpan(status: RunStatusCode | undefined, incomplete: boole
     case 'ok': return 'completed'
     case 'skipped': return 'skipped'
     case 'cancelled': return 'blocked'
+    case 'suspended': return 'in_progress'
     case 'error':
     case 'timeout':
     case 'budget_exhausted':

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -232,6 +232,7 @@ export type {
   DiagnosticOptions,
   ExportResult,
   ExecutionReceipt,
+  ExecutionReceiptApprovalDecision,
   ExecutionReceiptDependencyEdge,
   FlushOptions,
   FlushResult,
@@ -272,6 +273,20 @@ export { FileStore } from './memory/file-store.js'
 export { RedactingStore } from './memory/redacting-store.js'
 export type { RedactingStoreOptions } from './memory/redacting-store.js'
 export { SharedMemory } from './memory/shared.js'
+export {
+  APPROVAL_KEY_PREFIX,
+  DurableApprovalError,
+  DurableApprovalLedger,
+  approvalKey,
+  createApprovalRequest,
+  decideApproval,
+  getApprovalRecord,
+  hashApprovalRequest,
+} from './approval/durable.js'
+export type {
+  CreateApprovalRequestInput,
+  DurableApprovalErrorCode,
+} from './approval/durable.js'
 export {
   Checkpoint,
   CHECKPOINT_KEY_PREFIX,
@@ -329,6 +344,18 @@ export type {
   RunStatusCode,
   RunFlag,
   RunOutcomeFields,
+  ApprovalScope,
+  ApprovalRequestContent,
+  PlanApprovalContent,
+  TaskRoundApprovalContent,
+  TaskDispatchApprovalContent,
+  ToolCallApprovalContent,
+  ApprovalRequest,
+  ApprovalReviewer,
+  ApprovalDecisionRecord,
+  ApprovalRecord,
+  ApprovalDecisionInput,
+  ApprovalGateDecision,
   StructuredTraceError,
   TraceErrorKind,
   AgentBackendConfig,
@@ -402,6 +429,7 @@ export type {
   CheckpointSnapshotV1,
   CheckpointSnapshotV2,
   CheckpointSnapshotV3,
+  CheckpointSnapshotV4,
   CheckpointRunIdentity,
   CompletedTaskCheckpoint,
   InFlightTaskCheckpoint,

--- a/packages/core/src/memory/checkpoint.ts
+++ b/packages/core/src/memory/checkpoint.ts
@@ -6,8 +6,17 @@
  * SQLite, or any custom backend work without extra hooks.
  */
 
-import type { CheckpointOptions, CheckpointSnapshot, MemoryStore } from '../types.js'
+import type {
+  ApprovalRequest,
+  CheckpointOptions,
+  CheckpointSnapshot,
+  MemoryStore,
+} from '../types.js'
 import { validateRunMetadata } from '../observability/identity.js'
+import {
+  assertApprovalDecision,
+  isApprovalRequest,
+} from '../approval/durable.js'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -99,6 +108,7 @@ export class Checkpoint {
       snapshot['version'] !== 1
       && snapshot['version'] !== 2
       && snapshot['version'] !== 3
+      && snapshot['version'] !== 4
     ) return false
     if (
       snapshot['mode'] !== 'runTeam'
@@ -125,7 +135,7 @@ export class Checkpoint {
       if (typeof record['lastRootSpanId'] !== 'string') return false
     }
 
-    if (snapshot['version'] === 3) {
+    if (snapshot['version'] === 3 || snapshot['version'] === 4) {
       const inFlightTasks = snapshot['inFlightTasks']
       if (!Array.isArray(inFlightTasks)) return false
       const taskIds = new Set<string>()
@@ -133,6 +143,49 @@ export class Checkpoint {
         if (!Checkpoint.isInFlightTask(state)) return false
         if (taskIds.has(state.taskId)) return false
         taskIds.add(state.taskId)
+      }
+    }
+
+    if (snapshot['version'] === 4) {
+      const pendingApprovals = snapshot['pendingApprovals']
+      const approvalDecisions = snapshot['approvalDecisions']
+      const identity = snapshot['identity'] as Record<string, unknown>
+      if (!Array.isArray(pendingApprovals) || !Array.isArray(approvalDecisions)) return false
+      const pendingIds = new Set<string>()
+      for (const request of pendingApprovals) {
+        if (!isApprovalRequest(request) || request.runId !== identity['runId']) return false
+        if (pendingIds.has(request.id)) return false
+        pendingIds.add(request.id)
+      }
+      const decisionIds = new Set<string>()
+      for (const decision of approvalDecisions) {
+        try {
+          assertApprovalDecision(decision)
+        } catch {
+          return false
+        }
+        if (decision.runId !== identity['runId']) return false
+        if (decisionIds.has(decision.requestId)) return false
+        decisionIds.add(decision.requestId)
+      }
+      for (const state of snapshot['inFlightTasks'] as Array<Record<string, unknown>>) {
+        const pendingToolCalls = state['pendingToolCalls']
+        if (!Array.isArray(pendingToolCalls)) continue
+        for (const pending of pendingToolCalls as Array<Record<string, unknown>>) {
+          const request = pending['approvalRequest']
+          const decision = pending['approvalDecision']
+          if (request !== undefined) {
+            if (!isApprovalRequest(request) || !pendingIds.has(request.id)) return false
+          }
+          if (decision !== undefined) {
+            try {
+              assertApprovalDecision(decision, request as ApprovalRequest)
+            } catch {
+              return false
+            }
+            if (!decisionIds.has(decision.requestId)) return false
+          }
+        }
       }
     }
 
@@ -199,7 +252,28 @@ export class Checkpoint {
     if (!Checkpoint.isRecord(callRecord['input'])) return false
 
     const commit = pending['commit']
+    const approvalRequest = pending['approvalRequest']
+    const approvalDecision = pending['approvalDecision']
+    if (approvalRequest !== undefined) {
+      if (!isApprovalRequest(approvalRequest) || approvalRequest.scope !== 'tool_call') return false
+      const content = approvalRequest.content
+      if (
+        content.kind !== 'tool_call'
+        || content.toolCallId !== callRecord['id']
+        || content.toolName !== callRecord['name']
+      ) return false
+      if (approvalDecision !== undefined) {
+        try {
+          assertApprovalDecision(approvalDecision, approvalRequest)
+        } catch {
+          return false
+        }
+      }
+    } else if (approvalDecision !== undefined) {
+      return false
+    }
     if (commit === undefined) return true
+    if (approvalRequest !== undefined || approvalDecision !== undefined) return false
     if (commit === null || typeof commit !== 'object') return false
     const commitRecord = commit as Record<string, unknown>
     const result = commitRecord['result']

--- a/packages/core/src/memory/file-store.ts
+++ b/packages/core/src/memory/file-store.ts
@@ -126,6 +126,39 @@ export class FileStore implements MemoryStore {
   }
 
   /**
+   * Atomically replace one value within this FileStore instance.
+   *
+   * FileStore remains a single-process writer (see the module scope note);
+   * cross-process reviewers should decide only after the suspended runner has
+   * exited, or use a database-backed MemoryStore with cross-process CAS.
+   */
+  compareAndSet(
+    key: string,
+    expectedValue: string | null,
+    value: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<boolean> {
+    const run = this.writeChain.then(async () => {
+      await this.ensureLoaded()
+      const existing = this.data.get(key)
+      if ((existing?.value ?? null) !== expectedValue) return false
+      this.data.set(key, {
+        key,
+        value,
+        metadata: metadata !== undefined ? { ...metadata } : undefined,
+        createdAt: existing?.createdAt ?? new Date(),
+      })
+      await this.flush()
+      return true
+    })
+    this.writeChain = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
+  }
+
+  /**
    * Like {@link set}, but also records a turn-count expiry. Expiry filtering is
    * the caller's responsibility (typically {@link SharedMemory}); this store
    * only persists the field. `createdAt` is preserved on update.

--- a/packages/core/src/memory/redacting-store.ts
+++ b/packages/core/src/memory/redacting-store.ts
@@ -39,6 +39,11 @@ export interface RedactingStoreOptions {
  * Wraps any {@link MemoryStore}, redacting the value passed to `set` /
  * `setWithExpiry` before it is persisted. Metadata, keys, and read paths are
  * forwarded unchanged.
+ *
+ * This lossy decorator deliberately does not expose `compareAndSet`: exact
+ * content hashes are required for durable approvals, while redaction changes
+ * the reviewed content. Use a protected, non-redacting approval/checkpoint
+ * store when suspendable approvals are required.
  */
 export class RedactingStore implements MemoryStore {
   private readonly patterns: readonly RegExp[]

--- a/packages/core/src/memory/shared.ts
+++ b/packages/core/src/memory/shared.ts
@@ -17,6 +17,7 @@ import type {
   SharedMemoryWriteOptions,
 } from '../types.js'
 import { InMemoryStore } from './store.js'
+import { APPROVAL_KEY_PREFIX } from '../approval/durable.js'
 
 // ---------------------------------------------------------------------------
 // Runtime shape check
@@ -25,7 +26,7 @@ import { InMemoryStore } from './store.js'
 const STORE_METHODS = ['get', 'set', 'list', 'delete', 'clear'] as const
 const STRUCTURED_VALUE_ENCODING = 'json'
 const STRUCTURED_VALUE_METADATA_KEY = 'sharedMemoryValueEncoding'
-const RESERVED_STORE_PREFIXES = ['__oma_checkpoint__/'] as const
+const RESERVED_STORE_PREFIXES = ['__oma_checkpoint__/', APPROVAL_KEY_PREFIX] as const
 
 
 /**

--- a/packages/core/src/memory/store.ts
+++ b/packages/core/src/memory/store.ts
@@ -61,6 +61,24 @@ export class InMemoryStore implements MemoryStore {
     this.data.set(key, entry)
   }
 
+  /** Atomically replace one value when its current string matches exactly. */
+  async compareAndSet(
+    key: string,
+    expectedValue: string | null,
+    value: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<boolean> {
+    const existing = this.data.get(key)
+    if ((existing?.value ?? null) !== expectedValue) return false
+    this.data.set(key, {
+      key,
+      value,
+      metadata: metadata !== undefined ? { ...metadata } : undefined,
+      createdAt: existing?.createdAt ?? new Date(),
+    })
+    return true
+  }
+
   /**
    * Like {@link set}, but also records a turn-count expiry. The entry is
    * stored as-is — expiry filtering is the caller's responsibility (typically

--- a/packages/core/src/observability/execution-receipt.ts
+++ b/packages/core/src/observability/execution-receipt.ts
@@ -11,6 +11,17 @@ export interface ExecutionReceiptDependencyEdge {
   readonly to: string
 }
 
+/** Approval fact derived from a run result; the primary row stays in MemoryStore. */
+export interface ExecutionReceiptApprovalDecision {
+  readonly requestId: string
+  readonly scope: 'plan' | 'task_round' | 'task_dispatch' | 'tool_call'
+  readonly requestHash: string
+  readonly decision: 'approved' | 'rejected'
+  readonly reviewerId: string
+  readonly reviewerDisplayName?: string
+  readonly decidedAt: string
+}
+
 /**
  * Structured execution facts derived from run records and optional trace events.
  * Agent output text is deliberately excluded as a source of evidence.
@@ -35,6 +46,7 @@ export interface ExecutionReceipt {
   readonly dependencyEdges: readonly ExecutionReceiptDependencyEdge[]
   readonly independentRolesCount: number
   readonly independentReviewOccurred: boolean
+  readonly approvalDecisions?: readonly ExecutionReceiptApprovalDecision[]
   readonly totalTokens: {
     readonly input: number
     readonly output: number
@@ -93,6 +105,44 @@ function readFlags(value: unknown): readonly RunFlag[] | undefined {
     || flag === 'governance-overridden'
     || flag === 'review-skipped-due-to-budget')
   return flags.length > 0 ? [...new Set(flags)] : undefined
+}
+
+function readApprovalDecisions(
+  value: unknown,
+): readonly ExecutionReceiptApprovalDecision[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const decisions: ExecutionReceiptApprovalDecision[] = []
+  for (const item of value) {
+    if (!isRecord(item) || !isRecord(item['reviewer'])) continue
+    const requestId = readString(item['requestId'])
+    const scope = item['scope']
+    const requestHash = readString(item['requestHash'])
+    const decision = item['decision']
+    const reviewerId = readString(item['reviewer']['id'])
+    const reviewerDisplayName = readString(item['reviewer']['displayName'])
+    const decidedAt = readString(item['decidedAt'])
+    if (
+      !requestId
+      || (scope !== 'plan'
+        && scope !== 'task_round'
+        && scope !== 'task_dispatch'
+        && scope !== 'tool_call')
+      || !requestHash
+      || (decision !== 'approved' && decision !== 'rejected')
+      || !reviewerId
+      || !decidedAt
+    ) continue
+    decisions.push({
+      requestId,
+      scope,
+      requestHash,
+      decision,
+      reviewerId,
+      ...(reviewerDisplayName ? { reviewerDisplayName } : {}),
+      decidedAt,
+    })
+  }
+  return decisions.length > 0 ? decisions : undefined
 }
 
 function readTraceFacts(trace: readonly TraceEvent[] | undefined): TraceFacts {
@@ -186,6 +236,7 @@ function buildAgentReceipt(result: AgentRunResult, trace: TraceFacts): Execution
     : null
   const totalTokens = readTokenUsage(rawResult['tokenUsage'])
   const flags = readFlags(rawResult['flags'])
+  const approvalDecisions = readApprovalDecisions(rawResult['approvalDecisions'])
   const partial = trace.partial
     || workerAgentEvents.length === 0
     || rolesExecuted.length === 0
@@ -195,6 +246,7 @@ function buildAgentReceipt(result: AgentRunResult, trace: TraceFacts): Execution
 
   return {
     ...(flags ? { flags } : {}),
+    ...(approvalDecisions ? { approvalDecisions } : {}),
     mode: rolesExecuted.length > 1 ? 'multi-agent' : 'single',
     rolesExecuted,
     workerInstancesExecuted: rolesExecuted,
@@ -302,6 +354,7 @@ function buildTeamReceipt(result: TeamRunResult, trace: TraceFacts): ExecutionRe
 
   const totalTokens = readTokenUsage(rawResult['totalTokenUsage'])
   const flags = readFlags(rawResult['flags'])
+  const approvalDecisions = readApprovalDecisions(rawResult['approvalDecisions'])
   const rawMetrics = rawResult['metrics']
   const durationMs = isRecord(rawMetrics) && isFiniteNumber(rawMetrics['totalDurationMs'])
     ? rawMetrics['totalDurationMs']
@@ -315,6 +368,7 @@ function buildTeamReceipt(result: TeamRunResult, trace: TraceFacts): ExecutionRe
     ...(routingDecisionId ? { routingDecisionId } : {}),
     ...(routingDecisionSpanId ? { routingDecisionSpanId } : {}),
     ...(flags ? { flags } : {}),
+    ...(approvalDecisions ? { approvalDecisions } : {}),
     mode: rolesExecuted.length > 1 ? 'multi-agent' : 'single',
     rolesExecuted,
     workerInstancesExecuted: rolesExecuted,

--- a/packages/core/src/observability/in-memory-store.ts
+++ b/packages/core/src/observability/in-memory-store.ts
@@ -18,7 +18,7 @@ import {
 } from './store.js'
 
 const STATUS_CODES = new Set<RunStatusCode>([
-  'ok', 'error', 'cancelled', 'timeout', 'budget_exhausted', 'rejected', 'skipped',
+  'ok', 'error', 'cancelled', 'timeout', 'budget_exhausted', 'rejected', 'suspended', 'skipped',
 ])
 const SPAN_KINDS = new Set(['run', 'routing', 'agent', 'task', 'llm', 'tool', 'plan', 'consensus', 'checkpoint', 'callback'])
 const EVENT_NAMES = new Set([

--- a/packages/core/src/observability/index.ts
+++ b/packages/core/src/observability/index.ts
@@ -39,6 +39,7 @@ export { materializeRun } from './materialize.js'
 export { buildExecutionReceipt } from './execution-receipt.js'
 export type {
   ExecutionReceipt,
+  ExecutionReceiptApprovalDecision,
   ExecutionReceiptDependencyEdge,
 } from './execution-receipt.js'
 export { InMemoryTraceStore } from './in-memory-store.js'

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -44,8 +44,13 @@
 import type {
   AgentConfig,
   AgentRunResult,
+  ApprovalDecisionRecord,
+  ApprovalGateDecision,
+  ApprovalRequest,
+  ApprovalRequestContent,
   CheckpointOptions,
   CheckpointSnapshot,
+  InFlightTaskCheckpoint,
   ConsensusOptions,
   ConsensusResult,
   CoordinatorConfig,
@@ -165,7 +170,18 @@ import {
   TaskProfileValidationError,
   validateTaskProfilerResult,
 } from './task-profiler.js'
-import { executeQueue, saveRunCheckpoint } from './task-execution.js'
+import {
+  executeQueue,
+  persistPendingApproval,
+  saveRunCheckpoint,
+} from './task-execution.js'
+import {
+  assertDurableTaskApprovalSupport,
+  createApprovalRequest,
+  DurableApprovalError,
+  DurableApprovalLedger,
+  hashApprovalRequest,
+} from '../approval/durable.js'
 import {
   buildGovernanceTaskSpecs,
   finalizeGovernanceRun,
@@ -234,6 +250,26 @@ interface SemanticProfileRun {
   readonly model?: string
   readonly provider?: string
   readonly reasons: readonly string[]
+}
+
+function normalizeApprovalDecision(
+  value: ApprovalGateDecision,
+  callbackName: string,
+): { readonly action: 'allow' | 'deny' | 'suspend'; readonly reason?: string } {
+  if (value === true) return { action: 'allow' }
+  if (value === false) return { action: 'deny' }
+  if (
+    value === null
+    || typeof value !== 'object'
+    || (value.action !== 'allow' && value.action !== 'deny' && value.action !== 'suspend')
+    || ('reason' in value && value.reason !== undefined && typeof value.reason !== 'string')
+  ) {
+    throw new Error(`${callbackName} returned an invalid approval decision.`)
+  }
+  const reason = 'reason' in value ? value.reason : undefined
+  return reason === undefined
+    ? { action: value.action }
+    : { action: value.action, reason }
 }
 
 function validateExecutionRoutingConfig(config?: ExecutionRoutingConfig): void {
@@ -1673,18 +1709,39 @@ export class OpenMultiAgent {
       attributes: { 'oma.plan.task_count': planTasks.length },
     })
     const planReadyStartMs = planSpan?.startUnixMs ?? Date.now()
-    let approved = true
+    let planDecision: { readonly action: 'allow' | 'deny' | 'suspend'; readonly reason?: string } = {
+      action: 'allow',
+    }
     let planApprovalError: unknown
     if (this.config.onPlanReady) {
       try {
-        approved = await this.config.onPlanReady(planTasks)
+        planDecision = normalizeApprovalDecision(
+          await this.config.onPlanReady(planTasks),
+          'onPlanReady',
+        )
+        if (planDecision.action === 'suspend') {
+          assertDurableTaskApprovalSupport(planTasks)
+          const request = createApprovalRequest({
+            runId: identity.runId,
+            scope: 'plan',
+            boundary: 'coordinator-plan',
+            content: {
+              kind: 'plan',
+              continuation: options?.planOnly ? 'plan_only' : 'execute',
+              tasks: queue.snapshot().tasks,
+            },
+            ...(planDecision.reason !== undefined ? { reason: planDecision.reason } : {}),
+          })
+          await persistPendingApproval(queue, ctx, request)
+          ctx.outcomeStatus = statusOnly('suspended', 'Plan approval pending.')
+        }
       } catch (error) {
-        approved = false
+        planDecision = { action: 'deny' }
         planApprovalError = error
       }
     }
     if (
-      approved
+      planDecision.action === 'allow'
       && this.config.onPlanReady
       && consequentialUndeclared
       && this.config.requireConsequentialConfirmation
@@ -1699,7 +1756,7 @@ export class OpenMultiAgent {
         ...(coordinatorDecomposeSpanId ? { parentId: coordinatorDecomposeSpanId } : {}),
         agent: 'coordinator',
         taskCount: planTasks.length,
-        approved,
+        approved: planDecision.action === 'allow',
         startMs: planReadyStartMs,
         endMs: planReadyEndMs,
         durationMs: planReadyEndMs - planReadyStartMs,
@@ -1709,15 +1766,33 @@ export class OpenMultiAgent {
         ? classifyRunFailure(planApprovalError, { kind: 'callback' })
         : undefined
       planSpan.end({
-        status: planStatus?.status ?? statusOnly(approved ? 'ok' : 'rejected'),
+        status: planStatus?.status ?? statusOnly(
+          planDecision.action === 'allow'
+            ? 'ok'
+            : planDecision.action === 'suspend'
+              ? 'suspended'
+              : 'rejected',
+        ),
         ...(planStatus ? { error: planStatus.errorInfo } : {}),
-        attributes: { 'oma.plan.approved': approved },
+        attributes: {
+          'oma.plan.approved': planDecision.action === 'allow',
+          'oma.approval.decision': planDecision.action,
+        },
         ...(planLegacyEvent ? { legacyEvent: planLegacyEvent } : {}),
       })
     } else if (planLegacyEvent) {
       emitTrace(this.config.onTrace, planLegacyEvent)
     }
-    if (!approved) {
+    if (planDecision.action === 'suspend') {
+      const suspended = this.buildPlanOnlyTeamRunResult(agentResults, identity, goal, queue)
+      return finish(this.withCheckpointApprovals({
+        ...suspended,
+        success: false,
+        status: statusOnly('suspended', 'Plan approval pending.'),
+        planOnly: undefined,
+      }, activeCheckpoint))
+    }
+    if (planDecision.action === 'deny') {
       if (planApprovalError !== undefined) {
         const classified = classifyRunFailure(planApprovalError, { kind: 'callback' })
         return finish(this.buildTeamRunResult(
@@ -1770,6 +1845,17 @@ export class OpenMultiAgent {
       metrics: taskMetrics.get(task.id),
     }))
 
+    if (ctx.outcomeStatus?.code === 'suspended') {
+      return finish(this.withCheckpointApprovals(this.buildTeamRunResult(
+        agentResults,
+        identity,
+        goal,
+        taskRecords,
+        ctx.outcomeStatus,
+        ctx.outcomeErrorInfo,
+      ), activeCheckpoint))
+    }
+
     // ------------------------------------------------------------------
     // Step 5: Coordinator synthesises final result
     // ------------------------------------------------------------------
@@ -1794,7 +1880,7 @@ export class OpenMultiAgent {
         ctx.outcomeStatus = classified.status
         ctx.outcomeErrorInfo = classified.errorInfo
       }
-      return finish(this.buildTeamRunResult(
+      return finish(this.withCheckpointApprovals(this.buildTeamRunResult(
         agentResults,
         identity,
         goal,
@@ -1803,7 +1889,7 @@ export class OpenMultiAgent {
         ctx.outcomeErrorInfo,
         false,
         queue.getPlanRevisions(),
-      ))
+      ), activeCheckpoint))
     }
     agentResults.set('coordinator', synthesis.result)
     cumulativeUsage = synthesis.cumulativeUsage
@@ -1813,7 +1899,7 @@ export class OpenMultiAgent {
     // Only actual user tasks (non-coordinator keys) are counted in
     // buildTeamRunResult, so we do not increment completedTaskCount here.
 
-    return finish(this.buildTeamRunResult(
+    return finish(this.withCheckpointApprovals(this.buildTeamRunResult(
       agentResults,
       identity,
       goal,
@@ -1822,7 +1908,7 @@ export class OpenMultiAgent {
       ctx.outcomeErrorInfo,
       false,
       queue.getPlanRevisions(),
-    ))
+    ), activeCheckpoint))
   }
 
   // -------------------------------------------------------------------------
@@ -2080,7 +2166,15 @@ export class OpenMultiAgent {
     if (!validation.valid) {
       throw new Error(`Invalid checkpoint task dependencies: ${validation.errors.join(' ')}`)
     }
-    const restoredInFlightTasks = snapshot.version === 3 ? snapshot.inFlightTasks : []
+    let restoredInFlightTasks: InFlightTaskCheckpoint[] =
+      snapshot.version === 3 || snapshot.version === 4
+        ? snapshot.inFlightTasks.map((state) => ({
+            ...state,
+            ...(state.pendingToolCalls
+              ? { pendingToolCalls: state.pendingToolCalls.map((pending) => ({ ...pending })) }
+              : {}),
+          }))
+        : []
     for (const state of restoredInFlightTasks) {
       const task = queue.get(state.taskId)
       if (!task || !snapshot.queue.inProgress.includes(state.taskId)) {
@@ -2105,6 +2199,180 @@ export class OpenMultiAgent {
           inFlightTasks: new Map(restoredInFlightTasks.map((state) => [state.taskId, state])),
         }
       : undefined
+
+    if (snapshot.version === 4 && checkpointForResume) {
+      const hasTerminalRejection = snapshot.approvalDecisions.some(
+        (decision) => decision.scope !== 'tool_call' && decision.decision === 'rejected',
+      )
+      for (const decision of snapshot.approvalDecisions) {
+        const primary = await checkpointForResume.approvalLedger.get(decision.requestId)
+        if (!primary?.decision || !this.approvalDecisionsEqual(primary.decision, decision)) {
+          throw new DurableApprovalError(
+            'APPROVAL_INTEGRITY_ERROR',
+            `Checkpoint approval decision "${decision.requestId}" does not match the primary ledger.`,
+          )
+        }
+        checkpointForResume.approvalDecisions.set(decision.requestId, decision)
+      }
+
+      const unresolved: ApprovalRequest[] = []
+      let rejectedBoundary: ApprovalRequest | undefined
+      let approvedPlanOnly: ApprovalRequest | undefined
+
+      for (const request of snapshot.pendingApprovals) {
+        if (request.runId !== identity.runId) {
+          throw new DurableApprovalError(
+            'APPROVAL_INTEGRITY_ERROR',
+            `Approval request "${request.id}" belongs to another logical run.`,
+          )
+        }
+        this.assertApprovalMatchesCheckpoint(request, snapshot)
+        checkpointForResume.pendingApprovals.set(request.id, request)
+        const primary = await checkpointForResume.approvalLedger.ensureRequest(request)
+        if (!primary.decision) {
+          unresolved.push(request)
+          continue
+        }
+
+        checkpointForResume.approvalDecisions.set(request.id, primary.decision)
+        if (request.scope === 'tool_call') {
+          restoredInFlightTasks = restoredInFlightTasks.map((state) => ({
+            ...state,
+            ...(state.pendingToolCalls
+              ? {
+                  pendingToolCalls: state.pendingToolCalls.map((pending) =>
+                    pending.approvalRequest?.id === request.id
+                      ? { ...pending, approvalDecision: primary.decision }
+                      : pending),
+                }
+              : {}),
+          }))
+          continue
+        }
+
+        if (primary.decision.decision === 'approved') {
+          if (
+            request.content.kind === 'plan'
+            && request.content.continuation === 'plan_only'
+          ) {
+            approvedPlanOnly = request
+          } else if (request.scope === 'plan' || request.scope === 'task_round') {
+            checkpointForResume.pendingApprovals.delete(request.id)
+          } else {
+            checkpointForResume.approvedBoundaries.set(request.id, primary.decision)
+          }
+        } else {
+          rejectedBoundary = request
+        }
+      }
+      checkpointForResume.inFlightTasks.clear()
+      for (const state of restoredInFlightTasks) {
+        checkpointForResume.inFlightTasks.set(state.taskId, state)
+      }
+
+      const taskRecords = (): readonly TaskExecutionRecord[] => queue.list().map((task) => ({
+        id: task.id,
+        title: task.title,
+        assignee: task.assignee,
+        status: task.status,
+        dependsOn: task.dependsOn ?? [],
+        description: task.description,
+        memoryScope: task.memoryScope,
+        dependencyPayload: task.dependencyPayload,
+        role: task.role,
+        priority: task.priority,
+        metadata: task.metadata,
+        requires: task.requires,
+        maxRetries: task.maxRetries,
+        retryDelayMs: task.retryDelayMs,
+        retryBackoff: task.retryBackoff,
+        supersededByRevision: task.supersededByRevision,
+        recoveredByRevision: task.recoveredByRevision,
+      }))
+      const finishRestoreBoundary = (result: TeamRunResult): TeamRunResult => {
+        const completed = {
+          ...this.withCheckpointApprovals(result, checkpointForResume),
+          ...(restoreMetadata.metadata !== undefined ? { metadata: restoreMetadata.metadata } : {}),
+        }
+        this.completeOnlineEvaluation(
+          evaluationStartedAtMs === undefined ? undefined : {
+            input: { kind: 'restore', goal: snapshot.goal ?? options?.goal },
+            startedAtMs: evaluationStartedAtMs,
+          },
+          completed,
+        )
+        return completed
+      }
+
+      if (unresolved.length > 0) {
+        return finishRestoreBoundary(this.buildTeamRunResult(
+          agentResults,
+          identity,
+          snapshot.goal ?? options?.goal,
+          taskRecords(),
+          statusOnly('suspended', 'Durable approval decision pending.'),
+        ))
+      }
+
+      if (rejectedBoundary) {
+        checkpointForResume.pendingApprovals.delete(rejectedBoundary.id)
+        queue.skipRemaining('Skipped: durable approval rejected.')
+        await saveRunCheckpoint(queue, {
+          team,
+          pool: this.buildPool(team.getAgents()),
+          scheduler: this.createScheduler(options?.modelRouting, () => queue.list()),
+          agentResults,
+          config: this.config,
+          checkpoint: checkpointForResume,
+          identity,
+          ...(restoreMetadata.metadata !== undefined ? { metadata: restoreMetadata.metadata } : {}),
+          runId: identity.runId,
+          taskSpans: new Map(),
+          cumulativeUsage: ZERO_USAGE,
+          cumulativeCost: 0,
+          budgetExceededTriggered: false,
+          taskMetrics: new Map(),
+          taskById: new Map(queue.list().map((task) => [task.id, task])),
+          taskLeafById: new Map(queue.list().map((task) => [task.id, isLeafTask(task, queue.list())])),
+          recovery: resolveRecoveryOptions(this.config.recovery, options?.recovery),
+          recoveryPatchSignatures: new Set(),
+        })
+        return finishRestoreBoundary(this.buildTeamRunResult(
+          agentResults,
+          identity,
+          snapshot.goal ?? options?.goal,
+          taskRecords(),
+          statusOnly('rejected', 'Durable approval rejected.'),
+        ))
+      }
+
+      if (hasTerminalRejection) {
+        return finishRestoreBoundary(this.buildTeamRunResult(
+          agentResults,
+          identity,
+          snapshot.goal ?? options?.goal,
+          taskRecords(),
+          statusOnly('rejected', 'Durable approval rejected.'),
+        ))
+      }
+
+      if (approvedPlanOnly) {
+        checkpointForResume.pendingApprovals.delete(approvedPlanOnly.id)
+        const goal = snapshot.goal ?? options?.goal
+        if (goal === undefined) {
+          throw new DurableApprovalError(
+            'APPROVAL_INTEGRITY_ERROR',
+            'A plan-only approval checkpoint has no goal.',
+          )
+        }
+        return finishRestoreBoundary(this.buildPlanOnlyTeamRunResult(
+          agentResults,
+          identity,
+          goal,
+          queue,
+        ))
+      }
+    }
 
     return this.executeExplicitTaskQueue(
       team,
@@ -2489,7 +2757,6 @@ export class OpenMultiAgent {
     }
     const budgets = resolveRunBudgets(this.config, options)
 
-    const pool = this.buildPool(agentConfigs)
     const agentResults = initialAgentResults ?? new Map<string, AgentRunResult>()
     const checkpoint = activeCheckpoint ?? this.createActiveCheckpoint(
       team,
@@ -2497,6 +2764,15 @@ export class OpenMultiAgent {
       'runTasks',
       goal,
     )
+    const restoredConfirmationState = checkpoint?.mode === 'runTeam'
+      && this.config.requireConsequentialConfirmation
+      && [...checkpoint.approvalDecisions.values()].some(
+        (decision) => decision.scope === 'plan' && decision.decision === 'approved',
+      )
+      ? createConsequentialConfirmationState()
+      : undefined
+    if (restoredConfirmationState) restoredConfirmationState.planApproved = true
+    const pool = this.buildPool(agentConfigs, restoredConfirmationState)
     const ctx: RunContext = {
       team,
       pool,
@@ -2535,7 +2811,11 @@ export class OpenMultiAgent {
     // per-task outputs). Best-effort: a missing/unusable coordinator config or
     // a failing synthesis call must not discard the recovered work — on failure
     // we surface `synthesis_failed` and fall back to raw outputs.
-    if (checkpoint?.mode === 'runTeam' && goal !== undefined) {
+    if (
+      ctx.outcomeStatus?.code !== 'suspended'
+      && checkpoint?.mode === 'runTeam'
+      && goal !== undefined
+    ) {
       try {
         const coordinatorBaseConfig = buildCoordinatorBaseConfig(this.config, coordinatorForSynthesis, agentConfigs, false)
         const synthesis = await runCoordinatorSynthesis(this.config, team, queue, goal, coordinatorBaseConfig, {
@@ -2607,7 +2887,7 @@ export class OpenMultiAgent {
       metrics: ctx.taskMetrics.get(task.id),
     }))
 
-    const result = this.buildTeamRunResult(
+    const result = this.withCheckpointApprovals(this.buildTeamRunResult(
       agentResults,
       runIdentity,
       goal,
@@ -2616,7 +2896,7 @@ export class OpenMultiAgent {
       ctx.outcomeErrorInfo,
       false,
       queue.getPlanRevisions(),
-    )
+    ), checkpoint)
     const resultWithRouting = {
       ...result,
       ...(routingDecision !== undefined ? { routingDecision } : {}),
@@ -2661,13 +2941,148 @@ export class OpenMultiAgent {
     const store = explicitStore ?? this.fallbackCheckpointStore
     return {
       manager: new Checkpoint(store, options),
+      approvalLedger: new DurableApprovalLedger(store),
       mode,
       ...(goal !== undefined ? { goal } : {}),
       ...(options.runId !== undefined ? { runId: options.runId } : {}),
       reusesSharedMemoryStore: sharedStore !== undefined && store === sharedStore,
       inFlightTasks: new Map(),
+      pendingApprovals: new Map(),
+      approvalDecisions: new Map(),
+      approvedBoundaries: new Map(),
       saveChain: Promise.resolve(),
     }
+  }
+
+  private withCheckpointApprovals(
+    result: TeamRunResult,
+    checkpoint: ActiveCheckpoint | undefined,
+  ): TeamRunResult {
+    if (!checkpoint) return result
+    const decisions = [...checkpoint.approvalDecisions.values()]
+    const pending = [...checkpoint.pendingApprovals.values()].filter(
+      (request) => !checkpoint.approvalDecisions.has(request.id),
+    )
+    return {
+      ...result,
+      ...(pending.length > 0 ? { pendingApprovals: pending } : {}),
+      ...(decisions.length > 0 ? { approvalDecisions: decisions } : {}),
+    }
+  }
+
+  private approvalContentAtCheckpoint(
+    request: ApprovalRequest,
+    snapshot: CheckpointSnapshot,
+  ): ApprovalRequestContent {
+    const tasks = new Map(snapshot.queue.tasks.map((task) => [task.id, task]))
+    switch (request.content.kind) {
+      case 'plan':
+        if (request.boundary !== 'coordinator-plan') {
+          throw new DurableApprovalError(
+            'APPROVAL_INTEGRITY_ERROR',
+            `Plan approval "${request.id}" has an invalid boundary.`,
+          )
+        }
+        return {
+          kind: 'plan',
+          continuation: request.content.continuation,
+          tasks: snapshot.queue.tasks,
+        }
+      case 'task_dispatch': {
+        const task = tasks.get(request.content.task.id)
+        if (!task || request.boundary !== task.id) {
+          throw new DurableApprovalError(
+            'APPROVAL_STALE_DECISION',
+            `Task-dispatch approval "${request.id}" no longer identifies a pending task.`,
+          )
+        }
+        return { kind: 'task_dispatch', task }
+      }
+      case 'task_round': {
+        const completedTasks = request.content.completedTasks.map((task) => tasks.get(task.id))
+        const nextTasks = request.content.nextTasks.map((task) => tasks.get(task.id))
+        if (completedTasks.some((task) => !task) || nextTasks.some((task) => !task)) {
+          throw new DurableApprovalError(
+            'APPROVAL_STALE_DECISION',
+            `Round approval "${request.id}" references a task that no longer exists.`,
+          )
+        }
+        const boundary = [
+          request.content.completedTasks.map((task) => task.id).join(','),
+          request.content.nextTasks.map((task) => task.id).join(','),
+        ].join('->')
+        if (request.boundary !== boundary) {
+          throw new DurableApprovalError(
+            'APPROVAL_INTEGRITY_ERROR',
+            `Round approval "${request.id}" has an invalid boundary.`,
+          )
+        }
+        return {
+          kind: 'task_round',
+          completedTasks: completedTasks as NonNullable<(typeof completedTasks)[number]>[],
+          nextTasks: nextTasks as NonNullable<(typeof nextTasks)[number]>[],
+        }
+      }
+      case 'tool_call': {
+        const content = request.content
+        const state = (snapshot.version === 3 || snapshot.version === 4)
+          ? snapshot.inFlightTasks.find((item) => item.taskId === content.taskId)
+          : undefined
+        const pending = state?.pendingToolCalls?.find(
+          (item) => item.call.id === content.toolCallId,
+        )
+        if (
+          !state
+          || !pending
+          || pending.commit
+          || pending.approvalRequest?.id !== request.id
+          || state.assignee !== content.agentName
+          || pending.call.name !== content.toolName
+          || request.boundary !== `${state.taskId}:${pending.call.id}`
+        ) {
+          throw new DurableApprovalError(
+            'APPROVAL_STALE_DECISION',
+            `Tool approval "${request.id}" no longer identifies the pending invocation.`,
+          )
+        }
+        return {
+          ...content,
+          rawInput: pending.call.input,
+        }
+      }
+    }
+  }
+
+  private assertApprovalMatchesCheckpoint(
+    request: ApprovalRequest,
+    snapshot: CheckpointSnapshot,
+  ): void {
+    const content = this.approvalContentAtCheckpoint(request, snapshot)
+    const currentHash = hashApprovalRequest(
+      request.scope,
+      request.boundary,
+      content,
+    )
+    if (currentHash !== request.requestHash) {
+      throw new DurableApprovalError(
+        'APPROVAL_STALE_DECISION',
+        `Approval request "${request.id}" does not match the checkpointed execution boundary.`,
+      )
+    }
+  }
+
+  private approvalDecisionsEqual(
+    left: ApprovalDecisionRecord,
+    right: ApprovalDecisionRecord,
+  ): boolean {
+    return left.requestId === right.requestId
+      && left.runId === right.runId
+      && left.scope === right.scope
+      && left.requestHash === right.requestHash
+      && left.decision === right.decision
+      && left.reviewer.id === right.reviewer.id
+      && left.reviewer.displayName === right.reviewer.displayName
+      && left.decidedAt === right.decidedAt
   }
 
   private agentResultsFromCheckpoint(

--- a/packages/core/src/orchestrator/retry.ts
+++ b/packages/core/src/orchestrator/retry.ts
@@ -7,6 +7,7 @@
 import type { AgentRunResult, Task, TokenUsage } from '../types.js'
 import { isRetryableError } from '../errors.js'
 import { abortableDelay } from '../utils/abort.js'
+import { DurableApprovalError } from '../approval/durable.js'
 
 /** Maximum delay cap to prevent runaway exponential backoff (30 seconds). */
 export const MAX_RETRY_DELAY_MS = 30_000
@@ -97,6 +98,13 @@ export async function executeWithRetry(
       if (result.success) {
         return { ...result, tokenUsage: totalUsage }
       }
+      // Suspension is a durable continuation boundary, not a retryable task
+      // failure. Re-running here would ask for the same approval again and
+      // could race the primary decision record.
+      if (result.status?.code === 'suspended') {
+        return { ...result, tokenUsage: totalUsage }
+      }
+      if (result.error instanceof DurableApprovalError) throw result.error
       lastError = result.output
 
       // Non-streaming path carries the structured error on the result; a
@@ -109,6 +117,7 @@ export async function executeWithRetry(
 
       return { ...result, tokenUsage: totalUsage }
     } catch (err) {
+      if (err instanceof DurableApprovalError) throw err
       lastError = err instanceof Error ? err.message : String(err)
 
       // Streaming path: the structured error is in scope here. Skip retries on

--- a/packages/core/src/orchestrator/run-context.ts
+++ b/packages/core/src/orchestrator/run-context.ts
@@ -10,6 +10,8 @@
 
 import type {
   AgentRunResult,
+  ApprovalDecisionRecord,
+  ApprovalRequest,
   CheckpointSnapshot,
   InFlightTaskCheckpoint,
   ModelRoutingPolicy,
@@ -28,6 +30,7 @@ import type { AgentPool } from '../agent/pool.js'
 import type { Team } from '../team/team.js'
 import type { Scheduler } from './scheduler.js'
 import type { Checkpoint } from '../memory/checkpoint.js'
+import type { DurableApprovalLedger } from '../approval/durable.js'
 import type { TraceRuntime, TraceSpan } from '../observability/runtime.js'
 import type { ResolvedRecoveryOptions } from './recovery.js'
 import { createRunIdentity, validateRunMetadata } from '../observability/identity.js'
@@ -176,6 +179,7 @@ export interface RunContext {
 
 export interface ActiveCheckpoint {
   readonly manager: Checkpoint
+  readonly approvalLedger: DurableApprovalLedger
   readonly mode: CheckpointSnapshot['mode']
   readonly goal?: string
   readonly runId?: string
@@ -188,5 +192,11 @@ export interface ActiveCheckpoint {
   readonly reusesSharedMemoryStore: boolean
   /** Latest safe runner state for every task currently between queue boundaries. */
   readonly inFlightTasks: Map<string, InFlightTaskCheckpoint>
+  /** Reviewed boundaries not yet durably consumed by execution. */
+  readonly pendingApprovals: Map<string, ApprovalRequest>
+  /** Primary decisions loaded from the approval ledger and copied into results/checkpoints. */
+  readonly approvalDecisions: Map<string, ApprovalDecisionRecord>
+  /** Approved task/round boundaries that the execution loop may consume once. */
+  readonly approvedBoundaries: Map<string, ApprovalDecisionRecord>
   saveChain: Promise<void>
 }

--- a/packages/core/src/orchestrator/task-execution.ts
+++ b/packages/core/src/orchestrator/task-execution.ts
@@ -12,6 +12,10 @@ import type { RunOptions } from '../agent/runner.js'
 import type {
   AgentConfig,
   AgentRunResult,
+  ApprovalDecisionRecord,
+  ApprovalGateDecision,
+  ApprovalRequest,
+  ApprovalRequestContent,
   CheckpointSnapshot,
   OrchestratorEvent,
   StreamEvent,
@@ -59,6 +63,11 @@ import {
   planPatchSignature,
   validatePlanPatchEligibility,
 } from './recovery.js'
+import {
+  assertDurableTaskApprovalSupport,
+  createApprovalRequest,
+  DurableApprovalError,
+} from '../approval/durable.js'
 
 /**
  * Build {@link TeamInfo} for tool context, including nested `runDelegatedAgent`
@@ -207,8 +216,17 @@ export async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Prom
       }
     })
 
+    const pendingApprovals = new Map(active.pendingApprovals)
+    for (const state of active.inFlightTasks.values()) {
+      for (const pending of state.pendingToolCalls ?? []) {
+        if (pending.approvalRequest && !pending.commit) {
+          pendingApprovals.set(pending.approvalRequest.id, pending.approvalRequest)
+        }
+      }
+    }
+
     const snapshot: CheckpointSnapshot = {
-      version: 3,
+      version: 4,
       mode: active.mode,
       createdAt: new Date().toISOString(),
       ...(ctx.metadata !== undefined ? { metadata: ctx.metadata } : {}),
@@ -231,6 +249,8 @@ export async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Prom
       ...(sharedMem ? { turnCount: sharedMem.getTurnCount() } : {}),
       completedTaskResults,
       inFlightTasks: [...active.inFlightTasks.values()],
+      pendingApprovals: [...pendingApprovals.values()],
+      approvalDecisions: [...active.approvalDecisions.values()],
     }
 
     await active.manager.save(snapshot)
@@ -254,6 +274,102 @@ export async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Prom
     } satisfies OrchestratorEvent)
     return false
   }
+}
+
+interface NormalizedApprovalDecision {
+  readonly action: 'allow' | 'deny' | 'suspend'
+  readonly reason?: string
+}
+
+function normalizeApprovalDecision(
+  value: ApprovalGateDecision,
+  callbackName: string,
+): NormalizedApprovalDecision {
+  if (value === true) return { action: 'allow' }
+  if (value === false) return { action: 'deny' }
+  if (value === null || typeof value !== 'object') {
+    throw new Error(`${callbackName} returned an invalid approval decision.`)
+  }
+  if (value.action !== 'allow' && value.action !== 'deny' && value.action !== 'suspend') {
+    throw new Error(`${callbackName} returned an invalid approval decision.`)
+  }
+  if ('reason' in value && value.reason !== undefined && typeof value.reason !== 'string') {
+    throw new Error(`${callbackName} returned an invalid approval reason.`)
+  }
+  const reason = 'reason' in value ? value.reason : undefined
+  return reason === undefined
+    ? { action: value.action }
+    : { action: value.action, reason }
+}
+
+function approvalCandidate(
+  ctx: RunContext,
+  scope: ApprovalRequest['scope'],
+  boundary: string,
+  content: ApprovalRequestContent,
+): ApprovalRequest {
+  return createApprovalRequest({
+    runId: ctx.identity.runId,
+    scope,
+    boundary,
+    content,
+  })
+}
+
+function consumeApprovedBoundary(
+  ctx: RunContext,
+  candidate: ApprovalRequest,
+): ApprovalDecisionRecord | undefined {
+  const active = ctx.checkpoint
+  const decision = active?.approvedBoundaries.get(candidate.id)
+  if (!decision || decision.requestHash !== candidate.requestHash) return undefined
+  active!.approvedBoundaries.delete(candidate.id)
+  active!.pendingApprovals.delete(candidate.id)
+  return decision
+}
+
+function approvedDispatchTaskId(ctx: RunContext): string | undefined {
+  const active = ctx.checkpoint
+  if (!active) return undefined
+  for (const request of active.pendingApprovals.values()) {
+    if (
+      request.content.kind === 'task_dispatch'
+      && active.approvedBoundaries.has(request.id)
+    ) {
+      return request.content.task.id
+    }
+  }
+  return undefined
+}
+
+/** Persist a boundary before exposing it to an out-of-process reviewer. */
+export async function persistPendingApproval(
+  queue: TaskQueue,
+  ctx: RunContext,
+  request: ApprovalRequest,
+): Promise<void> {
+  const active = ctx.checkpoint
+  if (!active) {
+    throw new DurableApprovalError(
+      'APPROVAL_ATOMIC_STORE_REQUIRED',
+      'A suspend decision requires durable checkpoint configuration.',
+    )
+  }
+  active.approvalLedger.assertAtomicSupport()
+  active.pendingApprovals.set(request.id, request)
+  const saved = await saveRunCheckpoint(queue, ctx)
+  if (!saved) {
+    active.pendingApprovals.delete(request.id)
+    throw new DurableApprovalError(
+      'APPROVAL_INTEGRITY_ERROR',
+      'The approval boundary could not be checkpointed; suspension was not reported.',
+    )
+  }
+  await active.approvalLedger.ensureRequest(request)
+  ctx.config.onProgress?.({
+    type: 'approval_pending',
+    data: request,
+  } satisfies OrchestratorEvent)
 }
 
 function toCheckpointAgentResult(
@@ -555,6 +671,7 @@ export async function executeQueue(
   const inFlight = new Map<string, Promise<void>>()
   const dispatchErrors: unknown[] = []
   let stopDispatch: { readonly reason: string } | undefined
+  let suspendDispatch = false
   let fatalError: unknown
   let wakeCount = 0
   let wakeResolver: (() => void) | undefined
@@ -576,6 +693,11 @@ export async function executeQueue(
 
   const requestStop = (reason: string): void => {
     stopDispatch ??= { reason }
+    signalLoop()
+  }
+
+  const requestSuspend = (): void => {
+    suspendDispatch = true
     signalLoop()
   }
 
@@ -671,6 +793,19 @@ export async function executeQueue(
           dispatchErrors.length = 0
         }
 
+        if (ctx.outcomeStatus?.code === 'suspended') requestSuspend()
+
+        // A durable suspension drains work that was already admitted but
+        // preserves every not-yet-started task for restore.
+        if (suspendDispatch) {
+          if (inFlight.size > 0) {
+            await waitForSignal()
+            continue
+          }
+          await saveRunCheckpoint(queue, ctx)
+          break
+        }
+
         // drain-then-skip: once any terminal gate closes, no new task is
         // admitted. Existing task promises settle before the queue is skipped.
         if (stopDispatch) {
@@ -723,7 +858,17 @@ export async function executeQueue(
             task?.status === 'pending'
             && !(task.dependsOn ?? []).some((dependencyId) => inFlight.has(dependencyId)),
           )
-        const nextReady = scheduler.orderReadyTasks(readyTasks, queue.list())[0]
+        const approvedTaskId = approvedDispatchTaskId(ctx)
+        const nextReady = approvedTaskId === undefined
+          ? scheduler.orderReadyTasks(readyTasks, queue.list())[0]
+          : readyTasks.find((task) => task.id === approvedTaskId)
+
+        if (approvedTaskId !== undefined && !nextReady) {
+          throw new DurableApprovalError(
+            'APPROVAL_STALE_DECISION',
+            `Approved task-dispatch boundary "${approvedTaskId}" is no longer ready.`,
+          )
+        }
 
         if (!nextReady) {
           if (inFlight.size === 0) break
@@ -753,6 +898,19 @@ export async function executeQueue(
         }
 
         if (config.onTaskDispatch && assigned.assignee) {
+          const taskSnapshot = queue.snapshot().tasks.find((task) => task.id === assigned.id)
+          if (!taskSnapshot) throw new Error(`Task "${assigned.id}" has no approval snapshot.`)
+          const content = {
+            kind: 'task_dispatch',
+            task: taskSnapshot,
+          } as const
+          const candidate = approvalCandidate(
+            ctx,
+            'task_dispatch',
+            assigned.id,
+            content,
+          )
+          const priorApproval = consumeApprovedBoundary(ctx, candidate)
           const approvalSpan = ctx.traceRuntime?.startSpan({
             kind: 'callback',
             name: 'task_dispatch_callback',
@@ -763,27 +921,56 @@ export async function executeQueue(
               'oma.task.title': assigned.title,
             },
           })
-          let approved: boolean
-          try {
-            approved = await config.onTaskDispatch(assigned)
-          } catch (error) {
-            const classified = classifyRunFailure(error, { kind: 'callback' })
-            approvalSpan?.end({ status: classified.status, error: classified.errorInfo })
-            if (requestTerminalGateStop()) continue
-            ctx.outcomeStatus = classified.status
-            ctx.outcomeErrorInfo = classified.errorInfo
-            requestStop(
-              `Skipped: task dispatch callback error — ${
-                error instanceof Error ? error.message : String(error)
-              }`,
-            )
-            continue
+          let decision: NormalizedApprovalDecision = { action: 'allow' }
+          if (!priorApproval) {
+            try {
+              decision = normalizeApprovalDecision(
+                await config.onTaskDispatch(assigned),
+                'onTaskDispatch',
+              )
+              if (decision.action === 'suspend') {
+                assertDurableTaskApprovalSupport([assigned])
+                const request = createApprovalRequest({
+                  runId: ctx.identity.runId,
+                  scope: 'task_dispatch',
+                  boundary: assigned.id,
+                  content,
+                  ...(decision.reason !== undefined ? { reason: decision.reason } : {}),
+                })
+                await persistPendingApproval(queue, ctx, request)
+                ctx.outcomeStatus = statusOnly('suspended', 'Task dispatch approval pending.')
+                requestSuspend()
+              }
+            } catch (error) {
+              const classified = classifyRunFailure(error, { kind: 'callback' })
+              approvalSpan?.end({ status: classified.status, error: classified.errorInfo })
+              if (requestTerminalGateStop()) continue
+              ctx.outcomeStatus = classified.status
+              ctx.outcomeErrorInfo = classified.errorInfo
+              requestStop(
+                `Skipped: task dispatch callback error — ${
+                  error instanceof Error ? error.message : String(error)
+                }`,
+              )
+              continue
+            }
           }
 
-          approvalSpan?.event('approval_decision', { 'oma.approval.approved': approved })
-          approvalSpan?.end({ status: statusOnly(approved ? 'ok' : 'rejected') })
+          approvalSpan?.event('approval_decision', {
+            'oma.approval.decision': priorApproval ? 'approved' : decision.action,
+          })
+          approvalSpan?.end({
+            status: statusOnly(
+              priorApproval || decision.action === 'allow'
+                ? 'ok'
+                : decision.action === 'suspend'
+                  ? 'suspended'
+                  : 'rejected',
+            ),
+          })
           if (requestTerminalGateStop()) continue
-          if (!approved) {
+          if (decision.action === 'suspend') continue
+          if (decision.action === 'deny') {
             ctx.outcomeStatus = statusOnly('rejected', 'Task dispatch approval rejected.')
             requestStop('Skipped: task dispatch approval rejected.')
             continue
@@ -991,7 +1178,28 @@ export async function executeQueue(
         const onRunnerCheckpoint = ctx.checkpoint
           ? async (state: Parameters<NonNullable<RunOptions['onCheckpoint']>>[0]) => {
               ctx.checkpoint!.inFlightTasks.set(task.id, state)
-              await saveRunCheckpoint(queue, ctx)
+              const saved = await saveRunCheckpoint(queue, ctx)
+              if (!saved) throw new Error('Runner checkpoint persistence failed.')
+            }
+          : undefined
+        const onApprovalRequest = ctx.checkpoint
+          ? async (request: ApprovalRequest) => {
+              ctx.checkpoint!.pendingApprovals.set(request.id, request)
+              await ctx.checkpoint!.approvalLedger.ensureRequest(request)
+              config.onProgress?.({
+                type: 'approval_pending',
+                task: task.id,
+                agent: assignee,
+                data: request,
+              } satisfies OrchestratorEvent)
+            }
+          : undefined
+        const onApprovalPrepare = ctx.checkpoint
+          ? () => ctx.checkpoint!.approvalLedger.assertAtomicSupport()
+          : undefined
+        const onApprovalConsumed = ctx.checkpoint
+          ? (requestId: string) => {
+              ctx.checkpoint!.pendingApprovals.delete(requestId)
             }
           : undefined
 
@@ -1019,6 +1227,9 @@ export async function executeQueue(
           team: buildTaskAgentTeamInfo(ctx, task.id, traceBase, 0, [assignee]),
           ...(restoredRunnerState ? { resumeState: restoredRunnerState } : {}),
           ...(onRunnerCheckpoint ? { onCheckpoint: onRunnerCheckpoint } : {}),
+          ...(onApprovalPrepare ? { onApprovalPrepare } : {}),
+          ...(onApprovalRequest ? { onApprovalRequest } : {}),
+          ...(onApprovalConsumed ? { onApprovalConsumed } : {}),
         }
         const workerRoute = routeMatches(ctx.modelRouting, {
           phase: 'worker',
@@ -1144,6 +1355,8 @@ export async function executeQueue(
           { abortSignal: ctx.abortSignal },
         )
 
+        if (result.error instanceof DurableApprovalError) throw result.error
+
         const taskEndMs = Date.now()
 
         const taskLegacyEvent = legacyTaskEvent(result.success, taskEndMs, retryCount)
@@ -1198,6 +1411,25 @@ export async function executeQueue(
             task: task.id,
             agent: assignee,
             data: message,
+          } satisfies OrchestratorEvent)
+          return
+        }
+
+        if (result.status?.code === 'suspended') {
+          ctx.outcomeStatus = statusOnly(
+            'suspended',
+            'Durable approval required before task execution can continue.',
+          )
+          taskSpan?.end({
+            status: ctx.outcomeStatus,
+            attributes: { 'oma.task.retries': retryCount },
+            ...(taskLegacyEvent ? { legacyEvent: taskLegacyEvent } : {}),
+          })
+          config.onProgress?.({
+            type: 'agent_complete',
+            agent: assignee,
+            task: task.id,
+            data: result,
           } satisfies OrchestratorEvent)
           return
         }
@@ -1283,7 +1515,9 @@ export async function executeQueue(
         void taskPromise.then(
           () => {
             inFlight.delete(task.id)
-            if (ctx.budgetExceededTriggered) {
+            if (ctx.outcomeStatus?.code === 'suspended') {
+              requestSuspend()
+            } else if (ctx.budgetExceededTriggered) {
               requestStop(ctx.budgetExceededReason ?? 'Skipped: token budget exceeded.')
             } else {
               signalLoop()
@@ -1302,6 +1536,10 @@ export async function executeQueue(
 
       // Compatibility mode deliberately retains the complete batch barrier.
       await Promise.all(dispatchPromises)
+      if (ctx.outcomeStatus?.code === 'suspended') {
+        await saveRunCheckpoint(queue, ctx)
+        break
+      }
       if (ctx.budgetExceededTriggered) {
         queue.skipRemaining(ctx.budgetExceededReason ?? 'Skipped: token budget exceeded.')
         break
@@ -1313,32 +1551,71 @@ export async function executeQueue(
         const nextPending = queue.getByStatus('pending')
 
         if (nextPending.length > 0) {
+          const taskSnapshots = new Map(
+            queue.snapshot().tasks.map((task) => [task.id, task]),
+          )
+          const content = {
+            kind: 'task_round',
+            completedTasks: completedThisRound.map((task) => taskSnapshots.get(task.id)!),
+            nextTasks: nextPending.map((task) => taskSnapshots.get(task.id)!),
+          } as const
+          const boundary = [
+            completedThisRound.map((task) => task.id).join(','),
+            nextPending.map((task) => task.id).join(','),
+          ].join('->')
+          const candidate = approvalCandidate(ctx, 'task_round', boundary, content)
+          const priorApproval = consumeApprovedBoundary(ctx, candidate)
           const approvalSpan = ctx.traceRuntime?.startSpan({
             kind: 'callback',
             name: 'approval_callback',
             parent: ctx.traceRuntime.root,
             attributes: { 'oma.callback.name': 'onApproval' },
           })
-          let approved: boolean
-          try {
-            approved = await config.onApproval(completedThisRound, nextPending)
-          } catch (err) {
-            const reason = `Skipped: approval callback error — ${err instanceof Error ? err.message : String(err)}`
-            queue.skipRemaining(reason)
-            const classified = classifyRunFailure(err, { kind: 'callback' })
-            approvalSpan?.end({ status: classified.status, error: classified.errorInfo })
-            ctx.outcomeStatus = classified.status
-            ctx.outcomeErrorInfo = classified.errorInfo
+          let decision: NormalizedApprovalDecision = { action: 'allow' }
+          if (!priorApproval) {
+            try {
+              decision = normalizeApprovalDecision(
+                await config.onApproval(completedThisRound, nextPending),
+                'onApproval',
+              )
+              if (decision.action === 'suspend') {
+                assertDurableTaskApprovalSupport(nextPending)
+                const request = createApprovalRequest({
+                  runId: ctx.identity.runId,
+                  scope: 'task_round',
+                  boundary,
+                  content,
+                  ...(decision.reason !== undefined ? { reason: decision.reason } : {}),
+                })
+                await persistPendingApproval(queue, ctx, request)
+                ctx.outcomeStatus = statusOnly('suspended', 'Round approval pending.')
+              }
+            } catch (err) {
+              const reason = `Skipped: approval callback error — ${err instanceof Error ? err.message : String(err)}`
+              queue.skipRemaining(reason)
+              const classified = classifyRunFailure(err, { kind: 'callback' })
+              approvalSpan?.end({ status: classified.status, error: classified.errorInfo })
+              ctx.outcomeStatus = classified.status
+              ctx.outcomeErrorInfo = classified.errorInfo
+              break
+            }
+          }
+          if (decision.action === 'suspend') {
+            approvalSpan?.event('approval_decision', { 'oma.approval.decision': 'suspend' })
+            approvalSpan?.end({ status: statusOnly('suspended') })
             break
           }
-          if (!approved) {
+          if (decision.action === 'deny') {
             approvalSpan?.event('approval_decision', { 'oma.approval.approved': false })
             approvalSpan?.end({ status: statusOnly('rejected') })
             queue.skipRemaining('Skipped: approval rejected.')
             ctx.outcomeStatus = statusOnly('rejected', 'Approval rejected.')
             break
           }
-          approvalSpan?.event('approval_decision', { 'oma.approval.approved': true })
+          approvalSpan?.event('approval_decision', {
+            'oma.approval.approved': true,
+            ...(priorApproval ? { 'oma.approval.durable': true } : {}),
+          })
           approvalSpan?.end({ status: statusOnly('ok') })
         }
       }

--- a/packages/core/src/tool/executor.ts
+++ b/packages/core/src/tool/executor.ts
@@ -10,11 +10,25 @@
  * the framework.
  */
 
-import type { ToolCallGate, ToolCallGateMetadata, ToolResult, ToolResultMetadata, ToolUseContext } from '../types.js'
+import type {
+  ApprovalDecisionRecord,
+  ApprovalRequest,
+  ToolCallApprovalContent,
+  ToolCallGate,
+  ToolCallGateMetadata,
+  ToolResult,
+  ToolResultMetadata,
+  ToolUseContext,
+} from '../types.js'
 import type { ToolDefinition } from '../types.js'
 import { ToolRegistry } from './framework.js'
 import { Semaphore } from '../utils/semaphore.js'
 import type { ZodSchema } from 'zod'
+import {
+  assertApprovalDecision,
+  assertApprovalRequest,
+  hashApprovalRequest,
+} from '../approval/durable.js'
 
 // ---------------------------------------------------------------------------
 // ToolExecutor
@@ -42,6 +56,11 @@ export interface ToolExecutorOptions {
 export interface ToolExecutorExecutionOptions {
   /** Per-execution gate override. Takes priority over the constructor option. */
   readonly onToolCall?: ToolCallGate
+  /** Previously reviewed invocation supplied by checkpoint restore. */
+  readonly durableApproval?: {
+    readonly request: ApprovalRequest
+    readonly decision: ApprovalDecisionRecord
+  }
 }
 
 /** Describes one call in a batch. */
@@ -170,6 +189,9 @@ export class ToolExecutor {
     if (!inputParseResult.success) {
       return this.errorResult(
         `Invalid input for tool "${tool.name}":\n${inputParseResult.issuesMessage}`,
+        options.durableApproval
+          ? { approvalError: 'The current tool schema no longer accepts the reviewed input.' }
+          : undefined,
       )
     }
 
@@ -180,9 +202,51 @@ export class ToolExecutor {
       )
     }
 
+    const approvalContent = this.approvalContent(
+      tool.name,
+      rawInput,
+      inputParseResult.data as Record<string, unknown>,
+      tool.consequential === true,
+      context,
+    )
+    const restoredApproval = options.durableApproval
     const gate = options.onToolCall ?? this.onToolCall
     let gateMetadata: ToolCallGateMetadata | undefined
-    if (gate) {
+    let approvalDecision: ApprovalDecisionRecord | undefined
+    if (restoredApproval) {
+      try {
+        assertApprovalRequest(restoredApproval.request)
+        assertApprovalDecision(restoredApproval.decision, restoredApproval.request)
+        if (!approvalContent) {
+          throw new Error('Current tool context has no task/tool-call identity.')
+        }
+        const currentHash = hashApprovalRequest(
+          'tool_call',
+          restoredApproval.request.boundary,
+          approvalContent,
+        )
+        if (currentHash !== restoredApproval.request.requestHash) {
+          throw new Error('Current validated tool invocation differs from the reviewed content.')
+        }
+      } catch (error) {
+        return this.errorResult(
+          `Tool "${tool.name}" durable approval is stale or tampered: ${this.errorMessage(error)}`,
+          { approvalError: this.errorMessage(error) },
+        )
+      }
+      approvalDecision = restoredApproval.decision
+      if (approvalDecision.decision === 'rejected') {
+        gateMetadata = {
+          action: 'deny',
+          reason: `Rejected by durable reviewer "${approvalDecision.reviewer.id}".`,
+        }
+        return this.errorResult(`Tool "${tool.name}" denied by durable approval.`, {
+          toolCallGate: gateMetadata,
+          approvalDecision,
+        })
+      }
+      gateMetadata = { action: 'allow' }
+    } else if (gate) {
       let decision: unknown
       try {
         decision = await gate({
@@ -215,6 +279,18 @@ export class ToolExecutor {
           toolCallGate: gateMetadata,
         })
       }
+      if (gateMetadata.action === 'suspend') {
+        if (!approvalContent) {
+          return this.errorResult(
+            `Tool "${tool.name}" cannot suspend outside an orchestrated checkpointed task.`,
+            { toolCallGate: gateMetadata },
+          )
+        }
+        return this.errorResult(`Tool "${tool.name}" is awaiting durable approval.`, {
+          toolCallGate: gateMetadata,
+          approvalRequestContent: approvalContent,
+        })
+      }
     }
 
     // --- Execute ---
@@ -229,7 +305,13 @@ export class ToolExecutor {
           )
         }
       }
-      return this.withGateMetadata(this.maybeTruncate(tool, result), gateMetadata)
+      const withApproval = approvalDecision === undefined
+        ? result
+        : {
+            ...result,
+            metadata: { ...result.metadata, approvalDecision },
+          }
+      return this.withGateMetadata(this.maybeTruncate(tool, withApproval), gateMetadata)
     } catch (err) {
       return this.maybeTruncate(
         tool,
@@ -285,10 +367,10 @@ export class ToolExecutor {
   private gateMetadataFromDecision(decision: unknown): ToolCallGateMetadata | undefined {
     if (decision === null || typeof decision !== 'object') return undefined
     const action = (decision as { readonly action?: unknown }).action
-    if (action !== 'allow' && action !== 'deny') return undefined
+    if (action !== 'allow' && action !== 'deny' && action !== 'suspend') return undefined
     const reason = (decision as { readonly reason?: unknown }).reason
     if (reason !== undefined && typeof reason !== 'string') return undefined
-    if (action === 'deny' && reason !== undefined) {
+    if ((action === 'deny' || action === 'suspend') && reason !== undefined) {
       return { action, reason }
     }
     return { action }
@@ -304,6 +386,26 @@ export class ToolExecutor {
       : typeof err === 'string'
         ? err
         : JSON.stringify(err)
+  }
+
+  private approvalContent(
+    toolName: string,
+    rawInput: Record<string, unknown>,
+    input: Record<string, unknown>,
+    consequential: boolean,
+    context: ToolUseContext,
+  ): ToolCallApprovalContent | undefined {
+    if (!context.taskId || !context.toolCallId) return undefined
+    return {
+      kind: 'tool_call',
+      toolName,
+      rawInput,
+      input,
+      agentName: context.agent.name,
+      taskId: context.taskId,
+      toolCallId: context.toolCallId,
+      consequential,
+    }
   }
 
   /** Construct an error ToolResult. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -223,6 +223,7 @@ export type RunStatusCode =
   | 'timeout'
   | 'budget_exhausted'
   | 'rejected'
+  | 'suspended'
   | 'skipped'
 
 /** Normalised top-level outcome. */
@@ -256,6 +257,107 @@ export interface StructuredTraceError {
   readonly attempt?: number
 }
 
+// ---------------------------------------------------------------------------
+// Durable approvals
+// ---------------------------------------------------------------------------
+
+/** Durable approval boundary represented by an {@link ApprovalRequest}. */
+export type ApprovalScope = 'plan' | 'task_round' | 'task_dispatch' | 'tool_call'
+
+/** Exact checkpoint-resumable plan payload shown to a reviewer. */
+export interface PlanApprovalContent {
+  readonly kind: 'plan'
+  /** Whether approval continues execution or returns the already-built plan. */
+  readonly continuation: 'execute' | 'plan_only'
+  readonly tasks: readonly TaskSnapshot[]
+}
+
+/** Exact checkpoint-resumable legacy-round payload shown to a reviewer. */
+export interface TaskRoundApprovalContent {
+  readonly kind: 'task_round'
+  readonly completedTasks: readonly TaskSnapshot[]
+  readonly nextTasks: readonly TaskSnapshot[]
+}
+
+/** Exact checkpoint-resumable task-dispatch payload shown to a reviewer. */
+export interface TaskDispatchApprovalContent {
+  readonly kind: 'task_dispatch'
+  readonly task: TaskSnapshot
+}
+
+/** Exact validated tool invocation shown to a reviewer. */
+export interface ToolCallApprovalContent {
+  readonly kind: 'tool_call'
+  readonly toolName: string
+  /** Model-issued input retained so restore can detect a changed request. */
+  readonly rawInput: Readonly<Record<string, unknown>>
+  /** Zod-validated input that the tool implementation will receive. */
+  readonly input: Readonly<Record<string, unknown>>
+  readonly agentName: string
+  readonly taskId: string
+  readonly toolCallId: string
+  readonly consequential: boolean
+}
+
+/** Review payload supported by the durable approval subsystem. */
+export type ApprovalRequestContent =
+  | PlanApprovalContent
+  | TaskRoundApprovalContent
+  | TaskDispatchApprovalContent
+  | ToolCallApprovalContent
+
+/** Immutable, content-bound request persisted before a run reports suspension. */
+export interface ApprovalRequest {
+  readonly version: 1
+  readonly id: string
+  readonly runId: string
+  readonly scope: ApprovalScope
+  /** Stable boundary discriminator (for example a task or tool-call id). */
+  readonly boundary: string
+  /** SHA-256 of the canonical scope/boundary/content payload. */
+  readonly requestHash: string
+  readonly requestedAt: string
+  readonly reason?: string
+  readonly content: ApprovalRequestContent
+}
+
+/** Required human or service identity attached to a durable decision. */
+export interface ApprovalReviewer {
+  readonly id: string
+  readonly displayName?: string
+}
+
+/** Primary durable fact recording who decided what and when. */
+export interface ApprovalDecisionRecord {
+  readonly version: 1
+  readonly requestId: string
+  readonly runId: string
+  readonly scope: ApprovalScope
+  readonly requestHash: string
+  readonly decision: 'approved' | 'rejected'
+  readonly reviewer: ApprovalReviewer
+  readonly decidedAt: string
+}
+
+/** Stored approval ledger row. The request remains immutable after creation. */
+export interface ApprovalRecord {
+  readonly version: 1
+  readonly request: ApprovalRequest
+  readonly decision?: ApprovalDecisionRecord
+}
+
+/** Input accepted by {@link decideApproval}. */
+export interface ApprovalDecisionInput {
+  readonly requestId: string
+  /** Reviewer-side optimistic binding to the exact request that was inspected. */
+  readonly requestHash: string
+  readonly decision: 'approve' | 'reject'
+  readonly reviewer: ApprovalReviewer
+}
+
+/** Return value accepted by plan, round, and task-dispatch approval gates. */
+export type ApprovalGateDecision = boolean | ToolCallDecision
+
 /** Additive result fields introduced by Observability v2. */
 export interface RunOutcomeFields {
   /**
@@ -277,6 +379,10 @@ export interface RunOutcomeFields {
    * gate that returns `allow` to approve the call, or `deny` to reject it.
    */
   readonly confirmationRequired?: boolean
+  /** Requests that must receive durable decisions before {@link OpenMultiAgent.restore}. */
+  readonly pendingApprovals?: readonly ApprovalRequest[]
+  /** Durable decisions consumed by this logical run. */
+  readonly approvalDecisions?: readonly ApprovalDecisionRecord[]
 }
 
 /** Machine-readable warnings that describe how a run was governed. */
@@ -437,6 +543,7 @@ export interface ToolCallContext {
 export type ToolCallDecision =
   | { readonly action: 'allow' }
   | { readonly action: 'deny'; readonly reason?: string }
+  | { readonly action: 'suspend'; readonly reason?: string }
 
 /** Optional middleware invoked after input validation and before tool execution. */
 export type ToolCallGate = (context: ToolCallContext) => ToolCallDecision | Promise<ToolCallDecision>
@@ -495,6 +602,12 @@ export interface ToolResultMetadata {
   readonly tokenUsage?: TokenUsage
   /** Per-call gate decision, if an onToolCall hook evaluated this tool call. */
   readonly toolCallGate?: ToolCallGateMetadata
+  /** Internal hand-off from ToolExecutor to AgentRunner for a suspend decision. */
+  readonly approvalRequestContent?: ToolCallApprovalContent
+  /** Durable decision used instead of re-running an already-reviewed gate. */
+  readonly approvalDecision?: ApprovalDecisionRecord
+  /** Integrity error that prevented an approved tool invocation from executing. */
+  readonly approvalError?: string
 }
 
 /** Value returned by a tool's `execute` function. */
@@ -1903,6 +2016,7 @@ export interface OrchestratorEvent {
     | 'task_complete'
     | 'task_skipped'
     | 'task_retry'
+    | 'approval_pending'
     | 'plan_revision'
     | 'recovery_decision'
     | 'budget_exceeded'
@@ -2063,8 +2177,8 @@ export interface OrchestratorConfig {
    *
    * After a batch of tasks completes, this callback receives all
    * completed {@link Task}s from that round and the list of tasks about
-   * to start next. Return `true` to continue or `false` to abort —
-   * remaining tasks will be marked `'skipped'`.
+   * to start next. Return `true`/`allow` to continue, `false`/`deny` to abort,
+   * or `suspend` to persist this exact boundary for a later decision.
    *
    * Configuring this callback selects the legacy round-based executor. It is
    * mutually exclusive with {@link onTaskDispatch}.
@@ -2077,13 +2191,17 @@ export interface OrchestratorConfig {
    * callback — they are live references to queue state. Mutation is
    * undefined behavior.
    */
-  readonly onApproval?: (completedTasks: readonly Task[], nextTasks: readonly Task[]) => Promise<boolean>
+  readonly onApproval?: (
+    completedTasks: readonly Task[],
+    nextTasks: readonly Task[],
+  ) => ApprovalGateDecision | Promise<ApprovalGateDecision>
   /**
    * Optional per-task dispatch gate for event-driven DAG execution.
    *
    * Called after a ready task has an assignee and immediately before it is
-   * dispatched. Return `true` to start the task or `false` to stop new
-   * dispatches. On rejection, already-running tasks are allowed to settle and
+   * dispatched. Return `true`/`allow` to start the task, `false`/`deny` to stop
+   * new dispatches, or `suspend` to persist this exact task for a later
+   * decision. On rejection, already-running tasks are allowed to settle and
    * every remaining task is then marked `'skipped'`.
    *
    * This gate is mutually exclusive with {@link onApproval}. Configure
@@ -2093,13 +2211,16 @@ export interface OrchestratorConfig {
    * **Note:** Do not mutate the {@link Task} passed to this callback. It is a
    * live reference to queue state; mutation is undefined behavior.
    */
-  readonly onTaskDispatch?: (task: Readonly<Task>) => boolean | Promise<boolean>
+  readonly onTaskDispatch?: (
+    task: Readonly<Task>,
+  ) => ApprovalGateDecision | Promise<ApprovalGateDecision>
   /**
    * Optional approval gate called once after the coordinator decomposes the
    * goal into tasks and before execution begins.
    *
-   * Receives the full plan as a {@link Task} array. Return `true` to proceed
-   * or `false` to abort. A thrown callback is treated as an abort.
+   * Receives the full plan as a {@link Task} array. Return `true`/`allow` to
+   * proceed, `false`/`deny` to abort, or `suspend` to persist the exact plan for
+   * a later decision. A thrown callback is treated as an abort.
    *
    * Only invoked by `runTeam()`. `runAgent()` and `runTasks()` are
    * unaffected. The `TeamRunResult` returned on abort still reflects the
@@ -2109,7 +2230,9 @@ export interface OrchestratorConfig {
    * callback. They are live references to queue state; mutation is
    * undefined behavior.
    */
-  readonly onPlanReady?: (tasks: readonly Task[]) => Promise<boolean>
+  readonly onPlanReady?: (
+    tasks: readonly Task[],
+  ) => ApprovalGateDecision | Promise<ApprovalGateDecision>
   /**
    * Called for each streaming event emitted by an agent during runTeam().
    * When provided, agents run in streaming mode so the TUI can receive
@@ -2271,6 +2394,10 @@ export interface PendingToolCallCheckpoint {
   readonly call: ToolUseBlock
   /** Present only after the tool returned and its result was checkpointed. */
   readonly commit?: ToolCallCommitCheckpoint
+  /** Present while this exact validated invocation awaits or consumes review. */
+  readonly approvalRequest?: ApprovalRequest
+  /** Decision loaded from the primary approval ledger during restore. */
+  readonly approvalDecision?: ApprovalDecisionRecord
 }
 
 /**
@@ -2340,15 +2467,30 @@ export interface CheckpointSnapshotV2 extends CheckpointSnapshotBase {
   readonly identity: CheckpointRunIdentity
 }
 
-/** Current checkpoint schema with mid-task runner recovery. */
+/** Legacy checkpoint schema with mid-task runner recovery. */
 export interface CheckpointSnapshotV3 extends CheckpointSnapshotBase {
   readonly version: 3
   readonly identity: CheckpointRunIdentity
   readonly inFlightTasks: readonly InFlightTaskCheckpoint[]
 }
 
+/** Current checkpoint schema with durable approval continuation state. */
+export interface CheckpointSnapshotV4 extends CheckpointSnapshotBase {
+  readonly version: 4
+  readonly identity: CheckpointRunIdentity
+  readonly inFlightTasks: readonly InFlightTaskCheckpoint[]
+  /** Requests whose reviewed boundary has not yet been consumed by execution. */
+  readonly pendingApprovals: readonly ApprovalRequest[]
+  /** Durable decisions already consumed or ready to be consumed by this run. */
+  readonly approvalDecisions: readonly ApprovalDecisionRecord[]
+}
+
 /** Full persisted checkpoint for a task-based run. */
-export type CheckpointSnapshot = CheckpointSnapshotV1 | CheckpointSnapshotV2 | CheckpointSnapshotV3
+export type CheckpointSnapshot =
+  | CheckpointSnapshotV1
+  | CheckpointSnapshotV2
+  | CheckpointSnapshotV3
+  | CheckpointSnapshotV4
 
 /**
  * Optional overrides for the temporary coordinator agent created by `runTeam`.
@@ -2600,6 +2742,18 @@ export interface MemoryEntry {
 export interface MemoryStore {
   get(key: string): Promise<MemoryEntry | null>
   set(key: string, value: string, metadata?: Record<string, unknown>): Promise<void>
+  /**
+   * Optional atomic compare-and-set used by durable approval decisions.
+   * `expectedValue: null` means the key must not exist. Implementations that
+   * cannot make the comparison and write atomic across their supported writer
+   * scope must omit this method; suspendable approvals fail closed without it.
+   */
+  compareAndSet?(
+    key: string,
+    expectedValue: string | null,
+    value: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<boolean>
   /**
    * Optional: write an entry with a turn-count expiry. Stores that don't
    * implement this method silently lose TTL semantics — callers (e.g.

--- a/packages/core/tests/checkpoint.test.ts
+++ b/packages/core/tests/checkpoint.test.ts
@@ -978,8 +978,8 @@ describe('mid-task recovery conformance (#312)', () => {
     })
     expect(world.commits).toEqual(['B'])
     const persisted = await new Checkpoint(store).loadLatest()
-    expect(persisted?.version).toBe(3)
-    if (persisted?.version !== 3) throw new Error('expected checkpoint v3')
+    expect(persisted?.version).toBe(4)
+    if (persisted?.version !== 4) throw new Error('expected checkpoint v4')
     expect(persisted.inFlightTasks).toHaveLength(1)
     expect(persisted.inFlightTasks[0]).toMatchObject({
       phase: 'awaiting_model',
@@ -1030,8 +1030,8 @@ describe('mid-task recovery conformance (#312)', () => {
     })
     expect(world.commits).toEqual([])
     const persisted = await new Checkpoint(store).loadLatest()
-    expect(persisted?.version).toBe(3)
-    if (persisted?.version !== 3) throw new Error('expected checkpoint v3')
+    expect(persisted?.version).toBe(4)
+    if (persisted?.version !== 4) throw new Error('expected checkpoint v4')
     expect(persisted.inFlightTasks[0]).toMatchObject({
       phase: 'executing_tools',
       turns: 1,
@@ -1153,8 +1153,8 @@ describe('mid-task recovery conformance (#312)', () => {
     expect(commits).toEqual(['P'])
 
     const persisted = await new Checkpoint(store).loadLatest()
-    expect(persisted?.version).toBe(3)
-    if (persisted?.version !== 3) throw new Error('expected checkpoint v3')
+    expect(persisted?.version).toBe(4)
+    if (persisted?.version !== 4) throw new Error('expected checkpoint v4')
     const pending = persisted.inFlightTasks[0]?.pendingToolCalls
     expect(pending?.map(call => [call.call.id, call.commit?.result.content])).toEqual([
       ['tu-parallel-p', 'committed:P'],
@@ -1211,7 +1211,7 @@ describe('mid-task recovery conformance (#312)', () => {
     expect(world.commits).toEqual(['D'])
   })
 
-  it('persists the in-flight turn, tool commit, and queue boundary in checkpoint v3', async () => {
+  it('persists the in-flight turn, tool commit, and queue boundary in checkpoint v4', async () => {
     const store = new InMemoryStore()
     const abort = new AbortController()
     const world = externalWorld((label, count) => {
@@ -1237,8 +1237,8 @@ describe('mid-task recovery conformance (#312)', () => {
     // boundary, including the committed tool result that must be replayed.
     const persisted = await new Checkpoint(store, {}).loadLatest()
     expect(persisted).not.toBeNull()
-    expect(persisted?.version).toBe(3)
-    if (persisted?.version !== 3) throw new Error('expected checkpoint v3')
+    expect(persisted?.version).toBe(4)
+    if (persisted?.version !== 4) throw new Error('expected checkpoint v4')
     const snapshotJson = JSON.stringify(persisted)
     expect(snapshotJson).toContain('first done') // preserved: completed result
     expect(snapshotJson).toContain('committed:B') // preserved: per-call commit

--- a/packages/core/tests/durable-approval-validation.test.ts
+++ b/packages/core/tests/durable-approval-validation.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DurableApprovalError,
+  DurableApprovalLedger,
+  approvalKey,
+  createApprovalRequest,
+  InMemoryStore,
+} from '../src/index.js'
+import {
+  assertApprovalDecision,
+  assertApprovalRequest,
+  isApprovalRequest,
+} from '../src/approval/durable.js'
+import type {
+  ApprovalDecisionRecord,
+  ApprovalRequest,
+  ApprovalRequestContent,
+} from '../src/types.js'
+
+const requestedAt = new Date('2026-08-08T00:00:00.000Z')
+
+function toolContent(rawInput: unknown = { environment: 'staging' }): ApprovalRequestContent {
+  const input = rawInput as Record<string, unknown>
+  return {
+    kind: 'tool_call',
+    toolName: 'deploy',
+    rawInput: input,
+    input,
+    agentName: 'operator',
+    taskId: 'task-1',
+    toolCallId: 'call-1',
+    consequential: true,
+  }
+}
+
+function request(
+  overrides: Partial<Parameters<typeof createApprovalRequest>[0]> = {},
+): ApprovalRequest {
+  return createApprovalRequest({
+    runId: 'run-validation',
+    scope: 'tool_call',
+    boundary: 'task-1:call-1',
+    content: toolContent(),
+    requestedAt,
+    ...overrides,
+  })
+}
+
+function decisionFor(approval: ApprovalRequest): ApprovalDecisionRecord {
+  return {
+    version: 1,
+    requestId: approval.id,
+    runId: approval.runId,
+    scope: approval.scope,
+    requestHash: approval.requestHash,
+    decision: 'approved',
+    reviewer: { id: 'reviewer-1', displayName: 'Release reviewer' },
+    decidedAt: '2026-08-08T00:01:00.000Z',
+  }
+}
+
+describe('durable approval validation', () => {
+  it('rejects non-JSON approval payloads before hashing them', () => {
+    const cyclic: Record<string, unknown> = {}
+    cyclic['self'] = cyclic
+    const invalidPayloads: unknown[] = [
+      { amount: Number.NaN },
+      cyclic,
+      new Date('2026-08-08T00:00:00.000Z'),
+      { amount: undefined },
+      { amount: 1n },
+    ]
+
+    for (const rawInput of invalidPayloads) {
+      expect(() => request({ content: toolContent(rawInput) }))
+        .toThrowError(DurableApprovalError)
+    }
+  })
+
+  it('rejects invalid request creation inputs', () => {
+    expect(() => request({ runId: ' ' })).toThrow('runId and boundary must be non-empty')
+    expect(() => request({ boundary: ' ' })).toThrow('runId and boundary must be non-empty')
+    expect(() => request({ scope: 'plan' })).toThrow('does not match content kind')
+    expect(() => request({ reason: 42 as unknown as string })).toThrow('reason must be a string')
+  })
+
+  it('rejects malformed or content-inconsistent persisted requests', () => {
+    const valid = request()
+    const malformed: unknown[] = [
+      { ...valid, version: 2 },
+      { ...valid, id: 'not-an-approval-id' },
+      { ...valid, requestedAt: 'not-a-date' },
+      { ...valid, scope: 'plan', content: null },
+      {
+        ...valid,
+        scope: 'plan',
+        content: { kind: 'plan', continuation: 'later', tasks: [] },
+      },
+      {
+        ...valid,
+        scope: 'plan',
+        content: { kind: 'plan', continuation: 'execute', tasks: 'not-an-array' },
+      },
+      {
+        ...valid,
+        scope: 'plan',
+        content: { kind: 'plan', continuation: 'execute', tasks: [{}] },
+      },
+      {
+        ...valid,
+        scope: 'task_round',
+        content: { kind: 'task_round', completedTasks: [], nextTasks: 'not-an-array' },
+      },
+      { ...valid, content: { kind: 'tool_call' } },
+      { ...valid, scope: 'plan', content: { kind: 'unknown' } },
+      { ...valid, scope: 'plan' },
+      { ...valid, id: `apr_${'f'.repeat(32)}` },
+    ]
+
+    for (const value of malformed) {
+      expect(() => assertApprovalRequest(value)).toThrowError(DurableApprovalError)
+      expect(isApprovalRequest(value)).toBe(false)
+    }
+    expect(isApprovalRequest(valid)).toBe(true)
+  })
+
+  it('rejects malformed decisions and decisions bound to another request', () => {
+    const approval = request()
+    const valid = decisionFor(approval)
+    const malformed: unknown[] = [
+      { ...valid, version: 2 },
+      { ...valid, decision: 'pending' },
+      { ...valid, reviewer: { id: ' ' } },
+      { ...valid, reviewer: { id: 'reviewer-1', displayName: 42 } },
+      { ...valid, decidedAt: 'not-a-date' },
+    ]
+
+    for (const value of malformed) {
+      expect(() => assertApprovalDecision(value)).toThrowError(DurableApprovalError)
+    }
+    expect(() => assertApprovalDecision({ ...valid, runId: 'another-run' }, approval))
+      .toThrow('does not bind the pending request')
+    expect(() => assertApprovalDecision(valid, approval)).not.toThrow()
+  })
+})
+
+describe('durable approval ledger edge cases', () => {
+  it('treats the same request as idempotent and rejects conflicting metadata', async () => {
+    const store = new InMemoryStore()
+    const ledger = new DurableApprovalLedger(store)
+    const approval = request()
+
+    await expect(ledger.ensureRequest(approval)).resolves.toEqual({ version: 1, request: approval })
+    await expect(ledger.ensureRequest(approval)).resolves.toEqual({ version: 1, request: approval })
+    await expect(ledger.ensureRequest({ ...approval, reason: 'different review context' }))
+      .rejects.toMatchObject({ code: 'APPROVAL_CONFLICT' })
+  })
+
+  it('fails closed for missing, malformed, and mis-keyed ledger records', async () => {
+    const missing = new DurableApprovalLedger(new InMemoryStore())
+    await expect(missing.get(request().id)).resolves.toBeNull()
+
+    const malformedStore = new InMemoryStore()
+    const approval = request()
+    await malformedStore.set(approvalKey(approval.id), '{not-json')
+    await expect(new DurableApprovalLedger(malformedStore).get(approval.id))
+      .rejects.toMatchObject({ code: 'APPROVAL_INTEGRITY_ERROR' })
+
+    const misKeyedStore = new InMemoryStore()
+    const otherId = `apr_${'f'.repeat(32)}`
+    await misKeyedStore.set(
+      approvalKey(otherId),
+      JSON.stringify({ version: 1, request: approval }),
+    )
+    await expect(new DurableApprovalLedger(misKeyedStore).get(otherId))
+      .rejects.toMatchObject({ code: 'APPROVAL_INTEGRITY_ERROR' })
+  })
+
+  it('rejects invalid, missing, corrupt, mis-keyed, and repeated decisions', async () => {
+    const approval = request()
+    const ledger = new DurableApprovalLedger(new InMemoryStore())
+    await expect(ledger.decide({
+      requestId: approval.id,
+      requestHash: approval.requestHash,
+      decision: 'invalid' as 'approve',
+      reviewer: { id: 'reviewer-1' },
+    })).rejects.toMatchObject({ code: 'APPROVAL_VALIDATION_ERROR' })
+    await expect(ledger.decide({
+      requestId: approval.id,
+      requestHash: approval.requestHash,
+      decision: 'approve',
+      reviewer: { id: 'reviewer-1' },
+    })).rejects.toMatchObject({ code: 'APPROVAL_NOT_FOUND' })
+
+    const corruptStore = new InMemoryStore()
+    await corruptStore.set(approvalKey(approval.id), '{not-json')
+    await expect(new DurableApprovalLedger(corruptStore).decide({
+      requestId: approval.id,
+      requestHash: approval.requestHash,
+      decision: 'approve',
+      reviewer: { id: 'reviewer-1' },
+    })).rejects.toMatchObject({ code: 'APPROVAL_INTEGRITY_ERROR' })
+
+    const misKeyedStore = new InMemoryStore()
+    const otherId = `apr_${'f'.repeat(32)}`
+    await misKeyedStore.set(
+      approvalKey(otherId),
+      JSON.stringify({ version: 1, request: approval }),
+    )
+    await expect(new DurableApprovalLedger(misKeyedStore).decide({
+      requestId: otherId,
+      requestHash: approval.requestHash,
+      decision: 'approve',
+      reviewer: { id: 'reviewer-1' },
+    })).rejects.toMatchObject({ code: 'APPROVAL_INTEGRITY_ERROR' })
+
+    const decidedStore = new InMemoryStore()
+    const decidedLedger = new DurableApprovalLedger(decidedStore)
+    await decidedLedger.ensureRequest(approval)
+    await decidedLedger.decide({
+      requestId: approval.id,
+      requestHash: approval.requestHash,
+      decision: 'approve',
+      reviewer: { id: 'reviewer-1' },
+    })
+    await expect(decidedLedger.decide({
+      requestId: approval.id,
+      requestHash: approval.requestHash,
+      decision: 'reject',
+      reviewer: { id: 'reviewer-2' },
+    })).rejects.toMatchObject({ code: 'APPROVAL_CONFLICT' })
+  })
+})

--- a/packages/core/tests/durable-approval.test.ts
+++ b/packages/core/tests/durable-approval.test.ts
@@ -1,0 +1,683 @@
+import { describe, expect, it, vi } from 'vitest'
+import { z } from 'zod'
+import {
+  APPROVAL_KEY_PREFIX,
+  DurableApprovalLedger,
+  DurableApprovalError,
+  approvalKey,
+  buildExecutionReceipt,
+  createApprovalRequest,
+  decideApproval,
+  defineTool,
+  getApprovalRecord,
+  InMemoryStore,
+  OpenMultiAgent,
+} from '../src/index.js'
+import { Checkpoint } from '../src/memory/checkpoint.js'
+import type {
+  AgentConfig,
+  ApprovalRequest,
+  CheckpointSnapshotV4,
+  LLMAdapter,
+  LLMChatOptions,
+  LLMMessage,
+  LLMResponse,
+  MemoryStore,
+} from '../src/index.js'
+
+function textResponse(text: string): LLMResponse {
+  return {
+    id: `text-${text}`,
+    content: [{ type: 'text', text }],
+    model: 'mock-model',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function toolResponse(
+  name: string,
+  input: Record<string, unknown>,
+  id = 'tool-call-1',
+): LLMResponse {
+  return {
+    id: `tool-${id}`,
+    content: [{ type: 'tool_use', id, name, input }],
+    model: 'mock-model',
+    stop_reason: 'tool_use',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function scriptedAdapter(responses: readonly LLMResponse[]) {
+  let index = 0
+  const inputs: LLMMessage[][] = []
+  const adapter: LLMAdapter = {
+    name: 'durable-approval-test',
+    async chat(messages: LLMMessage[], _options: LLMChatOptions): Promise<LLMResponse> {
+      inputs.push(messages)
+      const response = responses[index]
+      if (!response) throw new Error(`No scripted response for call ${index + 1}.`)
+      index++
+      return response
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: textResponse('unused') }
+    },
+  }
+  return { adapter, calls: () => index, inputs }
+}
+
+function worker(name: string, adapter: LLMAdapter, extra: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    name,
+    model: 'mock-model',
+    adapter,
+    systemPrompt: `You are ${name}.`,
+    ...extra,
+  }
+}
+
+function onePending(result: { readonly pendingApprovals?: readonly ApprovalRequest[] }): ApprovalRequest {
+  expect(result.pendingApprovals).toHaveLength(1)
+  return result.pendingApprovals![0]!
+}
+
+async function approve(store: MemoryStore, request: ApprovalRequest, reviewer = 'reviewer-1') {
+  return decideApproval(store, {
+    requestId: request.id,
+    requestHash: request.requestHash,
+    decision: 'approve',
+    reviewer: { id: reviewer, displayName: 'Release reviewer' },
+  })
+}
+
+function ledgerRequest(): ApprovalRequest {
+  return createApprovalRequest({
+    runId: 'run-ledger',
+    scope: 'tool_call',
+    boundary: 'task-1:call-1',
+    content: {
+      kind: 'tool_call',
+      toolName: 'deploy',
+      rawInput: { environment: 'staging' },
+      input: { environment: 'staging' },
+      agentName: 'operator',
+      taskId: 'task-1',
+      toolCallId: 'call-1',
+      consequential: true,
+    },
+    requestedAt: new Date('2026-08-08T00:00:00.000Z'),
+  })
+}
+
+describe('durable approval ledger', () => {
+  it('binds decisions to the reviewed hash and resolves concurrent reviewers first-wins', async () => {
+    const store = new InMemoryStore()
+    const request = ledgerRequest()
+    await new DurableApprovalLedger(store).ensureRequest(request)
+
+    await expect(decideApproval(store, {
+      requestId: request.id,
+      requestHash: '0'.repeat(64),
+      decision: 'approve',
+      reviewer: { id: 'stale-reviewer' },
+    })).rejects.toMatchObject({ code: 'APPROVAL_STALE_DECISION' })
+
+    const decisions = await Promise.allSettled([
+      approve(store, request, 'reviewer-a'),
+      decideApproval(store, {
+        requestId: request.id,
+        requestHash: request.requestHash,
+        decision: 'reject',
+        reviewer: { id: 'reviewer-b' },
+      }),
+    ])
+
+    expect(decisions.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+    const rejected = decisions.find((result) => result.status === 'rejected')
+    expect(rejected).toMatchObject({
+      status: 'rejected',
+      reason: { code: 'APPROVAL_CONFLICT' },
+    })
+    const record = await getApprovalRecord(store, request.id)
+    expect(record?.decision).toMatchObject({
+      requestId: request.id,
+      requestHash: request.requestHash,
+      decision: 'approved',
+      reviewer: { id: 'reviewer-a' },
+    })
+    expect(Date.parse(record!.decision!.decidedAt)).not.toBeNaN()
+  })
+
+  it('rejects a tampered primary record instead of trusting it as execution state', async () => {
+    const store = new InMemoryStore()
+    const request = ledgerRequest()
+    await new DurableApprovalLedger(store).ensureRequest(request)
+    const entry = await store.get(approvalKey(request.id))
+    const record = JSON.parse(entry!.value) as { request: ApprovalRequest }
+    await store.set(approvalKey(request.id), JSON.stringify({
+      ...record,
+      request: {
+        ...record.request,
+        content: { ...record.request.content, toolName: 'delete_everything' },
+      },
+    }))
+
+    await expect(getApprovalRecord(store, request.id)).rejects.toBeInstanceOf(DurableApprovalError)
+  })
+
+  it('fails closed when the configured store has no atomic compare-and-set', async () => {
+    const base = new InMemoryStore()
+    const store: MemoryStore = {
+      get: (key) => base.get(key),
+      set: (key, value, metadata) => base.set(key, value, metadata),
+      list: () => base.list(),
+      delete: (key) => base.delete(key),
+      clear: () => base.clear(),
+    }
+
+    await expect(new DurableApprovalLedger(store).ensureRequest(ledgerRequest()))
+      .rejects.toMatchObject({ code: 'APPROVAL_ATOMIC_STORE_REQUIRED' })
+  })
+})
+
+describe('durable orchestration boundaries', () => {
+  it('fails closed before exposing a pending request when checkpoint storage has no CAS', async () => {
+    const base = new InMemoryStore()
+    const store: MemoryStore = {
+      get: (key) => base.get(key),
+      set: (key, value, metadata) => base.set(key, value, metadata),
+      list: () => base.list(),
+      delete: (key) => base.delete(key),
+      clear: () => base.clear(),
+    }
+    const adapter = scriptedAdapter([textResponse('must not run')])
+    const oma = new OpenMultiAgent({
+      onTaskDispatch: async () => ({ action: 'suspend' }),
+    })
+    const team = oma.createTeam('no-cas', {
+      name: 'no-cas',
+      agents: [worker('worker', adapter.adapter)],
+      sharedMemory: false,
+    })
+
+    const result = await oma.runTasks(team, [
+      { title: 'Protected', description: 'Must wait.', assignee: 'worker' },
+    ], { checkpoint: { store } })
+
+    expect(result.success).toBe(false)
+    expect(result.pendingApprovals).toBeUndefined()
+    expect(adapter.calls()).toBe(0)
+    expect((await store.list()).some((entry) => entry.key.startsWith(APPROVAL_KEY_PREFIX)))
+      .toBe(false)
+  })
+
+  it('suspends a generated plan, then restores and executes the exact approved plan', async () => {
+    const store = new InMemoryStore()
+    const coordinator = scriptedAdapter([
+      textResponse('[{"title":"Research","description":"Research first","assignee":"worker"}]'),
+    ])
+    const initialWorker = scriptedAdapter([textResponse('must not run')])
+    const onPlanReady = vi.fn(async () => ({ action: 'suspend' as const, reason: 'Human review' }))
+    const oma = new OpenMultiAgent({ defaultModel: 'mock-model', onPlanReady })
+    const team = oma.createTeam('plan-approval', {
+      name: 'plan-approval',
+      agents: [worker('worker', initialWorker.adapter)],
+      sharedMemory: false,
+    })
+
+    const suspended = await oma.runTeam(
+      team,
+      'Research the topic, then prepare a guide from the findings.',
+      {
+        mode: 'team',
+        checkpoint: { store },
+        coordinator: { model: 'mock-model', adapter: coordinator.adapter },
+      },
+    )
+    expect(onPlanReady).toHaveBeenCalledTimes(1)
+    expect(suspended.status?.code).toBe('suspended')
+    const request = onePending(suspended)
+    expect(suspended).toMatchObject({ success: false, status: { code: 'suspended' } })
+    expect(request).toMatchObject({ scope: 'plan', content: { kind: 'plan', continuation: 'execute' } })
+    expect(initialWorker.calls()).toBe(0)
+    await approve(store, request)
+
+    const resumedWorker = scriptedAdapter([textResponse('researched')])
+    const synthesis = scriptedAdapter([textResponse('final guide')])
+    const restoredGate = vi.fn(async () => false)
+    const resumedOma = new OpenMultiAgent({ defaultModel: 'mock-model', onPlanReady: restoredGate })
+    const resumedTeam = resumedOma.createTeam('plan-approval', {
+      name: 'plan-approval',
+      agents: [worker('worker', resumedWorker.adapter)],
+      sharedMemory: false,
+    })
+    const result = await resumedOma.restore(resumedTeam, {
+      checkpoint: { store },
+      coordinator: { model: 'mock-model', adapter: synthesis.adapter },
+    })
+
+    expect(result.success).toBe(true)
+    expect(result.tasks?.map((task) => [task.title, task.status])).toEqual([['Research', 'completed']])
+    expect(result.approvalDecisions?.[0]).toMatchObject({
+      requestId: request.id,
+      decision: 'approved',
+      reviewer: { id: 'reviewer-1' },
+    })
+    expect(resumedWorker.calls()).toBe(1)
+    expect(synthesis.calls()).toBe(1)
+    expect(restoredGate).not.toHaveBeenCalled()
+  })
+
+  it('restores an approved planOnly request without dispatching the plan', async () => {
+    const store = new InMemoryStore()
+    const coordinator = scriptedAdapter([
+      textResponse('[{"title":"Review","description":"Review only","assignee":"worker"}]'),
+    ])
+    const initialWorker = scriptedAdapter([textResponse('must not run')])
+    const oma = new OpenMultiAgent({
+      defaultModel: 'mock-model',
+      onPlanReady: async () => ({ action: 'suspend' }),
+    })
+    const team = oma.createTeam('plan-only-approval', {
+      name: 'plan-only-approval',
+      agents: [worker('worker', initialWorker.adapter)],
+      sharedMemory: false,
+    })
+
+    const suspended = await oma.runTeam(team, 'Prepare a review plan.', {
+      mode: 'team',
+      planOnly: true,
+      checkpoint: { store },
+      coordinator: { model: 'mock-model', adapter: coordinator.adapter },
+    })
+    const request = onePending(suspended)
+    expect(request).toMatchObject({
+      scope: 'plan',
+      content: { kind: 'plan', continuation: 'plan_only' },
+    })
+    expect(suspended.status?.code).toBe('suspended')
+    expect(initialWorker.calls()).toBe(0)
+    await approve(store, request)
+
+    const resumedWorker = scriptedAdapter([textResponse('must not run')])
+    const resumedGate = vi.fn(async () => false)
+    const resumed = new OpenMultiAgent({ onPlanReady: resumedGate })
+    const resumedTeam = resumed.createTeam('plan-only-approval', {
+      name: 'plan-only-approval',
+      agents: [worker('worker', resumedWorker.adapter)],
+      sharedMemory: false,
+    })
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const result = await resumed.restore(resumedTeam, { checkpoint: { store } })
+      expect(result).toMatchObject({ success: true, planOnly: true, status: { code: 'ok' } })
+      expect(result.tasks?.[0]?.status).toBe('pending')
+    }
+    expect(resumedWorker.calls()).toBe(0)
+    expect(resumedGate).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when a suspended task contains non-resumable verify wiring', async () => {
+    const store = new InMemoryStore()
+    const workerAdapter = scriptedAdapter([textResponse('must not run')])
+    const judgeAdapter = scriptedAdapter([textResponse('must not run')])
+    const judge = worker('judge', judgeAdapter.adapter)
+    const oma = new OpenMultiAgent({
+      onTaskDispatch: async () => ({ action: 'suspend' }),
+    })
+    const team = oma.createTeam('verify-approval', {
+      name: 'verify-approval',
+      agents: [worker('worker', workerAdapter.adapter), judge],
+      sharedMemory: false,
+    })
+
+    const result = await oma.runTasks(team, [{
+      title: 'Verified task',
+      description: 'This task has live verifier wiring.',
+      assignee: 'worker',
+      verify: { judges: [judge] },
+    }], { checkpoint: { store } })
+
+    expect(result.status?.code).toBe('error')
+    expect(result.pendingApprovals).toBeUndefined()
+    expect(workerAdapter.calls()).toBe(0)
+    expect(judgeAdapter.calls()).toBe(0)
+    expect((await store.list()).some((entry) => entry.key.startsWith(APPROVAL_KEY_PREFIX)))
+      .toBe(false)
+  })
+
+  it('suspends task dispatch before work and consumes that exact approval once after restart', async () => {
+    const store = new InMemoryStore()
+    const initialWorker = scriptedAdapter([textResponse('must not run')])
+    const dispatchGate = vi.fn(async () => ({ action: 'suspend' as const }))
+    const oma = new OpenMultiAgent({ onTaskDispatch: dispatchGate })
+    const team = oma.createTeam('dispatch-approval', {
+      name: 'dispatch-approval',
+      agents: [worker('worker', initialWorker.adapter)],
+      sharedMemory: false,
+    })
+
+    const suspended = await oma.runTasks(team, [
+      { title: 'Deploy', description: 'Deploy the reviewed build.', assignee: 'worker' },
+    ], { checkpoint: { store } })
+    const request = onePending(suspended)
+    expect(suspended.status?.code).toBe('suspended')
+    expect(request.scope).toBe('task_dispatch')
+    expect(initialWorker.calls()).toBe(0)
+    await approve(store, request)
+
+    const resumedWorker = scriptedAdapter([textResponse('deployed')])
+    const restoredGate = vi.fn(async () => false)
+    const resumedOma = new OpenMultiAgent({ onTaskDispatch: restoredGate })
+    const resumedTeam = resumedOma.createTeam('dispatch-approval', {
+      name: 'dispatch-approval',
+      agents: [worker('worker', resumedWorker.adapter)],
+      sharedMemory: false,
+    })
+    const result = await resumedOma.restore(resumedTeam, { checkpoint: { store } })
+
+    expect(result.success).toBe(true)
+    expect(result.tasks?.[0]?.status).toBe('completed')
+    expect(resumedWorker.calls()).toBe(1)
+    expect(restoredGate).not.toHaveBeenCalled()
+  })
+
+  it('keeps a rejected dispatch terminal across repeated restores', async () => {
+    const store = new InMemoryStore()
+    const initialWorker = scriptedAdapter([textResponse('must not run')])
+    const oma = new OpenMultiAgent({
+      onTaskDispatch: async () => ({ action: 'suspend' }),
+    })
+    const team = oma.createTeam('dispatch-rejection', {
+      name: 'dispatch-rejection',
+      agents: [worker('worker', initialWorker.adapter)],
+      sharedMemory: false,
+    })
+    const suspended = await oma.runTasks(team, [
+      { title: 'Deploy', description: 'Deploy.', assignee: 'worker' },
+    ], { checkpoint: { store } })
+    const request = onePending(suspended)
+    await decideApproval(store, {
+      requestId: request.id,
+      requestHash: request.requestHash,
+      decision: 'reject',
+      reviewer: { id: 'reviewer-1' },
+    })
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const adapter = scriptedAdapter([textResponse('must not run')])
+      const resumed = new OpenMultiAgent({ onTaskDispatch: async () => true })
+      const resumedTeam = resumed.createTeam('dispatch-rejection', {
+        name: 'dispatch-rejection',
+        agents: [worker('worker', adapter.adapter)],
+        sharedMemory: false,
+      })
+      const result = await resumed.restore(resumedTeam, { checkpoint: { store } })
+      expect(result.status?.code).toBe('rejected')
+      expect(result.tasks?.[0]?.status).toBe('skipped')
+      expect(adapter.calls()).toBe(0)
+    }
+  })
+
+  it('suspends a legacy round after completed work and resumes only the approved next round', async () => {
+    const store = new InMemoryStore()
+    const firstRun = scriptedAdapter([textResponse('first complete')])
+    const roundGate = vi.fn(async () => ({ action: 'suspend' as const }))
+    const oma = new OpenMultiAgent({ onApproval: roundGate })
+    const team = oma.createTeam('round-approval', {
+      name: 'round-approval',
+      agents: [worker('worker', firstRun.adapter)],
+      sharedMemory: false,
+    })
+
+    const suspended = await oma.runTasks(team, [
+      { title: 'Prepare', description: 'Prepare.', assignee: 'worker' },
+      { title: 'Publish', description: 'Publish.', assignee: 'worker', dependsOn: ['Prepare'] },
+    ], { checkpoint: { store } })
+    const request = onePending(suspended)
+    expect(suspended.status?.code).toBe('suspended')
+    expect(suspended.tasks?.map((task) => [task.title, task.status])).toEqual([
+      ['Prepare', 'completed'],
+      ['Publish', 'pending'],
+    ])
+    expect(request.scope).toBe('task_round')
+    expect(firstRun.calls()).toBe(1)
+    await approve(store, request)
+
+    const secondRun = scriptedAdapter([textResponse('published')])
+    const restoredGate = vi.fn(async () => false)
+    const resumedOma = new OpenMultiAgent({ onApproval: restoredGate })
+    const resumedTeam = resumedOma.createTeam('round-approval', {
+      name: 'round-approval',
+      agents: [worker('worker', secondRun.adapter)],
+      sharedMemory: false,
+    })
+    const result = await resumedOma.restore(resumedTeam, { checkpoint: { store } })
+
+    expect(result.success).toBe(true)
+    expect(result.tasks?.every((task) => task.status === 'completed')).toBe(true)
+    expect(secondRun.calls()).toBe(1)
+    expect(restoredGate).not.toHaveBeenCalled()
+  })
+})
+
+describe('durable tool-call approval', () => {
+  function toolHarness(store: InMemoryStore) {
+    const executions: number[] = []
+    const tool = defineTool({
+      name: 'charge_card',
+      description: 'Charge a card.',
+      consequential: true,
+      inputSchema: z.object({ amount: z.coerce.number().int().positive() }),
+      execute: async ({ amount }) => {
+        executions.push(amount)
+        return { data: `charged:${amount}`, isError: false }
+      },
+    })
+    const initialAdapter = scriptedAdapter([
+      toolResponse('charge_card', { amount: '7' }),
+    ])
+    const gate = vi.fn(async () => ({ action: 'suspend' as const, reason: 'Finance review' }))
+    const oma = new OpenMultiAgent({ onToolCall: gate })
+    const team = oma.createTeam('tool-approval', {
+      name: 'tool-approval',
+      agents: [worker('operator', initialAdapter.adapter, { customTools: [tool] })],
+      sharedMemory: false,
+    })
+    return { executions, tool, initialAdapter, gate, oma, team, store }
+  }
+
+  it('does not execute before suspension and executes the exact validated invocation once after approval', async () => {
+    const store = new InMemoryStore()
+    const harness = toolHarness(store)
+    const suspended = await harness.oma.runTasks(harness.team, [
+      {
+        title: 'Charge',
+        description: 'Charge the approved amount.',
+        assignee: 'operator',
+        maxRetries: 2,
+        retryDelayMs: 0,
+      },
+    ], { checkpoint: { store } })
+    const request = onePending(suspended)
+
+    expect(suspended.status?.code).toBe('suspended')
+    expect(harness.executions).toEqual([])
+    expect(request).toMatchObject({
+      scope: 'tool_call',
+      content: {
+        kind: 'tool_call',
+        toolName: 'charge_card',
+        rawInput: { amount: '7' },
+        input: { amount: 7 },
+        consequential: true,
+      },
+    })
+    expect(harness.gate).toHaveBeenCalledTimes(1)
+    await approve(store, request, 'finance@example.com')
+
+    const resumedAdapter = scriptedAdapter([textResponse('charge complete')])
+    const restoredGate = vi.fn(async () => ({ action: 'deny' as const }))
+    const resumedOma = new OpenMultiAgent({ onToolCall: restoredGate })
+    const resumedTeam = resumedOma.createTeam('tool-approval', {
+      name: 'tool-approval',
+      agents: [worker('operator', resumedAdapter.adapter, { customTools: [harness.tool] })],
+      sharedMemory: false,
+    })
+    const result = await resumedOma.restore(resumedTeam, { checkpoint: { store } })
+
+    expect(result.success).toBe(true)
+    expect(harness.executions).toEqual([7])
+    expect(restoredGate).not.toHaveBeenCalled()
+    expect(result.approvalDecisions?.[0]).toMatchObject({
+      requestId: request.id,
+      decision: 'approved',
+      reviewer: { id: 'finance@example.com' },
+    })
+    expect(buildExecutionReceipt(result).approvalDecisions).toEqual([
+      expect.objectContaining({
+        requestId: request.id,
+        decision: 'approved',
+        reviewerId: 'finance@example.com',
+      }),
+    ])
+  })
+
+  it('turns a durable rejection into a denied tool result without executing the side effect', async () => {
+    const store = new InMemoryStore()
+    const harness = toolHarness(store)
+    const suspended = await harness.oma.runTasks(harness.team, [
+      { title: 'Charge', description: 'Charge the approved amount.', assignee: 'operator' },
+    ], { checkpoint: { store } })
+    const request = onePending(suspended)
+    await decideApproval(store, {
+      requestId: request.id,
+      requestHash: request.requestHash,
+      decision: 'reject',
+      reviewer: { id: 'finance-reviewer' },
+    })
+
+    const resumedAdapter = scriptedAdapter([textResponse('charge cancelled')])
+    const resumedOma = new OpenMultiAgent({ onToolCall: async () => ({ action: 'allow' }) })
+    const resumedTeam = resumedOma.createTeam('tool-approval', {
+      name: 'tool-approval',
+      agents: [worker('operator', resumedAdapter.adapter, { customTools: [harness.tool] })],
+      sharedMemory: false,
+    })
+    const result = await resumedOma.restore(resumedTeam, { checkpoint: { store } })
+
+    expect(result.success).toBe(true)
+    expect(harness.executions).toEqual([])
+    expect(JSON.stringify(resumedAdapter.inputs[0])).toContain('denied by durable approval')
+    expect(result.approvalDecisions?.[0]?.decision).toBe('rejected')
+  })
+
+  it('rejects approval when the current tool schema no longer accepts the reviewed input', async () => {
+    const store = new InMemoryStore()
+    const harness = toolHarness(store)
+    const suspended = await harness.oma.runTasks(harness.team, [
+      {
+        title: 'Charge',
+        description: 'Charge the approved amount.',
+        assignee: 'operator',
+        maxRetries: 2,
+        retryDelayMs: 0,
+      },
+    ], { checkpoint: { store } })
+    const request = onePending(suspended)
+    await approve(store, request)
+
+    const replacementExecutions: number[] = []
+    const replacementTool = defineTool({
+      name: 'charge_card',
+      description: 'Charge a card under the new limit.',
+      consequential: true,
+      inputSchema: z.object({ amount: z.coerce.number().int().positive().max(5) }),
+      execute: async ({ amount }) => {
+        replacementExecutions.push(amount)
+        return { data: `charged:${amount}`, isError: false }
+      },
+    })
+    const resumedAdapter = scriptedAdapter([textResponse('must not run')])
+    const resumedOma = new OpenMultiAgent({ onToolCall: async () => ({ action: 'allow' }) })
+    const resumedTeam = resumedOma.createTeam('tool-approval', {
+      name: 'tool-approval',
+      agents: [worker('operator', resumedAdapter.adapter, { customTools: [replacementTool] })],
+      sharedMemory: false,
+    })
+
+    await expect(resumedOma.restore(resumedTeam, { checkpoint: { store } }))
+      .rejects.toMatchObject({ code: 'APPROVAL_STALE_DECISION' })
+    expect(harness.executions).toEqual([])
+    expect(replacementExecutions).toEqual([])
+    expect(resumedAdapter.calls()).toBe(0)
+  })
+
+  it('rejects a checkpoint whose pending tool input changed after review', async () => {
+    const store = new InMemoryStore()
+    const harness = toolHarness(store)
+    const suspended = await harness.oma.runTasks(harness.team, [
+      { title: 'Charge', description: 'Charge the approved amount.', assignee: 'operator' },
+    ], { checkpoint: { store } })
+    const request = onePending(suspended)
+    await approve(store, request)
+
+    const checkpoint = new Checkpoint(store)
+    const snapshot = await checkpoint.loadLatest()
+    expect(snapshot?.version).toBe(4)
+    const tampered = structuredClone(snapshot) as CheckpointSnapshotV4
+    const state = tampered.inFlightTasks[0]!
+    const pending = state.pendingToolCalls![0]!
+    ;(pending.call.input as Record<string, unknown>)['amount'] = '7000'
+    await checkpoint.save(tampered)
+
+    const resumedAdapter = scriptedAdapter([textResponse('must not run')])
+    const resumedOma = new OpenMultiAgent({ onToolCall: async () => ({ action: 'allow' }) })
+    const resumedTeam = resumedOma.createTeam('tool-approval', {
+      name: 'tool-approval',
+      agents: [worker('operator', resumedAdapter.adapter, { customTools: [harness.tool] })],
+      sharedMemory: false,
+    })
+
+    await expect(resumedOma.restore(resumedTeam, { checkpoint: { store } }))
+      .rejects.toMatchObject({ code: 'APPROVAL_STALE_DECISION' })
+    expect(harness.executions).toEqual([])
+    expect(resumedAdapter.calls()).toBe(0)
+  })
+
+  it('rejects a checkpoint that hides an in-flight approval from the top-level pending set', async () => {
+    const store = new InMemoryStore()
+    const harness = toolHarness(store)
+    const suspended = await harness.oma.runTasks(harness.team, [
+      { title: 'Charge', description: 'Charge the approved amount.', assignee: 'operator' },
+    ], { checkpoint: { store } })
+    onePending(suspended)
+
+    const checkpoint = new Checkpoint(store)
+    const snapshot = await checkpoint.loadLatest()
+    expect(snapshot?.version).toBe(4)
+    const tampered = structuredClone(snapshot) as CheckpointSnapshotV4
+    ;(tampered as { pendingApprovals: ApprovalRequest[] }).pendingApprovals = []
+    await checkpoint.save(tampered)
+
+    const resumedAdapter = scriptedAdapter([textResponse('must not run')])
+    const resumedOma = new OpenMultiAgent({ onToolCall: async () => ({ action: 'allow' }) })
+    const resumedTeam = resumedOma.createTeam('tool-approval', {
+      name: 'tool-approval',
+      agents: [worker('operator', resumedAdapter.adapter, { customTools: [harness.tool] })],
+      sharedMemory: false,
+    })
+
+    await expect(resumedOma.restore(resumedTeam, { checkpoint: { store } }))
+      .rejects.toThrow('not a checkpoint snapshot')
+    expect(harness.executions).toEqual([])
+    expect(resumedAdapter.calls()).toBe(0)
+  })
+})
+
+describe('approval key namespace', () => {
+  it('keeps approval facts separate from checkpoint and telemetry keys', () => {
+    expect(approvalKey('apr_test')).toBe(`${APPROVAL_KEY_PREFIX}apr_test`)
+  })
+})

--- a/packages/core/tests/file-store.test.ts
+++ b/packages/core/tests/file-store.test.ts
@@ -121,6 +121,21 @@ describe('FileStore — concurrency and atomicity', () => {
     expect(seen).toEqual([...keys].sort())
   })
 
+  it('allows only one concurrent compare-and-set decision on one instance', async () => {
+    const store = new FileStore(filePath)
+    await store.set('approval', 'pending')
+
+    const outcomes = await Promise.all([
+      store.compareAndSet('approval', 'pending', 'approved'),
+      store.compareAndSet('approval', 'pending', 'rejected'),
+    ])
+
+    expect(outcomes.filter(Boolean)).toHaveLength(1)
+    expect(['approved', 'rejected']).toContain((await store.get('approval'))?.value)
+    expect((await new FileStore(filePath).get('approval'))?.value)
+      .toBe((await store.get('approval'))?.value)
+  })
+
   it('leaves no temp files behind after writes', async () => {
     const store = new FileStore(filePath)
     await Promise.all([store.set('a', '1'), store.set('b', '2'), store.set('c', '3')])

--- a/packages/core/tests/observability-v2-identity.test.ts
+++ b/packages/core/tests/observability-v2-identity.test.ts
@@ -273,7 +273,7 @@ describe('OBS-1A outcome semantics', () => {
 })
 
 describe('OBS-1A checkpoint identity restore', () => {
-  it('writes v3 and restores with the same runId, incremented attempt, and a new trace link', async () => {
+  it('writes v4 and restores with the same runId, incremented attempt, and a new trace link', async () => {
     const store = new InMemoryStore()
     const oma = new OpenMultiAgent({ defaultModel: 'test-model' })
     const initial = await oma.runTasks(teamWith(), [
@@ -281,8 +281,8 @@ describe('OBS-1A checkpoint identity restore', () => {
     ], { checkpoint: { store, runId: 'logical-run' } })
     const stored = await new Checkpoint(store, { runId: 'logical-run' }).loadLatest()
 
-    expect(stored?.version).toBe(3)
-    if (stored?.version !== 3) throw new Error('expected checkpoint v3')
+    expect(stored?.version).toBe(4)
+    if (stored?.version !== 4) throw new Error('expected checkpoint v4')
     expect(stored.identity).toEqual({
       runId: initial.identity?.runId,
       attempt: 1,

--- a/packages/core/tests/redacting-store.test.ts
+++ b/packages/core/tests/redacting-store.test.ts
@@ -29,6 +29,11 @@ class NoExpiryStore implements MemoryStore {
 }
 
 describe('RedactingStore', () => {
+  it('does not advertise lossy compare-and-set for exact durable approvals', () => {
+    const store: MemoryStore = new RedactingStore(new InMemoryStore())
+    expect(store.compareAndSet).toBeUndefined()
+  })
+
   describe('set / read', () => {
     it('redacts a plain-string value on set; get returns the redacted value', async () => {
       const inner = new InMemoryStore()

--- a/packages/core/tests/shared-memory.test.ts
+++ b/packages/core/tests/shared-memory.test.ts
@@ -4,9 +4,23 @@ import { SharedMemory } from '../src/memory/shared.js'
 import { RedactingStore } from '../src/memory/redacting-store.js'
 import { InMemoryStore } from '../src/memory/store.js'
 import { Team } from '../src/team/team.js'
+import { APPROVAL_KEY_PREFIX } from '../src/approval/durable.js'
 import type { MemoryEntry, MemoryStore } from '../src/types.js'
 
 describe('SharedMemory', () => {
+  it('keeps checkpoint and approval records out of agent-visible memory', async () => {
+    const store = new InMemoryStore()
+    const mem = new SharedMemory(store)
+    await mem.write('agent', 'visible', 'value')
+    await store.set('__oma_checkpoint__/latest', '{"checkpoint":true}')
+    await store.set(`${APPROVAL_KEY_PREFIX}apr_test`, '{"approval":true}')
+
+    expect((await mem.listAll()).map((entry) => entry.key)).toEqual(['agent/visible'])
+    expect(await mem.read(`${APPROVAL_KEY_PREFIX}apr_test`)).toBeNull()
+    expect((await mem.snapshot()).entries.map((entry) => entry.key)).toEqual(['agent/visible'])
+    expect(await mem.getSummary()).not.toContain('approval')
+  })
+
   // -------------------------------------------------------------------------
   // Write & read
   // -------------------------------------------------------------------------

--- a/scripts/example-catalog.test.mjs
+++ b/scripts/example-catalog.test.mjs
@@ -26,7 +26,7 @@ function copyCatalog() {
 }
 
 test('the checked-in catalog covers every discovered example unit', () => {
-  assert.equal(catalog.examples.length, 59)
+  assert.equal(catalog.examples.length, 60)
   assert.deepEqual(validateExampleCatalog(catalog, examplesRoot), [])
 })
 
@@ -43,9 +43,10 @@ test('the public schema and runtime validator use the same controlled vocabulary
 
 test('discovery uses standalone scripts and immediate example directories as units', () => {
   const discovered = discoverExampleUnits(examplesRoot)
-  assert.equal(discovered.length, 59)
+  assert.equal(discovered.length, 60)
   assert.ok(discovered.includes('basics/single-agent.ts'))
   assert.ok(discovered.includes('patterns/event-driven-dag.ts'))
+  assert.ok(discovered.includes('patterns/durable-approval.ts'))
   assert.ok(discovered.includes('integrations/trace-observability.ts'))
   assert.ok(discovered.includes('integrations/observability-v2'))
   assert.ok(!discovered.includes('integrations/observability-v2/run-viewer.ts'))


### PR DESCRIPTION
## Summary

- add a backward-compatible suspend outcome to plan, round, task-dispatch, and tool-call gates
- persist content-bound pending requests and first-wins reviewer decisions in the checkpoint MemoryStore with atomic compare-and-set
- resume only the approved plan, task, or validated tool invocation; fail closed on missing state, stale hashes, schema drift, or tampering
- carry reviewer, decision, hash, and time into derived execution receipts while keeping the primary record outside telemetry
- document store guarantees, restart behavior, trust boundaries, and intentionally deferred cases; add a no-key runnable example

## Stacked dependency

This PR is stacked on #475, which implements the #312 mid-task checkpoint recovery required for tool-call suspension. Its base is feat/312-mid-task-checkpoint-recovery so this diff contains only #474. Merge #475 first, then retarget or rebase this PR onto main.

## Explicit limits

- Task gates with live verify wiring fail closed on suspend because the current checkpoint schema cannot reconstruct judge adapters, schemas, or callbacks.
- FileStore compare-and-set is atomic only within one instance; concurrent cross-process reviewers need a database-backed MemoryStore.
- Standalone runAgent, the simple-goal shortcut, process backends, and ACP backends do not expose resumable private tool-loop state.
- Event sourcing and transition replay remain out of scope under #313.

## Validation

- npm run lint -w @open-multi-agent/core
- npm run test -w @open-multi-agent/core (125 files, 1847 tests)
- npm run build -w @open-multi-agent/core
- npm run test:example-catalog
- npx tsx packages/core/examples/patterns/durable-approval.ts
- git diff --check

Closes #474