### PR TITLE
fix(release-bot): sync otel version constant on release

### DIFF
--- a/packages/release-bot/src/apply-plan.ts
+++ b/packages/release-bot/src/apply-plan.ts
@@ -9,11 +9,14 @@ const TEMPLATE_MANIFESTS = [
   'packages/create-oma-app/templates/security/package.json',
 ] as const
 
+const OTEL_VERSION_CONSTANT_PATH = 'packages/otel/src/version.ts'
+
 export const RELEASE_PLAN_PATHS = [
   'CHANGELOG.md',
   'package-lock.json',
   'packages/core/package.json',
   'packages/otel/package.json',
+  OTEL_VERSION_CONSTANT_PATH,
   'packages/create-oma-app/package.json',
   ...TEMPLATE_MANIFESTS,
 ] as const
@@ -50,6 +53,7 @@ export async function applyReleasePlan(
       manifest => { manifest.version = plan.nextVersions.otel },
       changed,
     )
+    await updateOtelVersionConstant(repoRoot, plan.nextVersions.otel, changed)
   }
 
   for (const path of TEMPLATE_MANIFESTS) {
@@ -185,6 +189,27 @@ async function updateManifest(
     await writeFile(absolute, newContent)
     changed.add(path)
   }
+}
+
+async function updateOtelVersionConstant(
+  repoRoot: string,
+  nextVersion: string,
+  changed: Set<string>,
+): Promise<void> {
+  if (!/^\d+\.\d+\.\d+$/.test(nextVersion)) {
+    throw new Error(`Refusing to write an invalid otel version constant: "${nextVersion}".`)
+  }
+  const absolute = join(repoRoot, OTEL_VERSION_CONSTANT_PATH)
+  const oldContent = await readFile(absolute, 'utf8')
+  const newContent = oldContent.replace(
+    /export const PACKAGE_VERSION = '[^']+'/,
+    `export const PACKAGE_VERSION = '${nextVersion}'`,
+  )
+  if (newContent === oldContent) {
+    throw new Error(`${OTEL_VERSION_CONSTANT_PATH} does not declare a PACKAGE_VERSION constant.`)
+  }
+  await writeFile(absolute, newContent)
+  changed.add(OTEL_VERSION_CONSTANT_PATH)
 }
 
 function wrapBullet(text: string, width = 80): string {

--- a/packages/release-bot/tests/apply-plan.test.ts
+++ b/packages/release-bot/tests/apply-plan.test.ts
@@ -77,6 +77,21 @@ describe('release plan materialization', () => {
     expect(Math.max(...changelog.split('\n').map(line => line.length))).toBeLessThanOrEqual(80)
   })
 
+  it('bumps the otel version constant alongside package.json when otel releases', async () => {
+    const root = await createFixture()
+    const otelPlan: ReleasePlan = {
+      ...plan,
+      nextVersions: { ...plan.nextVersions, otel: '0.1.2' },
+      bumps: { ...plan.bumps, otel: 'patch' },
+    }
+    const changed = await applyReleasePlan(root, otelPlan)
+
+    expect(changed).toContain('packages/otel/src/version.ts')
+    expect(await version(root, 'packages/otel/package.json')).toBe('0.1.2')
+    const versionTs = await readFile(join(root, 'packages/otel/src/version.ts'), 'utf8')
+    expect(versionTs).toContain("export const PACKAGE_VERSION = '0.1.2'")
+  })
+
   it('unwraps hard-wrapped changelog prose for GitHub Release rendering', () => {
     const changelog = insertReleaseEntry(
       '# Changelog\n\n## Unreleased\n\n## 1.14.0 - 2026-08-01\n\nOld.\n',
@@ -100,6 +115,7 @@ async function createFixture(): Promise<string> {
   temporaryRoots.push(root)
   await writeJson(root, 'packages/core/package.json', { name: '@open-multi-agent/core', version: '1.14.0' })
   await writeJson(root, 'packages/otel/package.json', { name: '@open-multi-agent/otel', version: '0.1.1' })
+  await writeText(root, 'packages/otel/src/version.ts', "export const PACKAGE_VERSION = '0.1.1'\n")
   await writeJson(root, 'packages/create-oma-app/package.json', { name: 'create-oma-app', version: '0.7.0' })
   for (const path of [
     'packages/create-oma-app/template/package.json',


### PR DESCRIPTION
## What

Syncs `packages/otel/src/version.ts`'s `PACKAGE_VERSION` constant when the
release plan bumps `@open-multi-agent/otel`.

## Why

The release plan bumps `packages/otel/package.json` but not the hardcoded
`PACKAGE_VERSION` in `packages/otel/src/version.ts`, so the `version-sync`
guard test fails validation after any otel bump. The constant is the default
tracer `instrumentationVersion` and is intentionally kept in sync with
package.json by that test.

The plan now bumps the constant alongside the manifest, adds the path to
`RELEASE_PLAN_PATHS`, fails closed if the constant is missing, and validates
the version before writing it into the generated source file.

## Test plan

- `npm run lint -w @open-multi-agent/release-bot`
- `npm run test -w @open-multi-agent/release-bot` (30 passed)
- `npm run build -w @open-multi-agent/release-bot`

All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
