### PR TITLE
fix(release-bot): raise run token budget to 500k

### DIFF
--- a/packages/release-bot/src/orchestrator.ts
+++ b/packages/release-bot/src/orchestrator.ts
@@ -196,7 +196,7 @@ Approve only when a human maintainer could safely review the resulting release P
     defaultProvider: options.adapter ? undefined : 'deepseek',
     defaultApiKey: options.adapter ? undefined : options.apiKey,
     maxConcurrency: 2,
-    maxTokenBudget: 120_000,
+    maxTokenBudget: 500_000,
     onProgress: options.onProgress,
   })
   const team = orchestrator.createTeam('oma-release-bot', {


### PR DESCRIPTION
## What

Raises the release-bot run-level token budget from 120,000 to 500,000.

## Why

The first scheduled release (2026-08-14) failed closed. The two evidence
agents consumed roughly 117k of the 120k ceiling before synthesis, so the
release-planner tripped `budget_exceeded` and the reviewer was skipped,
leaving no release PR.

500k keeps the ceiling as a runaway-loop guard while giving a large
release (two evidence agents plus planner and reviewer) comfortable
headroom.

## Test plan

- `npm run lint -w @open-multi-agent/release-bot`
- `npm run test -w @open-multi-agent/release-bot` (29 passed)
- `npm run build -w @open-multi-agent/release-bot`

All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
