### PR TITLE
fix(maintainer): verify GraphQL bot identity by database id

### DIFF
--- a/.github/workflows/maintainer-bot.yml
+++ b/.github/workflows/maintainer-bot.yml
@@ -80,6 +80,11 @@ jobs:
               throw new Error('Minted App slug or installation ID does not match the trusted contract.')
             }
             const botLogin = `${expected.slug}[bot]`
+            // IssueComment actors expose the App slug while REST bot users include the [bot] suffix.
+            const isExpectedGraphQlBotActor = actor =>
+              actor?.__typename === 'Bot' &&
+              actor.databaseId === expected.botUserId &&
+              (actor.login === expected.slug || actor.login === botLogin)
             const [viewer, appResponse, botResponse, accessResponse] = await Promise.all([
               github.graphql('query { viewer { login } }'),
               github.request('GET /apps/{app_slug}', { app_slug: expected.slug }),
@@ -111,19 +116,17 @@ jobs:
                 query OMAStatusCommentAuthorship($id: ID!) {
                   node(id: $id) {
                     ... on IssueComment {
-                      author { login }
-                      editor { login }
-                      viewerDidAuthor
+                      author { __typename login ... on Bot { databaseId } }
+                      editor { __typename login ... on Bot { databaseId } }
                       createdViaEmail
                     }
                   }
                 }
               `, { id: comment.node_id })
               if (
-                proof.node?.author?.login !== botLogin ||
-                proof.node.viewerDidAuthor !== true ||
-                proof.node.createdViaEmail ||
-                (proof.node.editor !== null && proof.node.editor?.login !== botLogin)
+                !isExpectedGraphQlBotActor(proof.node?.author) ||
+                proof.node?.createdViaEmail !== false ||
+                (proof.node?.editor !== null && !isExpectedGraphQlBotActor(proof.node?.editor))
               ) throw new Error('Status comment App authorship or editor provenance is invalid.')
             }
             const repo = await github.rest.repos.get(context.repo)
@@ -435,8 +438,14 @@ jobs:
             const claimId = `${context.runId}.${process.env.GITHUB_RUN_ATTEMPT}`
             const runUrl = `${context.serverUrl}/${repository}/actions/runs/${context.runId}`
             const baseSha = process.env.OMA_BASE_SHA || context.sha
-            const botLogin = `${process.env.OMA_APP_SLUG}[bot]`
+            const appSlug = process.env.OMA_APP_SLUG ?? ''
+            const botLogin = `${appSlug}[bot]`
             const botUserId = Number(process.env.OMA_APP_BOT_USER_ID)
+            // IssueComment actors expose the App slug while REST bot users include the [bot] suffix.
+            const isExpectedGraphQlBotActor = actor =>
+              actor?.__typename === 'Bot' &&
+              actor.databaseId === botUserId &&
+              (actor.login === appSlug || actor.login === botLogin)
             const viewer = await github.graphql('query { viewer { login } }')
             if (viewer.viewer?.login !== botLogin || !Number.isSafeInteger(botUserId) || botUserId <= 0) {
               throw new Error('Failure fallback does not have the expected App identity.')
@@ -457,19 +466,17 @@ jobs:
               query OMAStatusCommentAuthorship($id: ID!) {
                 node(id: $id) {
                   ... on IssueComment {
-                    author { login }
-                    editor { login }
-                    viewerDidAuthor
+                    author { __typename login ... on Bot { databaseId } }
+                    editor { __typename login ... on Bot { databaseId } }
                     createdViaEmail
                   }
                 }
               }
             `, { id: current.node_id })
             if (
-              proof.node?.author?.login !== botLogin ||
-              proof.node.viewerDidAuthor !== true ||
-              proof.node.createdViaEmail ||
-              (proof.node.editor !== null && proof.node.editor?.login !== botLogin)
+              !isExpectedGraphQlBotActor(proof.node?.author) ||
+              proof.node?.createdViaEmail !== false ||
+              (proof.node?.editor !== null && !isExpectedGraphQlBotActor(proof.node?.editor))
             ) throw new Error('Failure fallback status provenance is invalid.')
             const matches = [...current.body.matchAll(new RegExp(`<!--\\s*${marker}\\s+(\\{[^\\n]*\\})\\s*-->`, 'g'))]
             if (matches.length !== 1) throw new Error('Trusted Maintainer Bot comment has invalid machine metadata.')
@@ -548,19 +555,17 @@ jobs:
               query OMAUpdatedStatusCommentAuthorship($id: ID!) {
                 node(id: $id) {
                   ... on IssueComment {
-                    author { login }
-                    editor { login }
-                    viewerDidAuthor
+                    author { __typename login ... on Bot { databaseId } }
+                    editor { __typename login ... on Bot { databaseId } }
                     createdViaEmail
                   }
                 }
               }
             `, { id: updated.node_id })
             if (
-              updatedProof.node?.author?.login !== botLogin ||
-              updatedProof.node.viewerDidAuthor !== true ||
-              updatedProof.node.createdViaEmail ||
-              (updatedProof.node.editor !== null && updatedProof.node.editor?.login !== botLogin)
+              !isExpectedGraphQlBotActor(updatedProof.node?.author) ||
+              updatedProof.node?.createdViaEmail !== false ||
+              (updatedProof.node?.editor !== null && !isExpectedGraphQlBotActor(updatedProof.node?.editor))
             ) throw new Error('Updated failure status App provenance is invalid.')
             await core.summary
               .addHeading(`OMA Maintainer Bot — ${status}`)

--- a/docs/maintainer-bot.md
+++ b/docs/maintainer-bot.md
@@ -161,9 +161,12 @@ Because GitHub-hosted runners are ephemeral, `$RUNNER_TEMP` is never the
 cross-run authority. Activation v1 instead uses one status comment owned by
 the precisely verified dedicated App bot, containing a bounded
 machine-readable claim ledger, Actions run status, and deterministic branch/PR
-metadata. REST actor ID/login/type plus GraphQL author/editor/viewer provenance
-must all match the verified App; ordinary users and `github-actions[bot]`
-markers are ignored as durable authority. The ledger retains prior
+metadata. The token viewer and REST actor ID/login/type must match the verified
+App bot. GraphQL author/editor actors must independently match that Bot's
+database ID and type; their login may use GitHub's App slug form or the REST
+`[bot]` form, and email-created comments are rejected. Ordinary users and
+`github-actions[bot]` markers are ignored as durable authority. The ledger
+retains prior
 runKeys when a later revision becomes visible and fails closed at 64 claims
 instead of silently dropping idempotency history.
 

--- a/packages/maintainer-host/src/github.ts
+++ b/packages/maintainer-host/src/github.ts
@@ -31,21 +31,30 @@ const installationRepositoriesSchema = z.object({
 const viewerSchema = z.object({
   data: z.object({ viewer: z.object({ login: z.string().min(1) }) }),
 })
+const issueCommentActorSchema = z.object({
+  __typename: z.string().min(1),
+  login: z.string().min(1),
+  databaseId: z.number().int().positive().optional(),
+})
 const issueCommentAuthorshipSchema = z.object({
   data: z.object({
     node: z.object({
-      author: z.object({ login: z.string().min(1) }).nullable(),
-      editor: z.object({ login: z.string().min(1) }).nullable(),
-      viewerDidAuthor: z.boolean(),
+      author: issueCommentActorSchema.nullable(),
+      editor: issueCommentActorSchema.nullable(),
       createdViaEmail: z.boolean(),
     }).nullable(),
   }),
 })
 
+export interface GitHubIssueCommentActor {
+  readonly databaseId: number | null
+  readonly login: string
+  readonly type: string
+}
+
 export interface GitHubIssueCommentAuthorship {
-  readonly authorLogin: string | null
-  readonly editorLogin: string | null
-  readonly viewerDidAuthor: boolean
+  readonly author: GitHubIssueCommentActor | null
+  readonly editor: GitHubIssueCommentActor | null
   readonly createdViaEmail: boolean
 }
 
@@ -128,9 +137,8 @@ export class GitHubRestClient implements GitHubClient {
       query: `query OMAStatusCommentAuthorship($id: ID!) {
         node(id: $id) {
           ... on IssueComment {
-            author { login }
-            editor { login }
-            viewerDidAuthor
+            author { __typename login ... on Bot { databaseId } }
+            editor { __typename login ... on Bot { databaseId } }
             createdViaEmail
           }
         }
@@ -139,9 +147,8 @@ export class GitHubRestClient implements GitHubClient {
     }))
     if (result.data.node === null) throw new Error('Trusted Maintainer Bot status comment no longer exists.')
     return {
-      authorLogin: result.data.node.author?.login ?? null,
-      editorLogin: result.data.node.editor?.login ?? null,
-      viewerDidAuthor: result.data.node.viewerDidAuthor,
+      author: issueCommentActor(result.data.node.author),
+      editor: issueCommentActor(result.data.node.editor),
       createdViaEmail: result.data.node.createdViaEmail,
     }
   }
