### PR TITLE
feat(maintainer): record OMA token usage and cost in pipeline trace

### DIFF
--- a/docs/maintainer-bot.md
+++ b/docs/maintainer-bot.md
@@ -548,8 +548,9 @@ the actual PR checks; the bot never approves or merges based on CI alone.
 Each attempted engine run also writes one bounded, run-key-bound JSON trace for
 the fixed `admission`, `coding`, `validation`, `review`, and `proposal` stages.
 The workflow attempts to upload only that trace for seven days on success or
-failure. It contains stage status and timestamps, not prompts, source, diffs,
-model output, tokens, credentials, or error text. Trace persistence is
+failure. It contains stage status, timestamps, and the reported OMA token usage
+and estimated cost totals, not prompts, source, diffs, model output, credentials,
+or error text. Trace persistence is
 best-effort telemetry and never changes the authoritative pipeline result.
 Claude Code process token usage is reported as `unknown (not reported)` rather
 than zero.

--- a/packages/maintainer-bot/src/pipeline-trace.ts
+++ b/packages/maintainer-bot/src/pipeline-trace.ts
@@ -29,6 +29,11 @@ export const pipelineTraceArtifactSchema = z.object({
   issueNumber: z.number().int().positive(),
   baseSha: z.string().regex(/^[0-9a-f]{40}$/),
   claudeCodeTokenUsage: claudeCodeTokenUsageSchema,
+  omaTokenUsage: z.object({
+    input_tokens: z.number().int().nonnegative(),
+    output_tokens: z.number().int().nonnegative(),
+  }).strict(),
+  estimatedCostUsd: z.number().finite().nonnegative(),
   events: z.array(pipelineTraceEventSchema).max(10),
 }).strict()
 
@@ -56,11 +61,21 @@ export class PipelineTraceWriter {
       issueNumber: options.issueNumber,
       baseSha: options.baseSha,
       claudeCodeTokenUsage: options.claudeCodeTokenUsage,
+      omaTokenUsage: { input_tokens: 0, output_tokens: 0 },
+      estimatedCostUsd: 0,
       events: [],
     })
   }
 
