### PR TITLE
fix(maintainer): isolate validation build outputs

### DIFF
--- a/docs/maintainer-bot.md
+++ b/docs/maintainer-bot.md
@@ -112,8 +112,12 @@ backend never falls through to the other backend.
    already scope-checked candidate to the shared canary validation CLI, which
    rebuilds base plus the exact patch in a disposable snapshot and executes all
    trusted commands only through fail-closed `/usr/bin/bwrap`, with no host
-   fallback. Candidate capture and disposable-workspace integrity checks use
-   the same fixed Git diff format before comparing the patch byte for byte.
+   fallback. Trusted build commands may declare canonical, ignored scratch
+   directories; each is overmounted by a bounded 64 MiB `tmpfs` for that one
+   command and disappears before workspace-integrity checks. The production
+   preflight verifies this isolation on the runner. Candidate capture and
+   disposable-workspace integrity checks use the same fixed Git diff format
+   before comparing the patch byte for byte.
 7. A new OMA team and agent perform fresh-context review using only confirmed
    requirements, acceptance criteria, the final diff, validation evidence,
    bounded current-file snapshots, and relevant context. Implementer reasoning
@@ -339,9 +343,12 @@ best effort.
 Validation commands come only from trusted configuration. Issue or model text
 cannot choose an executable, argv, cwd, or timeout. All registered commands
 run, results and skipped checks are recorded, and failed or truncated evidence
-blocks proposal eligibility. On the Claude path, the actual candidate checkout
-is never mounted as the validation workspace, and validation-created tracked or
-ignored side effects cannot flow back into it. The current-file repair snapshots are non-symlink
+blocks proposal eligibility. A validation scratch path must be absent from the
+pinned candidate, ignored by that checkout, outside protected roots, and an
+empty regular-directory mountpoint. Undeclared or persistent output still fails
+the full filesystem manifest check. On the Claude path, the actual candidate
+checkout is never mounted as the validation workspace, and validation-created
+tracked or ignored side effects cannot flow back into it. The current-file repair snapshots are non-symlink
 regular files, path checked, per-file bounded, and capped at 180 KB total.
 
 DeepSeek inference is remote. The minimum relevant public-repository context —

--- a/packages/maintainer-bot/src/schema.ts
+++ b/packages/maintainer-bot/src/schema.ts
@@ -3,6 +3,28 @@ import { z } from 'zod'
 const sha40 = z.string().regex(/^[0-9a-f]{40}$/)
 const sha256 = z.string().regex(/^[0-9a-f]{64}$/)
 const repoPath = z.string().trim().min(1).max(500)
+const scratchPath = z.string().min(1).max(500).superRefine((value, context) => {
+  const parts = value.split('/')
+  if (
+    value !== value.trim()
+    || value.includes('\\')
+    || value.startsWith('/')
+    || value.endsWith('/')
+    || value.includes('\0')
+    || parts.some(part => part.length === 0 || part === '.' || part === '..')
+  ) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'validation scratch paths must be canonical repository-relative paths',
+    })
+  }
+  if (parts.some(part => ['.git', 'node_modules', '.env', '.npmrc', '.claude'].includes(part))) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'validation scratch paths cannot overlap protected repository roots',
+    })
+  }
+})
 const environmentName = z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/).max(200)
 const boundedLine = z.string().trim().min(1).max(1_000).refine(
   value => !/[\r\n]/.test(value),
@@ -173,6 +195,7 @@ export const validationCommandSchema = z.object({
   timeoutMs: z.number().int().positive().max(30 * 60_000).default(10 * 60_000),
   env: z.record(environmentName, z.string().max(2_000)).default({}),
   unsetEnv: z.array(environmentName).max(100).default([]),
+  scratchPaths: z.array(scratchPath).max(20).default([]),
 }).superRefine((command, context) => {
   for (const name of Object.keys(command.env)) {
     if (/(?:TOKEN|SECRET|PASSWORD|PASSWD|COOKIE|CREDENTIAL|PRIVATE_KEY|API_KEY|AUTH_SOCK)/i.test(name)) {
@@ -196,6 +219,26 @@ export const validationCommandSchema = z.object({
       path: ['unsetEnv'],
       message: 'validation unsetEnv entries must be unique',
     })
+  }
+  if (new Set(command.scratchPaths).size !== command.scratchPaths.length) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['scratchPaths'],
+      message: 'validation scratch paths must be unique',
+    })
+  }
+  for (let leftIndex = 0; leftIndex < command.scratchPaths.length; leftIndex += 1) {
+    const left = command.scratchPaths[leftIndex]!
+    for (let rightIndex = leftIndex + 1; rightIndex < command.scratchPaths.length; rightIndex += 1) {
+      const right = command.scratchPaths[rightIndex]!
+      if (left.startsWith(`${right}/`) || right.startsWith(`${left}/`)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['scratchPaths', rightIndex],
+          message: 'validation scratch paths cannot overlap',
+        })
+      }
+    }
   }
 })
 

