### PR TITLE
fix(maintainer-harness): isolate model cache environment

### DIFF
--- a/.github/workflows/maintainer-harness-canary.yml
+++ b/.github/workflows/maintainer-harness-canary.yml
@@ -150,7 +150,6 @@ jobs:
             LANG="${LANG:-C.UTF-8}" \
             CI=1 \
             TMPDIR="$RUNNER_TEMP" \
-            npm_config_cache="$RUNNER_TEMP/npm-cache" \
             node packages/maintainer-harness-canary/dist/cli.js run \
             --provider-key-fd 3 \
             --request "$RUNNER_TEMP/oma-harness-control/request.json" \

--- a/packages/maintainer-harness-canary/src/environment.ts
+++ b/packages/maintainer-harness-canary/src/environment.ts
@@ -7,7 +7,6 @@ const SAFE_SOURCE_NAMES = [
   'TZ',
   'CI',
   'TMPDIR',
-  'npm_config_cache',
 ] as const
 
 export function buildHarnessEnvironment(options: {

--- a/packages/maintainer-harness-canary/tests/canary.test.ts
+++ b/packages/maintainer-harness-canary/tests/canary.test.ts
@@ -233,6 +233,7 @@ describe('harness environment, settings, and credential isolation', () => {
         RUNNER_TRACKING_ID: 'tracking',
         NPM_TOKEN: 'npm-token',
         NODE_AUTH_TOKEN: 'node-token',
+        npm_config_cache: '/tmp/host-npm-cache',
         SSH_AUTH_SOCK: '/tmp/ssh.sock',
         OMA_MAINTAINER_BOT_APP_PRIVATE_KEY: 'private-key',
       },
@@ -241,10 +242,15 @@ describe('harness environment, settings, and credential isolation', () => {
     })
     expect(env['ANTHROPIC_AUTH_TOKEN']).toBe(FAKE_KEY)
     expect(env['CLAUDE_CODE_SUBPROCESS_ENV_SCRUB']).toBe('1')
-    for (const name of ['GITHUB_TOKEN', 'GH_TOKEN', 'ACTIONS_RUNTIME_TOKEN', 'RUNNER_TRACKING_ID', 'NPM_TOKEN', 'NODE_AUTH_TOKEN', 'SSH_AUTH_SOCK', 'OMA_MAINTAINER_BOT_APP_PRIVATE_KEY']) {
+    for (const name of ['GITHUB_TOKEN', 'GH_TOKEN', 'ACTIONS_RUNTIME_TOKEN', 'RUNNER_TRACKING_ID', 'NPM_TOKEN', 'NODE_AUTH_TOKEN', 'npm_config_cache', 'SSH_AUTH_SOCK', 'OMA_MAINTAINER_BOT_APP_PRIVATE_KEY']) {
       expect(env[name]).toBeUndefined()
     }
-    expect(() => assertHarnessCredentialIsolation({ GITHUB_TOKEN: 'x', CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: '1' })).toThrow(/forbidden host credentials/)
+    for (const name of ['GITHUB_TOKEN', 'NPM_TOKEN', 'NODE_AUTH_TOKEN', 'npm_config_cache']) {
+      expect(() => assertHarnessCredentialIsolation({
+        [name]: 'must-be-rejected',
+        CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: '1',
+      })).toThrow(/forbidden host credentials/)
+    }
     expect(() => assertHarnessCredentialIsolation({ ANTHROPIC_AUTH_TOKEN: 'x' })).toThrow(/scrubbing/)
 
     const settings = buildHarnessSettings({

--- a/packages/maintainer-harness-canary/tests/workflow.test.ts
+++ b/packages/maintainer-harness-canary/tests/workflow.test.ts
@@ -9,6 +9,10 @@ describe('GitHub-hosted harness canary workflow', () => {
     const validationSandbox = await readFile(resolve(process.cwd(), 'src/validation-sandbox.ts'), 'utf8')
     const boundedProcess = await readFile(resolve(process.cwd(), 'src/bounded-process.ts'), 'utf8')
     const appArmorProfile = await readFile(resolve(process.cwd(), 'config/bwrap.apparmor'), 'utf8')
+    const installStep = workflow.match(/      - name: Install repository dependencies and pinned Claude Code[\s\S]*?(?=\n      - name:)/)?.[0]
+    const modelStep = workflow.match(/      - name: Run credential-isolated Claude Code and DeepSeek canary[\s\S]*?(?=\n      - name:)/)?.[0]
+    expect(installStep).toBeDefined()
+    expect(modelStep).toBeDefined()
     expect(workflow).toContain('workflow_dispatch:')
     expect(workflow).toContain('runs-on: ubuntu-24.04')
     const triggers = workflow.slice(workflow.indexOf('on:'), workflow.indexOf('permissions:'))
@@ -20,6 +24,10 @@ describe('GitHub-hosted harness canary workflow', () => {
     expect(workflow).not.toContain('pull-requests: write')
     expect(workflow).toContain('persist-credentials: false')
     expect(workflow).toContain('@anthropic-ai/claude-code@2.1.220')
+    expect(installStep).toContain('npm_config_cache: ${{ runner.temp }}/npm-cache')
+    expect(modelStep).toContain('exec env -i')
+    expect(modelStep).not.toContain('npm_config_cache')
+    expect(workflow.match(/npm_config_cache/g)).toHaveLength(1)
     expect(workflow).toContain('sudo apt-get install --yes --no-install-recommends apparmor bubblewrap socat')
     expect(workflow).toContain("test \"$(sysctl -n kernel.apparmor_restrict_unprivileged_userns)\" = '1'")
     expect(workflow.match(/apparmor_restrict_unprivileged_userns/g)).toHaveLength(2)


### PR DESCRIPTION
## Root cause

GitHub Actions run [31578794685](https://github.com/open-multi-agent/open-multi-agent/actions/runs/31578794685) failed before Claude Code or DeepSeek started. `buildHarnessEnvironment()` treated `npm_config_cache` as a safe host value, while the case-insensitive `NPM_` credential isolation rule correctly rejected the same name. The Secret-bearing workflow step also injected that value into its clean `env -i` block.

## Fix

- Stop copying `npm_config_cache` from the host source environment into the harness/model environment.
- Remove `npm_config_cache` from the Secret-bearing model step's `env -i` block.
- Keep the isolated npm cache on the dependency installation step, outside the model environment.
- Add regression coverage for source filtering, direct NPM credential rejection, and the workflow step boundaries.

## Security boundaries

- The `NPM_`, `NODE_AUTH_TOKEN`, GitHub, Actions, SSH, and other credential rejection rules remain fail-closed and are not relaxed.
- `contents` and `issues` remain read-only; checkout still uses `persist-credentials: false`.
- Provider credential delivery remains isolated on FD 3, and Claude subprocess scrubbing remains enabled.
- Bubblewrap/AppArmor preflight, no-host-fallback validation, and the artifact whitelist remain unchanged.
- `.github/workflows/maintainer-bot.yml` has zero diff.

## Validation

- `npm run lint -w @open-multi-agent/maintainer-harness-canary`
- `npm run test -w @open-multi-agent/maintainer-harness-canary` (42 tests passed)
- `npm run build -w @open-multi-agent/maintainer-harness-canary`
- `npm run lint`
- `npm test` (all workspaces passed after rerunning outside the local IPC-restricted sandbox)
- `npm run build`
- YAML safe parse and focused workflow environment/permission assertions
- Sandbox, AppArmor, artifact-upload, production-workflow-zero-diff, and `git diff --check` assertions

The failed run artifact was parsed against the repository schema and its hash verified; it contains no model turns, safe events, or validation results.

## Not performed

- No real canary rerun or provider call
- No Secret read or change
- No Issue, label, or comment mutation
- No merge, release, publish, or deploy

Docs are unchanged because this fixes an internal workflow environment contradiction without changing a user-facing contract.
