### PR TITLE
docs: surface examples in README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@
 <p align="center">
   <a href="https://open-multi-agent.com">Website</a> ·
   <a href="https://open-multi-agent.com/getting-started/introduction/">Docs</a> ·
-  <a href="https://www.npmjs.com/package/@open-multi-agent/core">npm</a> ·
-  <a href="https://github.com/open-multi-agent/open-multi-agent/discussions">Discussions</a>
+  <a href="./packages/core/examples/">Examples</a> ·
+  <a href="https://www.npmjs.com/package/@open-multi-agent/core">npm</a>
 </p>
 
 <p align="center">

--- a/README_zh.md
+++ b/README_zh.md
@@ -33,8 +33,8 @@
 <p align="center">
   <a href="https://open-multi-agent.com/zh/">官网</a> ·
   <a href="https://open-multi-agent.com/zh/getting-started/introduction/">文档</a> ·
-  <a href="https://www.npmjs.com/package/@open-multi-agent/core">npm</a> ·
-  <a href="https://github.com/open-multi-agent/open-multi-agent/discussions">讨论区</a>
+  <a href="./packages/core/examples/">示例</a> ·
+  <a href="https://www.npmjs.com/package/@open-multi-agent/core">npm</a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Replace the top-level Discussions link with an Examples link in both root READMEs.
- Point the new entry at the existing `packages/core/examples/` directory.

## Motivation

Make runnable examples more visible without moving them out of the core package.

## Scope and impact

- Affected areas: root documentation only.
- Public API or behavior changes: none.
- Compatibility or migration impact: none.
- Dependency, security, or privacy impact: none.
- Intentional non-goal: relocating the examples directory.

## Validation

- `git diff --check origin/main...HEAD`
- Verified `packages/core/examples/README.md` exists.
- Tests were not run because this is a documentation-only change.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING
