### PR TITLE
docs(otel): use canonical URLs for cross-workspace links

### DIFF
--- a/packages/otel/README.md
+++ b/packages/otel/README.md
@@ -40,7 +40,7 @@ any global provider.
 Core `egressPolicy` does not wrap this application-owned provider or any
 exporter attached to it. Configure telemetry egress in the provider/exporter or
 at the infrastructure boundary; see the core
-[egress enforcement matrix](../../docs/egress-policy.md#enforcement-matrix).
+[egress enforcement matrix](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/egress-policy.md#enforcement-matrix).
 
 ## Lifecycle and ownership
 
@@ -65,7 +65,7 @@ Use a `BatchingTraceSink` directly via `createOtelTraceExporter()` when the
 application owns batching configuration itself.
 
 For a complete no-network example with the official `InMemorySpanExporter`, see
-[`otel-provider.ts`](../core/examples/integrations/observability-v2/otel-provider.ts).
+[`otel-provider.ts`](https://github.com/open-multi-agent/open-multi-agent/blob/main/packages/core/examples/integrations/observability-v2/otel-provider.ts).
 
 ### Process lifecycle
 


### PR DESCRIPTION
## What

Replace two repository-relative links in `packages/otel/README.md` with
canonical GitHub URLs so they resolve both on GitHub and from the published
npm package.

## Why

The `@open-multi-agent/otel` package publishes only `dist`, `README.md`, and
`LICENSE`. The two links currently point outside the package directory
(`../../docs/egress-policy.md` and `../core/examples/...`), so they break for
anyone reading the packaged README. Canonical URLs work in both contexts.

## Test plan

- Confirmed `docs/egress-policy.md` exists and contains `## Enforcement matrix`.
- Confirmed `packages/core/examples/integrations/observability-v2/otel-provider.ts` exists.
- `git diff --check` passes.

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)
