### PR TITLE
docs: cover LLM egress policy and shell executor in the Chinese READMEs

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -189,7 +189,7 @@ Core 用户可以在本地保存 trace，并用离线 Run Viewer 查看。只有
 | 目标 | 从这里开始 |
 |---|---|
 | 安装与运行 | [核心包使用指南](packages/core/README_zh.md) · [示例](packages/core/examples/README.md) · [CLI](docs/cli.md) |
-| 配置模型与工具 | [Provider](docs/providers.md) · [工具与沙箱](docs/tool-configuration.md) · [外部 Agent](docs/external-agents.md) |
+| 配置模型与工具 | [Provider](docs/providers.md) · [LLM 出网策略](docs/egress-policy.md) · [工具与沙箱](docs/tool-configuration.md) · [外部 Agent](docs/external-agents.md) |
 | 稳定运行 | [可观测性](docs/observability.md) · [评测](docs/evaluation.md) · [Checkpoint 与恢复](docs/checkpoint.md) · [持久化审批](docs/durable-approvals.md) · [自适应恢复](docs/adaptive-recovery.md) · [上下文管理](docs/context-management.md) |
 | 控制编排 | [Consensus](docs/consensus.md) · [执行路由](docs/execution-routing.md) · [模型路由](docs/model-routing.md) · [任务调度](docs/task-scheduling.md) · [计划回放](docs/plan-replay.md) · [共享记忆](docs/shared-memory.md) |
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -217,7 +217,7 @@ Coordinator -> 任务 DAG -> Scheduler -> AgentPool
 
 可选集成只在使用时加载：core 直接安装的只有 `@anthropic-ai/sdk`、`openai` 和 `zod`，其余 SDK 都是按需懒加载的可选 peer，OpenTelemetry 完全归属 `@open-multi-agent/otel`。依赖变更按实际价值与安全、体积、维护、兼容成本权衡，不设固定数量上限。
 
-凭证、模型、AI SDK 桥接、推理设置、MCP 与本地端点配置见 [Provider](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md)和[工具配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md)。
+凭证、模型、AI SDK 桥接、推理设置、MCP、本地端点配置，以及出网管控的确切生效边界，见 [Provider](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers.md)、[框架级 LLM 出网策略](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/egress-policy.md)和[工具配置](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md)。
 
 **Provider 赞助商**
 
@@ -238,7 +238,7 @@ Coordinator -> 任务 DAG -> Scheduler -> AgentPool
 
 预算检查发生在 turn 和任务边界，因此单次运行最多可能超出一个模型 turn，不是分厘精确的截停。`estimateCost` 收到每次调用的 token 用量，以及 agent、生效的 `model`、`provider`、阶段和 `taskId`；价格表由应用自己维护。
 
-内置工具默认拒绝，且每个对模型可见的工具结果都会发送给你的模型 provider，读取与执行权限应审慎授予。工具可通过 `modelOutput` 将应用自有数据与发送给模型的文本、图片或文件内容分开；完整契约见[工具配置指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md#rich-image-and-file-results)。文件工具受配置的 `cwd` 限制；`bash` 一旦授权便不受该沙箱约束。trace、shell 输出和 Viewer payload 默认自动脱敏，但结果消息与 checkpoint 属于各自独立的持久化边界。
+内置工具默认拒绝，且每个对模型可见的工具结果都会发送给你的模型 provider，读取与执行权限应审慎授予。工具可通过 `modelOutput` 将应用自有数据与发送给模型的文本、图片或文件内容分开；完整契约见[工具配置指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md#rich-image-and-file-results)。文件工具受配置的 `cwd` 限制；`bash` 一旦授权便不受该沙箱约束。其执行目标可通过 [`ShellExecutor`](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/tool-configuration.md#shell-executors) 替换，而默认的 `LocalShellExecutor` 保持宿主执行，本身不构成安全边界。trace、shell 输出和 Viewer payload 默认自动脱敏，但结果消息与 checkpoint 属于各自独立的持久化边界。
 
 ### 可观测性
 


### PR DESCRIPTION
## What

Two v1.16.0 surfaces are documented in the English READMEs but were missing
from their Chinese counterparts, so readers following the Chinese entry
points could not reach either boundary.

- **LLM egress policy.** `packages/core/README_zh.md` and `README_zh.md` did
  not link `docs/egress-policy.md`, while the English versions do (core
  Providers section and the root doc table). The opt-in `EgressPolicy` was
  therefore undiscoverable from the Chinese side. Rendered as
  「框架级 LLM 出网策略」and「LLM 出网策略」; the repository had no prior
  Chinese term for egress.
- **Shell executor.** `packages/core/README_zh.md` dropped the sentence
  covering `ShellExecutor` and the fact that the default
  `LocalShellExecutor` preserves host execution and is not a security
  boundary. That is a security-relevant omission rather than a stylistic one.

## Verification

- `git diff --check` clean.
- `docs/egress-policy.md` exists, and so does the `#shell-executors` anchor
  in `docs/tool-configuration.md`.
- Compared the `docs/*.md` link sets between each English and Chinese pair.
  They now differ only by `providers-atlascloud.md`, which is intentionally
  localized as `providers-atlascloud_zh.md`.

Documentation only. No code, template, or generated output changed.
