### PR TITLE
feat(maintainer): activate supervised Claude Code beta

### DIFF
--- a/docs/maintainer-bot-architecture.md
+++ b/docs/maintainer-bot-architecture.md
@@ -107,11 +107,8 @@ Lost `RUNNING` claims remain human-recovery cases rather than automatic resume.
 
 ## Supervised beta activation
 
-The checked-in production policy remains `legacy`. A future supervised beta is
-enabled by a separately reviewed change of the one selector to `claude-code`.
-Before that change lands, maintainers must confirm the existing provider Secret,
-dedicated GitHub App writer configuration, pinned Claude installation, Ubuntu
-sandbox preflight, and ordinary workflow CI in the target repository. No
-Secret, repository variable, permission, label, Issue, or Actions setting is
-changed by this implementation. Local scripted tests are not live model or
-canary evidence.
+The checked-in production policy selects `claude-code` for the supervised beta.
+Rollback requires a separately reviewed change of the same selector to
+`legacy`; there is no runtime fallback. This policy activation does not change
+any Secret, repository variable, permission, label, Issue, or Actions setting.
+Local scripted tests are not live model or canary evidence.

--- a/packages/maintainer-host/config/production-policy.json
+++ b/packages/maintainer-host/config/production-policy.json
@@ -6,7 +6,7 @@
   "agentReadyLabel": "agent-ready",
   "policyVersion": "maintainer-activation-v1",
   "promptVersion": "maintainer-prompts-v1",
-  "executionBackend": "legacy",
+  "executionBackend": "claude-code",
   "model": "deepseek-v4-flash",
   "claudeCode": {
     "version": "2.1.220",

--- a/packages/maintainer-host/tests/activation.test.ts
+++ b/packages/maintainer-host/tests/activation.test.ts
@@ -404,7 +404,7 @@ async function runToProposal(localGitConfigKeys?: readonly string[]) {
   const repoRoot = await fixtureRepo()
   const runner = repositoryRunner(repoRoot, localGitConfigKeys)
   const github = new FakeGitHub()
-  const policy = await productionPolicy()
+  const policy = { ...await productionPolicy(), executionBackend: 'legacy' as const }
   const event = labelEvent()
   const activation = await prepareActivation({
     event,
@@ -454,7 +454,7 @@ async function runClaudeToProposal() {
   const repoRoot = await fixtureRepo()
   const runner = repositoryRunner(repoRoot)
   const github = new FakeGitHub()
-  const policy = { ...await productionPolicy(), executionBackend: 'claude-code' as const }
+  const policy = await productionPolicy()
   const event = labelEvent()
   const activation = await prepareActivation({
     event, github, runner, repoRoot, policy,

--- a/packages/maintainer-host/tests/policy.test.ts
+++ b/packages/maintainer-host/tests/policy.test.ts
@@ -89,12 +89,12 @@ describe('trusted production policy and command registry', () => {
       .toThrow(/allowed paths must be unique/)
   })
 
-  it('uses one mutually exclusive backend selector and can roll back to the legacy engine', async () => {
+  it('uses Claude Code by default and can roll back to the legacy engine', async () => {
     const policy = await productionPolicy()
     const path = 'packages/core/tests/subpath-exports.test.ts'
-    expect(buildProductionConfig(policy, [path]).executionBackend).toBe('legacy')
-    const claudePolicy = productionPolicySchema.parse({ ...policy, executionBackend: 'claude-code' })
-    expect(buildProductionConfig(claudePolicy, [path]).executionBackend).toBe('claude-code')
+    expect(buildProductionConfig(policy, [path]).executionBackend).toBe('claude-code')
+    const legacyPolicy = productionPolicySchema.parse({ ...policy, executionBackend: 'legacy' })
+    expect(buildProductionConfig(legacyPolicy, [path]).executionBackend).toBe('legacy')
     expect(() => productionPolicySchema.parse({ ...policy, executionBackend: 'both' })).toThrow()
   })
 })


### PR DESCRIPTION
## Summary

Activate the supervised Claude Code production beta by changing the single checked-in `executionBackend` selector from `legacy` to `claude-code`. Keep `legacy` as an explicit, reviewable rollback value and update the directly affected policy/activation tests and architecture wording.

## Motivation

The production Claude Code backend, OMA orchestration and independent review, fail-closed Bubblewrap validation, and deterministic GitHub App Draft PR writer are already present on `main`. This separately reviewed policy change enables that prepared path without adding a second switch or runtime fallback.

## Scope and impact

- Affected areas: `@open-multi-agent/maintainer-host` production policy and tests; maintainer architecture documentation.
- Behavior: admitted future maintainer runs select the OMA-scheduled Claude Code worker. A selected-backend failure remains fail closed.
- Rollback: another reviewed policy change can set the selector back to `legacy`; there is no runtime fallback.
- Security/privacy: deterministic host code still owns admission, durable claims, validation, and the GitHub App writer. The model receives no GitHub/App/npm/SSH write credentials.
- Not changed: Secrets, Variables, Actions settings, permissions, labels, Issues, workflow triggers, provider configuration, dependencies, or public APIs.
- Not performed: no real Issue was labeled or triggered, and no real-provider/paid canary or E2E was run.

## Validation

- `npm ci --cache /tmp/oma-claude-beta-npm-cache` — passed
- `npm run test -w @open-multi-agent/maintainer-host -- policy.test.ts activation.test.ts workflow.test.ts` — passed (19 tests)
- `npm run lint -w @open-multi-agent/maintainer-host` — passed
- `npm run test -w @open-multi-agent/maintainer-host` — passed (44 tests)
- `npm run build -w @open-multi-agent/maintainer-host` — passed
- `git diff --check` — passed
- Workflow static assertions are covered by `workflow.test.ts`; standalone `actionlint` was unavailable locally.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING — no dependency changes