### PR TITLE
feat(core): add OrcaRouter provider adapter

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -44,6 +44,7 @@ The framework ships a wired-in provider name for each of these. Set `provider` a
 | MiniMax (China) | `provider: 'minimax'` + `MINIMAX_BASE_URL` | `MINIMAX_API_KEY` | `MiniMax-M3` | Set `MINIMAX_BASE_URL=https://api.minimaxi.com/v1`. |
 | MiMo | `provider: 'mimo'` | `MIMO_API_KEY` (+ optional `MIMO_BASE_URL`) | `mimo-v2.5-pro` | OpenAI-compatible. Defaults to pay-as-you-go endpoint `https://api.xiaomimimo.com/v1`; Token Plan keys (`tp-...`) require the cluster base URL from your subscription page, such as `https://token-plan-cn.xiaomimimo.com/v1`. Supports reasoning/tool-call loops through the built-in MiMo adapter. See [`providers/mimo`](../packages/core/examples/providers/mimo.ts). |
 | Qiniu | `provider: 'qiniu'` | `QINIU_API_KEY` | `deepseek-v3` | OpenAI-compatible. Endpoint `https://api.qnaigc.com/v1`; multiple model families, see [Qiniu AI docs](https://developer.qiniu.com/aitokenapi/12882/ai-inference-api). |
+| OrcaRouter | `provider: 'orcarouter'` | `ORCAROUTER_API_KEY` | `anthropic/claude-haiku-4.5` | OpenAI-compatible. Aggregation gateway over 190+ models behind a single endpoint `https://api.orcarouter.ai/v1` and key. Model names use the `provider/model` namespace (e.g. `anthropic/claude-haiku-4.5`, `orcarouter/auto`). See [`providers/orcarouter`](../packages/core/examples/providers/orcarouter.ts). |
 | AWS Bedrock | `provider: 'bedrock'` | none (AWS SDK credential chain) | `anthropic.claude-3-5-haiku-20241022-v1:0` | No API key. Set `AWS_REGION` or pass `region` as the 4th arg to `createAdapter`. Credentials come from env vars, shared config, or IAM role. Newer Claude models can require a cross-region inference profile prefix such as `us.`. Also supports Llama, Mistral, and Cohere. See [`providers/bedrock`](../packages/core/examples/providers/bedrock.ts). Requires `npm install @aws-sdk/client-bedrock-runtime`. |
 
 ## OpenAI-Compatible Providers
@@ -57,6 +58,7 @@ No bundled shortcut is needed when a server speaks OpenAI Chat Completions. Use 
 | LM Studio (local) | `provider: 'openai'` + `baseURL` | none | server-loaded | |
 | llama.cpp server (local) | `provider: 'openai'` + `baseURL` | none | server-loaded | |
 | OpenRouter | `provider: 'openai'` + `baseURL: 'https://openrouter.ai/api/v1'` + `apiKey` | `OPENROUTER_API_KEY` | `openai/gpt-4o-mini` | |
+| OrcaRouter | `provider: 'openai'` + `baseURL: 'https://api.orcarouter.ai/v1'` + `apiKey` | `ORCAROUTER_API_KEY` | `anthropic/claude-haiku-4.5` | Prefer the built-in `orcarouter` provider when using the OrcaRouter gateway. |
 | Groq | `provider: 'openai'` + `baseURL: 'https://api.groq.com/openai/v1'` | `GROQ_API_KEY` | `llama-3.3-70b-versatile` | |
 | Mistral | `provider: 'openai'` + `baseURL: 'https://api.mistral.ai/v1'` | `MISTRAL_API_KEY` | `mistral-large-latest` | See [`providers/mistral`](../packages/core/examples/providers/mistral.ts). |
 | MiMo | `provider: 'openai'` + `baseURL: 'https://api.xiaomimimo.com/v1'` | `MIMO_API_KEY` | `mimo-v2.5-pro` | Prefer the built-in `mimo` provider when using tool-calling agent loops. Token Plan users should set their `token-plan-*.xiaomimimo.com/v1` base URL. |

--- a/packages/core/examples/catalog.json
+++ b/packages/core/examples/catalog.json
@@ -684,6 +684,16 @@
       "level": "beginner"
     },
     {
+      "id": "orcarouter",
+      "path": "providers/orcarouter.ts",
+      "title": "OrcaRouter",
+      "description": "Run the standard three-agent team through OrcaRouter's OpenAI-compatible aggregation gateway.",
+      "section": "models-providers",
+      "capabilities": ["provider-adapter", "openai-compatible"],
+      "format": "script",
+      "level": "beginner"
+    },
+    {
       "id": "qwen",
       "path": "providers/qwen.ts",
       "title": "Qwen",

--- a/packages/core/examples/providers/orcarouter.ts
+++ b/packages/core/examples/providers/orcarouter.ts
@@ -1,0 +1,165 @@
+/**
+ * Multi-Agent Team Collaboration with OrcaRouter
+ *
+ * Three specialized agents (architect, developer, reviewer) collaborate via `runTeam()`
+ * to build a minimal Express.js REST API. Every agent uses an OrcaRouter-routed model.
+ *
+ * Run:
+ *   npx tsx packages/core/examples/providers/orcarouter.ts
+ *
+ * Prerequisites:
+ *   ORCAROUTER_API_KEY environment variable must be set.
+ *
+ * Models:
+ *   OrcaRouter fronts 190+ models behind one OpenAI-compatible endpoint. Model names
+ *   use the `provider/model` namespace, e.g. `anthropic/claude-haiku-4.5`,
+ *   `openai/gpt-4o`, `deepseek/deepseek-chat`, or the virtual route `orcarouter/auto`.
+ */
+
+import { join } from 'node:path'
+import { OpenMultiAgent } from '../../src/index.js'
+import type { AgentConfig, OrchestratorEvent } from '../../src/types.js'
+
+// Built-in filesystem tools are sandboxed to `<cwd>/.agent-workspace` by
+// default; route generated output there so the demo runs without
+// disabling the sandbox.
+const OUTPUT_DIR = join(process.cwd(), '.agent-workspace', 'orcarouter-api')
+
+// ---------------------------------------------------------------------------
+// Agent definitions
+// ---------------------------------------------------------------------------
+const architect: AgentConfig = {
+  name: 'architect',
+  model: 'anthropic/claude-haiku-4.5',
+  provider: 'orcarouter',
+  systemPrompt: `You are a software architect with deep experience in Node.js and REST API design.
+Your job is to design clear, production-quality API contracts and file/directory structures.
+Output concise plans in markdown — no unnecessary prose.`,
+  tools: ['bash', 'file_write'],
+  maxTurns: 5,
+  temperature: 0.2,
+}
+
+const developer: AgentConfig = {
+  name: 'developer',
+  model: 'openai/gpt-4o',
+  provider: 'orcarouter',
+  systemPrompt: `You are a TypeScript/Node.js developer. You implement what the architect specifies.
+Write clean, runnable code with proper error handling. Use the tools to write files and run tests.`,
+  tools: ['bash', 'file_read', 'file_write', 'file_edit'],
+  maxTurns: 12,
+  temperature: 0.1,
+}
+
+const reviewer: AgentConfig = {
+  name: 'reviewer',
+  model: 'anthropic/claude-haiku-4.5',
+  provider: 'orcarouter',
+  systemPrompt: `You are a senior code reviewer. Review code for correctness, security, and clarity.
+Provide a structured review with: LGTM items, suggestions, and any blocking issues.
+Read files using the tools before reviewing.`,
+  tools: ['bash', 'file_read', 'grep'],
+  maxTurns: 5,
+  temperature: 0.3,
+}
+
+// ---------------------------------------------------------------------------
+// Progress tracking
+// ---------------------------------------------------------------------------
+const startTimes = new Map<string, number>()
+
+function handleProgress(event: OrchestratorEvent): void {
+  const ts = new Date().toISOString().slice(11, 23) // HH:MM:SS.mmm
+  switch (event.type) {
+    case 'agent_start':
+      startTimes.set(event.agent ?? '', Date.now())
+      console.log(`[${ts}] AGENT START → ${event.agent}`)
+      break
+    case 'agent_complete': {
+      const elapsed = Date.now() - (startTimes.get(event.agent ?? '') ?? Date.now())
+      console.log(`[${ts}] AGENT DONE ← ${event.agent} (${elapsed}ms)`)
+      break
+    }
+    case 'task_start':
+      console.log(`[${ts}] TASK START ↓ ${event.task}`)
+      break
+    case 'task_complete':
+      console.log(`[${ts}] TASK DONE ↑ ${event.task}`)
+      break
+    case 'message':
+      console.log(`[${ts}] MESSAGE • ${event.agent} → (team)`)
+      break
+    case 'error':
+      console.error(`[${ts}] ERROR ✗ agent=${event.agent} task=${event.task}`)
+      if (event.data instanceof Error) console.error(` ${event.data.message}`)
+      break
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrate
+// ---------------------------------------------------------------------------
+const orchestrator = new OpenMultiAgent({
+  defaultModel: 'anthropic/claude-haiku-4.5',
+  defaultProvider: 'orcarouter',
+  maxConcurrency: 1, // sequential for readable output
+  onProgress: handleProgress,
+})
+
+const team = orchestrator.createTeam('api-team', {
+  name: 'api-team',
+  agents: [architect, developer, reviewer],
+  sharedMemory: true,
+  maxConcurrency: 1,
+})
+
+console.log(`Team "${team.name}" created with agents: ${team.getAgents().map(a => a.name).join(', ')}`)
+console.log('\nStarting team run...\n')
+console.log('='.repeat(60))
+
+const goal = `Create a minimal Express.js REST API in ${OUTPUT_DIR}/ with:
+- GET /health → { status: "ok" }
+- GET /users → returns a hardcoded array of 2 user objects
+- POST /users → accepts { name, email } body, logs it, returns 201
+- Proper error handling middleware
+- The server should listen on port 3001
+- Include a package.json with the required dependencies`
+
+const result = await orchestrator.runTeam(team, goal)
+
+console.log('\n' + '='.repeat(60))
+
+// ---------------------------------------------------------------------------
+// Results
+// ---------------------------------------------------------------------------
+console.log('\nTeam run complete.')
+console.log(`Success: ${result.success}`)
+console.log(`Total tokens — input: ${result.totalTokenUsage.input_tokens}, output: ${result.totalTokenUsage.output_tokens}`)
+
+console.log('\nPer-agent results:')
+for (const [agentName, agentResult] of result.agentResults) {
+  const status = agentResult.success ? 'OK' : 'FAILED'
+  const tools = agentResult.toolCalls.length
+  console.log(` ${agentName.padEnd(12)} [${status}] tool_calls=${tools}`)
+  if (!agentResult.success) {
+    console.log(` Error: ${agentResult.output.slice(0, 120)}`)
+  }
+}
+
+// Sample outputs
+const developerResult = result.agentResults.get('developer')
+if (developerResult?.success) {
+  console.log('\nDeveloper output (last 600 chars):')
+  console.log('─'.repeat(60))
+  const out = developerResult.output
+  console.log(out.length > 600 ? '...' + out.slice(-600) : out)
+  console.log('─'.repeat(60))
+}
+
+const reviewerResult = result.agentResults.get('reviewer')
+if (reviewerResult?.success) {
+  console.log('\nReviewer output:')
+  console.log('─'.repeat(60))
+  console.log(reviewerResult.output)
+  console.log('─'.repeat(60))
+}

--- a/packages/core/src/cli/oma.ts
+++ b/packages/core/src/cli/oma.ts
@@ -190,6 +190,7 @@ export const PROVIDER_REFERENCE: ReadonlyArray<{
   { id: 'doubao', apiKeyEnv: ['ARK_API_KEY'], baseUrlSupported: true, notes: 'OpenAI-compatible Volcengine Ark endpoint at https://ark.cn-beijing.volces.com/api/v3. Set provider to doubao and choose a model available to your Ark key.' },
   { id: 'hunyuan', apiKeyEnv: ['HUNYUAN_API_KEY', 'HUNYUAN_BASE_URL'], baseUrlSupported: true, notes: 'OpenAI-compatible. Defaults to the current Tencent MaaS / TokenHub endpoint https://tokenhub.tencentmaas.com/v1 (sk-... keys, models like hy3-preview). The legacy Tencent Cloud endpoint https://api.hunyuan.cloud.tencent.com/v1 (models like hunyuan-turbos-latest) is being retired by Tencent (shutdown 2026-09-30); target it via HUNYUAN_BASE_URL until then. Tool calling verified on hy3-preview / hunyuan-turbos / hunyuan-functioncall.' },
   { id: 'qiniu', apiKeyEnv: ['QINIU_API_KEY'], baseUrlSupported: true, notes: 'OpenAI-compatible endpoint at https://api.qnaigc.com/v1. Set provider to qiniu and choose a model available to your key.' },
+  { id: 'orcarouter', apiKeyEnv: ['ORCAROUTER_API_KEY'], baseUrlSupported: true, notes: 'OpenAI-compatible aggregation gateway at https://api.orcarouter.ai/v1. Model names use the provider/model namespace (e.g. anthropic/claude-haiku-4.5, orcarouter/auto).' },
   {
     id: 'copilot',
     apiKeyEnv: ['GITHUB_COPILOT_TOKEN', 'GITHUB_TOKEN'],
@@ -747,6 +748,7 @@ const DEFAULT_MODEL_HINT: Record<SupportedProvider, string> = {
   doubao: 'doubao-seed-1-8-251228',
   hunyuan: 'hy3-preview',
   qiniu: 'deepseek-v3',
+  orcarouter: 'anthropic/claude-haiku-4.5',
   bedrock: 'anthropic.claude-3-5-haiku-20241022-v1:0',
 }
 

--- a/packages/core/src/llm/adapter.ts
+++ b/packages/core/src/llm/adapter.ts
@@ -45,7 +45,7 @@ import {
  * directly and bypassing this factory, or via {@link AISdkAdapter} from
  * `@open-multi-agent/core/ai-sdk` (optional peer `ai`).
  */
-export type SupportedProvider = 'anthropic' | 'azure-openai' | 'bedrock' | 'copilot' | 'deepseek' | 'doubao' | 'grok' | 'hunyuan' | 'minimax' | 'mimo' | 'openai' | 'gemini' | 'qiniu'
+export type SupportedProvider = 'anthropic' | 'azure-openai' | 'bedrock' | 'copilot' | 'deepseek' | 'doubao' | 'grok' | 'hunyuan' | 'minimax' | 'mimo' | 'openai' | 'gemini' | 'qiniu' | 'orcarouter'
 
 const PROVIDER_DEFAULT_BASE_URLS: Partial<Record<SupportedProvider, string>> = {
   anthropic: 'https://api.anthropic.com',
@@ -56,6 +56,7 @@ const PROVIDER_DEFAULT_BASE_URLS: Partial<Record<SupportedProvider, string>> = {
   minimax: 'https://api.minimax.io/v1',
   mimo: 'https://api.xiaomimimo.com/v1',
   openai: 'https://api.openai.com/v1',
+  orcarouter: 'https://api.orcarouter.ai/v1',
   qiniu: 'https://api.qnaigc.com/v1',
 }
 
@@ -144,6 +145,7 @@ function prepareProviderBaseURL(
  * - `hunyuan`      → `HUNYUAN_API_KEY`, optional `HUNYUAN_BASE_URL`
  *                     (defaults to the Tencent MaaS / TokenHub endpoint)
  * - `qiniu`        → `QINIU_API_KEY`
+ * - `orcarouter`   → `ORCAROUTER_API_KEY`
  * - `bedrock`      → no API key; credentials via AWS SDK default provider chain
  *                     (env vars, shared config, IAM role). Pass `region` (4th arg)
  *                     or set `AWS_REGION`; falls back to `'us-east-1'`.
@@ -216,6 +218,10 @@ export async function createAdapter(
     case 'qiniu': {
       const { QiniuAdapter } = await import('./qiniu.js')
       return new QiniuAdapter(apiKey, policyBaseURL, policy)
+    }
+    case 'orcarouter': {
+      const { OrcaRouterAdapter } = await import('./orcarouter.js')
+      return new OrcaRouterAdapter(apiKey, policyBaseURL, policy)
     }
     case 'azure-openai': {
       // For azure-openai, the `baseURL` parameter serves as the Azure endpoint URL.

--- a/packages/core/src/llm/orcarouter.ts
+++ b/packages/core/src/llm/orcarouter.ts
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview OrcaRouter adapter.
+ *
+ * Thin wrapper around OpenAIAdapter that hard-codes the OrcaRouter
+ * OpenAI-compatible endpoint and ORCAROUTER_API_KEY environment variable
+ * fallback.
+ */
+
+import type { EgressPolicy } from '../types.js'
+import { OpenAIAdapter } from './openai.js'
+
+/**
+ * LLM adapter for OrcaRouter models.
+ *
+ * OrcaRouter is an OpenAI-compatible aggregation gateway that fronts 190+
+ * models (Anthropic, OpenAI, Google, DeepSeek, Qwen, …) behind a single
+ * endpoint and API key. Model names use the `provider/model` namespace, e.g.
+ * `anthropic/claude-haiku-4.5` or `orcarouter/auto`.
+ *
+ * Thread-safe. Can be shared across agents.
+ *
+ * Usage:
+ *   provider: 'orcarouter'
+ *   model: 'anthropic/claude-haiku-4.5' (or any OrcaRouter-routed model name)
+ */
+export class OrcaRouterAdapter extends OpenAIAdapter {
+  readonly name = 'orcarouter'
+
+  constructor(apiKey?: string, baseURL?: string, egressPolicy?: EgressPolicy) {
+    // Allow override of baseURL (for proxies or future changes) but default to
+    // the official OrcaRouter endpoint.
+    super(
+      apiKey ?? process.env['ORCAROUTER_API_KEY'],
+      baseURL ?? 'https://api.orcarouter.ai/v1',
+      egressPolicy,
+      'orcarouter',
+    )
+  }
+}

--- a/packages/core/tests/orcarouter-adapter.test.ts
+++ b/packages/core/tests/orcarouter-adapter.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock OpenAI constructor (must be hoisted for Vitest)
+// ---------------------------------------------------------------------------
+const OpenAIMock = vi.hoisted(() => vi.fn())
+
+vi.mock('openai', () => ({
+  default: OpenAIMock,
+}))
+
+import { OrcaRouterAdapter } from '../src/llm/orcarouter.js'
+import { createAdapter } from '../src/llm/adapter.js'
+
+// ---------------------------------------------------------------------------
+// OrcaRouterAdapter tests
+// ---------------------------------------------------------------------------
+
+describe('OrcaRouterAdapter', () => {
+  beforeEach(() => {
+    OpenAIMock.mockClear()
+  })
+
+  it('has name "orcarouter"', () => {
+    const adapter = new OrcaRouterAdapter()
+    expect(adapter.name).toBe('orcarouter')
+  })
+
+  it('uses ORCAROUTER_API_KEY by default', () => {
+    const original = process.env['ORCAROUTER_API_KEY']
+    process.env['ORCAROUTER_API_KEY'] = 'orca-test-key-123'
+
+    try {
+      new OrcaRouterAdapter()
+      expect(OpenAIMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'orca-test-key-123',
+          baseURL: 'https://api.orcarouter.ai/v1',
+        })
+      )
+    } finally {
+      if (original === undefined) {
+        delete process.env['ORCAROUTER_API_KEY']
+      } else {
+        process.env['ORCAROUTER_API_KEY'] = original
+      }
+    }
+  })
+
+  it('uses official OrcaRouter baseURL by default', () => {
+    new OrcaRouterAdapter('some-key')
+    expect(OpenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'some-key',
+        baseURL: 'https://api.orcarouter.ai/v1',
+      })
+    )
+  })
+
+  it('allows overriding apiKey and baseURL', () => {
+    new OrcaRouterAdapter('custom-key', 'https://custom.endpoint/v1')
+    expect(OpenAIMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'custom-key',
+        baseURL: 'https://custom.endpoint/v1',
+      })
+    )
+  })
+
+  it('createAdapter("orcarouter") returns OrcaRouterAdapter instance', async () => {
+    const adapter = await createAdapter('orcarouter')
+    expect(adapter).toBeInstanceOf(OrcaRouterAdapter)
+  })
+})

--- a/scripts/example-catalog.test.mjs
+++ b/scripts/example-catalog.test.mjs
@@ -26,7 +26,7 @@ function copyCatalog() {
 }
 
 test('the checked-in catalog covers every discovered example unit', () => {
-  assert.equal(catalog.examples.length, 62)
+  assert.equal(catalog.examples.length, 63)
   assert.deepEqual(validateExampleCatalog(catalog, examplesRoot), [])
 })
 
@@ -43,7 +43,7 @@ test('the public schema and runtime validator use the same controlled vocabulary
 
 test('discovery uses standalone scripts and immediate example directories as units', () => {
   const discovered = discoverExampleUnits(examplesRoot)
-  assert.equal(discovered.length, 62)
+  assert.equal(discovered.length, 63)
   assert.ok(discovered.includes('basics/single-agent.ts'))
   assert.ok(discovered.includes('patterns/event-driven-dag.ts'))
   assert.ok(discovered.includes('patterns/durable-approval.ts'))


### PR DESCRIPTION
## Summary

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway that brings 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single endpoint and API key. Beyond routing, it runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. This PR registers it as a named provider so users can opt in directly.

Concretely, this adds a built-in `orcarouter` provider that mirrors the existing `grok`/`deepseek` thin-adapter wiring in `@open-multi-agent/core`:

- New `OrcaRouterAdapter` (subclass of `OpenAIAdapter`) hard-coding the `https://api.orcarouter.ai/v1` endpoint and an `ORCAROUTER_API_KEY` environment-variable fallback, in `packages/core/src/llm/orcarouter.ts`.
- `orcarouter` registered in `SupportedProvider`, `PROVIDER_DEFAULT_BASE_URLS`, and the `createAdapter()` factory via dynamic `import()` (no new dependency — the existing `openai` SDK is reused).
- CLI support: default model hint and a `PROVIDER_REFERENCE` entry (`ORCAROUTER_API_KEY`, `baseUrlSupported`, notes).
- Five focused adapter tests in `packages/core/tests/orcarouter-adapter.test.ts`.
- `docs/providers.md` rows in both the Built-In Provider Shortcuts and OpenAI-Compatible Providers tables.
- A runnable example team (`packages/core/examples/providers/orcarouter.ts`) registered in the example catalog.

Model names use OrcaRouter's `provider/model` namespace (e.g. `anthropic/claude-haiku-4.5`, `openai/gpt-4o`, or the virtual route `orcarouter/auto`).

I'm an engineer on the OrcaRouter team.

## Motivation

Teams already using OpenAI-compatible providers in OMA get a first-class, named OrcaRouter option — same agent config shape, one env var, one base URL — rather than having to pass `baseURL` and a raw `apiKey` through the generic `openai` provider. This matches how `grok` and `deepseek` are already handled.

## Scope and impact

- Affects `@open-multi-agent/core` only: `src/llm/orcarouter.ts` (new), `src/llm/adapter.ts`, `src/cli/oma.ts`, plus docs, tests, and an example + catalog entry.
- Public API: additive. `provider: 'orcarouter'` becomes a valid value; no existing behavior or config changes.
- No new dependencies — the core already ships the `openai` SDK used by the adapter.
- Security: the adapter sets the same egress controls as the other OpenAI-family adapters (`egressPolicy` passthrough). No credentials are logged; the key is read from `ORCAROUTER_API_KEY`.

## Validation

- `npm run lint -w @open-multi-agent/core` (tsc --noEmit) — pass
- `npm run build -w @open-multi-agent/core` — pass
- `npm run test -w @open-multi-agent/core -- orcarouter-adapter` — 5/5 pass
- `npm run test:example-catalog` — 9/9 pass (63 examples, includes the new `providers/orcarouter` entry)
- Full `npm run test -w @open-multi-agent/core`: 1906 passed; the 32 remaining failures are in `file-trace-store.test.ts`, `eval-file-store.test.ts`, `cli.test.ts` (dashboard file export), and `built-in-tools.test.ts` (grep on an inaccessible path) and reproduce identically on a clean checkout with these changes stashed — they are pre-existing Windows `EPERM`/fsync temp-directory failures unrelated to this change.
- L3 live test against the real gateway: `OrcaRouterAdapter` with a real key called `https://api.orcarouter.ai/v1` (model `anthropic/claude-haiku-4.5`); returned 200 with `model: claude-haiku-4-5-20251001` and the expected reply.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING
