### PR TITLE
fix(orchestrator): refresh structured output after verify revision

### DIFF
--- a/packages/core/src/orchestrator/consensus.ts
+++ b/packages/core/src/orchestrator/consensus.ts
@@ -154,6 +154,8 @@ export interface ConsensusCoreParams {
   readonly prompt: string
   /** Proposed answer to scrutinise (proposer output, or the task result). */
   readonly initialAnswer: string
+  /** Parsed output paired with `initialAnswer`, when the proposer uses an output schema. */
+  readonly initialStructured?: unknown
   /** Usage attributable so far that should be reported back (proposer usage, or zero for the verify hook). */
   readonly initialUsage: TokenUsage
   /** Tokens already spent that count toward the budget but are not re-reported (e.g. prior task usage). */
@@ -181,12 +183,17 @@ export interface ConsensusCoreParams {
   readonly consensusSpan?: TraceSpan
 }
 
+/** Internal consensus result that preserves parsed output across revision rounds. */
+interface ConsensusCoreResult extends ConsensusResult {
+  readonly structured?: unknown
+}
+
 /**
  * Run the judge/refutation loop over a proposed answer: judges run sequentially
  * (so quorum and budget can stop the rest), dissent is recorded to shared memory
  * and trace, and `onDissent` decides whether to revise, reject, or keep.
  */
-export async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusResult> {
+export async function runConsensusCore(params: ConsensusCoreParams): Promise<ConsensusCoreResult> {
   const {
     team, prompt, judges, mode, quorum, maxRounds, verdictSchema, onDissent,
     judgePrompt, budget, budgetBaseTokens, reviseProposer, defaults, onTrace, runId,
@@ -196,6 +203,7 @@ export async function runConsensusCore(params: ConsensusCoreParams): Promise<Con
   const sharedMem = team.getSharedMemoryInstance()
 
   let answer = params.initialAnswer
+  let structured = params.initialStructured
   let usage = params.initialUsage
   const dissent: string[] = []
   let rounds = 0
@@ -293,7 +301,10 @@ export async function runConsensusCore(params: ConsensusCoreParams): Promise<Con
       )
       usage = addUsage(usage, r.tokenUsage)
       if (!r.success && executionFailure === undefined) executionFailure = r
-      if (r.success && r.output) answer = r.output
+      if (r.success && r.output) {
+        answer = r.output
+        structured = r.structured
+      }
       if (overBudget() || params.shouldStop?.()) { budgetHit = true; break }
       continue
     }
@@ -304,6 +315,7 @@ export async function runConsensusCore(params: ConsensusCoreParams): Promise<Con
     accepted || (!budgetHit && onDissent === 'keep') ? 'accepted' : 'rejected'
   return {
     answer,
+    ...(structured !== undefined ? { structured } : {}),
     verdict,
     dissent,
     rounds,
@@ -352,6 +364,7 @@ export async function runTaskVerify(
     team,
     prompt: task.description,
     initialAnswer: result.output,
+    initialStructured: result.structured,
     initialUsage: ZERO_USAGE,
     budgetBaseTokens: ctx.cumulativeUsage.input_tokens + ctx.cumulativeUsage.output_tokens,
     judges: verify.judges,
@@ -429,6 +442,7 @@ export async function runTaskVerify(
     result: {
       ...result,
       output: useRevision ? consensus.answer : result.output,
+      structured: useRevision ? consensus.structured : result.structured,
       tokenUsage: addUsage(result.tokenUsage, consensus.tokenUsage),
     },
     verification: {

--- a/packages/core/tests/consensus.test.ts
+++ b/packages/core/tests/consensus.test.ts
@@ -489,6 +489,53 @@ describe('per-task verify hook', () => {
     expect((await mem.read(`worker/task:${taskId}:verdict`))?.value).toBe('accepted')
   })
 
+  it('replaces stale structured output when a verified task accepts a revision', async () => {
+    const worker = captureAdapter((p) =>
+      p.includes('previous answer')
+        ? '{"decision":"quarantine"}'
+        : '{"decision":"accept"}',
+    )
+    const judge = captureAdapter((p) =>
+      p.includes('quarantine') ? ACCEPT : DISSENT,
+    )
+    const consumer = captureAdapter('done')
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', {
+      name: 't',
+      agents: [{
+        ...agent('worker', worker.adapter),
+        outputSchema: z.object({ decision: z.enum(['accept', 'quarantine']) }),
+      }, agent('consumer', consumer.adapter)],
+    })
+
+    const run = await orch.runTasks(team, [
+      {
+        title: 'verified',
+        description: 'classify the interval',
+        assignee: 'worker',
+        verify: {
+          judges: [agent('judge', judge.adapter)],
+          quorum: 1,
+          maxRounds: 2,
+          onDissent: 'revise',
+        },
+      },
+      {
+        title: 'consume-verdict',
+        description: 'use the verified structured decision',
+        assignee: 'consumer',
+        dependsOn: ['verified'],
+        dependencyPayload: 'structured',
+      },
+    ])
+    const taskId = run.tasks![0]!.id
+
+    expect(run.taskResults?.get(taskId)?.output).toBe('{"decision":"quarantine"}')
+    expect(run.taskResults?.get(taskId)?.structured).toEqual({ decision: 'quarantine' })
+    expect(consumer.prompts[0]).toContain('{"decision":"quarantine"}')
+    expect(consumer.prompts[0]).not.toContain('{"decision":"accept"}')
+  })
+
   it('feeds the prior answer into the revision prompt', async () => {
     const worker = captureAdapter((p) => (p.includes('previous answer') ? 'revised' : 'original'))
     const judge = captureAdapter(DISSENT)


### PR DESCRIPTION
## Summary

Keep `AgentRunResult.output` and `AgentRunResult.structured` in sync when a per-task verify loop accepts a revised answer. Downstream tasks using `dependencyPayload: 'structured'` now receive the accepted revision instead of the stale pre-review value.

## Motivation

Fixes #535.

An accepted verify revision previously replaced only the text output. The parsed structured result remained attached to the original answer, so the same completed task could expose contradictory representations.

## Scope and impact

- Affected area: `@open-multi-agent/core` consensus/task verification.
- Public API changes: None.
- Compatibility or migration impact: None.
- Security or privacy impact: None.
- Documentation/examples: Not applicable; this restores the existing structured-output contract.
- Dependencies: No changes.

## Validation

- `npm test -w @open-multi-agent/core -- consensus.test.ts` — passed (21 tests).
- `npm run lint -w @open-multi-agent/core` — passed.
- `npm run build -w @open-multi-agent/core` — passed.
- `npm test -w @open-multi-agent/core` — passed (1,947 tests across 131 files).
- `git diff --check` — passed.

## Checklist

- [x] Tests were added or updated for changed behavior.
- [x] User-facing documentation and examples are not applicable.
- [x] Compatibility, breaking changes, and migration requirements are not applicable.
- [x] No dependency changes.