--- a/packages/maintainer-bot/tests/schema.test.ts
+++ b/packages/maintainer-bot/tests/schema.test.ts
@@ -46,4 +46,28 @@ describe('validation command schema', () => {
       id: 'unsafe-test', command: 'npm', args: ['test'], env: { GITHUB_TOKEN: 'value' },
     })).toThrow(/credential-like/)
   })
+
+  it('accepts only distinct canonical scratch directories outside protected roots', () => {
+    expect(validationCommandSchema.parse({
+      id: 'otel-build', command: 'npm', args: ['run', 'build'],
+      scratchPaths: ['packages/otel/dist'],
+    }).scratchPaths).toEqual(['packages/otel/dist'])
+    expect(validationCommandSchema.parse({
+      id: 'no-output', command: 'git', args: ['diff', '--check'],
+    }).scratchPaths).toEqual([])
+
+    for (const scratchPaths of [
+      ['packages/otel/dist', 'packages/otel/dist'],
+      ['packages/otel', 'packages/otel/dist'],
+      ['../outside'],
+      ['packages//otel/dist'],
+      ['.git/output'],
+      ['node_modules/cache'],
+      ['.env'],
+    ]) {
+      expect(() => validationCommandSchema.parse({
+        id: 'unsafe-output', command: 'npm', args: ['run', 'build'], scratchPaths,
+      })).toThrow(/scratch path/)
+    }
+  })
 })

--- a/packages/maintainer-harness-canary/src/production-validation.ts
+++ b/packages/maintainer-harness-canary/src/production-validation.ts
@@ -60,6 +60,7 @@ export async function runProductionSandboxValidation(options: {
       changedPaths: contract.changedFiles.map(file => file.path),
       candidateDiff: contract.candidateDiff,
       maxFileBytes: contract.limits.maxFileBytes,
+      scratchPaths: contract.validationCommands.flatMap(command => command.scratchPaths),
       parentDir: options.workspaceParentDir,
     })
     const results: ValidationResult[] = []

--- a/packages/maintainer-harness-canary/src/runner.ts
+++ b/packages/maintainer-harness-canary/src/runner.ts
@@ -217,6 +217,7 @@ export async function runHarnessCanary(options: RunHarnessCanaryOptions): Promis
         changedPaths,
         candidateDiff: diff,
         maxFileBytes: policy.limits.maxFileBytes,
