### PR TITLE
fix(maintainer): reserve context budget for required sources

### DIFF
--- a/docs/maintainer-bot.md
+++ b/docs/maintainer-bot.md
@@ -194,6 +194,25 @@ TypeScript/JavaScript relative-import relationships, bounded relevant Git
 history and linked evidence, validation commands, and source-level SHA-256
 provenance.
 
+Context allocation is required-first. The system policy, Issue evidence,
+root-to-target policy chain, exact target files, applicable package and
+TypeScript configuration, and synthetic workspace map are captured before any
+optional source may spend the byte budget. If any required source exceeds the
+per-source limit or the required set cannot fit inside the total file/byte
+limits intact, context remains insufficient and the run fails closed.
+
+Optional imports, related tests/docs/source, history, and linked evidence then
+fill the remaining budget in deterministic priority/path order. An optional
+source is truncated only by the per-source limit; when its bounded content
+does not fit the remaining total budget it is omitted so smaller later sources
+can still fit. Truncation and omission produce deterministic warnings, and
+`omittedCandidateCount` includes optional repository candidates omitted by
+either the file or byte limit. Optional pressure alone does not make context
+insufficient. For exact single-file scopes, workspace-wide examples are not
+selected merely because the target belongs to that workspace; selection is
+limited to required metadata, relative-import dependencies, and content with
+specific path/import/keyword relevance.
+
 System policy is highest priority. Repository policies are identified
 separately. Issue text, comments, commit messages, ordinary repository files,
 diffs, and external material are all untrusted evidence, never instructions.

--- a/packages/maintainer-bot/src/context.ts
+++ b/packages/maintainer-bot/src/context.ts
@@ -37,6 +37,11 @@ interface Candidate {
   readonly trust: ContextSource['trust']
 }
 
