### PR TITLE
fix(maintainer-host): distinguish production policy rejections

### DIFF
--- a/docs/maintainer-bot.md
+++ b/docs/maintainer-bot.md
@@ -388,11 +388,18 @@ report pre-model `NEEDS_HUMAN`; it is not part of the durable state machine.
 
 - `STARTED`: the label delivery is visible and deterministic checks are starting.
 - `RUNNING`: fixed revision/base, permission, DoR, scope, duplicate, and App identity/installation checks passed; the isolated engine is running.
-- `NEEDS_CLARIFICATION`: the strict Issue template or Definition of Ready is incomplete or conflicting.
-- `MANUAL_ONLY`: policy classifies the work as architecture, security, permissions, privacy, license, CI/release, broad API/refactor, uncontrolled dependency, or otherwise human-only.
-- `NEEDS_HUMAN`: stale/crashed state, drift, App configuration/identity, conflicting branch/PR, or safety gate requires intervention.
+- `NEEDS_CLARIFICATION`: the Issue content, required format, or acceptance information is incomplete or conflicting, so the Definition of Ready cannot be established.
+- `MANUAL_ONLY`: the task category itself is not eligible for automated development, including architecture, security, permissions, privacy, license, CI/release, broad API/refactor, or uncontrolled dependency work.
+- `NEEDS_HUMAN`: repository policy or authorization must be revised, or the environment, control plane, stale/crashed state, drift, App configuration/identity, conflicting branch/PR, or another safety gate requires maintainer intervention. A production-policy rejection stops before model execution and is not a request for more Issue detail.
 - `FAILED`: infrastructure or engine failure produced no eligible Draft PR.
 - `DRAFT_PR_CREATED`: exactly one open Draft PR exists; human review remains required.
+
+When an otherwise complete Issue targets a path missing from the production
+allowlist, a maintainer must first merge the narrow policy correction. The
+maintainer then rechecks the Issue against the updated policy, removes and
+re-adds `agent-ready`, and thereby authorizes a fresh run against the new
+default-branch base. The blocked run is never resumed and its old label event
+does not authorize work on the newer base.
 
 To configure activation without exposing credential values:
 

--- a/packages/maintainer-host/config/production-policy.json
+++ b/packages/maintainer-host/config/production-policy.json
@@ -13,6 +13,7 @@
     "packages/core/src",
     "packages/core/tests",
     "packages/core/examples",
+    "packages/otel/README.md",
     "packages/otel/src",
     "packages/otel/tests",
     "packages/create-oma-app/src",

