### PR TITLE
docs: add architecture slogan and tighten Get started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,35 @@ Scaffold a PR review agent, security analysis agent, or teaching DAG:
 npm create oma-app@latest my-oma
 ```
 
-In an interactive terminal, that one command selects a starter and runtime, installs dependencies, and runs a deterministic local demo. The demo needs no API key and makes no model request: scripted model responses drive the real OMA scheduler, result aggregation, and offline dashboard. The [Core package guide](packages/core/README.md#quick-start) covers the flags and runtime choices.
+In an interactive terminal, that one command selects a starter and runtime, installs dependencies, and runs a deterministic local demo. The demo needs no API key and makes no model request: scripted model responses drive the real OMA scheduler, result aggregation, and offline dashboard.
 
 Or add OMA to an existing backend:
 
 ```bash
 npm install @open-multi-agent/core
 ```
+
+```typescript
+import { OpenMultiAgent } from '@open-multi-agent/core'
+
+const oma = new OpenMultiAgent({ defaultProvider: 'openai', defaultModel: 'gpt-5.4' })
+
+const team = oma.createTeam('research-team', {
+  name: 'research-team',
+  agents: [
+    { name: 'researcher', systemPrompt: 'Find the relevant facts.' },
+    { name: 'analyst', systemPrompt: 'Compare evidence and identify tradeoffs.' },
+  ],
+  sharedMemory: true,
+})
+
+const result = await oma.runTeam(team, 'Compare three approaches and recommend one.')
+
+console.log(result.agentResults.get('coordinator')?.output)
+```
+
+<details>
+<summary>Full example: DAG readback, token usage, and model overrides</summary>
 
 ```typescript
 import { OpenMultiAgent } from '@open-multi-agent/core'
@@ -92,11 +114,15 @@ console.log(result.agentResults.get('coordinator')?.output)
 console.log(result.totalTokenUsage)
 ```
 
+</details>
+
 Set `OPENAI_API_KEY` to run this example. [Providers](docs/providers.md) covers other hosted models, local servers, OpenAI-compatible endpoints, and AI SDK providers.
 
 `runTeam()` plans from a goal, `runAgent()` runs a single agent, and `runTasks()` executes an explicit pipeline. The [Core package guide](packages/core/README.md) walks through all three modes, provider and credential setup, and the production checklist. The [example index](packages/core/examples/README.md) lists 50+ runnable examples across basics, cookbook workflows, patterns, providers, and integrations.
 
 ## Why OMA
+
+**Every seam, an interface. Every run, a record.**
 
 OMA combines dynamic orchestration with the control, evidence, and recovery paths needed to move multi-agent systems from prototype to production.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -55,13 +55,35 @@
 npm create oma-app@latest my-oma
 ```
 
-在交互式终端中，这一条命令会完成 starter 与 runtime 选择、依赖安装，并运行确定性的本地 Demo。Demo 不需要 API Key，也不会发起模型请求：预置模型响应负责模拟生成边界，OMA 的调度、结果聚合与离线 Dashboard 均真实运行。命令行参数与 runtime 选项见[核心包使用指南](packages/core/README_zh.md#快速开始)。
+在交互式终端中，这一条命令会完成 starter 与 runtime 选择、依赖安装，并运行确定性的本地 Demo。Demo 不需要 API Key，也不会发起模型请求：预置模型响应负责模拟生成边界，OMA 的调度、结果聚合与离线 Dashboard 均真实运行。
 
 也可以把 OMA 直接加入现有后端：
 
 ```bash
 npm install @open-multi-agent/core
 ```
+
+```typescript
+import { OpenMultiAgent } from '@open-multi-agent/core'
+
+const oma = new OpenMultiAgent({ defaultProvider: 'openai', defaultModel: 'gpt-5.4' })
+
+const team = oma.createTeam('research-team', {
+  name: 'research-team',
+  agents: [
+    { name: 'researcher', systemPrompt: 'Find the relevant facts.' },
+    { name: 'analyst', systemPrompt: 'Compare evidence and identify tradeoffs.' },
+  ],
+  sharedMemory: true,
+})
+
+const result = await oma.runTeam(team, 'Compare three approaches and recommend one.')
+
+console.log(result.agentResults.get('coordinator')?.output)
+```
+
+<details>
+<summary>完整示例：DAG 回读、token 统计与环境变量覆盖</summary>
 
 ```typescript
 import { OpenMultiAgent } from '@open-multi-agent/core'
@@ -91,11 +113,15 @@ console.log(result.agentResults.get('coordinator')?.output)
 console.log(result.totalTokenUsage)
 ```
 
+</details>
+
 运行这段示例需要设置 `OPENAI_API_KEY`。其他云端模型、本地服务、OpenAI 兼容端点与 AI SDK provider 的配置见 [Provider 文档](docs/providers.md)。
 
 `runTeam()` 从目标自动规划，`runAgent()` 运行单个 Agent，`runTasks()` 执行显式流水线。三种模式、Provider 与凭证配置、生产检查清单见[核心包使用指南](packages/core/README_zh.md)。[示例索引](packages/core/examples/README.md)收录 50+ 个可运行示例，覆盖基础、cookbook 流程、模式、Provider 与集成。
 
 ## 为什么选择 OMA
+
+**万物皆接口，一切皆数据。**
 
 OMA 将动态编排与生产所需的控制、证据和恢复能力结合起来，帮助多智能体系统从原型走向生产环境。
 


### PR DESCRIPTION
Add the architecture slogan "Every seam, an interface. Every run, a record." (「万物皆接口，一切皆数据。」) as the thesis line of the Why OMA section, and tighten the Get started section.

Get started changes:

- Trim the inline TypeScript example from 27 to 16 lines, keeping the shortest path: create a team, run one goal, read the result.
- Move the full example (DAG readback, token usage, model overrides) into a collapsed `<details>` block.
- Drop a duplicated core-guide link in the scaffold paragraph.

Both `README.md` and `README_zh.md` are updated in sync.