### PR TITLE
fix(maintainer): canonicalize candidate diffs

### DIFF
--- a/docs/maintainer-bot.md
+++ b/docs/maintainer-bot.md
@@ -112,7 +112,8 @@ backend never falls through to the other backend.
    already scope-checked candidate to the shared canary validation CLI, which
    rebuilds base plus the exact patch in a disposable snapshot and executes all
    trusted commands only through fail-closed `/usr/bin/bwrap`, with no host
-   fallback.
+   fallback. Candidate capture and disposable-workspace integrity checks use
+   the same fixed Git diff format before comparing the patch byte for byte.
 7. A new OMA team and agent perform fresh-context review using only confirmed
    requirements, acceptance criteria, the final diff, validation evidence,
    bounded current-file snapshots, and relevant context. Implementer reasoning

--- a/packages/maintainer-bot/src/command.ts
+++ b/packages/maintainer-bot/src/command.ts
@@ -22,6 +22,36 @@ export interface CommandRunner {
   ): Promise<CommandResult>
 }
 
+const CANONICAL_GIT_DIFF_OPTIONS = [
+  '--binary',
+  '--no-ext-diff',
+  '--no-color',
+  '--no-renames',
+  '--no-textconv',
+  '--full-index',
+  '--unified=5',
+  '--no-indent-heuristic',
+  '--diff-algorithm=myers',
+  '--src-prefix=a/',
+  '--dst-prefix=b/',
+] as const
+
+export function canonicalGitDiffArgs(options: {
+  readonly baseSha?: string
+  readonly paths: readonly string[]
+}): string[] {
+  if (options.paths.length === 0) {
+    throw new Error('Canonical Git diff requires at least one path.')
+  }
+  return [
+    'diff',
+    ...CANONICAL_GIT_DIFF_OPTIONS,
+    ...(options.baseSha === undefined ? [] : [options.baseSha]),
+    '--',
+    ...options.paths,
+  ]
+}
+
 export class CommandError extends Error {
   readonly command: string
   readonly args: readonly string[]

--- a/packages/maintainer-bot/src/review-bundle.ts
+++ b/packages/maintainer-bot/src/review-bundle.ts
@@ -1,7 +1,7 @@
 import { lstat, readFile, realpath } from 'node:fs/promises'
 import { relative, sep } from 'node:path'
 import { z } from 'zod'
-import type { CommandRunner } from './command.js'
+import { canonicalGitDiffArgs, type CommandRunner } from './command.js'
 import { sha256 } from './hash.js'
 import {
   assertApprovedEditPath,
@@ -75,14 +75,10 @@ export async function collectReviewBundle(
 
   const tracked = await options.runner.run(
     'git',
-    [
-      'diff',
-      '--no-ext-diff',
-      '--unified=5',
-      options.request.baseSha,
-      '--',
-      ...options.manifest.approvedEditScopes.map(scope => normalizeRepoPath(scope.path)),
-    ],
+    canonicalGitDiffArgs({
+      baseSha: options.request.baseSha,
+      paths: options.manifest.approvedEditScopes.map(scope => normalizeRepoPath(scope.path)),
+    }),
     { cwd: options.repoRoot, maxOutputChars: (options.maxDiffChars ?? 300_000) + 1 },
   )
   let diff = tracked.stdout

--- a/packages/maintainer-bot/tests/command.test.ts
+++ b/packages/maintainer-bot/tests/command.test.ts
@@ -1,5 +1,35 @@
 import { describe, expect, it } from 'vitest'
-import { assertModelCredentialIsolation } from '../src/command.js'
+import { assertModelCredentialIsolation, canonicalGitDiffArgs } from '../src/command.js'
+
+describe('canonical Git diff arguments', () => {
+  it('pins the patch representation used across checkout boundaries', () => {
+    expect(canonicalGitDiffArgs({
+      baseSha: 'a'.repeat(40),
+      paths: ['packages/core/src/index.ts', 'packages/core/tests/subpath-exports.test.ts'],
+    })).toEqual([
+      'diff',
+      '--binary',
+      '--no-ext-diff',
+      '--no-color',
+      '--no-renames',
+      '--no-textconv',
+      '--full-index',
+      '--unified=5',
+      '--no-indent-heuristic',
+      '--diff-algorithm=myers',
+      '--src-prefix=a/',
+      '--dst-prefix=b/',
+      'a'.repeat(40),
+      '--',
+      'packages/core/src/index.ts',
+      'packages/core/tests/subpath-exports.test.ts',
+    ])
+  })
+
+  it('rejects an empty path set instead of widening the diff', () => {
+    expect(() => canonicalGitDiffArgs({ paths: [] })).toThrow(/at least one path/)
+  })
+})
 
 describe('model credential isolation', () => {
   it('rejects write credentials even when their names have a host-specific prefix', () => {

--- a/packages/maintainer-bot/tests/review-bundle.test.ts
+++ b/packages/maintainer-bot/tests/review-bundle.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { describe, expect, it } from 'vitest'
+import { canonicalGitDiffArgs } from '../src/command.js'
 import { hashJson, sha256 } from '../src/hash.js'
 import { collectReviewBundle } from '../src/review-bundle.js'
 import { contextManifestSchema } from '../src/schema.js'
@@ -61,6 +62,10 @@ describe('fresh reviewer evidence bundle', () => {
       expect.objectContaining({ path: 'packages/demo/src/new.ts', contentHash: sha256('export const added = true\n') }),
     ]))
     expect(bundle.relevantContext.map(source => source.locator)).toContain('AGENTS.md')
+    expect(runner.calls.find(call => call.args[0] === 'diff')?.args).toEqual(canonicalGitDiffArgs({
+      baseSha: authorizedRequest().baseSha,
+      paths: ['packages/demo'],
+    }))
   })
 
   it('rejects unexpected protected changes before review', async () => {

--- a/packages/maintainer-harness-canary/src/runner.ts
+++ b/packages/maintainer-harness-canary/src/runner.ts
@@ -4,6 +4,7 @@ import { lstat, mkdir, mkdtemp, readdir, realpath, rename, writeFile } from 'nod
 import { tmpdir } from 'node:os'
 import { isAbsolute, join, relative, resolve, sep } from 'node:path'
 import {
+  canonicalGitDiffArgs,
   NodeCommandRunner,
   canonicalJson,
   hashJson,
@@ -195,7 +196,7 @@ export async function runHarnessCanary(options: RunHarnessCanaryOptions): Promis
       changedPaths = parseAndValidateStatus(status.stdout, request, policy)
       if (changedPaths.length === 0) throw new Error('Harness completed without a candidate patch.')
       await assertNoSymlinksOrOversize(changedPaths, repoRoot, policy.limits.maxFileBytes)
-      const diffResult = await commandRunner.run('git', ['diff', '--binary', '--no-ext-diff', '--no-color', '--', ...changedPaths], { cwd: repoRoot })
+      const diffResult = await commandRunner.run('git', canonicalGitDiffArgs({ paths: changedPaths }), { cwd: repoRoot })
       diff = diffResult.stdout
       const diffBytes = Buffer.byteLength(diff)
       if (diffBytes === 0) throw new Error('Harness changed paths but produced no tracked diff.')
@@ -237,7 +238,7 @@ export async function runHarnessCanary(options: RunHarnessCanaryOptions): Promis
       const finalPaths = parseAndValidateStatus(finalStatus.stdout, request, policy)
       if (canonicalJson(finalPaths) !== canonicalJson(changedPaths)) throw new Error('Validation changed the candidate path set.')
       await assertNoSymlinksOrOversize(finalPaths, repoRoot, policy.limits.maxFileBytes)
-      const finalDiff = await commandRunner.run('git', ['diff', '--binary', '--no-ext-diff', '--no-color', '--', ...finalPaths], { cwd: repoRoot })
+      const finalDiff = await commandRunner.run('git', canonicalGitDiffArgs({ paths: finalPaths }), { cwd: repoRoot })
       if (finalDiff.stdout !== diff) throw new Error('Validation changed the candidate patch.')
       await assertArtifactDirectory(artifactDir, [])
     } catch (error) {

--- a/packages/maintainer-harness-canary/src/validation-workspace.ts
+++ b/packages/maintainer-harness-canary/src/validation-workspace.ts
@@ -2,6 +2,7 @@ import { readFile, readdir, readlink, realpath, rm, lstat, mkdir, mkdtemp, write
 import { tmpdir } from 'node:os'
 import { join, relative, resolve, sep } from 'node:path'
 import {
+  canonicalGitDiffArgs,
   NodeCommandRunner,
   canonicalJson,
   sha256,
@@ -116,9 +117,10 @@ export async function assertValidationWorkspaceIntegrity(
   }
   const diff = statusPaths.length === 0
     ? ''
-    : (await commandRunner.run('git', [
-        'diff', '--binary', '--no-ext-diff', '--no-color', '--', ...statusPaths,
-      ], { cwd: workspace.repoRoot, env: gitEnvironment })).stdout
+    : (await commandRunner.run('git', canonicalGitDiffArgs({ paths: statusPaths }), {
+        cwd: workspace.repoRoot,
+        env: gitEnvironment,
+      })).stdout
   if (diff !== workspace.candidateDiff) {
     throw new Error('Validation changed the disposable workspace candidate patch.')
   }

--- a/packages/maintainer-harness-canary/tests/canary.test.ts
+++ b/packages/maintainer-harness-canary/tests/canary.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
 import { describe, expect, it } from 'vitest'
-import type { CommandResult } from '@open-multi-agent/maintainer-bot'
+import { canonicalGitDiffArgs, type CommandResult } from '@open-multi-agent/maintainer-bot'
 import {
   assertHarnessCredentialIsolation,
   BoundedProcessError,
@@ -386,7 +386,7 @@ describe('fail-closed deterministic validation sandbox', () => {
     const original = await readFile(join(fixture.root, BASE_FILE), 'utf8')
     const candidate = original.replace('// TODO missing barrels', "assert.ok('/observability')")
     await writeFile(join(fixture.root, BASE_FILE), candidate)
-    const diff = (await exec('git', ['diff', '--binary', '--no-ext-diff', '--no-color', '--', BASE_FILE], { cwd: fixture.root })).stdout
+    const diff = await canonicalDiff(fixture.root, [BASE_FILE], fixture.baseSha)
     const runner = new StrictMockValidationSandboxRunner()
     const results = await runProductionSandboxValidation({
       contract: productionValidationContract(fixture.baseSha, candidate, diff),
@@ -401,12 +401,34 @@ describe('fail-closed deterministic validation sandbox', () => {
     expect(await readFile(join(fixture.root, BASE_FILE), 'utf8')).toBe(candidate)
   })
 
+  it('preserves a #501-shaped two-hunk patch across disposable validation', async () => {
+    const fixture = await repoFixture('success')
+    const original = await readFile(join(fixture.root, BASE_FILE), 'utf8')
+    const candidate = original
+      .replace("import test from 'node:test'", "import test from 'node:test' // first distant edit")
+      .replace('// TODO missing barrels', "assert.ok('/observability') // second distant edit")
+    await writeFile(join(fixture.root, BASE_FILE), candidate)
+    const diff = await canonicalDiff(fixture.root, [BASE_FILE], fixture.baseSha)
+    expect(diff.match(/^@@/gm)).toHaveLength(2)
+
+    const results = await runProductionSandboxValidation({
+      contract: productionValidationContract(fixture.baseSha, candidate, diff),
+      repoRoot: fixture.root,
+      sandboxProcessRunner: new StrictMockValidationSandboxRunner(),
+      sourceEnvironment: { PATH: process.env['PATH'] },
+    })
+
+    expect(results).toHaveLength(1)
+    expect(results[0]).toMatchObject({ id: 'focused-subpath-test', success: true })
+    expect(await readFile(join(fixture.root, BASE_FILE), 'utf8')).toBe(candidate)
+  })
+
   it('fails closed without host fallback and cannot return sandbox pollution to the source checkout', async () => {
     const fixture = await repoFixture('success')
     const original = await readFile(join(fixture.root, BASE_FILE), 'utf8')
     const candidate = original.replace('// TODO missing barrels', "assert.ok('/observability')")
     await writeFile(join(fixture.root, BASE_FILE), candidate)
-    const diff = (await exec('git', ['diff', '--binary', '--no-ext-diff', '--no-color', '--', BASE_FILE], { cwd: fixture.root })).stdout
+    const diff = await canonicalDiff(fixture.root, [BASE_FILE])
     const contract = productionValidationContract(fixture.baseSha, candidate, diff)
     await expect(runProductionSandboxValidation({
       contract,
@@ -479,7 +501,7 @@ describe('fail-closed deterministic validation sandbox', () => {
     await writeFile(join(fixture.root, BASE_FILE), candidate)
     await writeFile(join(fixture.root, 'ignored-host.txt'), 'ignored host state\n')
     await writeFile(join(fixture.root, 'untracked-host.txt'), 'untracked host state\n')
-    const diff = (await exec('git', ['diff', '--binary', '--no-ext-diff', '--no-color', '--', BASE_FILE], { cwd: fixture.root })).stdout
+    const diff = await canonicalDiff(fixture.root, [BASE_FILE])
     const parent = await mkdtemp(join(tmpdir(), 'oma-validation-parent-'))
     const workspace = await createValidationWorkspace({
       sourceRepoRoot: fixture.root,
@@ -495,7 +517,7 @@ describe('fail-closed deterministic validation sandbox', () => {
     expect(await fileExists(join(workspace.repoRoot, 'ignored-host.txt'))).toBe(false)
     expect(await fileExists(join(workspace.repoRoot, 'untracked-host.txt'))).toBe(false)
     expect((await exec('git', ['rev-parse', 'HEAD'], { cwd: workspace.repoRoot })).stdout.trim()).toBe(fixture.baseSha)
-    expect((await exec('git', ['diff', '--binary', '--no-ext-diff', '--no-color', '--', BASE_FILE], { cwd: workspace.repoRoot })).stdout).toBe(diff)
+    expect(await canonicalDiff(workspace.repoRoot, [BASE_FILE])).toBe(diff)
     await cleanupValidationWorkspace(workspace)
     expect(await readdir(parent)).toEqual([])
   })
@@ -505,7 +527,7 @@ describe('fail-closed deterministic validation sandbox', () => {
     const command = prepareCanaryRequest({ ...snapshot(), baseSha: fixture.baseSha }, policy()).validationCommands[0]!
     const original = await readFile(join(fixture.root, BASE_FILE), 'utf8')
     await writeFile(join(fixture.root, BASE_FILE), original.replace('// TODO missing barrels', "assert.ok('/observability')"))
-    const diff = (await exec('git', ['diff', '--binary', '--no-ext-diff', '--no-color', '--', BASE_FILE], { cwd: fixture.root })).stdout
+    const diff = await canonicalDiff(fixture.root, [BASE_FILE])
     const workspace = await createValidationWorkspace({
       sourceRepoRoot: fixture.root,
       baseSha: fixture.baseSha,
@@ -1080,7 +1102,8 @@ async function repoFixture(mode: string, terminalEvents?: readonly Record<string
   await mkdir(join(root, 'packages/core/tests'), { recursive: true })
   await mkdir(join(root, 'packages/core/src'), { recursive: true })
   await writeFile(join(root, '.gitignore'), 'node_modules/\nignored-host.txt\n')
-  await writeFile(join(root, BASE_FILE), `import test from 'node:test'\nimport assert from 'node:assert/strict'\n\ntest('subpaths', () => {\n  assert.ok('existing')\n  // TODO missing barrels\n})\n`)
+  const distantContext = Array.from({ length: 18 }, (_, index) => `// stable context ${index + 1}`).join('\n')
+  await writeFile(join(root, BASE_FILE), `import test from 'node:test'\nimport assert from 'node:assert/strict'\n\n${distantContext}\n\ntest('subpaths', () => {\n  assert.ok('existing')\n  // TODO missing barrels\n})\n`)
   await writeFile(join(root, 'packages/core/src/extra.ts'), 'export const extra = true\n')
   await exec('git', ['init', '-q'], { cwd: root })
   await exec('git', ['config', 'user.name', 'Canary Test'], { cwd: root })
@@ -1191,4 +1214,8 @@ async function fileExists(path: string): Promise<boolean> {
   } catch {
     return false
   }
+}
+
+async function canonicalDiff(repoRoot: string, paths: readonly string[], baseSha?: string): Promise<string> {
+  return (await exec('git', canonicalGitDiffArgs({ baseSha, paths }), { cwd: repoRoot })).stdout
 }


### PR DESCRIPTION
## Summary

- use one canonical Git diff representation across candidate capture, review, and disposable validation
- preserve byte-for-byte fail-closed patch integrity without false failures from different context settings
- add a two-hunk regression matching the #501 failure shape and pin the canonical arguments

## Root cause

The review candidate was captured with `--unified=5`, while the disposable validation workspace recomputed the same patch with Git's default three context lines. Identical file contents could therefore produce different diff strings and fail integrity validation.

## Validation

- `npm run lint`
- `npm test`
- `npm run build`
- `npm run lint -w @open-multi-agent/maintainer-bot`
- `npm run test -w @open-multi-agent/maintainer-bot` — 93 tests
- `npm run test -w @open-multi-agent/maintainer-harness-canary` — 70 tests
- `npm run build -w @open-multi-agent/maintainer-harness-canary`
- `npm run test -w @open-multi-agent/maintainer-host` — 66 tests
- `git diff --check`

## Scope

This changes patch serialization only. Existing path, size, credential-isolation, sandbox, and fail-closed mutation checks remain in place.