+        scratchPaths: request.validationCommands.flatMap(command => command.scratchPaths),
         parentDir: options.validationWorkspaceParentDir,
       })
       validationResults = await runValidations({

--- a/packages/maintainer-harness-canary/src/schema.ts
+++ b/packages/maintainer-harness-canary/src/schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod'
-import { validationCommandSchema } from '@open-multi-agent/maintainer-bot'
+import { pathWithin, validationCommandSchema } from '@open-multi-agent/maintainer-bot'
 
 const sha40 = z.string().regex(/^[0-9a-f]{40}$/)
 const sha256 = z.string().regex(/^[0-9a-f]{64}$/)
@@ -26,6 +26,21 @@ export const canaryPolicySchema = z.object({
     maxProcessOutputBytes: z.number().int().positive().max(10_000_000),
     maxValidationOutputBytes: z.number().int().positive().max(200_000),
   }),
+}).superRefine((policy, context) => {
+  policy.validationRules.forEach((rule, ruleIndex) => {
+    rule.validationCommands.forEach((command, commandIndex) => {
+      command.scratchPaths.forEach((scratchPath, scratchIndex) => {
+        if (policy.protectedPaths.some(protectedPath =>
+          pathWithin(scratchPath, protectedPath) || pathWithin(protectedPath, scratchPath))) {
+          context.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['validationRules', ruleIndex, 'validationCommands', commandIndex, 'scratchPaths', scratchIndex],
+            message: 'validation scratch paths cannot overlap protected repository paths',
+          })
+        }
+      })
+    })
+  })
 })
 
 export type CanaryPolicy = z.infer<typeof canaryPolicySchema>

