### PR TITLE
fix(release-bot): disable thinking for synthesis agents

### DIFF
--- a/packages/release-bot/src/orchestrator.ts
+++ b/packages/release-bot/src/orchestrator.ts
@@ -88,6 +88,7 @@ export async function generateReleaseDecision(
   } satisfies Partial<AgentConfig>
   const synthesisRole = {
     ...shared,
+    thinking: { enabled: false },
     maxTurns: 3,
     maxTokens: 3_500,
     callTimeoutMs: 90_000,


### PR DESCRIPTION
## What

Disables extended thinking for the two synthesis agents (`release-planner`
and `release-reviewer`). The two evidence agents keep high-effort thinking.

## Why

The manual re-run after #518 still failed, this time at `release-reviewer`
with `StructuredOutputValidationError: Structured output validation failed
after retry.`

The reviewer runs with `thinking: { enabled: true, effort: 'high' }` and
`maxTokens: 3_500`. Its reasoning consumed the whole output budget (two
attempts at roughly 3500 reasoning tokens each, empty `text` both times),
so it never emitted the JSON `releaseReviewSchema` requires. The two
evidence agents complete fine and the planner completed this run, but the
reviewer's longer consistency check does not converge before the cap.

Disabling thinking for the synthesis agents routes the full output budget
to the structured JSON answer. The evidence agents keep high-effort
thinking since they produce the deep analysis the reviewer cross-checks.

## Test plan

- `npm run lint -w @open-multi-agent/release-bot`
- `npm run test -w @open-multi-agent/release-bot` (29 passed)
- `npm run build -w @open-multi-agent/release-bot`

All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