@@ -272,6 +279,17 @@ export class GitHubRestClient implements GitHubClient {
     })
     if (!response.ok) throw new GitHubApiError(response.status, method, path.replace(/\?.*$/, ''))
     return response.status === 204 ? null : response.json()
+  }
+}
+
+function issueCommentActor(
+  actor: z.infer<typeof issueCommentActorSchema> | null,
+): GitHubIssueCommentActor | null {
+  if (actor === null) return null
+  return {
+    databaseId: actor.databaseId ?? null,
+    login: actor.login,
+    type: actor.__typename,
   }
 }
 

--- a/packages/maintainer-host/src/status.ts
+++ b/packages/maintainer-host/src/status.ts
@@ -5,7 +5,7 @@ import {
   type StatusClaim,
   type StatusMetadata,
 } from './schema.js'
-import type { GitHubClient } from './github.js'
+import type { GitHubClient, GitHubIssueCommentActor } from './github.js'
 import { sanitizePublicLine } from './public-output.js'
 
 export const STATUS_MARKER = 'oma-maintainer-bot-status:v2'
@@ -60,6 +60,16 @@ export function isExpectedAppBotUser(
   return user.id === identity.botUserId
     && user.login === identity.botLogin
     && user.type === 'Bot'
+}
+
+export function isExpectedGraphQlAppBotActor(
+  actor: GitHubIssueCommentActor | null,
+  identity: GitHubAppWriterIdentity,
+): boolean {
+  // IssueComment actors expose the App slug while REST bot users include the [bot] suffix.
+  return actor?.databaseId === identity.botUserId
+    && actor.type === 'Bot'
+    && (actor.login === identity.slug || actor.login === identity.botLogin)
 }
 
 export async function findTrustedStatusComment(input: {
@@ -152,10 +162,9 @@ async function assertTrustedStatusCommentAuthorship(
   }
   const authorship = await github.getIssueCommentAuthorship(comment.node_id)
   if (
-    authorship.authorLogin !== identity.botLogin
-    || authorship.viewerDidAuthor !== true
+    !isExpectedGraphQlAppBotActor(authorship.author, identity)
     || authorship.createdViaEmail
-    || authorship.editorLogin !== null && authorship.editorLogin !== identity.botLogin
+    || authorship.editor !== null && !isExpectedGraphQlAppBotActor(authorship.editor, identity)
   ) {
     throw new Error('Maintainer Bot status comment authorship or editor provenance is not the expected GitHub App.')
   }

--- a/packages/maintainer-host/tests/github.test.ts
+++ b/packages/maintainer-host/tests/github.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { GitHubRestClient } from '../src/github.js'
+import { APP_BOT_USER_ID, APP_SLUG } from './helpers.js'
+
+describe('GitHub issue comment authorship', () => {
+  it('preserves GraphQL Bot database identity when actor login omits the REST suffix', async () => {
+    let requestBody: { query?: string } | undefined
+    const actor = {
+      __typename: 'Bot',
+      login: APP_SLUG,
+      databaseId: APP_BOT_USER_ID,
+    }
+    const client = new GitHubRestClient({
+      token: 'test-installation-token',
+      fetchImpl: async (_input, init) => {
+        requestBody = JSON.parse(String(init?.body)) as { query?: string }
+        return new Response(JSON.stringify({
+          data: {
+            node: {
+              author: actor,
+              editor: actor,
+              createdViaEmail: false,
+            },
+          },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } })
+      },
+    })
+
+    await expect(client.getIssueCommentAuthorship('IC_test')).resolves.toEqual({
+      author: { databaseId: APP_BOT_USER_ID, login: APP_SLUG, type: 'Bot' },
+      editor: { databaseId: APP_BOT_USER_ID, login: APP_SLUG, type: 'Bot' },
+      createdViaEmail: false,
+    })
+    expect(requestBody?.query).toContain('... on Bot { databaseId }')
+    expect(requestBody?.query).not.toContain('viewerDidAuthor')
+  })
+})

--- a/packages/maintainer-host/tests/helpers.ts
+++ b/packages/maintainer-host/tests/helpers.ts
@@ -6,7 +6,7 @@ import type {
   CommandRunner,
   RunCommandOptions,
 } from '@open-multi-agent/maintainer-bot'
-import type { GitHubClient } from '../src/github.js'
+import type { GitHubClient, GitHubIssueCommentAuthorship } from '../src/github.js'
 import { loadProductionPolicy } from '../src/policy.js'
 import type {
   GitHubActor,
@@ -120,12 +120,7 @@ export class FakeGitHub implements GitHubClient {
   app = { id: APP_ID, clientId: APP_CLIENT_ID, slug: APP_SLUG }
   botUser: GitHubActor = { id: APP_BOT_USER_ID, login: APP_BOT_LOGIN, type: 'Bot' }
   installationRepositories = [REPOSITORY]
-  commentAuthorshipOverrides = new Map<string, {
-    authorLogin: string | null
-    editorLogin: string | null
-    viewerDidAuthor: boolean
-    createdViaEmail: boolean
-  }>()
+  commentAuthorshipOverrides = new Map<string, GitHubIssueCommentAuthorship>()
   issue: GitHubIssue = issueFromEvent()
   comments: GitHubComment[] = []
   timeline: GitHubTimelineEvent[] = []
@@ -158,10 +153,10 @@ export class FakeGitHub implements GitHubClient {
     if (override !== undefined) return structuredClone(override)
     const comment = this.comments.find(candidate => candidate.node_id === nodeId)
     if (comment === undefined) throw new Error('comment not found')
+    const author = graphQlActor(comment.user)
     return {
-      authorLogin: comment.user.login,
-      editorLogin: comment.updated_at === comment.created_at ? null : comment.user.login,
-      viewerDidAuthor: comment.user.login === this.viewerLogin,
+      author,
+      editor: comment.updated_at === comment.created_at ? null : author,
       createdViaEmail: false,
     }
   }
@@ -280,6 +275,16 @@ export function githubActionsComment(id: number, body: string): GitHubComment {
   return {
     ...botComment(id, body),
     user: { id: 41_898_282, login: 'github-actions[bot]', type: 'Bot' },
+  }
+}
+
+function graphQlActor(user: GitHubActor) {
+  return {
+    databaseId: user.id,
+    login: user.type === 'Bot' && user.login.endsWith('[bot]')
+      ? user.login.slice(0, -'[bot]'.length)
+      : user.login,
+    type: user.type,
   }
 }
 

--- a/packages/maintainer-host/tests/status.test.ts
+++ b/packages/maintainer-host/tests/status.test.ts
@@ -35,7 +35,7 @@ function metadata(overrides: Record<string, unknown> = {}) {
 }
 
 describe('single trusted BOT status comment', () => {
-  it('round-trips machine metadata and ignores user and github-actions marker forgeries', async () => {
+  it('accepts the GraphQL App slug actor form and ignores user and github-actions marker forgeries', async () => {
     const body = renderStatusComment(metadata(), 'Running deterministic checks.')
     expect(parseStatusComment(body)).toMatchObject({ status: 'RUNNING', runKey: 'c'.repeat(64) })
     const forged = { ...botComment(1, body), user: { id: 99, login: 'attacker', type: 'User' } }
@@ -79,14 +79,40 @@ describe('single trusted BOT status comment', () => {
     const wrongEditor = new FakeGitHub()
     wrongEditor.comments = [botComment(4, body)]
     wrongEditor.commentAuthorshipOverrides.set('IC_4', {
-      authorLogin: APP_IDENTITY.botLogin,
-      editorLogin: 'attacker',
-      viewerDidAuthor: true,
+      author: {
+        databaseId: APP_IDENTITY.botUserId,
+        login: APP_IDENTITY.slug,
+        type: 'Bot',
+      },
+      editor: {
+        databaseId: 99,
+        login: 'attacker',
+        type: 'User',
+      },
       createdViaEmail: false,
     })
     await expect(findTrustedStatusComment({
       github: wrongEditor,
       comments: wrongEditor.comments,
+      identity: APP_IDENTITY,
+      repository: REPOSITORY,
+      issueNumber: 488,
+    })).rejects.toThrow(/authorship or editor provenance/)
+
+    const wrongAuthor = new FakeGitHub()
+    wrongAuthor.comments = [botComment(5, body)]
+    wrongAuthor.commentAuthorshipOverrides.set('IC_5', {
+      author: {
+        databaseId: APP_IDENTITY.botUserId + 1,
+        login: APP_IDENTITY.slug,
+        type: 'Bot',
+      },
+      editor: null,
+      createdViaEmail: false,
+    })
+    await expect(findTrustedStatusComment({
+      github: wrongAuthor,
+      comments: wrongAuthor.comments,
       identity: APP_IDENTITY,
       repository: REPOSITORY,
       issueNumber: 488,

--- a/packages/maintainer-host/tests/workflow.test.ts
+++ b/packages/maintainer-host/tests/workflow.test.ts
@@ -40,6 +40,13 @@ describe('GitHub Actions activation workflow', () => {
     expect(workflow).toContain("terminalClaim ? previous.status : 'FAILED'")
     expect(workflow).toContain('process.env.GITHUB_WORKFLOW_SHA')
     expect(workflow).toContain('workflowSha !== baseSha')
+    expect(workflow.match(/const isExpectedGraphQlBotActor = actor =>/g)).toHaveLength(2)
+    expect(workflow.match(/author \{ __typename login \.\.\. on Bot \{ databaseId \} \}/g)).toHaveLength(3)
+    expect(workflow.match(/editor \{ __typename login \.\.\. on Bot \{ databaseId \} \}/g)).toHaveLength(3)
+    expect(workflow.match(/!isExpectedGraphQlBotActor\(/g)).toHaveLength(6)
+    expect(workflow).not.toContain('viewerDidAuthor')
+    expect(workflow).toContain('comment.user?.id !== expected.botUserId')
+    expect(workflow).toContain('updated.user?.id !== botUserId')
 
     const tokenStep = workflow.slice(
       workflow.indexOf('- name: Create repository-scoped Maintainer Bot App token'),


### PR DESCRIPTION
## Summary

- verify GitHub GraphQL `IssueComment` Bot actors by exact database ID and type while accepting the App slug login form returned by GraphQL
- apply the same fail-closed provenance contract to STARTED publication, durable host status, and App-authenticated failure fallback paths
- add parser, status, workflow, and negative identity regression coverage, and align the maintainer-bot operations contract

## Root cause

[The first live activation run](https://github.com/open-multi-agent/open-multi-agent/actions/runs/31464018202) successfully minted the repository-scoped App token and created the App-owned STARTED comment, then rejected that same comment during provenance verification.

GitHub REST identifies the bot as `oma-maintainer-bot[bot]`, while GraphQL exposes the `IssueComment.author.login` actor as the App slug `oma-maintainer-bot`. The previous implementation compared both representations to the REST login verbatim.

This change keeps the exact REST Bot ID/login/type checks and the separately verified App token viewer, then independently verifies GraphQL author/editor actors using the same numeric Bot database ID and type. Email-created comments, wrong actors, and wrong editors still fail closed.

## Security boundary

- no permission, secret, installation-scope, model, or Draft-PR authorization changes
- exact App metadata, token viewer, repository scope, REST Bot identity, GraphQL Bot identity, and editor provenance remain required
- ordinary users and `github-actions[bot]` comments remain ineligible as durable authority

## Validation

- `git diff --check origin/main...HEAD`
- focused maintainer-host regression suite: 3 files, 6 tests passed
- `npm run lint -w @open-multi-agent/maintainer-host`
- `npm run test -w @open-multi-agent/maintainer-host`: 9 files, 37 tests passed
- `npm run build -w @open-multi-agent/maintainer-host`
- `npm run lint`
- `npm test`: example catalog plus all workspace suites passed (2,142 tests total)
- `npm run build`
- actionlint v1.7.12 against `.github/workflows/maintainer-bot.yml`

Provider E2E was not run because this change is entirely in the deterministic GitHub host/workflow boundary and does not invoke DeepSeek.
