### PR TITLE
chore: release core v1.15.0 and create-oma-app v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 ## Unreleased
 
+## 1.15.0 - 2026-08-09
+
+### Added
+
+- Durable approval gates can suspend plan, round, task-dispatch, and tool-call
+  decisions, persist content-bound pending requests and first-wins reviewer
+  decisions in a checkpoint `MemoryStore`, and resume only the approved plan,
+  task, or validated tool invocation. Missing state, stale hashes, schema drift,
+  and tampering fail closed, while derived execution receipts carry the review
+  evidence without making telemetry the authoritative record. New checkpoint
+  writes use schema version 4 to preserve approval continuation state.
+- Checkpoint recovery preserves in-flight built-in runner messages, turn and
+  token accounting, pending tool calls, and independently committed tool
+  results. Restore replays committed results without re-executing their tools,
+  reruns only missing calls, and exposes the stable model-issued `toolCallId`
+  to tools and per-call gates for external idempotency.
+- `Agent.run()`, `Agent.stream()`, and `OpenMultiAgent.runAgent()` accept
+  complete structured message histories. Persistent `Agent.prompt()`
+  conversations can accept one structured user turn, including image input,
+  with runtime validation, defensive copies, and full-message access in
+  `beforeRun`.
+- Rich tool results separate application-owned `ToolResult.data` from validated,
+  model-visible text, image, and file `modelOutput`. Built-in adapters and MCP
+  map supported content explicitly, while runner context, checkpoints,
+  recovery, progress, evaluation, and privacy-safe trace summaries preserve the
+  richer result.
+- `AgentConfig.history` restores persisted conversation messages into a new
+  `Agent` so subsequent `prompt()` calls can continue an earlier conversation.
+
+### Compatibility
+
+- Existing string inputs, string/error tool results, and compression markers
+  keep their previous behavior. Structured input and rich tool output are
+  additive; adapter- and model-specific media limits still apply.
+- Checkpoint readers remain compatible with version 1, version 2, and version 3
+  snapshots. OMA cannot atomically commit an arbitrary external side effect
+  together with its checkpoint write, so consequential integrations still need
+  external idempotency for that crash window.
+- `runTeam()` and `runTasks()` remain text-only. Process and ACP backends remain
+  task-grained and reject structured input rather than silently dropping it.
+- Existing approval callbacks can continue returning allow or deny. Suspension
+  is additive; task gates with live verification wiring, standalone
+  `runAgent()`, the simple-goal shortcut, process backends, and ACP backends do
+  not expose every resumable private tool-loop path.
+- `@open-multi-agent/otel@0.1.1` is not republished. Its
+  `@open-multi-agent/core@^1.11.0` dependency remains compatible with core
+  `1.15.0`.
+
 ## 1.14.0 - 2026-08-01
 
 ### Breaking changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -5214,7 +5214,7 @@
     },
     "packages/core": {
       "name": "@open-multi-agent/core",
-      "version": "1.14.0",
+      "version": "1.15.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",
@@ -5297,7 +5297,7 @@
       }
     },
     "packages/create-oma-app": {
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "bin": {
         "create-oma-app": "dist/index.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@open-multi-agent/core",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "TypeScript multi-agent framework: one runTeam() call from goal to result. Auto task decomposition and parallel execution for multi-step LLM jobs. Deploys anywhere Node.js runs.",
   "files": [
     "dist",

--- a/packages/create-oma-app/package.json
+++ b/packages/create-oma-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-oma-app",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Scaffold PR review, security analysis, and multi-agent DAG starters on @open-multi-agent/core.",
   "type": "module",
   "bin": {

--- a/packages/create-oma-app/template/package.json
+++ b/packages/create-oma-app/template/package.json
@@ -10,7 +10,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.14.0"
+    "@open-multi-agent/core": "1.15.0"
   },
   "devDependencies": {
     "tsx": "^4.21.0"

--- a/packages/create-oma-app/templates/demo/package.json
+++ b/packages/create-oma-app/templates/demo/package.json
@@ -11,7 +11,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.14.0"
+    "@open-multi-agent/core": "1.15.0"
   },
   "devDependencies": {
     "tsx": "^4.21.0"

--- a/packages/create-oma-app/templates/pr-review/package.json
+++ b/packages/create-oma-app/templates/pr-review/package.json
@@ -11,7 +11,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.14.0",
+    "@open-multi-agent/core": "1.15.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/create-oma-app/templates/security/package.json
+++ b/packages/create-oma-app/templates/security/package.json
@@ -11,7 +11,7 @@
     "demo": "tsx src/index.ts --demo"
   },
   "dependencies": {
-    "@open-multi-agent/core": "1.14.0",
+    "@open-multi-agent/core": "1.15.0",
     "zod": "^3.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Bump `@open-multi-agent/core` from `1.14.0` to `1.15.0`.
- Bump `create-oma-app` from `0.7.0` to `0.8.0` and pin every starter template to core `1.15.0`.
- Add the core `1.15.0` changelog covering durable approval suspension and resume, mid-turn checkpoint recovery, structured agent input and conversation history, and rich tool results.
- Keep `@open-multi-agent/otel` at `0.1.1`; it has no changes and its `@open-multi-agent/core@^1.11.0` dependency remains compatible.

## Motivation

Prepare the coordinated weekly core and scaffolder release after the merged work since `v1.14.0`. `create-oma-app` ships alongside core because generated projects pin the core version exactly. The OpenTelemetry adapter remains independently versioned.

## Scope and impact

- Affected areas: release metadata, package manifests, starter template pins, `package-lock.json`, and `CHANGELOG.md`.
- Public API and behavior: this PR contains no new implementation; it versions and documents already merged changes.
- Compatibility: the release is additive. Existing string input and tool-result contracts remain supported, checkpoint readers retain v1-v3 compatibility, and current writes use checkpoint schema v4.
- Security and privacy: no security or privacy behavior is changed by this release commit.
- Non-goals: npm publication, Git tags, GitHub Release publication, and merging are intentionally outside this PR.

## Validation

- `npm run lint` — passed.
- `npm test` — passed across the example catalog, core, create-oma-app, and OTel workspaces.
- `npm run build` — passed for every workspace.
- `npm run test:coverage` — passed with coverage thresholds satisfied.
- `npm run typecheck:template -w create-oma-app` — passed for demo, PR review, and security templates.
- `npm run test:scaffold` — passed using an isolated npm cache.
- `npm run test:observability-examples` — passed.
- `npm run test:eval-examples` — passed.
- `npm run bench:observability:ci` — passed.
- `npm run test:observability-pack` — passed against the current packages and the minimum compatible core `1.11.0` tarball.
- `npm pack --dry-run --json` — passed for core, create-oma-app, and OTel.
- `npm audit --omit=dev --audit-level=high` — passed with 0 vulnerabilities.
- `node packages/core/dist/cli/oma.js help` — passed.
- `git diff --check origin/main...HEAD` — passed.

The scaffold smoke was rerun with an isolated npm cache after the default user cache returned `EPERM`. The observability package smoke was rerun with its CI-required minimum-core tarball. Both final runs passed.

Provider E2E was not run because this release commit changes metadata only and no provider adapter code. CI remains the source of truth for the complete Node 20, 22, and 24 matrix.

## Checklist

- [x] No new behavior is introduced by this release commit; the existing full test suite covers the merged implementation.
- [x] User-facing changes and compatibility notes are documented in `CHANGELOG.md`.
- [x] Compatibility and migration boundaries are documented.
- [x] No new dependency is introduced; the only dependency updates are the required exact starter-template pins.