-  async record(stage: PipelineTraceStage, status: PipelineTraceStatus, now: () => Date): Promise<void> {
+  async record(
+    stage: PipelineTraceStage,
+    status: PipelineTraceStatus,
+    now: () => Date,
+    metrics?: {
+      readonly tokenUsage: { readonly input_tokens: number; readonly output_tokens: number }
+      readonly estimatedCostUsd: number
+    },
+  ): Promise<void> {
     const event = pipelineTraceEventSchema.parse({ stage, status, at: now().toISOString() })
     const prior = this.artifact.events.at(-1)
     if (status === 'start') {
@@ -69,6 +84,10 @@ export class PipelineTraceWriter {
       throw new Error('Pipeline trace completion must close the active stage.')
     }
     this.artifact.events.push(event)
+    if (metrics !== undefined) {
+      this.artifact.omaTokenUsage = { ...metrics.tokenUsage }
+      this.artifact.estimatedCostUsd = metrics.estimatedCostUsd
+    }
     pipelineTraceArtifactSchema.parse(this.artifact)
     await atomicWriteJson(this.path, this.artifact)
   }

--- a/packages/maintainer-bot/src/pipeline.ts
+++ b/packages/maintainer-bot/src/pipeline.ts
@@ -175,6 +175,8 @@ export async function runMaintainerBot(
     issueRevision: admission.issueRevision,
     baseSha: request.baseSha,
   })
+  let usage: TokenUsage = zeroUsage
+  let cost = 0
   const trace = new PipelineTraceWriter({
     artifactDir: input.artifactDir,
     runKey,
@@ -185,7 +187,7 @@ export async function runMaintainerBot(
   let activeTraceStage: PipelineTraceStage | undefined
   const traceStage = async (stage: PipelineTraceStage, status: 'start' | 'complete' | 'failure') => {
     try {
-      await trace.record(stage, status, now)
+      await trace.record(stage, status, now, { tokenUsage: usage, estimatedCostUsd: cost })
     } catch {
       // Telemetry is best-effort and must never change the authoritative pipeline result.
     }
@@ -216,8 +218,6 @@ export async function runMaintainerBot(
   const abortSignal = input.abortSignal === undefined
     ? deadline
     : mergeAbortSignals(input.abortSignal, deadline)
-  let usage: TokenUsage = zeroUsage
-  let cost = 0
   const appliedEdits: AppliedEdit[] = []
   let implementationSummary = ''
   let risks: string[] = []

--- a/packages/maintainer-bot/tests/pipeline-trace.test.ts
+++ b/packages/maintainer-bot/tests/pipeline-trace.test.ts
@@ -24,7 +24,10 @@ describe('bounded pipeline trace artifact', () => {
     const now = () => new Date(`2026-08-14T00:00:${String(tick++).padStart(2, '0')}.000Z`)
     for (const stage of ['admission', 'coding', 'validation', 'review', 'proposal'] as const) {
       await writer.record(stage, 'start', now)
-      await writer.record(stage, 'complete', now)
+      await writer.record(stage, 'complete', now, {
+        tokenUsage: { input_tokens: 123, output_tokens: 45 },
+        estimatedCostUsd: 0.000_03,
+      })
     }
 
     const raw = await readFile(writer.path, 'utf8')
@@ -37,6 +40,8 @@ describe('bounded pipeline trace artifact', () => {
       'proposal:start', 'proposal:complete',
     ])
     expect(artifact.claudeCodeTokenUsage).toBe('not_reported')
+    expect(artifact.omaTokenUsage).toEqual({ input_tokens: 123, output_tokens: 45 })
+    expect(artifact.estimatedCostUsd).toBe(0.000_03)
     expect(raw).not.toMatch(/prompt|source|diff|token=|ghp_|sk-/i)
     expect(raw.length).toBeLessThan(4_000)
     expect(pipelineTraceArtifactSchema.safeParse({

--- a/packages/maintainer-bot/tests/pipeline.test.ts
+++ b/packages/maintainer-bot/tests/pipeline.test.ts
@@ -171,7 +171,11 @@ describe('maintainer-bot vertical pipeline', () => {
     const trace = JSON.parse(await readFile(join(
       artifactDir,
       `${result.record.runKey}.pipeline-trace.json`,
-    ))) as { events: Array<{ stage: string; status: string }> }
+    ))) as {
+      omaTokenUsage: { input_tokens: number; output_tokens: number }
+      estimatedCostUsd: number
+      events: Array<{ stage: string; status: string }>
+    }
     expect(trace.events.map(event => `${event.stage}:${event.status}`)).toEqual([
       'admission:start', 'admission:complete',
       'coding:start', 'coding:complete',
@@ -179,6 +183,8 @@ describe('maintainer-bot vertical pipeline', () => {
       'review:start', 'review:complete',
       'proposal:start', 'proposal:complete',
     ])
+    expect(trace.omaTokenUsage).toEqual(result.tokenUsage)
+    expect(trace.estimatedCostUsd).toBe(result.estimatedCostUsd)
   })
 
   it('keeps trace persistence failure isolated from the authoritative pipeline result', async () => {


### PR DESCRIPTION
## Summary

- surface the already-computed OMA token usage and estimated cost on the bounded pipeline trace
- matches PRD 3.3 "record OMA's own model-call token/cost" — previously these totals were returned in the run result but never persisted to the trace artifact
- Claude Code coding usage stays `not reported`; no execution boundary changes

## Validation

- `npm run lint -w @open-multi-agent/maintainer-bot` — pass
- `npm test -w @open-multi-agent/maintainer-bot` — pass (105/105)
