### PR TITLE
fix(release-bot): align create-oma-app bump and dedupe release changelog

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -36,9 +36,12 @@ Each DAG task has one task-level attempt; malformed structured output may use
 OMA's single in-run correction, but the whole role is not restarted. Per-role
 turn and output budgets bound model work, and the complete planning DAG aborts
 after ten minutes. When core changes but `packages/create-oma-app` does not,
-deterministic policy forces a create-oma-app patch bump for the template pin.
-The planner's scaffolder bump class is authoritative only when that workspace
-has merged changes of its own; normalization occurs before independent review.
+deterministic policy maps core's bump to a create-oma-app bump by breaking
+nature: a core major bumps create-oma-app minor (its 0.x minor position carries
+the "breaking" signal), and any non-breaking core bump bumps create-oma-app
+patch. The planner's scaffolder bump class is authoritative only when that
+workspace has merged changes of its own; normalization occurs before
+independent review.
 
 The weekly workflow creates a **ready** release PR automatically. A maintainer
 reviews and merges it manually. Merge is the release approval, but it is not a

--- a/packages/release-bot/src/apply-plan.ts
+++ b/packages/release-bot/src/apply-plan.ts
@@ -78,10 +78,12 @@ export async function applyReleasePlan(
 
 export function insertReleaseEntry(changelog: string, plan: ReleasePlan): string {
   const section = findTopLevelSection(changelog, 'Unreleased')
-  const existing = changelog.slice(section.bodyStart, section.end).trim()
+  // The planner's changelog is the single source of truth for the new release.
+  // `## Unreleased` content already fed the planner as reference evidence, so
+  // appending it again here would duplicate the same changes under two sets of
+  // Added/Changed/Fixed headings.
   const generated = renderChangelogSections(plan.changelog)
-  const body = [existing, generated].filter(Boolean).join('\n\n')
-  const entry = `## Unreleased\n\n## ${plan.nextVersions.core} - ${plan.releaseDate}\n\n${body}\n\n`
+  const entry = `## Unreleased\n\n## ${plan.nextVersions.core} - ${plan.releaseDate}\n\n${generated}\n\n`
   return changelog.slice(0, section.start) + entry + changelog.slice(section.end)
 }
 

--- a/packages/release-bot/src/schema.ts
+++ b/packages/release-bot/src/schema.ts
@@ -181,6 +181,19 @@ export type ReleaseDecision =
   | { readonly status: 'rejected'; readonly proposal: ReleaseProposal; readonly review: ReleaseReview }
   | { readonly status: 'release'; readonly plan: ReleasePlan; readonly proposal: ReleaseProposal; readonly review: ReleaseReview }
 
+/**
+ * Map core's bump to the create-oma-app bump for a core-only release.
+ *
+ * create-oma-app is still 0.x, so its minor position carries the "breaking"
+ * signal: a core major (breaking) bumps create minor; any non-breaking core
+ * bump (minor/patch) bumps create patch. This replaces the old "mirror core's
+ * level" policy, which inflated create's minor position on every non-breaking
+ * core release.
+ */
+function createOmaAppBumpForCoreOnly(coreBump: VersionBump): Exclude<VersionBump, 'none'> {
+  return coreBump === 'major' ? 'minor' : 'patch'
+}
+
 /** Apply repository-owned bump policy before a proposal reaches review. */
 export function normalizeReleaseProposal(
   evidence: ReleaseEvidence,
@@ -190,7 +203,7 @@ export function normalizeReleaseProposal(
   if (proposal.decision !== 'release' || evidence.workspaceChanges.createOmaApp) {
     return proposal
   }
-  return { ...proposal, createOmaAppBump: 'patch' }
+  return { ...proposal, createOmaAppBump: createOmaAppBumpForCoreOnly(proposal.coreBump) }
 }
 
 export function buildReleaseDecision(
@@ -219,10 +232,12 @@ export function buildReleaseDecision(
   const proposedCreateOmaAppBump = requireBump(proposal.createOmaAppBump, 'create-oma-app')
   // A core release always changes create-oma-app's template pins. When the
   // scaffolder workspace had no merged changes of its own, that mechanical pin
-  // is a patch release regardless of the model's proposed bump class.
+  // bump follows core's breaking nature: a core major bumps create minor (its
+  // 0.x minor position = breaking), any non-breaking core bump bumps create
+  // patch.
   const createOmaAppBump = evidence.workspaceChanges.createOmaApp
     ? proposedCreateOmaAppBump
-    : 'patch'
+    : createOmaAppBumpForCoreOnly(coreBump)
   const otelBump = proposal.otelBump === 'none' ? null : proposal.otelBump
 
   return {

--- a/packages/release-bot/tests/apply-plan.test.ts
+++ b/packages/release-bot/tests/apply-plan.test.ts
@@ -72,7 +72,7 @@ describe('release plan materialization', () => {
     const changelog = await readFile(join(root, 'CHANGELOG.md'), 'utf8')
     expect(changelog).toContain('## Unreleased\n\n## 1.15.0 - 2026-08-10')
     expect(changelog).toContain('### Added')
-    expect(changelog).toContain('Existing manually curated note.')
+    expect(changelog).not.toContain('Existing manually curated note.')
     expect(changelog).toContain('## 1.14.0 - 2026-08-01')
     expect(Math.max(...changelog.split('\n').map(line => line.length))).toBeLessThanOrEqual(80)
   })
@@ -90,6 +90,15 @@ describe('release plan materialization', () => {
     expect(await version(root, 'packages/otel/package.json')).toBe('0.1.2')
     const versionTs = await readFile(join(root, 'packages/otel/src/version.ts'), 'utf8')
     expect(versionTs).toContain("export const PACKAGE_VERSION = '0.1.2'")
+  })
+
+  it('does not duplicate Unreleased content into the new release section', () => {
+    const changelog = insertReleaseEntry(
+      '# Changelog\n\n## Unreleased\n\n### Added\n\n- Handwritten leftover.\n\n## 1.14.0 - 2026-08-01\n\nOld.\n',
+      plan,
+    )
+    expect(changelog).not.toContain('Handwritten leftover.')
+    expect((changelog.match(/### Added/g) ?? []).length).toBe(1)
   })
 
   it('unwraps hard-wrapped changelog prose for GitHub Release rendering', () => {

--- a/packages/release-bot/tests/schema.test.ts
+++ b/packages/release-bot/tests/schema.test.ts
@@ -48,6 +48,18 @@ describe('release decision', () => {
     expect(normalizeReleaseProposal(evidence, proposal).createOmaAppBump).toBe('patch')
   })
 
+  it('maps a core-only major (breaking) to a create-oma-app minor', () => {
+    const majorProposal = {
+      ...proposal,
+      coreBump: 'major' as const,
+      changelog: {
+        ...proposal.changelog,
+        breakingChanges: ['Existing callers must migrate to the new input shape.'],
+      },
+    }
+    expect(normalizeReleaseProposal(evidence, majorProposal).createOmaAppBump).toBe('minor')
+  })
+
   it('calculates concrete versions only after independent approval', () => {
     const decision = buildReleaseDecision(evidence, proposal, review, '2026-08-10')
     expect(decision.status).toBe('release')
@@ -69,6 +81,25 @@ describe('release decision', () => {
     expect(decision.status).toBe('release')
     if (decision.status !== 'release') throw new Error('expected release')
     expect(decision.plan.nextVersions.createOmaApp).toBe('0.8.0')
+    expect(decision.plan.bumps.createOmaApp).toBe('minor')
+  })
+
+  it('bumps create-oma-app minor when a core-only release is major (breaking)', () => {
+    const decision = buildReleaseDecision(evidence, {
+      ...proposal,
+      coreBump: 'major' as const,
+      changelog: {
+        ...proposal.changelog,
+        breakingChanges: ['Existing callers must migrate to the new input shape.'],
+      },
+    }, review, '2026-08-10')
+    expect(decision.status).toBe('release')
+    if (decision.status !== 'release') throw new Error('expected release')
+    expect(decision.plan.nextVersions).toEqual({
+      core: '2.0.0',
+      otel: '0.1.1',
+      createOmaApp: '0.8.0',
+    })
     expect(decision.plan.bumps.createOmaApp).toBe('minor')
   })
 


### PR DESCRIPTION
## Summary

Two release-bot behavior fixes:

1. **create-oma-app bump follows core's breaking nature.** A core-only release
   no longer forces a flat patch. A core major (breaking) now bumps
   create-oma-app minor, since its 0.x minor position carries the "breaking"
   signal, while non-breaking core bumps stay patch. This replaces the old
   "mirror core's level" policy.

2. **Changelog dedupe.** `insertReleaseEntry` no longer re-appends the
   `## Unreleased` body on top of the planner-generated changelog, which had
   produced duplicate Added/Changed/Fixed sections in the release PR.

## Changes

- `schema.ts`: add `createOmaAppBumpForCoreOnly()` (major -> minor, else
  patch) and use it in `normalizeReleaseProposal` and `buildReleaseDecision`.
- `apply-plan.ts`: drop the stale `## Unreleased` content from
  `insertReleaseEntry`; the planner's changelog is now the single source of
  truth.
- `.github/RELEASING.md`: describe the breaking-nature mapping.
- Tests: cover the core-major -> create-minor branch and the no-duplicate
  changelog behavior.

## Validation

- `npm run lint -w @open-multi-agent/release-bot`: pass
- `npm run test -w @open-multi-agent/release-bot`: 33 tests pass
- `git diff --check`: clean
