### PR TITLE
fix(core): export public config types from the package root

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -337,6 +337,7 @@ export type {
   // Tools
   ToolDefinition,
   ToolResult,
+  ToolResultMetadata,
   ToolUseContext,
   ToolCallContext,
   ToolCallDecision,
@@ -381,12 +382,15 @@ export type {
   AcpAgentBackendConfig,
   AcpPermissionPolicy,
   AcpPermissionRequest,
+  ProcessAgentBackendConfig,
+  ProcessBackendInputMode,
   BeforeRunHookContext,
   BeforeRunHookResult,
   ToolCallRecord,
   LoopDetectionConfig,
   LoopDetectionInfo,
   ContextStrategy,
+  ThinkingConfig,
 
   // Team
   TeamConfig,
@@ -443,6 +447,7 @@ export type {
   OrchestratorConfig,
   OrchestratorEvent,
   CoordinatorConfig,
+  CostEstimateContext,
   CheckpointOptions,
   CheckpointSnapshot,
   CheckpointSnapshotV1,
@@ -458,6 +463,9 @@ export type {
   TaskQueueSnapshotV1,
   TaskQueueSnapshotV2,
   TaskSnapshot,
+  MessageBusSnapshot,
+  MessageSnapshot,
+  MessageReadStateSnapshot,
 
   // Trace
   TraceEventType,

--- a/packages/core/tests/public-type-export-coverage.test.ts
+++ b/packages/core/tests/public-type-export-coverage.test.ts
@@ -1,0 +1,124 @@
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Root-barrel coverage guard.
+ *
+ * `AgentConfig.thinking` shipped typed as `ThinkingConfig` while that interface
+ * was missing from `src/index.ts`, so a consumer could hold the value but never
+ * name its type without importing an internal source path. Type-only re-exports
+ * are erased at runtime, so a runtime import smoke test cannot catch this — the
+ * check has to run through the compiler.
+ *
+ * The invariant: every symbol exported from `src/types.ts` that is named in the
+ * declaration of a public config surface must also be re-exported from
+ * `src/index.ts`. Reachability is walked over type reference syntax rather than
+ * resolved types, because that is the question a consumer actually faces (can I
+ * write this name?) and because resolving generics transitively does not
+ * terminate on recursive types such as `ZodSchema`.
+ */
+
+/** Public entry types whose declarations define what a consumer has to be able to name. */
+const ANCHORS = [
+  'AgentConfig',
+  'TeamConfig',
+  'OrchestratorConfig',
+  'CoordinatorConfig',
+  'ToolDefinition',
+  'ToolResult',
+  'LLMChatOptions',
+  'LLMStreamOptions',
+  'CheckpointSnapshotV4',
+  'AgentRunResult',
+  'TeamRunResult',
+]
+
+type NamedTypeDeclaration =
+  | ts.InterfaceDeclaration
+  | ts.TypeAliasDeclaration
+  | ts.EnumDeclaration
+  | ts.ClassDeclaration
+
+describe('public type export coverage', () => {
+  it('re-exports every types.ts symbol reachable from a public config declaration', () => {
+    const srcDir = fileURLToPath(new URL('../src/', import.meta.url))
+    const indexPath = `${srcDir}index.ts`
+    const typesPath = `${srcDir}types.ts`
+
+    const program = ts.createProgram([indexPath, typesPath], {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      strict: true,
+      skipLibCheck: true,
+      noEmit: true,
+    })
+    const checker = program.getTypeChecker()
+    const indexFile = program.getSourceFile(indexPath)
+    const typesFile = program.getSourceFile(typesPath)
+    expect(indexFile).toBeDefined()
+    expect(typesFile).toBeDefined()
+
+    const indexModule = checker.getSymbolAtLocation(indexFile!)
+    expect(indexModule).toBeDefined()
+    const rootExports = new Set(checker.getExportsOfModule(indexModule!).map((s) => s.getName()))
+
+    // Every named type declared in types.ts, exported or not. Non-exported
+    // declarations still have to be traversed: `CheckpointSnapshotBase` is
+    // internal but contributes `MessageBusSnapshot` to the public snapshots.
+    const declarations = new Map<string, NamedTypeDeclaration>()
+    const exportedFromTypes = new Set<string>()
+    for (const statement of typesFile!.statements) {
+      if (
+        !ts.isInterfaceDeclaration(statement) &&
+        !ts.isTypeAliasDeclaration(statement) &&
+        !ts.isEnumDeclaration(statement) &&
+        !ts.isClassDeclaration(statement)
+      ) continue
+      const name = statement.name?.text
+      if (!name) continue
+      declarations.set(name, statement)
+      if (statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) {
+        exportedFromTypes.add(name)
+      }
+    }
+
+    for (const anchor of ANCHORS) {
+      // Guard the guard: a renamed anchor must fail loudly, not silently pass.
+      expect(declarations.has(anchor)).toBe(true)
+    }
+
+    const referencedNames = (node: ts.Node): string[] => {
+      const names: string[] = []
+      const walk = (child: ts.Node): void => {
+        if (ts.isTypeReferenceNode(child) && ts.isIdentifier(child.typeName)) {
+          names.push(child.typeName.text)
+        } else if (ts.isExpressionWithTypeArguments(child) && ts.isIdentifier(child.expression)) {
+          names.push(child.expression.text)
+        }
+        ts.forEachChild(child, walk)
+      }
+      ts.forEachChild(node, walk)
+      return names
+    }
+
+    const visited = new Set<string>()
+    const queue = [...ANCHORS]
+    while (queue.length > 0) {
+      const name = queue.shift()!
+      if (visited.has(name)) continue
+      visited.add(name)
+      const declaration = declarations.get(name)
+      if (!declaration) continue
+      for (const referenced of referencedNames(declaration)) {
+        if (declarations.has(referenced) && !visited.has(referenced)) queue.push(referenced)
+      }
+    }
+
+    const missing = [...visited]
+      .filter((name) => exportedFromTypes.has(name) && !rootExports.has(name))
+      .sort()
+    expect(missing).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem

`AgentConfig.thinking` is declared as `ThinkingConfig`, but that interface is not re-exported from `packages/core/src/index.ts`. A consumer can set the field but cannot name its type:

```ts
import type { ThinkingConfig } from '@open-multi-agent/core'
//            ^ TS2305: has no exported member 'ThinkingConfig'
```

The only workaround is reaching into an internal source path, which is not a supported import surface.

## Scope

Diffing all 167 types exported from `types.ts` against the 150 re-exported from `index.ts` left 17 unaccounted names. Nine are already public via `execution-router.js`, leaving eight real gaps:

| Type | Public field it annotates |
|---|---|
| `ThinkingConfig` | `AgentConfig.thinking`, `LLMChatOptions.thinking` |
| `ToolResultMetadata` | `ToolResult.metadata`, reachable via `AgentConfig.customTools` |
| `ProcessAgentBackendConfig`, `ProcessBackendInputMode` | the process arm of `AgentConfig.backend` |
| `CostEstimateContext` | second parameter of `OrchestratorConfig.estimateCost` |
| `MessageBusSnapshot`, `MessageSnapshot`, `MessageReadStateSnapshot` | `messageBus` on the checkpoint snapshot base |

Each already had a nameable sibling, which is what marks these as oversights rather than deliberate privacy: `ToolResult.modelOutput` was nameable while `.metadata` was not, `estimateCost` exposed `TokenUsage` but not its context, and the snapshot base exposed `queue` and `sharedMemory` but not `messageBus`. `AcpAgentBackendConfig` is root-exported and duplicated into `/acp`, while its process twin was root-absent.

Two of the eight, `ProcessAgentBackendConfig` and `ProcessBackendInputMode`, did have a working import path via `@open-multi-agent/core/process`. That was asymmetry with the ACP arm rather than inaccessibility.

## Test

Type-only re-exports are erased at runtime, `tests/` is excluded from `tsc --noEmit`, and vitest does not typecheck, so no existing test could catch this. `public-type-export-coverage.test.ts` walks type-reference syntax from eleven public anchor declarations and asserts every reachable `types.ts` export is also re-exported from the root.

It fails against the unpatched `index.ts` with exactly the eight names above, so it is not a vacuous guard.

## Verification

- `npm run lint`, `npm run build`, `npm test` at the root: clean, 1946 core tests plus 79 across otel, create-oma-app and release-bot
- All eight names confirmed present in `dist/index.d.ts`
- A consumer fixture importing all eight from `@open-multi-agent/core` failed with eight `TS2305` errors against an unpatched build and typechecks clean against the patched one

No documentation changes: none of the eight names appear in `docs/` or the READMEs, so nothing was directing users to internal paths.
