### PR TITLE
fix(orchestrator): keep parsed consensus output out of the public result

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -25,6 +25,7 @@ Opening your first PR gets you added here. See the [contribution guide](.github/
 - [@tlysanhuo](https://github.com/tlysanhuo) (trace span parent linkage)
 - [@LambIessz](https://github.com/LambIessz) (orchestrator cost budget, MessageBus persistence in checkpoints, retryable route fallback)
 - [@Bobuyoucrypto](https://github.com/Bobuyoucrypto) (Windows bash timeout process-tree kill)
+- [@green3sf](https://github.com/green3sf) (structured output refresh after an accepted verify revision)
 
 ## Provider integrations
 

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -2691,7 +2691,11 @@ export class OpenMultiAgent {
       })
     }
 
-    const result = await runConsensusCore({
+    // `structured` belongs to the per-task verify hook, where one task result
+    // carries one parsed value. Here several proposer answers may be joined into
+    // a single string, so no parsed value corresponds to it; drop it rather than
+    // leak an undeclared field onto the public ConsensusResult.
+    const { structured: _structured, ...result } = await runConsensusCore({
       team,
       prompt,
       initialAnswer: candidates.join('\n\n---\n\n'),

--- a/packages/core/tests/consensus.test.ts
+++ b/packages/core/tests/consensus.test.ts
@@ -253,12 +253,40 @@ describe('runConsensus onDissent', () => {
     expect(res.verdict).toBe('rejected')
   })
 
+
   it('keep stops but keeps the answer (accepted despite dissent)', async () => {
     const { res, proposerCalls } = await run('keep')
     expect(proposerCalls).toBe(1)
     expect(res.rounds).toBe(1)
     expect(res.verdict).toBe('accepted')
     expect(res.dissent.length).toBeGreaterThan(0)
+  })
+
+  it('does not surface the revision proposer\'s parsed output on the public result', async () => {
+    // A schema-bearing proposer parses its revision internally, but runConsensus
+    // may join several proposer answers into one string, so no single parsed value
+    // corresponds to `answer`. The public ConsensusResult must not carry one.
+    const proposer: AgentConfig = {
+      ...agent('proposer', captureAdapter((p) =>
+        p.includes('previous answer') ? '{"decision":"quarantine"}' : '{"decision":"accept"}',
+      ).adapter),
+      outputSchema: z.object({ decision: z.enum(['accept', 'quarantine']) }),
+    }
+    const judge = captureAdapter((p) => (p.includes('quarantine') ? ACCEPT : DISSENT))
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', { name: 't', agents: [] })
+
+    const res = await orch.runConsensus(team, 'classify the interval', {
+      proposer,
+      judges: [agent('judge', judge.adapter)],
+      quorum: 1,
+      maxRounds: 2,
+      onDissent: 'revise',
+    })
+
+    expect(res.verdict).toBe('accepted')
+    expect(res.answer).toBe('{"decision":"quarantine"}')
+    expect(Object.keys(res)).not.toContain('structured')
   })
 })
 
@@ -534,6 +562,54 @@ describe('per-task verify hook', () => {
     expect(run.taskResults?.get(taskId)?.structured).toEqual({ decision: 'quarantine' })
     expect(consumer.prompts[0]).toContain('{"decision":"quarantine"}')
     expect(consumer.prompts[0]).not.toContain('{"decision":"accept"}')
+  })
+
+  it('keeps the original structured output when a revision is rejected', async () => {
+    // Mirror of the accepted-revision case: the worker still produces a revision,
+    // but no judge ever accepts it, so both halves of the original pair must survive.
+    const worker = captureAdapter((p) =>
+      p.includes('previous answer')
+        ? '{"decision":"quarantine"}'
+        : '{"decision":"accept"}',
+    )
+    const judge = captureAdapter(DISSENT) // never accepts -> verdict stays rejected
+    const consumer = captureAdapter('done')
+    const orch = new OpenMultiAgent()
+    const team = orch.createTeam('t', {
+      name: 't',
+      agents: [{
+        ...agent('worker', worker.adapter),
+        outputSchema: z.object({ decision: z.enum(['accept', 'quarantine']) }),
+      }, agent('consumer', consumer.adapter)],
+    })
+
+    const run = await orch.runTasks(team, [
+      {
+        title: 'verified',
+        description: 'classify the interval',
+        assignee: 'worker',
+        verify: {
+          judges: [agent('judge', judge.adapter)],
+          quorum: 1,
+          maxRounds: 2,
+          onDissent: 'revise',
+        },
+      },
+      {
+        title: 'consume-verdict',
+        description: 'use the verified structured decision',
+        assignee: 'consumer',
+        dependsOn: ['verified'],
+        dependencyPayload: 'structured',
+      },
+    ])
+    const taskId = run.tasks![0]!.id
+
+    // The rejected revision must not leak into either representation.
+    expect(run.taskResults?.get(taskId)?.output).toBe('{"decision":"accept"}')
+    expect(run.taskResults?.get(taskId)?.structured).toEqual({ decision: 'accept' })
+    expect(consumer.prompts[0]).toContain('{"decision":"accept"}')
+    expect(consumer.prompts[0]).not.toContain('{"decision":"quarantine"}')
   })
 
   it('feeds the prior answer into the revision prompt', async () => {


### PR DESCRIPTION
## Summary

Three follow-ups to #536, which fixed a stale `structured` value after an accepted verify revision.

- `runConsensus()` no longer returns an undeclared `structured` field.
- Both halves of the verify contract are now covered by tests: an accepted revision replaces the `output`/`structured` pair, a rejected one preserves it.
- green3sf is credited in CONTRIBUTORS.md for #536.

## Motivation

`runConsensusCore()` is shared by the per-task `verify` hook and the standalone `runConsensus()`. The parsed value is meaningful only in the first: one task result carries one parsed value. `runConsensus()` may join several proposer answers into a single string, so no parsed value corresponds to its `answer`. Returning one anyway put a field on a public result that callers could come to depend on while the type contract never promised it.

The test gap was the mirror image of the original bug. Before this change, replacing the ternary in `runTaskVerify` with an unconditional `consensus.structured` still passed the entire suite, because no rejected-revision test used an `outputSchema`.

## Scope and impact

- Affected area: `@open-multi-agent/core` consensus, plus CONTRIBUTORS.md.
- Public API changes: none in the type surface. `runConsensus()` stops emitting an undeclared runtime field introduced in #536.
- Compatibility or migration impact: none. The field was never part of `ConsensusResult` and has not shipped in a release.
- Security or privacy impact: None.
- Documentation/examples: not applicable; no documented behavior changes.
- Dependencies: No changes.

## Validation

- `npm test -w @open-multi-agent/core -- consensus.test.ts` passed (23 tests).
- `npm test -w @open-multi-agent/core` passed (1,949 tests across 131 files).
- `npm run lint -w @open-multi-agent/core` passed.
- `npm run build -w @open-multi-agent/core` passed.
- `git diff --check` passed.
- Both new tests were checked against a mutated source tree: reverting the strip fails the public-shape test, and dropping the ternary fails the rejected-revision test.

## Checklist

- [x] Tests were added or updated for changed behavior
- [x] User-facing documentation and examples are not applicable
- [x] Compatibility, breaking changes, and migration requirements are not applicable
- [x] No dependency changes
