### PR TITLE
chore(release-bot): match user-agent to the renamed GitHub App slug

### DIFF
--- a/packages/release-bot/src/github.ts
+++ b/packages/release-bot/src/github.ts
@@ -146,7 +146,7 @@ export class GitHubApiClient implements GitHubClient {
         accept: 'application/vnd.github+json',
         authorization: `Bearer ${this.token}`,
         'content-type': 'application/json',
-        'user-agent': 'open-multi-agent-release-bot',
+        'user-agent': 'oma-release-bot',
         'x-github-api-version': '2026-03-10',
         ...init?.headers,
       },

--- a/packages/release-bot/src/registry.ts
+++ b/packages/release-bot/src/registry.ts
@@ -23,7 +23,7 @@ export class NpmRegistryClient implements RegistryClient {
       headers: {
         accept: 'application/json',
         'cache-control': 'no-cache',
-        'user-agent': 'open-multi-agent-release-bot',
+        'user-agent': 'oma-release-bot',
       },
     })
     if (response.status === 404) return null


### PR DESCRIPTION
## Summary

Updates the two outbound `user-agent` headers in the release bot from `open-multi-agent-release-bot` to `oma-release-bot`, matching the renamed GitHub App.

## Motivation

The release bot GitHub App was renamed to `oma-release-bot`. The old slug no longer resolves on GitHub, so these headers advertised an identity that cannot be looked up from a GitHub or npm request log.

## Scope and impact

- Affected workspace: `@open-multi-agent/release-bot` only.
- Public API or behavior: None. Both headers are informational and take no part in authentication or authorization.
- Workflows: None. `.github/workflows/release-bot.yml` already derives the bot commit identity from `steps.app-token.outputs.app-slug`, so it followed the rename without a change. The app ID, client ID, private key, and installation are unaffected by an App rename.
- Compatibility and migration: None.
- Security and privacy: None.
- Non-goals: no documentation change. `.github/RELEASING.md` describes the App generically and never names it.

## Validation

- `npm run lint -w @open-multi-agent/release-bot`: passed
- `npm run test -w @open-multi-agent/release-bot`: passed, 9 files and 33 tests
- `git diff --check`: clean
- Repository-wide search for the old slug: no remaining occurrences
- Not run: full-workspace `npm run lint`, `npm test`, and `npm run build`. The change is two string literals inside one private workspace and crosses no package boundary. CI covers the full matrix.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided. No test change: the headers are informational and no test asserts them.
- [x] User-facing documentation and examples were updated, or this is not applicable. Not applicable: the workspace is private and never published.
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable. Not applicable.
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING. No dependency change.