--- a/packages/maintainer-host/src/request.ts
+++ b/packages/maintainer-host/src/request.ts
@@ -188,10 +188,14 @@ export async function buildControlPlaneRequest(
   try {
     targetWorkspaces = resolveTargetWorkspaces(options.policy, markdown.value.targetPaths)
   } catch (error) {
+    const policyDetail = error instanceof Error ? error.message : String(error)
     throw new ControlPlaneBuildError(
       'TARGET_POLICY_REJECTED',
-      'NEEDS_CLARIFICATION',
-      [error instanceof Error ? error.message : String(error)],
+      'NEEDS_HUMAN',
+      [
+        'The requested target path is blocked by repository production policy. The model was not run. A maintainer must update the production policy, recheck the Issue, and reauthorize it against the new default-branch base.',
+        `Policy detail: ${policyDetail}`,
+      ],
     )
   }
   const issue = maintainerIssueSchema.parse({

--- a/packages/maintainer-host/tests/activation.test.ts
+++ b/packages/maintainer-host/tests/activation.test.ts
@@ -26,6 +26,8 @@ import {
   RecordingRunner,
   REPOSITORY,
   SECOND_SHA,
+  ISSUE_BODY,
+  cleanRunner,
   labelEvent,
   ok,
 } from './helpers.js'
@@ -224,6 +226,65 @@ describe('mocked GitHub + scripted OMA activation path', () => {
     expect(context).toMatchObject({ shouldRun: false, status: 'NEEDS_HUMAN' })
     expect(context.detail).toMatch(/changed between the labeled event and the first trusted GitHub snapshot/)
     expect(github.createdPullRequests).toBe(0)
+  })
+
+  it('publishes NEEDS_HUMAN and stops before local or model work when production policy rejects the target', async () => {
+    const github = new FakeGitHub()
+    github.issue.body = ISSUE_BODY.replaceAll(
+      'packages/create-oma-app/tests/runtime.test.ts',
+      'packages/otel/package.json',
+    )
+    const event = labelEvent({ issue: { ...labelEvent().issue, body: github.issue.body } })
+    const runner = cleanRunner()
+    const context = await prepareActivation({
+      event,
+      github,
+      runner,
+      repoRoot: '/unused-before-policy-admission',
+      policy: await productionPolicy(),
+      eventId: '104.1',
+      receivedAt: '2026-08-10T18:05:00Z',
+      claimId: '104.1',
+      actionsRunId: 104,
+      runUrl: `https://github.com/${REPOSITORY}/actions/runs/104`,
+      baseShaHint: BASE_SHA,
+      eventSnapshotMatched: true,
+      writerContract: APP_CONTRACT,
+      removedBootstrapCommentCount: 0,
+    })
+    expect(context).toMatchObject({ shouldRun: false, status: 'NEEDS_HUMAN' })
+    expect(context.detail).toContain('blocked by repository production policy')
+    expect(context.detail).toContain('The model was not run')
+    expect(context.detail).toContain('reauthorize')
+    expect(runner.calls).toEqual([])
+    expect(github.comments.at(-1)?.body).toContain('OMA Maintainer Bot — NEEDS_HUMAN')
+    expect(github.comments.at(-1)?.body).not.toContain('NEEDS_CLARIFICATION')
+  })
+
+  it('keeps incomplete Issue Markdown as NEEDS_CLARIFICATION before model work', async () => {
+    const github = new FakeGitHub()
+    github.issue.body = '## Problem\n\nMissing the required fields.'
+    const event = labelEvent({ issue: { ...labelEvent().issue, body: github.issue.body } })
+    const runner = cleanRunner()
+    const context = await prepareActivation({
+      event,
+      github,
+      runner,
+      repoRoot: '/unused-before-markdown-admission',
+      policy: await productionPolicy(),
+      eventId: '105.1',
+      receivedAt: '2026-08-10T18:06:00Z',
+      claimId: '105.1',
+      actionsRunId: 105,
+      runUrl: `https://github.com/${REPOSITORY}/actions/runs/105`,
+      baseShaHint: BASE_SHA,
+      eventSnapshotMatched: true,
+      writerContract: APP_CONTRACT,
+      removedBootstrapCommentCount: 0,
+    })
+    expect(context).toMatchObject({ shouldRun: false, status: 'NEEDS_CLARIFICATION' })
+    expect(runner.calls).toEqual([])
+    expect(github.comments.at(-1)?.body).toContain('OMA Maintainer Bot — NEEDS_CLARIFICATION')
   })
 
   it('never invokes the writer after a failed engine result', async () => {

--- a/packages/maintainer-host/tests/engine.test.ts
+++ b/packages/maintainer-host/tests/engine.test.ts
@@ -1,5 +1,9 @@
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { assertNoHostCredentials, buildIsolatedModelEnvironment } from '../src/engine.js'
+import { assertNoHostCredentials, buildIsolatedModelEnvironment, runIsolatedEngine } from '../src/engine.js'
+import { APP_IDENTITY } from './helpers.js'
 
 describe('credential-isolated model process environment', () => {
   it('allows only DeepSeek plus the minimal non-secret runtime environment', () => {
@@ -37,5 +41,45 @@ describe('credential-isolated model process environment', () => {
       DEEPSEEK_API_KEY: 'allowed',
       ACTIONS_RUNTIME_TOKEN: 'forbidden',
     })).toThrow(/ACTIONS_RUNTIME_TOKEN/)
+  })
+
+  it('does not invoke the model process for a non-runnable policy terminal', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'oma-maintainer-engine-skip-'))
+    const activationPath = join(root, 'activation.json')
+    const resultPath = join(root, 'engine-result.json')
+    const detail = 'The requested target path is blocked by repository production policy. The model was not run.'
+    await writeFile(activationPath, JSON.stringify({
+      schemaVersion: 1,
+      shouldRun: false,
+      claimId: '104.1',
+      actionsRunId: 104,
+      runUrl: 'https://github.com/open-multi-agent/open-multi-agent/actions/runs/104',
+      commentId: 1,
+      branch: null,
+      writerIdentity: APP_IDENTITY,
+      removedBootstrapCommentCount: 0,
+      request: null,
+      config: null,
+      admission: null,
+      status: 'NEEDS_HUMAN',
+      detail,
+    }))
+
+    const result = await runIsolatedEngine({
+      activationPath,
+      resultPath,
+      repoRoot: root,
+      stateDir: join(root, 'state'),
+      artifactDir: join(root, 'artifacts'),
+      maintainerBotCli: join(root, 'must-not-be-invoked.js'),
+    })
+    expect(result).toEqual({
+      schemaVersion: 1,
+      attempted: false,
+      exitCode: 0,
+      status: 'NEEDS_HUMAN',
+      detail,
+    })
+    expect(JSON.parse(await readFile(resultPath, 'utf8'))).toEqual(result)
   })
 })

--- a/packages/maintainer-host/tests/policy.test.ts
+++ b/packages/maintainer-host/tests/policy.test.ts
@@ -28,6 +28,23 @@ describe('trusted production policy and command registry', () => {
       .toEqual(['OMA_MODEL'])
   })
 
+  it('accepts only the enumerated OTel README and selects the full OTel validation suite', async () => {
+    const policy = await productionPolicy()
+    const path = 'packages/otel/README.md'
+    expect(resolveTargetWorkspaces(policy, [path])).toEqual(['@open-multi-agent/otel'])
+    expect(buildProductionConfig(policy, [path]).validationCommands.map(command => command.id)).toEqual([
+      'git-diff-check',
+      'otel-lint',
+      'otel-test',
+      'otel-build',
+    ])
+
+    expect(() => resolveTargetWorkspaces(policy, ['packages/otel/package.json']))
+      .toThrow(/outside the trusted production allowlist/)
+    expect(() => resolveTargetWorkspaces(policy, ['packages/otel/CHANGELOG.md']))
+      .toThrow(/outside the trusted production allowlist/)
+  })
+
   it('routes workflow, permission, public-entry, and cross-workspace requests to manual risks', async () => {
     const policy = await productionPolicy()
     expect(deriveRiskFlags({

--- a/packages/maintainer-host/tests/request.test.ts
+++ b/packages/maintainer-host/tests/request.test.ts
@@ -89,6 +89,22 @@ describe('GitHub event to deterministic ControlPlaneRequest', () => {
       && error.code === 'ISSUE_MARKDOWN_INVALID')
   })
 
+  it('routes repository production policy rejection to maintainer intervention', async () => {
+    const github = new FakeGitHub()
+    github.issue.body = ISSUE_BODY.replaceAll(
+      'packages/create-oma-app/tests/runtime.test.ts',
+      'packages/otel/package.json',
+    )
+    const event = labelEvent({ issue: { ...labelEvent().issue, body: github.issue.body } })
+    await expect(build(github, event)).rejects.toSatisfy((error: unknown) =>
+      error instanceof ControlPlaneBuildError
+      && error.publicStatus === 'NEEDS_HUMAN'
+      && error.code === 'TARGET_POLICY_REJECTED'
+      && error.reasons.join(' ').includes('blocked by repository production policy')
+      && error.reasons.join(' ').includes('model was not run')
+      && error.reasons.join(' ').includes('reauthorize'))
+  })
+
   it('does not interpret executable text embedded in the Issue body', async () => {
     const github = new FakeGitHub()
     const injected = ISSUE_BODY.replace(


### PR DESCRIPTION
## Summary

- allow exactly `packages/otel/README.md` in the Maintainer Bot production policy
- map `TARGET_POLICY_REJECTED` to `NEEDS_HUMAN` while preserving `ISSUE_MARKDOWN_INVALID` as `NEEDS_CLARIFICATION`
- publish bounded, sanitized guidance that the model did not run and a maintainer must update policy and reauthorize
- add policy, request, activation, and engine regression coverage and document the recovery flow

## Motivation

Related to #501.

The Issue is complete enough for deterministic admission, but run 31606895321 stopped because its exact target path was outside the production allowlist. The host reported that policy rejection as `NEEDS_CLARIFICATION`, incorrectly implying that the Issue needed more information.

## Scope and impact

- Affected area: `@open-multi-agent/maintainer-host` production policy and public terminal-state semantics, plus maintainer documentation.
- The OTel policy expansion is limited to the exact file `packages/otel/README.md`; `packages/otel/package.json` and other unenumerated OTel files remain denied.
- The exact README target resolves to `@open-multi-agent/otel` and receives `git-diff-check`, `otel-lint`, `otel-test`, and `otel-build`.
- `protectedPaths`, `manualOnlyPaths`, workflows, permissions, Secrets, package manifests, publication, and control-plane boundaries are unchanged.
- `packages/otel/README.md` is intentionally unchanged. After this policy PR lands, a maintainer must recheck #501 and remove/re-add `agent-ready` so the Bot can run against the new `main` base.
- No public API, compatibility, migration, dependency, security, or privacy impact.

## Validation

- `git diff --check` — passed
- `npm run test -w @open-multi-agent/maintainer-host -- policy.test.ts request.test.ts activation.test.ts engine.test.ts` — 29 tests passed
- `npm run lint -w @open-multi-agent/maintainer-host` — passed
- `npm run test -w @open-multi-agent/maintainer-host` — 42 tests passed
- `npm run build -w @open-multi-agent/maintainer-host` — passed
- `npm run lint` — passed
- `npm test` — passed across all workspaces
- `npm run build` — passed across all workspaces
- Maintainer Bot workflow static test passed; `.github/workflows/maintainer-bot.yml` has no diff

Real-provider E2E and live Maintainer Bot workflows were not run because this change is fully covered by mocked deterministic tests and must not consume provider credentials or mutate live repository state during local validation.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING (no dependency changes)