+interface SourceDraft {
+  readonly source: Omit<ContextSource, 'contentHash' | 'byteLength' | 'truncated'>
+  readonly candidatePath?: string
+}
+
 export async function buildContextManifest(options: BuildContextOptions): Promise<ContextManifest> {
   if (!options.admission.mayDevelop || options.admission.status !== 'AGENT_READY') {
     throw new Error('Context for code development can be built only after deterministic AGENT_READY admission.')
@@ -121,7 +126,7 @@ export async function buildContextManifest(options: BuildContextOptions): Promis
       addCandidate({
         path,
         priority: path === '.github/CONTRIBUTING.md' ? 90 : 85,
-        required: path !== 'tsconfig.json',
+        required: true,
         kind: 'repository-file',
         trust: 'untrusted-evidence',
       })
@@ -133,18 +138,39 @@ export async function buildContextManifest(options: BuildContextOptions): Promis
     options.request.issue.targetWorkspaces,
     targets,
   )
-  for (const path of workspaceFiles) {
+  for (const path of workspaceFiles.required) {
     addCandidate({
       path,
-      priority: /(?:package|tsconfig)\.json$/.test(path) ? 90 : 75,
-      required: /(?:package|tsconfig)\.json$/.test(path),
+      priority: 90,
+      required: true,
+      kind: 'repository-file',
+      trust: 'untrusted-evidence',
+    })
+  }
+
+  const importDependencies = await collectImportDependencies(
+    repoRoot,
+    targets.filter(target => approvedEditScopes.some(scope => scope.path === target && scope.kind === 'file')),
+    options.config.context.maxFiles,
+  )
+  for (const path of importDependencies) {
+    addCandidate({
+      path,
+      priority: 92,
+      required: false,
       kind: 'repository-file',
       trust: 'untrusted-evidence',
     })
   }
 
   const keywords = issueKeywords(options.request.issue.title, options.request.issue.problem)
-  const related = await collectRelatedFiles(repoRoot, workspaceFiles, keywords, options.config.context.maxFiles)
+  const related = await collectRelatedFiles(
+    repoRoot,
+    workspaceFiles.optional,
+    keywords,
+    approvedEditScopes,
+    options.config.context.maxFiles,
+  )
   for (const path of related) {
     addCandidate({
       path,
@@ -158,105 +184,95 @@ export async function buildContextManifest(options: BuildContextOptions): Promis
   const sortedCandidates = [...candidates.values()].sort(
     (a, b) => b.priority - a.priority || a.path.localeCompare(b.path),
   )
-  const selected = sortedCandidates.slice(0, options.config.context.maxFiles)
-  const omitted = sortedCandidates.slice(options.config.context.maxFiles)
-  if (omitted.some(candidate => candidate.required)) {
+  const requiredCandidates = sortedCandidates.filter(candidate => candidate.required)
+  const optionalCandidates = sortedCandidates.filter(candidate => !candidate.required)
+  const selectedRequired = requiredCandidates.slice(0, options.config.context.maxFiles)
+  const optionalFileSlots = Math.max(0, options.config.context.maxFiles - selectedRequired.length)
+  const selectedOptional = optionalCandidates.slice(0, optionalFileSlots)
+  const omittedCandidatePaths = new Set(
+    optionalCandidates.slice(optionalFileSlots).map(candidate => candidate.path),
+  )
+  if (requiredCandidates.length > options.config.context.maxFiles) {
     errors.push('Required target or policy files exceed the configured context file limit.')
-  } else if (omitted.length > 0) {
-    warnings.push(`${omitted.length} lower-priority related context files were omitted by the file limit.`)
+  }
+  if (omittedCandidatePaths.size > 0) {
+    warnings.push(`${omittedCandidatePaths.size} lower-priority related context files were omitted by the file limit.`)
   }
 
   const sources: ContextSource[] = []
-  let totalBytes = 0
-  const addTextSource = (
-    input: Omit<ContextSource, 'contentHash' | 'byteLength' | 'truncated'>,
-    required: boolean,
-  ): boolean => {
-    const raw = Buffer.from(input.content, 'utf8')
-    const remaining = options.config.context.maxBytes - totalBytes
-    if (remaining <= 0) {
-      const message = `Context byte limit omitted ${input.locator}.`
-      if (required) errors.push(message)
-      else warnings.push(message)
-      return false
-    }
-    const bounded = boundUtf8(raw, Math.min(options.config.context.maxBytesPerFile, remaining))
-    if (bounded.truncated) {
-      const message = `Context source was truncated: ${input.locator}`
-      if (required) errors.push(message)
-      else warnings.push(message)
-    }
-    const source = sourceFromText({
-      ...input,
-      content: bounded.content,
-      originalByteLength: input.originalByteLength,
-      truncated: bounded.truncated,
-    })
-    totalBytes += source.byteLength
-    sources.push(source)
-    return true
-  }
-  addTextSource({
-    id: 'system-policy',
-    kind: 'system-policy',
-    locator: 'maintainer-bot://system-policy/v1',
-    trust: 'system-policy',
-    priority: 100,
-    content: SYSTEM_POLICY,
-    originalByteLength: Buffer.byteLength(SYSTEM_POLICY),
-  }, true)
+  const requiredSources: SourceDraft[] = [{
+    source: {
+      id: 'system-policy',
+      kind: 'system-policy',
+      locator: 'maintainer-bot://system-policy/v1',
+      trust: 'system-policy',
+      priority: 100,
+      content: SYSTEM_POLICY,
+      originalByteLength: Buffer.byteLength(SYSTEM_POLICY),
+    },
+  }]
+  const optionalSources: SourceDraft[] = []
   const issueContent = canonicalJson({
     issue: options.request.issue,
     confirmedAcceptanceCriteria: options.request.issue.acceptanceCriteria,
     issueRevision: options.admission.issueRevision,
     baseSha: options.request.baseSha,
   })
-  addTextSource({
-    id: 'issue',
-    kind: 'issue',
-    locator: `${options.request.issue.repository}#${options.request.issue.number}`,
-    trust: 'untrusted-evidence',
-    priority: 95,
-    content: issueContent,
-    originalByteLength: Buffer.byteLength(issueContent),
-  }, true)
+  requiredSources.push({
+    source: {
+      id: 'issue',
+      kind: 'issue',
+      locator: `${options.request.issue.repository}#${options.request.issue.number}`,
+      trust: 'untrusted-evidence',
+      priority: 95,
+      content: issueContent,
+      originalByteLength: Buffer.byteLength(issueContent),
+    },
+  })
 
-  const includedPaths: string[] = []
-  for (const candidate of selected) {
+  const workspaceMap = await buildWorkspaceMap(repoRoot)
+  const workspaceMapContent = canonicalJson(workspaceMap)
+  requiredSources.push({
+    source: {
+      id: 'workspace-map',
+      kind: 'workspace-map',
+      locator: 'workspace-map://package-json',
+      trust: 'untrusted-evidence',
+      priority: 90,
+      content: workspaceMapContent,
+      originalByteLength: Buffer.byteLength(workspaceMapContent),
+    },
+  })
+
+  for (const candidate of [...selectedRequired, ...selectedOptional]) {
     try {
       const raw = await readSafeRepositoryFile(repoRoot, candidate.path)
       if (candidate.required && hasConflictMarkers(raw.toString('utf8'))) {
         errors.push(`Required context contains unresolved conflict markers: ${candidate.path}`)
       }
-      const included = addTextSource({
-        id: `file:${candidate.path}`,
-        kind: candidate.kind,
-        locator: candidate.path,
-        trust: candidate.trust,
-        priority: candidate.priority,
-        content: raw.toString('utf8'),
-        originalByteLength: raw.byteLength,
-      }, candidate.kind === 'repository-policy' || candidate.required)
-      if (included) includedPaths.push(candidate.path)
+      const draft: SourceDraft = {
+        source: {
+          id: `file:${candidate.path}`,
+          kind: candidate.kind,
+          locator: candidate.path,
+          trust: candidate.trust,
+          priority: candidate.priority,
+          content: raw.toString('utf8'),
+          originalByteLength: raw.byteLength,
+        },
+        candidatePath: candidate.path,
+      }
+      if (candidate.required) requiredSources.push(draft)
+      else optionalSources.push(draft)
     } catch (error) {
       const message = `Could not read context file ${candidate.path}: ${error instanceof Error ? error.message : String(error)}`
       if (candidate.required) errors.push(message)
-      else warnings.push(message)
+      else {
+        warnings.push(message)
+        omittedCandidatePaths.add(candidate.path)
+      }
     }
   }
-
-  const importRelations = await collectImportRelations(repoRoot, includedPaths)
-  const workspaceMap = await buildWorkspaceMap(repoRoot)
-  const workspaceMapContent = canonicalJson(workspaceMap)
-  addTextSource({
-    id: 'workspace-map',
-    kind: 'workspace-map',
-    locator: 'workspace-map://package-json',
-    trust: 'untrusted-evidence',
-    priority: 90,
-    content: workspaceMapContent,
-    originalByteLength: Buffer.byteLength(workspaceMapContent),
-  }, true)
 
   const history = await options.runner.run(
     'git',
@@ -271,26 +287,84 @@ export async function buildContextManifest(options: BuildContextOptions): Promis
     { cwd: repoRoot, allowFailure: true, maxOutputChars: 80_000 },
   )
   if (history.exitCode !== 0) warnings.push('Relevant git history could not be collected.')
-  addTextSource({
-    id: 'git-history',
-    kind: 'git-history',
-    locator: `git:${options.request.baseSha}`,
-    trust: 'untrusted-evidence',
-    priority: 50,
-    content: history.stdout,
-    originalByteLength: Buffer.byteLength(history.stdout),
-  }, false)
+  optionalSources.push({
+    source: {
+      id: 'git-history',
+      kind: 'git-history',
+      locator: `git:${options.request.baseSha}`,
+      trust: 'untrusted-evidence',
+      priority: 50,
+      content: history.stdout,
+      originalByteLength: Buffer.byteLength(history.stdout),
+    },
+  })
 
   const linkedEvidence = canonicalJson(options.request.issue.linkedPullRequests)
-  addTextSource({
-    id: 'linked-evidence',
-    kind: 'linked-evidence',
-    locator: `${options.request.issue.repository}#${options.request.issue.number}:linked`,
-    trust: 'untrusted-evidence',
-    priority: 45,
-    content: linkedEvidence,
-    originalByteLength: Buffer.byteLength(linkedEvidence),
-  }, false)
+  optionalSources.push({
+    source: {
+      id: 'linked-evidence',
+      kind: 'linked-evidence',
+      locator: `${options.request.issue.repository}#${options.request.issue.number}:linked`,
+      trust: 'untrusted-evidence',
+      priority: 45,
+      content: linkedEvidence,
+      originalByteLength: Buffer.byteLength(linkedEvidence),
+    },
+  })
+
+  let totalBytes = 0
+  const includedPaths: string[] = []
+  for (const draft of requiredSources) {
+    const raw = Buffer.from(draft.source.content, 'utf8')
+    const remaining = options.config.context.maxBytes - totalBytes
+    if (raw.byteLength > options.config.context.maxBytesPerFile) {
+      errors.push(`Required context source exceeds maxBytesPerFile: ${draft.source.locator}`)
+    }
+    if (raw.byteLength > remaining) {
+      errors.push(`Required context sources exceed the configured context byte limit at ${draft.source.locator}.`)
+    }
+    const maxBytes = Math.max(0, Math.min(
+      options.config.context.maxBytesPerFile,
+      remaining,
+    ))
+    if (maxBytes === 0 && raw.byteLength > 0) continue
+    const bounded = boundUtf8(raw, maxBytes)
+    const source = sourceFromText({
+      ...draft.source,
+      content: bounded.content,
+      truncated: bounded.truncated,
+    })
+    totalBytes += source.byteLength
+    sources.push(source)
+    if (draft.candidatePath !== undefined) includedPaths.push(draft.candidatePath)
+  }
+
+  for (const draft of optionalSources.sort(
+    (a, b) => b.source.priority - a.source.priority || a.source.locator.localeCompare(b.source.locator),
+  )) {
+    const raw = Buffer.from(draft.source.content, 'utf8')
+    const bounded = boundUtf8(raw, options.config.context.maxBytesPerFile)
+    const boundedBytes = Buffer.byteLength(bounded.content)
+    const remaining = options.config.context.maxBytes - totalBytes
+    if (boundedBytes > remaining) {
+      warnings.push(`Context byte limit omitted optional source: ${draft.source.locator}`)
+      if (draft.candidatePath !== undefined) omittedCandidatePaths.add(draft.candidatePath)
+      continue
+    }
+    if (bounded.truncated) {
+      warnings.push(`Optional context source was truncated by maxBytesPerFile: ${draft.source.locator}`)
+    }
+    const source = sourceFromText({
+      ...draft.source,
+      content: bounded.content,
+      truncated: bounded.truncated,
+    })
+    totalBytes += source.byteLength
+    sources.push(source)
+    if (draft.candidatePath !== undefined) includedPaths.push(draft.candidatePath)
+  }
+
+  const importRelations = await collectImportRelations(repoRoot, includedPaths)
 
   const partial = {
     schemaVersion: 1 as const,
@@ -311,7 +385,7 @@ export async function buildContextManifest(options: BuildContextOptions): Promis
     retrieval: {
       method: 'deterministic-file-tree-import-history-v1' as const,
       selectedFiles: includedPaths,
-      omittedCandidateCount: omitted.length,
+      omittedCandidateCount: omittedCandidatePaths.size,
       importRelations,
     },
     sufficiency: {
@@ -377,8 +451,9 @@ async function collectWorkspaceFiles(
   root: string,
   workspaceNames: readonly string[],
   targets: readonly string[],
-): Promise<string[]> {
-  const paths = new Set<string>()
+): Promise<{ required: string[]; optional: string[] }> {
+  const required = new Set<string>()
+  const optional = new Set<string>()
   const packageDirs = await safeReadDir(join(root, 'packages'))
   for (const entry of packageDirs) {
     if (!entry.isDirectory()) continue
@@ -388,21 +463,24 @@ async function collectWorkspaceFiles(
     const matchesName = typeof parsed.name === 'string' && workspaceNames.includes(parsed.name)
     const matchesTarget = targets.some(target => pathWithin(target, `packages/${entry.name}`))
     if (!matchesName && !matchesTarget) continue
-    for (const file of [packagePath, `packages/${entry.name}/tsconfig.json`, `packages/${entry.name}/README.md`]) {
-      if (await isRegularFile(root, file)) paths.add(file)
+    for (const file of [packagePath, `packages/${entry.name}/tsconfig.json`]) {
+      if (await isRegularFile(root, file)) required.add(file)
     }
+    const readmePath = `packages/${entry.name}/README.md`
+    if (await isRegularFile(root, readmePath)) optional.add(readmePath)
     for (const folder of ['src', 'tests', 'fixtures', 'examples']) {
       const base = `packages/${entry.name}/${folder}`
-      for (const file of await walkTextFiles(root, base, 200)) paths.add(file)
+      for (const file of await walkTextFiles(root, base, 200)) optional.add(file)
     }
   }
-  return [...paths].sort()
+  return { required: [...required].sort(), optional: [...optional].sort() }
 }
 
 async function collectRelatedFiles(
   root: string,
   workspaceFiles: readonly string[],
   keywords: readonly string[],
+  targetScopes: readonly ApprovedEditScope[],
   limit: number,
 ): Promise<string[]> {
   const candidates = new Set<string>()
@@ -410,21 +488,70 @@ async function collectRelatedFiles(
   if (await isRegularFile(root, 'README.md')) candidates.add('README.md')
   for (const path of workspaceFiles) candidates.add(path)
 
+  const singleFileTarget = targetScopes.length > 0 && targetScopes.every(scope => scope.kind === 'file')
+  const targetPaths = targetScopes.map(scope => scope.path)
+  const targetStems = targetPaths.map(path => {
+    const name = posix.basename(path).replace(/\.[^.]+$/, '')
+    return name.replace(/\.(?:test|spec)$/, '').toLowerCase()
+  })
   const scored: Array<{ path: string; score: number }> = []
   for (const path of candidates) {
     let content: string
     try {
-      content = (await readSafeRepositoryFile(root, path)).toString('utf8').toLowerCase()
+      content = (await readSafeRepositoryFile(root, path)).toString('utf8')
     } catch {
       continue
     }
-    const score = keywords.reduce((total, keyword) => total + (content.includes(keyword) ? 1 : 0), 0)
-    if (score > 0 || /(?:package|tsconfig)\.json$/.test(path)) scored.push({ path, score })
+    const lowerContent = content.toLowerCase()
+    const score = keywords.reduce((total, keyword) => total + (lowerContent.includes(keyword) ? 1 : 0), 0)
+    const pathRelated = targetStems.some(stem => stem.length >= 4 && path.toLowerCase().includes(stem))
+    const importsTarget = relativeImports(path, content).some(imported => targetPaths.includes(imported))
+    const isExample = path.includes('/examples/')
+    const relevant = !singleFileTarget
+      ? score > 0
+      : pathRelated || importsTarget || (!isExample && score >= 2)
+    if (relevant) scored.push({ path, score: score + (pathRelated ? 20 : 0) + (importsTarget ? 30 : 0) })
   }
   return scored
     .sort((a, b) => b.score - a.score || a.path.localeCompare(b.path))
     .slice(0, limit)
     .map(item => item.path)
+}
+
+async function collectImportDependencies(
+  root: string,
+  targets: readonly string[],
+  limit: number,
+): Promise<string[]> {
+  const targetSet = new Set(targets)
+  const collected = new Set<string>()
+  const queue = [...targets].sort()
+  while (queue.length > 0 && collected.size < limit) {
+    const from = queue.shift()!
+    let content: string
+    try {
+      content = (await readSafeRepositoryFile(root, from)).toString('utf8')
+    } catch {
+      continue
+    }
+    for (const imported of relativeImports(from, content)) {
+      if (targetSet.has(imported) || collected.has(imported) || !await isRegularFile(root, imported)) continue
+      collected.add(imported)
+      queue.push(imported)
+      if (collected.size >= limit) break
+    }
+  }
+  return [...collected].sort()
+}
+
+function relativeImports(from: string, content: string): string[] {
+  const imports = new Set<string>()
+  for (const match of content.matchAll(/(?:from\s+|import\s*\()(['"])(\.\.?\/[^'"]+)\1/g)) {
+    const specifier = match[2]
+    if (specifier === undefined) continue
+    for (const candidate of importCandidates(from, specifier)) imports.add(candidate)
+  }
+  return [...imports]
 }
 
 async function collectImportRelations(

--- a/packages/maintainer-bot/tests/context.test.ts
+++ b/packages/maintainer-bot/tests/context.test.ts
@@ -20,6 +20,7 @@ async function contextRepo(): Promise<string> {
     private: true,
     workspaces: ['packages/*'],
   }))
+  await writeFile(join(root, 'tsconfig.json'), '{}\n')
   await writeFile(join(root, 'packages/demo/AGENTS.md'), '# Demo policy\n')
   await writeFile(join(root, 'packages/demo/package.json'), JSON.stringify({ name: '@fixture/demo' }))
   await writeFile(join(root, 'packages/demo/tsconfig.json'), '{}\n')
@@ -139,6 +140,139 @@ describe('versioned repository context manifest', () => {
     })
     expect(manifest.sufficiency.sufficient).toBe(false)
     expect(manifest.sufficiency.errors.join(' ')).toMatch(/Required target or policy files exceed/)
+  })
+
+  it('reserves byte budget for required sources before omitting optional context', async () => {
+    const repoRoot = await contextRepo()
+    await writeFile(
+      join(repoRoot, 'docs/greeting-pressure.md'),
+      `# Greeting output fixture\n${'greeting output punctuation '.repeat(500)}`,
+    )
+    const request = authorizedRequest()
+    const config = testConfig({ context: {
+      maxFiles: 80,
+      maxBytes: 5_000,
+      maxBytesPerFile: 4_000,
+      maxHistoryEntries: 5,
+    } })
+    const first = await buildContextManifest({
+      repoRoot,
+      request,
+      admission: evaluateAdmission(request),
+      config,
+      runner: contextRunner(),
+      now: () => new Date('2026-08-10T01:00:00.000Z'),
+    })
+    const second = await buildContextManifest({
+      repoRoot,
+      request,
+      admission: evaluateAdmission(request),
+      config,
+      runner: contextRunner(),
+      now: () => new Date('2026-08-10T01:00:00.000Z'),
+    })
+
+    expect(first.sufficiency).toMatchObject({ sufficient: true, errors: [] })
+    expect(first.sources.map(source => source.locator)).toEqual(expect.arrayContaining([
+      'maintainer-bot://system-policy/v1',
+      'open-multi-agent/open-multi-agent#101',
+      'workspace-map://package-json',
+      'AGENTS.md',
+      '.github/CONTRIBUTING.md',
+      'package.json',
+      'tsconfig.json',
+      'packages/demo/package.json',
+      'packages/demo/tsconfig.json',
+      'packages/demo/src/greeting.ts',
+    ]))
+    expect(first.sources.map(source => source.locator)).not.toContain('docs/greeting-pressure.md')
+    expect(first.sufficiency.warnings).toContain(
+      'Context byte limit omitted optional source: docs/greeting-pressure.md',
+    )
+    expect(first.retrieval.omittedCandidateCount).toBeGreaterThan(0)
+    expect(second.sufficiency.warnings).toEqual(first.sufficiency.warnings)
+    expect(second.retrieval).toEqual(first.retrieval)
+  })
+
+  it('warns deterministically when optional context is truncated without failing sufficiency', async () => {
+    const repoRoot = await contextRepo()
+    await writeFile(
+      join(repoRoot, 'packages/demo/tests/greeting-large.test.ts'),
+      `import { greeting } from "../src/greeting.js"\n${'// greeting output punctuation\n'.repeat(300)}`,
+    )
+    const request = authorizedRequest()
+    const manifest = await buildContextManifest({
+      repoRoot,
+      request,
+      admission: evaluateAdmission(request),
+      config: testConfig({ context: {
+        maxFiles: 80,
+        maxBytes: 50_000,
+        maxBytesPerFile: 4_000,
+        maxHistoryEntries: 5,
+      } }),
+      runner: contextRunner(),
+    })
+
+    expect(manifest.sufficiency.sufficient).toBe(true)
+    expect(manifest.sufficiency.warnings).toContain(
+      'Optional context source was truncated by maxBytesPerFile: packages/demo/tests/greeting-large.test.ts',
+    )
+    expect(manifest.sources.find(
+      source => source.locator === 'packages/demo/tests/greeting-large.test.ts',
+    )?.truncated).toBe(true)
+  })
+
+  it('fails closed when a required source cannot fit intact', async () => {
+    const repoRoot = await contextRepo()
+    await writeFile(
+      join(repoRoot, 'packages/demo/src/greeting.ts'),
+      `export const greeting = "${'x'.repeat(6_000)}"\n`,
+    )
+    const request = authorizedRequest()
+    const manifest = await buildContextManifest({
+      repoRoot,
+      request,
+      admission: evaluateAdmission(request),
+      config: testConfig({ context: {
+        maxFiles: 80,
+        maxBytes: 50_000,
+        maxBytesPerFile: 4_000,
+        maxHistoryEntries: 5,
+      } }),
+      runner: contextRunner(),
+    })
+
+    expect(manifest.sufficiency.sufficient).toBe(false)
+    expect(manifest.sufficiency.errors).toContain(
+      'Required context source exceeds maxBytesPerFile: packages/demo/src/greeting.ts',
+    )
+    expect(manifest.sources.find(source => source.locator === 'packages/demo/src/greeting.ts')?.truncated)
+      .toBe(true)
+  })
+
+  it('does not pull unrelated workspace examples or package-lock into single-file context', async () => {
+    const repoRoot = await contextRepo()
+    await mkdir(join(repoRoot, 'packages/demo/examples'), { recursive: true })
+    await writeFile(join(repoRoot, 'package-lock.json'), '{"lockfileVersion":3}\n')
+    for (let index = 0; index < 20; index += 1) {
+      await writeFile(
+        join(repoRoot, `packages/demo/examples/unrelated-${index}.ts`),
+        'export const greetingOutputPunctuationFixture = true\n',
+      )
+    }
+    const request = authorizedRequest()
+    const manifest = await buildContextManifest({
+      repoRoot,
+      request,
+      admission: evaluateAdmission(request),
+      config: testConfig(),
+      runner: contextRunner(),
+    })
+
+    expect(manifest.sufficiency.sufficient).toBe(true)
+    expect(manifest.retrieval.selectedFiles.some(path => path.includes('/examples/'))).toBe(false)
+    expect(manifest.retrieval.selectedFiles).not.toContain('package-lock.json')
   })
 
   it('fails closed on unresolved conflict markers in required context', async () => {


### PR DESCRIPTION
## Summary

- allocate context file and byte budgets to required system, Issue, policy, target, package/tsconfig, and workspace-map sources before optional evidence
- fill remaining capacity deterministically with byte-aware optional selection and auditable omission/truncation warnings
- narrow exact single-file retrieval so unrelated workspace examples do not consume the context budget
- add regression coverage and document the selection contract

## Motivation

The #491 live canary in Actions run 31466745316 reached NEEDS_HUMAN before model execution because optional repository candidates consumed the total byte budget before the required workspace map was added. This PR fixes that maintainer context selection and budgeting defect. It references #491 as canary evidence but does not implement or close the original test request.

Refs #491.

## Scope and impact

Affected area: @open-multi-agent/maintainer-bot context capture and docs/maintainer-bot.md.

Required context still fails closed when it cannot fit intact. Optional byte or file pressure now produces deterministic warnings without making context insufficient. Manifest hashes continue to bind the complete manifest; selectedFiles and importRelations continue to describe included repository files, while omittedCandidateCount now covers optional repository candidates omitted by either file or byte limits.

No production context limits, provider behavior, maintainer-host contract, public package API, dependencies, security boundary, or migration requirements change.

## Validation

- npm run test -w @open-multi-agent/maintainer-bot -- tests/context.test.ts — 9 passed
- npm run lint -w @open-multi-agent/maintainer-bot — passed
- npm run test -w @open-multi-agent/maintainer-bot — 84 passed
- npm run build -w @open-multi-agent/maintainer-bot — passed
- git diff --check — passed

Provider E2E was not run because context capture fails or succeeds before any model call and this change requires no provider credential. Maintainer-host and root checks were not run because the change does not cross the host or public contract boundaries; CI remains the source of truth for the Node 20/22/24 matrix.

## Checklist

- [x] Tests were added or updated for changed behavior
- [x] User-facing documentation was updated; examples are not applicable
- [x] Compatibility, breaking changes, and migration requirements are not applicable
- [x] No dependency changes were made