--- a/packages/maintainer-harness-canary/src/validation-sandbox.ts
+++ b/packages/maintainer-harness-canary/src/validation-sandbox.ts
@@ -22,6 +22,7 @@ import {
 
 export const BUBBLEWRAP_PATH = '/usr/bin/bwrap'
 export const SANDBOX_REPO_ROOT = '/workspace'
+export const VALIDATION_SCRATCH_MAX_BYTES = 64 * 1024 * 1024
 
 const PROTECTED_ENVIRONMENT_NAMES = new Set([
   'PATH',
@@ -84,6 +85,7 @@ export async function buildValidationSandboxInvocation(options: {
   const dependencyRoot = await realpath(resolve(options.dependencyRoot))
   const resolverHostsPath = await resolveValidationResolverFile(options.resolverHostsPath, VALIDATION_HOSTS)
   const resolverNsswitchPath = await resolveValidationResolverFile(options.resolverNsswitchPath, VALIDATION_NSSWITCH)
+  await assertScratchMountpoints(workspaceRoot, options.command)
   const gitMetadataRoot = await realpath(resolve(workspaceRoot, '.git'))
   const hostCwd = await realpath(resolve(workspaceRoot, options.command.cwd))
   const cwdRelation = relative(workspaceRoot, hostCwd)
@@ -109,6 +111,10 @@ export async function buildValidationSandboxInvocation(options: {
     ...options.command.env,
   }
   for (const name of options.command.unsetEnv) delete sandboxEnvironment[name]
+  const scratchMounts = options.command.scratchPaths.flatMap(scratchPath => [
+    '--size', String(VALIDATION_SCRATCH_MAX_BYTES),
+    '--tmpfs', `${SANDBOX_REPO_ROOT}/${scratchPath}`,
+  ])
 
   const args = [
     '--die-with-parent',
@@ -135,6 +141,7 @@ export async function buildValidationSandboxInvocation(options: {
     '--bind', workspaceRoot, SANDBOX_REPO_ROOT,
     '--ro-bind', gitMetadataRoot, `${SANDBOX_REPO_ROOT}/.git`,
     '--ro-bind', dependencyRoot, `${SANDBOX_REPO_ROOT}/node_modules`,
+    ...scratchMounts,
     '--chdir', sandboxCwd,
     '--clearenv',
     ...Object.entries(sandboxEnvironment).flatMap(([name, value]) => ['--setenv', name, value]),
@@ -163,6 +170,27 @@ async function resolveValidationResolverFile(path: string, expected: string): Pr
     throw new ValidationSandboxError('Validation resolver configuration differs from the fixed loopback policy.')
   }
   return canonicalPath
+}
+
+async function assertScratchMountpoints(
+  workspaceRoot: string,
+  command: ValidationCommand,
+): Promise<void> {
+  if (command.scratchPaths.length === 0) return
+  for (const scratchPath of command.scratchPaths) {
+    const absolute = resolve(workspaceRoot, scratchPath)
+    const relation = relative(workspaceRoot, absolute)
+    if (relation === '..' || relation.startsWith(`..${sep}`) || relation.startsWith(sep)) {
+      throw new ValidationSandboxError('Validation scratch path resolves outside the repository.')
+    }
+    const info = await lstat(absolute)
+    if (!info.isDirectory() || info.isSymbolicLink()) {
+      throw new ValidationSandboxError('Validation scratch mountpoint must be a regular directory.')
+    }
+    if ((await readdir(absolute)).length !== 0) {
+      throw new ValidationSandboxError('Validation scratch mountpoint must be empty before execution.')
+    }
+  }
 }
 
 export async function runValidationInSandbox(options: {
@@ -205,12 +233,14 @@ export async function preflightValidationSandbox(options: {
 const { realpathSync, unlinkSync, writeFileSync } = require('node:fs')
 const { lookup } = require('node:dns').promises
 const temporary = '/workspace/packages/core/vitest.config.ts.timestamp-oma-preflight.mjs'
+const scratchOutput = '/workspace/dist/oma-validation-preflight.txt'
 ;(async () => {
   try {
     writeFileSync(temporary, 'export default {}\\n')
   } finally {
     unlinkSync(temporary)
   }
+  writeFileSync(scratchOutput, 'ephemeral\\n')
   if (realpathSync('/workspace/node_modules/@open-multi-agent/core') !== '/workspace/packages/core') {
     throw new Error('Workspace dependency symlink escaped the disposable snapshot.')
   }
@@ -227,6 +257,7 @@ const temporary = '/workspace/packages/core/vitest.config.ts.timestamp-oma-prefl
     timeoutMs: 30_000,
     env: {},
     unsetEnv: [],
+    scratchPaths: ['dist'],
   }
   let result: CommandResult
   let workspace: ValidationWorkspace | undefined
@@ -237,6 +268,7 @@ const temporary = '/workspace/packages/core/vitest.config.ts.timestamp-oma-prefl
       changedPaths: [],
       candidateDiff: '',
       maxFileBytes: Number.MAX_SAFE_INTEGER,
+      scratchPaths: command.scratchPaths,
       parentDir: options.workspaceParentDir,
     })
     result = await runValidationInSandbox({

--- a/packages/maintainer-harness-canary/src/validation-workspace.ts
+++ b/packages/maintainer-harness-canary/src/validation-workspace.ts
@@ -37,6 +37,7 @@ export async function createValidationWorkspace(options: {
   readonly changedPaths: readonly string[]
   readonly candidateDiff: string
   readonly maxFileBytes: number
+  readonly scratchPaths?: readonly string[]
   readonly parentDir?: string
 }): Promise<ValidationWorkspace> {
   const sourceRepoRoot = await realpath(resolve(options.sourceRepoRoot))
@@ -69,6 +70,12 @@ export async function createValidationWorkspace(options: {
         env: gitEnvironment,
       })
     }
+    await prepareScratchMountpoints(
+      commandRunner,
+      repoRoot,
+      gitEnvironment,
+      options.scratchPaths ?? [],
+    )
     await mkdir(join(repoRoot, 'node_modules'))
     const dependencyRoot = await realpath(resolve(sourceRepoRoot, 'node_modules'))
     const workspace = {
@@ -87,6 +94,44 @@ export async function createValidationWorkspace(options: {
   } catch (error) {
     await rm(containerRoot, { recursive: true, force: true })
     throw error
+  }
+}
+
+async function prepareScratchMountpoints(
+  commandRunner: NodeCommandRunner,
+  repoRoot: string,
+  environment: NodeJS.ProcessEnv,
+  scratchPaths: readonly string[],
+): Promise<void> {
+  for (const scratchPath of [...new Set(scratchPaths)].sort()) {
+    const absolute = resolveWorkspacePath(repoRoot, scratchPath)
+    try {
+      await lstat(absolute)
+      throw new Error('Validation scratch path must not already exist in the candidate snapshot.')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    }
+    await assertRegularDirectoryChain(repoRoot, scratchPath)
+    const ignored = await commandRunner.run(
+      'git',
+      ['check-ignore', '--quiet', '--no-index', '--', `${scratchPath}/`],
+      { cwd: repoRoot, env: environment, allowFailure: true },
+    )
+    if (ignored.exitCode !== 0) {
+      throw new Error('Validation scratch path must be ignored by the pinned repository checkout.')
+    }
+    await mkdir(absolute, { mode: 0o700 })
+  }
+}
+
+async function assertRegularDirectoryChain(repoRoot: string, scratchPath: string): Promise<void> {
+  const parts = scratchPath.split('/')
+  for (let index = 1; index < parts.length; index += 1) {
+    const parent = resolveWorkspacePath(repoRoot, parts.slice(0, index).join('/'))
+    const info = await lstat(parent)
+    if (!info.isDirectory() || info.isSymbolicLink()) {
+      throw new Error('Validation scratch path parent must be a regular repository directory.')
+    }
   }
 }
 

--- a/packages/maintainer-harness-canary/tests/canary.test.ts
+++ b/packages/maintainer-harness-canary/tests/canary.test.ts
@@ -34,6 +34,7 @@ import {
   type SandboxProcessRunner,
   VALIDATION_HOSTS,
   VALIDATION_NSSWITCH,
+  VALIDATION_SCRATCH_MAX_BYTES,
   ValidationSandboxPreflightError,
 } from '../src/index.js'
 
@@ -125,6 +126,10 @@ class StrictMockValidationSandboxRunner implements SandboxProcessRunner {
       '--die-with-parent', '--new-session', '--unshare-user', '--unshare-pid', '--unshare-net',
       '--cap-drop', 'ALL', '--proc', '/proc', '--tmpfs', '/tmp', '--tmpfs', '/home', '--clearenv',
     ]))
+    for (const scratchPath of args.filter((value, index) =>
+      args[index - 1] === '--tmpfs' && value.startsWith('/workspace/'))) {
+      expect(scratchPath).toMatch(/^\/workspace\/[A-Za-z0-9._/-]+$/)
+    }
     const hostsBind = args.findIndex((value, index) => value === '--ro-bind' && args[index + 2] === '/etc/hosts')
     const nsswitchBind = args.findIndex((value, index) => value === '--ro-bind' && args[index + 2] === '/etc/nsswitch.conf')
     expect(hostsBind).toBeGreaterThanOrEqual(0)
@@ -574,6 +579,66 @@ describe('fail-closed deterministic validation sandbox', () => {
     }
   })
 
+  it('mounts only trusted ignored build outputs on bounded per-command tmpfs', async () => {
+    const fixture = await repoFixture('success')
+    const command = {
+      ...prepareCanaryRequest({ ...snapshot(), baseSha: fixture.baseSha }, policy()).validationCommands[0]!,
+      scratchPaths: ['dist'],
+    }
+    const workspace = await createValidationWorkspace({
+      sourceRepoRoot: fixture.root,
+      baseSha: fixture.baseSha,
+      changedPaths: [],
+      candidateDiff: '',
+      maxFileBytes: 20_000,
+      scratchPaths: command.scratchPaths,
+    })
+    try {
+      const invocation = await buildValidationSandboxInvocation({
+        workspaceRoot: workspace.repoRoot,
+        dependencyRoot: workspace.dependencyRoot,
+        resolverHostsPath: workspace.resolverHostsPath,
+        resolverNsswitchPath: workspace.resolverNsswitchPath,
+        command,
+      })
+      expect(invocation.args).toEqual(expect.arrayContaining([
+        '--size', String(VALIDATION_SCRATCH_MAX_BYTES), '--tmpfs', '/workspace/dist',
+      ]))
+      expect(await readdir(join(workspace.repoRoot, 'dist'))).toEqual([])
+      await writeFile(join(workspace.repoRoot, 'dist/untrusted-host-output'), 'blocked\n')
+      await expect(buildValidationSandboxInvocation({
+        workspaceRoot: workspace.repoRoot,
+        dependencyRoot: workspace.dependencyRoot,
+        resolverHostsPath: workspace.resolverHostsPath,
+        resolverNsswitchPath: workspace.resolverNsswitchPath,
+        command,
+      })).rejects.toThrow(/must be empty/)
+      await unlink(join(workspace.repoRoot, 'dist/untrusted-host-output'))
+    } finally {
+      await cleanupValidationWorkspace(workspace)
+    }
+  })
+
+  it('rejects scratch paths that exist in the candidate or are not ignored by the pinned checkout', async () => {
+    const fixture = await repoFixture('success')
+    await expect(createValidationWorkspace({
+      sourceRepoRoot: fixture.root,
+      baseSha: fixture.baseSha,
+      changedPaths: [],
+      candidateDiff: '',
+      maxFileBytes: 20_000,
+      scratchPaths: ['packages/core'],
+    })).rejects.toThrow(/must not already exist/)
+    await expect(createValidationWorkspace({
+      sourceRepoRoot: fixture.root,
+      baseSha: fixture.baseSha,
+      changedPaths: [],
+      candidateDiff: '',
+      maxFileBytes: 20_000,
+      scratchPaths: ['unignored-output'],
+    })).rejects.toThrow(/must be ignored/)
+  })
+
   it('rejects policy attempts to override protected or credential environment names', async () => {
     const fixture = await repoFixture('success')
     const validCommand = prepareCanaryRequest({ ...snapshot(), baseSha: fixture.baseSha }, policy()).validationCommands[0]!
@@ -587,6 +652,22 @@ describe('fail-closed deterministic validation sandbox', () => {
         command,
       })).rejects.toThrow(/environment/)
     }
+  })
+
+  it('rejects policy scratch paths that overlap protected canary paths', async () => {
+    const fixture = await repoFixture('success')
+    const selectedPolicy = policy()
+    const rule = selectedPolicy.validationRules[0]!
+    const command = rule.validationCommands[0]!
+    const unsafePolicy = {
+      ...selectedPolicy,
+      protectedPaths: [...selectedPolicy.protectedPaths, 'packages/core/generated'],
+      validationRules: [{
+        ...rule,
+        validationCommands: [{ ...command, scratchPaths: ['packages/core/generated/dist'] }],
+      }],
+    }
+    await expect(runFixture(fixture, { policy: unsafePolicy })).rejects.toThrow(/scratch paths cannot overlap protected/)
   })
 
   it('fails closed before launch when fixed resolver policy files are changed', async () => {
@@ -655,7 +736,7 @@ describe('fail-closed deterministic validation sandbox', () => {
     expect(JSON.parse(JSON.stringify(diagnostic))).toEqual(diagnostic)
   })
 
-  it('preflights a Vite-style sibling write only in the disposable workspace and cleans it', async () => {
+  it('preflights disposable sibling writes and bounded scratch output, then cleans them', async () => {
     const fixture = await repoFixture('success')
     const parent = await mkdtemp(join(tmpdir(), 'oma-preflight-parent-'))
     const runner = new StrictMockValidationSandboxRunner()
@@ -667,6 +748,9 @@ describe('fail-closed deterministic validation sandbox', () => {
     expect(runner.viteTemporaryWorkspaces).toHaveLength(1)
     const preflightInvocation = runner.invocations[0]!
     expect(preflightInvocation.args.some(value => value.includes("lookup('localhost', { all: true })"))).toBe(true)
+    expect(preflightInvocation.args).toEqual(expect.arrayContaining([
+      '--size', String(VALIDATION_SCRATCH_MAX_BYTES), '--tmpfs', '/workspace/dist',
+    ]))
     expect(runner.viteTemporaryWorkspaces[0]).not.toBe(await realpath(fixture.root))
     expect((await readdir(join(fixture.root, 'packages/core'))).some(name => name.includes('.timestamp-'))).toBe(false)
     expect(await readdir(parent)).toEqual([])
@@ -1101,7 +1185,7 @@ async function repoFixture(mode: string, terminalEvents?: readonly Record<string
   const capturePath = join(harnessDir, 'capture.json')
   await mkdir(join(root, 'packages/core/tests'), { recursive: true })
   await mkdir(join(root, 'packages/core/src'), { recursive: true })
-  await writeFile(join(root, '.gitignore'), 'node_modules/\nignored-host.txt\n')
+  await writeFile(join(root, '.gitignore'), 'node_modules/\ndist/\nignored-host.txt\n')
   const distantContext = Array.from({ length: 18 }, (_, index) => `// stable context ${index + 1}`).join('\n')
   await writeFile(join(root, BASE_FILE), `import test from 'node:test'\nimport assert from 'node:assert/strict'\n\n${distantContext}\n\ntest('subpaths', () => {\n  assert.ok('existing')\n  // TODO missing barrels\n})\n`)
   await writeFile(join(root, 'packages/core/src/extra.ts'), 'export const extra = true\n')

--- a/packages/maintainer-host/config/production-policy.json
+++ b/packages/maintainer-host/config/production-policy.json
@@ -154,7 +154,8 @@
       "command": "npm",
       "args": ["run", "build", "-w", "@open-multi-agent/core"],
       "cwd": ".",
-      "timeoutMs": 600000
+      "timeoutMs": 600000,
+      "scratchPaths": ["packages/core/dist"]
     },
     {
       "id": "otel-lint",
@@ -175,7 +176,8 @@
       "command": "npm",
       "args": ["run", "build", "-w", "@open-multi-agent/otel"],
       "cwd": ".",
-      "timeoutMs": 600000
+      "timeoutMs": 600000,
+      "scratchPaths": ["packages/otel/dist"]
     },
     {
       "id": "create-runtime-ambient",
@@ -240,7 +242,8 @@
       "command": "npm",
       "args": ["run", "build", "-w", "@open-multi-agent/maintainer-bot"],
       "cwd": ".",
-      "timeoutMs": 600000
+      "timeoutMs": 600000,
+      "scratchPaths": ["packages/maintainer-bot/dist"]
     }
   ],
   "context": {

--- a/packages/maintainer-host/src/schema.ts
+++ b/packages/maintainer-host/src/schema.ts
@@ -4,6 +4,7 @@ import {
   controlPlaneRequestSchema,
   maintainerConfigSchema,
   normalizeRepoPath,
+  pathWithin,
   validationCommandSchema,
 } from '@open-multi-agent/maintainer-bot'
 
@@ -214,6 +215,18 @@ export const productionPolicySchema = z.object({
   policy.workspaces.forEach((workspace, index) => {
     unique(workspace.validationIds, ['workspaces', index, 'validationIds'], 'workspace validation ids')
     unique(workspace.pathRules.map(rule => rule.path), ['workspaces', index, 'pathRules'], 'workspace path rules')
+  })
+  policy.validationRegistry.forEach((command, commandIndex) => {
+    command.scratchPaths.forEach((scratchPath, scratchIndex) => {
+      if (policy.protectedPaths.some(protectedPath =>
+        pathWithin(scratchPath, protectedPath) || pathWithin(protectedPath, scratchPath))) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['validationRegistry', commandIndex, 'scratchPaths', scratchIndex],
+          message: 'validation scratch paths cannot overlap protected repository paths',
+        })
+      }
+    })
   })
   const registryIds = new Set(policy.validationRegistry.map(command => command.id))
   if (registryIds.size !== policy.validationRegistry.length) {

--- a/packages/maintainer-host/tests/policy.test.ts
+++ b/packages/maintainer-host/tests/policy.test.ts
@@ -56,6 +56,20 @@ describe('trusted production policy and command registry', () => {
       'otel-test',
       'otel-build',
     ])
+    const validationCommands = buildProductionConfig(policy, [path]).validationCommands
+    expect(validationCommands.find(command => command.id === 'otel-build')?.scratchPaths)
+      .toEqual(['packages/otel/dist'])
+    expect(validationCommands.find(command => command.id === 'otel-test')?.scratchPaths)
+      .toEqual([])
+
+    for (const [id, scratchPath] of [
+      ['core-build', 'packages/core/dist'],
+      ['otel-build', 'packages/otel/dist'],
+      ['maintainer-bot-build', 'packages/maintainer-bot/dist'],
+    ] as const) {
+      expect(policy.validationRegistry.find(command => command.id === id)?.scratchPaths)
+        .toEqual([scratchPath])
+    }
 
     expect(() => resolveTargetWorkspaces(policy, ['packages/otel/package.json']))
       .toThrow(/outside the trusted production allowlist/)
@@ -162,6 +176,23 @@ describe('trusted production policy and command registry', () => {
       .toThrow(/literal, not globs/)
     expect(() => productionPolicySchema.parse({ ...policy, allowedPaths: ['packages/core', 'packages/core'] }))
       .toThrow(/allowed paths must be unique/)
+  })
+
+  it('rejects unsafe validation scratch paths in trusted production policy', async () => {
+    const policy = await productionPolicy()
+    const fixedProtectedRegistry = policy.validationRegistry.map(command =>
+      command.id === 'otel-build'
+        ? { ...command, scratchPaths: ['.env'] }
+        : command)
+    expect(() => productionPolicySchema.parse({ ...policy, validationRegistry: fixedProtectedRegistry }))
+      .toThrow(/scratch path/)
+
+    const policyProtectedRegistry = policy.validationRegistry.map(command =>
+      command.id === 'otel-build'
+        ? { ...command, scratchPaths: ['packages/maintainer-host/generated'] }
+        : command)
+    expect(() => productionPolicySchema.parse({ ...policy, validationRegistry: policyProtectedRegistry }))
+      .toThrow(/scratch path/)
   })
 
   it('uses Claude Code by default and can roll back to the legacy engine', async () => {


### PR DESCRIPTION
## 问题

真实 Claude Code Beta 在 #501 的验证阶段运行 `otel-build` 后生成被 Git 忽略的 `packages/otel/dist`，完整文件系统清单因此将正常构建产物误判为候选污染，run 31700692582 以 `Validation left filesystem changes in the disposable workspace.` 失败。

## 修复

- 为可信验证命令增加严格解析的 `scratchPaths` 契约
- 只允许 pinned checkout 中不存在、已被 Git 忽略、路径规范且不与 protected path 重叠的目录
- 在每条 Bubblewrap 命令内以 64 MiB `tmpfs` 覆盖声明目录；命令退出后产物自动消失
- 保留完整 workspace manifest：未声明写入、持久化写入、非空/符号链接 mountpoint 仍 fail closed
- 为 core、OTel、maintainer-bot 的 build 命令登记对应 `dist`
- 将真实 scratch 写入加入 production sandbox preflight，并更新安全边界文档

## 验证

- `git diff --check`
- `npm run lint`
- `npm test`
- `npm run build`
- focused schema/policy/canary regressions（canary 72 tests + workflow test；全仓全部通过）
- 额外实测：移除现成 `packages/core/dist` 后，OTel build 仍可独立通过

## 边界

- 未调用真实模型或付费 API
- 未修改 GitHub Actions workflow、Secrets、仓库设置
- 未重跑 #501；合并后应从新 main 重新触发真实 Beta 验证
- 本 PR 不启用自动合并