### PR TITLE
feat(examples): add market data integrity verify loop

### DIFF
--- a/packages/core/examples/README.md
+++ b/packages/core/examples/README.md
@@ -89,6 +89,7 @@ End-to-end examples framed around a concrete problem (meeting summarization, tra
 | [`cookbook/rare-disease-information-triage`](cookbook/rare-disease-information-triage.ts) | Source-isolated rare disease information triage with mock fixtures, seeded misinformation/conflict detection, and safety-boundary arbitration. |
 | [`cookbook/personalized-interview-simulator`](cookbook/personalized-interview-simulator.ts) | Interactive interviewer loop with observer flags, shared memory, and structured debrief. |
 | [`cookbook/narrative-puzzle-hint-arbitration`](cookbook/narrative-puzzle-hint-arbitration.ts) | Multi-source hint arbitration with an external safety veto that sits outside the generation loop. |
+| [`cookbook/market-data-integrity-verify-loop`](cookbook/market-data-integrity-verify-loop.ts) | Binance L2 integrity gate where source-specific judges refute a provisional report and require a verified quarantine revision. |
 | [`cookbook/translation-backtranslation`](cookbook/translation-backtranslation.ts) | Translate → back-translate with a different provider → flag semantic drift (cross-model). |
 
 ## integrations — external systems

--- a/packages/core/examples/catalog.json
+++ b/packages/core/examples/catalog.json
@@ -165,6 +165,17 @@
       "level": "advanced"
     },
     {
+      "id": "market-data-integrity-verify-loop",
+      "path": "cookbook/market-data-integrity-verify-loop.ts",
+      "title": "Market Data Integrity Verify Loop",
+      "description": "Challenge a provisional Binance L2 integrity report with source-specific protocol and backtest-risk judges before revising it to quarantine.",
+      "section": "goal",
+      "goal": "use-case-recipes",
+      "capabilities": ["run-tasks", "task-dependencies", "structured-output", "consensus", "conflict-detection"],
+      "format": "script",
+      "level": "advanced"
+    },
+    {
       "id": "translation-backtranslation",
       "path": "cookbook/translation-backtranslation.ts",
       "title": "Translation and Backtranslation",

--- a/packages/core/examples/cookbook/market-data-integrity-verify-loop.ts
+++ b/packages/core/examples/cookbook/market-data-integrity-verify-loop.ts
@@ -187,9 +187,11 @@ or collector assumption. Do not invent snapshot or reconnect facts.
 
 On a revision call, reviewer critiques are new evidence from source-specific
 judges. Address every critique, cite exact source values and affected ranges,
-and change the decision when the policy requires it. A proven boundary gap or
-an unverified reconnect overlapping active trades must never remain ACCEPT.
-Return only schema-valid JSON.`,
+and change the decision when the policy requires it. Preserve each literal
+source filename from the critiques in the matching violated_invariants[].source;
+in this recipe those filenames are snapshot-metadata.json and collector-log.txt.
+A proven boundary gap or an unverified reconnect overlapping active trades must
+never remain ACCEPT. Return only schema-valid JSON.`,
   outputSchema: IntegrityReport,
   afterRun: captureProposal,
   maxTurns: 1,
@@ -222,7 +224,10 @@ const judgeInstructions: Record<string, string> = {
 the MOCK source below. Apply its stated bridge invariant exactly. Reject any
 ACCEPT report when the first retained event does not bridge lastUpdateId + 1.
 A revised report passes only if it names the exact missing update-ID range,
-quarantines the interval, and recommends rebuilding a verified overlap.
+quarantines the interval, cites the literal filename snapshot-metadata.json in
+the matching violated invariant, and recommends rebuilding a verified overlap.
+When dissenting, include snapshot-metadata.json verbatim in the critique so the
+proposer can preserve it in the revised report.
 
 ## Judge-only MOCK source: snapshot-metadata.json
 ${snapshotMetadata}`,
@@ -232,7 +237,10 @@ Reject any ACCEPT report when a reconnect overlaps active trading and the
 collector admits that it skipped the snapshot bridge check. A revised report
 passes only if it follows the policy, records the disconnect-to-first-event
 window (2026-08-18T09:29:59.940Z to 09:30:00.210Z), and keeps the interval out
-of backtests until replacement data is verified.
+of backtests until replacement data is verified. The matching violated
+invariant must cite the literal filename collector-log.txt. When dissenting,
+include collector-log.txt verbatim in the critique so the proposer can preserve
+it in the revised report.
 
 ## Judge-only MOCK source: collector-log.txt
 ${collectorLog}
@@ -301,63 +309,71 @@ const team = orchestrator.createTeam('market-data-integrity-team', {
 // Execute and prove the intended conflict/revision path
 // ---------------------------------------------------------------------------
 
-function assertExpectedPath(report: IntegrityReport): void {
-  if (proposalAttempts[0]?.decision !== 'ACCEPT') {
-    throw new Error('Expected the seeded first proposal to be ACCEPT.')
-  }
-  if (proposalAttempts.at(-1)?.decision !== 'QUARANTINE') {
-    throw new Error('Expected judge dissent to revise the proposal to QUARANTINE.')
-  }
-
+function expectedPathAssertions(
+  report: IntegrityReport,
+): Array<{ name: string; pass: boolean }> {
   const roundOneJudges = new Set(
     consensusEvents.filter((event) => event.round === 1).map((event) => event.agent),
   )
-  for (const judge of ['protocol-continuity-judge', 'backtest-risk-judge']) {
-    if (!roundOneJudges.has(judge)) {
-      throw new Error(`Expected quorum: 2 to run ${judge} in round one.`)
-    }
-  }
-
   const roundTwoAccepted = new Set(
     consensusEvents
       .filter((event) => event.round === 2 && event.accepted)
       .map((event) => event.agent),
   )
-  if (roundTwoAccepted.size !== 2) {
-    throw new Error('Expected both source-specific judges to accept the revised report.')
-  }
-
   const missingRangeRecorded = report.affected_ranges.some(
     (item) => item.kind === 'update_id' && item.range.includes('900101') && item.range.includes('900104'),
   )
-  if (!missingRangeRecorded) {
-    throw new Error('Revised report omitted the proven 900101-900104 update-ID gap.')
-  }
-
   const reconnectWindowRecorded = report.affected_ranges.some(
     (item) =>
       item.kind === 'time' &&
       item.range.includes('09:29:59.940') &&
       item.range.includes('09:30:00.210'),
   )
-  if (!reconnectWindowRecorded) {
-    throw new Error('Revised report omitted the collector reconnect window.')
-  }
-
   const evidenceSources = new Set(report.violated_invariants.map((item) => item.source))
-  if (![...evidenceSources].some((source) => source.includes('snapshot-metadata.json'))) {
-    throw new Error('Revised report did not cite the protocol judge source.')
-  }
-  if (![...evidenceSources].some((source) => source.includes('collector-log.txt'))) {
-    throw new Error('Revised report did not cite the backtest-risk judge source.')
-  }
-
   const hasReplacementAction = report.recommended_actions.some((action) =>
     /re-?download|rebuild|replace/i.test(action),
   )
-  if (!hasReplacementAction) {
-    throw new Error('Revised report omitted a concrete replacement-data remediation.')
-  }
+
+  return [
+    {
+      name: 'the seeded first proposal is ACCEPT',
+      pass: proposalAttempts[0]?.decision === 'ACCEPT',
+    },
+    {
+      name: 'judge dissent revises the proposal to QUARANTINE',
+      pass: proposalAttempts.at(-1)?.decision === 'QUARANTINE',
+    },
+    {
+      name: 'both source-specific judges run in round one',
+      pass: ['protocol-continuity-judge', 'backtest-risk-judge'].every((judge) =>
+        roundOneJudges.has(judge),
+      ),
+    },
+    {
+      name: 'both source-specific judges accept the revised report',
+      pass: roundTwoAccepted.size === 2,
+    },
+    {
+      name: 'the revised report records the proven 900101-900104 update-ID gap',
+      pass: missingRangeRecorded,
+    },
+    {
+      name: 'the revised report records the collector reconnect window',
+      pass: reconnectWindowRecorded,
+    },
+    {
+      name: 'the revised report cites snapshot-metadata.json',
+      pass: [...evidenceSources].some((source) => source.includes('snapshot-metadata.json')),
+    },
+    {
+      name: 'the revised report cites collector-log.txt',
+      pass: [...evidenceSources].some((source) => source.includes('collector-log.txt')),
+    },
+    {
+      name: 'the revised report includes a concrete replacement-data remediation',
+      pass: hasReplacementAction,
+    },
+  ]
 }
 
 async function main(): Promise<void> {
@@ -372,8 +388,6 @@ async function main(): Promise<void> {
   const reportResult = reportTask ? result.taskResults?.get(reportTask.id) : undefined
   const report = IntegrityReport.parse(reportResult?.structured)
 
-  assertExpectedPath(report)
-
   console.log(`Decision path: ${proposalAttempts.map((item) => item.decision).join(' -> ')}`)
   console.log('\nJudge audit trail:')
   for (const event of consensusEvents) {
@@ -384,6 +398,18 @@ async function main(): Promise<void> {
 
   console.log('\nVerified Market Data Integrity Report:')
   console.log(JSON.stringify(report, null, 2))
+
+  console.log('\n## Runtime Assertions\n')
+  let hasFailure = false
+  for (const assertion of expectedPathAssertions(report)) {
+    console.log(`- ${assertion.pass ? 'PASS' : 'FAIL'}: ${assertion.name}`)
+    if (!assertion.pass) hasFailure = true
+  }
+
+  if (hasFailure) {
+    console.error('Runtime assertion failed.')
+    process.exit(1)
+  }
 }
 
 main().catch((error) => {

--- a/packages/core/examples/cookbook/market-data-integrity-verify-loop.ts
+++ b/packages/core/examples/cookbook/market-data-integrity-verify-loop.ts
@@ -1,0 +1,392 @@
+/**
+ * Binance L2 Market Data Integrity Gate (Per-Task Verify Loop)
+ *
+ * Demonstrates a provisional market-data decision that must survive two
+ * source-specific judges before an interval can enter a backtest:
+ *
+ *   depth updates ──> depth-sequence-extractor ──┐
+ *                                                ├─> integrity-report-proposer
+ *   aggregate trades -> trade-activity-extractor ┘              │
+ *                                                                v
+ *                                            per-task verify, quorum: 2
+ *                                        ┌─────────────────────────────┐
+ *                                        │ protocol-continuity-judge   │
+ *                                        │ backtest-risk-judge         │
+ *                                        └─────────────────────────────┘
+ *
+ * The first report is intentionally provisional: retained depth events are
+ * locally continuous, so the proposer emits ACCEPT. Each judge receives a
+ * different withheld MOCK source through `judgePrompt: (judge) => string`.
+ * They expose a snapshot boundary gap and reconnect risk, forcing a revision
+ * to an actionable QUARANTINE report. `quorum: 2` ensures one accepting judge
+ * can never short-circuit the other. No `mode` is set because `judgePrompt`
+ * replaces the built-in mode instruction.
+ *
+ * Run:
+ *   npx tsx packages/core/examples/cookbook/market-data-integrity-verify-loop.ts
+ *
+ * Prerequisites:
+ *   ANTHROPIC_API_KEY env var must be set.
+ *   Requires Node.js >= 20.
+ *
+ * Fixtures:
+ *   Every file under examples/fixtures/market-data-integrity-verify-loop/ is
+ *   MOCK and synthetic. The example makes no exchange or network data request.
+ */
+
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { z } from 'zod'
+import { OpenMultiAgent } from '../../src/index.js'
+import type {
+  AgentConfig,
+  AgentRunResult,
+  ConsensusTrace,
+  RunTaskSpec,
+  TraceEvent,
+} from '../../src/types.js'
+
+// ---------------------------------------------------------------------------
+// MOCK fixture loading
+// ---------------------------------------------------------------------------
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const fixtureRoot = path.join(__dirname, '../fixtures/market-data-integrity-verify-loop')
+
+function readFixture(name: string): string {
+  return readFileSync(path.join(fixtureRoot, name), 'utf8')
+}
+
+const depthUpdates = readFixture('depth-updates.json')
+const aggregateTrades = readFixture('aggregate-trades.json')
+const snapshotMetadata = readFixture('snapshot-metadata.json')
+const collectorLog = readFixture('collector-log.txt')
+const dataQualityPolicy = readFixture('data-quality-policy.md')
+
+const MODEL = process.env['MODEL'] ?? 'claude-sonnet-4-6'
+const providerConfig = {
+  provider: 'anthropic' as const,
+  model: MODEL,
+  apiKey: process.env['ANTHROPIC_API_KEY'],
+  baseURL: process.env['ANTHROPIC_BASE_URL'],
+  tools: [] as const,
+}
+
+// ---------------------------------------------------------------------------
+// Structured evidence and report contracts
+// ---------------------------------------------------------------------------
+
+const DepthSequenceAudit = z.object({
+  source_is_mock: z.literal(true),
+  symbol: z.string(),
+  event_count: z.number().int().nonnegative(),
+  first_update_id: z.number().int(),
+  final_update_id: z.number().int(),
+  retained_sequence_contiguous: z.boolean(),
+  crossed_book_observed: z.boolean(),
+  invalid_quantity_observed: z.boolean(),
+  snapshot_boundary_checked: z.literal(false),
+  evidence_limit: z.string(),
+})
+
+const TradeActivityAudit = z.object({
+  source_is_mock: z.literal(true),
+  symbol: z.string(),
+  trade_count: z.number().int().nonnegative(),
+  first_trade_at: z.string(),
+  last_trade_at: z.string(),
+  total_quantity: z.number().nonnegative(),
+  activity_during_boundary_window: z.boolean(),
+  evidence_limit: z.string(),
+})
+
+const IntegrityReport = z.object({
+  source_is_mock: z.literal(true),
+  symbol: z.string(),
+  interval: z.object({
+    start: z.string(),
+    end: z.string(),
+  }),
+  decision: z.enum(['ACCEPT', 'QUARANTINE', 'REPAIR_REQUIRED']),
+  summary: z.string(),
+  violated_invariants: z.array(z.object({
+    invariant: z.string(),
+    source: z.string(),
+    evidence: z.string(),
+  })),
+  affected_ranges: z.array(z.object({
+    kind: z.enum(['update_id', 'time']),
+    range: z.string(),
+    reason: z.string(),
+  })),
+  supporting_evidence: z.array(z.object({
+    source: z.string(),
+    finding: z.string(),
+  })),
+  evidence_limitations: z.array(z.string()),
+  recommended_actions: z.array(z.string()),
+  revision_notes: z.array(z.string()),
+})
+type IntegrityReport = z.infer<typeof IntegrityReport>
+
+const JudgeVerdict = z.object({
+  accept: z.boolean(),
+  critique: z.string(),
+})
+
+// Capture both proposer calls to prove that the verify loop changed the
+// structured decision rather than merely appending a warning after the fact.
+const proposalAttempts: IntegrityReport[] = []
+
+function captureProposal(result: AgentRunResult): AgentRunResult {
+  const parsed = IntegrityReport.safeParse(result.structured)
+  if (parsed.success) proposalAttempts.push(parsed.data)
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Agents
+// ---------------------------------------------------------------------------
+
+const depthExtractor: AgentConfig = {
+  name: 'depth-sequence-extractor',
+  ...providerConfig,
+  systemPrompt: `You audit only the provided MOCK Binance-style diff-depth file.
+Check continuity between retained events, crossed-book updates, and invalid
+quantities. You do not have snapshot metadata, so snapshot_boundary_checked
+must be false and you must state that limitation. Return only schema-valid JSON.`,
+  outputSchema: DepthSequenceAudit,
+  maxTurns: 1,
+  maxTokens: 1200,
+  temperature: 0,
+}
+
+const tradeExtractor: AgentConfig = {
+  name: 'trade-activity-extractor',
+  ...providerConfig,
+  systemPrompt: `You audit only the provided MOCK aggregate-trade file. Report
+the event count, time window, summed quantity, and whether trades occurred in
+the 2026-08-18T09:30:00.000Z to 09:30:00.210Z boundary window. You cannot infer
+depth continuity from trades. Return only schema-valid JSON.`,
+  outputSchema: TradeActivityAudit,
+  maxTurns: 1,
+  maxTokens: 1000,
+  temperature: 0,
+}
+
+const reportProposer: AgentConfig = {
+  name: 'integrity-report-proposer',
+  ...providerConfig,
+  systemPrompt: `You produce an auditable market-data integrity report.
+
+On the initial call, use only the dependency evidence supplied to the task. If
+the retained depth sequence is continuous and contains no direct corruption,
+issue a provisional ACCEPT while explicitly listing every unverified boundary
+or collector assumption. Do not invent snapshot or reconnect facts.
+
+On a revision call, reviewer critiques are new evidence from source-specific
+judges. Address every critique, cite exact source values and affected ranges,
+and change the decision when the policy requires it. A proven boundary gap or
+an unverified reconnect overlapping active trades must never remain ACCEPT.
+Return only schema-valid JSON.`,
+  outputSchema: IntegrityReport,
+  afterRun: captureProposal,
+  maxTurns: 1,
+  maxTokens: 2400,
+  temperature: 0,
+}
+
+const protocolJudge: AgentConfig = {
+  name: 'protocol-continuity-judge',
+  ...providerConfig,
+  systemPrompt: 'You are an independent Binance diff-depth protocol auditor.',
+  outputSchema: JudgeVerdict,
+  maxTurns: 1,
+  maxTokens: 900,
+  temperature: 0,
+}
+
+const backtestRiskJudge: AgentConfig = {
+  name: 'backtest-risk-judge',
+  ...providerConfig,
+  systemPrompt: 'You are an independent market-data quality and backtest-risk auditor.',
+  outputSchema: JudgeVerdict,
+  maxTurns: 1,
+  maxTokens: 900,
+  temperature: 0,
+}
+
+const judgeInstructions: Record<string, string> = {
+  'protocol-continuity-judge': `Review only snapshot-to-stream continuity using
+the MOCK source below. Apply its stated bridge invariant exactly. Reject any
+ACCEPT report when the first retained event does not bridge lastUpdateId + 1.
+A revised report passes only if it names the exact missing update-ID range,
+quarantines the interval, and recommends rebuilding a verified overlap.
+
+## Judge-only MOCK source: snapshot-metadata.json
+${snapshotMetadata}`,
+  'backtest-risk-judge': `Review only backtest contamination risk using the two
+MOCK sources below plus the trade activity stated in the proposed report.
+Reject any ACCEPT report when a reconnect overlaps active trading and the
+collector admits that it skipped the snapshot bridge check. A revised report
+passes only if it follows the policy, records the disconnect-to-first-event
+window (2026-08-18T09:29:59.940Z to 09:30:00.210Z), and keeps the interval out
+of backtests until replacement data is verified.
+
+## Judge-only MOCK source: collector-log.txt
+${collectorLog}
+
+## Judge-only MOCK source: data-quality-policy.md
+${dataQualityPolicy}`,
+}
+
+// ---------------------------------------------------------------------------
+// Task DAG and verify configuration
+// ---------------------------------------------------------------------------
+
+const tasks: RunTaskSpec[] = [
+  {
+    title: 'extract-depth-sequence',
+    description: `Audit this isolated MOCK depth source.\n\n${depthUpdates}`,
+    assignee: 'depth-sequence-extractor',
+  },
+  {
+    title: 'extract-trade-activity',
+    description: `Audit this isolated MOCK trade source.\n\n${aggregateTrades}`,
+    assignee: 'trade-activity-extractor',
+  },
+  {
+    title: 'propose-integrity-report',
+    description: `Using only the two structured dependency results, decide
+whether the BTCUSDT interval can enter a backtest. Produce the complete
+Market Data Integrity Report. This is a provisional thesis: do not assume that
+snapshot-boundary or collector-lifecycle evidence was checked unless it appears
+in the dependencies.`,
+    assignee: 'integrity-report-proposer',
+    dependsOn: ['extract-depth-sequence', 'extract-trade-activity'],
+    dependencyPayload: 'structured',
+    verify: {
+      judges: [protocolJudge, backtestRiskJudge],
+      quorum: 2,
+      maxRounds: 2,
+      onDissent: 'revise',
+      verdictSchema: JudgeVerdict,
+      judgePrompt: (judgeName: string) =>
+        judgeInstructions[judgeName] ??
+        'Reject because this judge has no source-specific review instruction.',
+    },
+  },
+]
+
+const consensusEvents: ConsensusTrace[] = []
+
+function collectTrace(event: TraceEvent): void {
+  if (event.type === 'consensus') consensusEvents.push(event)
+}
+
+const orchestrator = new OpenMultiAgent({
+  defaultProvider: 'anthropic',
+  defaultModel: MODEL,
+  onTrace: collectTrace,
+})
+
+const team = orchestrator.createTeam('market-data-integrity-team', {
+  name: 'market-data-integrity-team',
+  agents: [depthExtractor, tradeExtractor, reportProposer],
+  sharedMemory: true,
+})
+
+// ---------------------------------------------------------------------------
+// Execute and prove the intended conflict/revision path
+// ---------------------------------------------------------------------------
+
+function assertExpectedPath(report: IntegrityReport): void {
+  if (proposalAttempts[0]?.decision !== 'ACCEPT') {
+    throw new Error('Expected the seeded first proposal to be ACCEPT.')
+  }
+  if (proposalAttempts.at(-1)?.decision !== 'QUARANTINE') {
+    throw new Error('Expected judge dissent to revise the proposal to QUARANTINE.')
+  }
+
+  const roundOneJudges = new Set(
+    consensusEvents.filter((event) => event.round === 1).map((event) => event.agent),
+  )
+  for (const judge of ['protocol-continuity-judge', 'backtest-risk-judge']) {
+    if (!roundOneJudges.has(judge)) {
+      throw new Error(`Expected quorum: 2 to run ${judge} in round one.`)
+    }
+  }
+
+  const roundTwoAccepted = new Set(
+    consensusEvents
+      .filter((event) => event.round === 2 && event.accepted)
+      .map((event) => event.agent),
+  )
+  if (roundTwoAccepted.size !== 2) {
+    throw new Error('Expected both source-specific judges to accept the revised report.')
+  }
+
+  const missingRangeRecorded = report.affected_ranges.some(
+    (item) => item.kind === 'update_id' && item.range.includes('900101') && item.range.includes('900104'),
+  )
+  if (!missingRangeRecorded) {
+    throw new Error('Revised report omitted the proven 900101-900104 update-ID gap.')
+  }
+
+  const reconnectWindowRecorded = report.affected_ranges.some(
+    (item) =>
+      item.kind === 'time' &&
+      item.range.includes('09:29:59.940') &&
+      item.range.includes('09:30:00.210'),
+  )
+  if (!reconnectWindowRecorded) {
+    throw new Error('Revised report omitted the collector reconnect window.')
+  }
+
+  const evidenceSources = new Set(report.violated_invariants.map((item) => item.source))
+  if (![...evidenceSources].some((source) => source.includes('snapshot-metadata.json'))) {
+    throw new Error('Revised report did not cite the protocol judge source.')
+  }
+  if (![...evidenceSources].some((source) => source.includes('collector-log.txt'))) {
+    throw new Error('Revised report did not cite the backtest-risk judge source.')
+  }
+
+  const hasReplacementAction = report.recommended_actions.some((action) =>
+    /re-?download|rebuild|replace/i.test(action),
+  )
+  if (!hasReplacementAction) {
+    throw new Error('Revised report omitted a concrete replacement-data remediation.')
+  }
+}
+
+async function main(): Promise<void> {
+  console.log('Binance L2 Market Data Integrity Gate')
+  console.log('='.repeat(64))
+  console.log('All inputs are MOCK. No exchange connection will be made.\n')
+
+  const result = await orchestrator.runTasks(team, tasks)
+  if (!result.success) throw new Error('The market-data integrity workflow failed.')
+
+  const reportTask = result.tasks?.find((task) => task.title === 'propose-integrity-report')
+  const reportResult = reportTask ? result.taskResults?.get(reportTask.id) : undefined
+  const report = IntegrityReport.parse(reportResult?.structured)
+
+  assertExpectedPath(report)
+
+  console.log(`Decision path: ${proposalAttempts.map((item) => item.decision).join(' -> ')}`)
+  console.log('\nJudge audit trail:')
+  for (const event of consensusEvents) {
+    const verdict = event.accepted ? 'ACCEPT' : 'DISSENT'
+    console.log(`  round ${event.round} | ${event.agent} | ${verdict}`)
+    if (event.dissent) console.log(`    ${event.dissent}`)
+  }
+
+  console.log('\nVerified Market Data Integrity Report:')
+  console.log(JSON.stringify(report, null, 2))
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error)
+  process.exitCode = 1
+})

--- a/packages/core/examples/fixtures/market-data-integrity-verify-loop/README.md
+++ b/packages/core/examples/fixtures/market-data-integrity-verify-loop/README.md
@@ -1,0 +1,19 @@
+# Market Data Integrity Verify Loop Fixtures
+
+All files in this directory are **MOCK** fixtures created for the cookbook
+example. They contain no exchange credentials and do not make live network
+requests.
+
+| File | Consumer | Purpose |
+|---|---|---|
+| `depth-updates.json` | Depth sequence extractor | Retained Binance-style diff-depth events that are locally continuous. |
+| `aggregate-trades.json` | Trade activity extractor | Independent evidence that the market traded during the suspect boundary window. |
+| `snapshot-metadata.json` | Protocol continuity judge | Snapshot-to-stream boundary metadata with an intentionally missing update-ID range. |
+| `collector-log.txt` | Backtest risk judge | A collector disconnect, reconnect, and late first buffered event. |
+| `data-quality-policy.md` | Backtest risk judge | The decision policy for accept, quarantine, and repair outcomes. |
+
+The conflict is deliberate: the proposer sees only the locally continuous
+retained depth events and aggregate trades, so it emits a provisional `ACCEPT`.
+The verify hook gives each judge a different withheld source. The judges expose
+the boundary gap and reconnect risk, and the proposer must revise the report to
+`QUARANTINE` before both judges accept it.

--- a/packages/core/examples/fixtures/market-data-integrity-verify-loop/aggregate-trades.json
+++ b/packages/core/examples/fixtures/market-data-integrity-verify-loop/aggregate-trades.json
@@ -1,0 +1,37 @@
+{
+  "fixture": {
+    "classification": "MOCK",
+    "description": "Synthetic Binance-style aggregate trades"
+  },
+  "symbol": "BTCUSDT",
+  "trades": [
+    {
+      "aggregate_trade_id": 700501,
+      "event_time": "2026-08-18T09:30:00.082Z",
+      "price": "115000.20",
+      "quantity": "0.180",
+      "buyer_was_maker": false
+    },
+    {
+      "aggregate_trade_id": 700502,
+      "event_time": "2026-08-18T09:30:00.119Z",
+      "price": "115000.10",
+      "quantity": "0.310",
+      "buyer_was_maker": true
+    },
+    {
+      "aggregate_trade_id": 700503,
+      "event_time": "2026-08-18T09:30:00.164Z",
+      "price": "115000.20",
+      "quantity": "0.260",
+      "buyer_was_maker": false
+    },
+    {
+      "aggregate_trade_id": 700504,
+      "event_time": "2026-08-18T09:30:00.196Z",
+      "price": "115000.30",
+      "quantity": "0.145",
+      "buyer_was_maker": false
+    }
+  ]
+}

--- a/packages/core/examples/fixtures/market-data-integrity-verify-loop/collector-log.txt
+++ b/packages/core/examples/fixtures/market-data-integrity-verify-loop/collector-log.txt
@@ -1,0 +1,7 @@
+# MOCK FIXTURE — synthetic collector lifecycle log
+2026-08-18T09:29:59.940Z WARN  depth-stream BTCUSDT websocket disconnected reason=abnormal_close
+2026-08-18T09:29:59.979Z INFO  depth-stream BTCUSDT websocket reconnected connection_id=conn-42
+2026-08-18T09:30:00.001Z INFO  snapshot     BTCUSDT REST snapshot requested request_id=snap-77
+2026-08-18T09:30:00.052Z INFO  snapshot     BTCUSDT REST snapshot received lastUpdateId=900100 request_id=snap-77
+2026-08-18T09:30:00.210Z INFO  depth-stream BTCUSDT first buffered event U=900105 u=900106 connection_id=conn-42
+2026-08-18T09:30:00.211Z WARN  depth-stream BTCUSDT snapshot bridge was not evaluated collector_mode=legacy

--- a/packages/core/examples/fixtures/market-data-integrity-verify-loop/data-quality-policy.md
+++ b/packages/core/examples/fixtures/market-data-integrity-verify-loop/data-quality-policy.md
@@ -1,0 +1,22 @@
+# MOCK Market Data Quality Policy
+
+This synthetic policy is for the cookbook scenario only.
+
+## Decisions
+
+- `ACCEPT`: the snapshot-to-stream bridge invariant passes, retained update IDs
+  are continuous, quantities are valid, the reconstructed book never crosses,
+  and no unexplained collector interruption overlaps market activity.
+- `QUARANTINE`: any missing update-ID range is proven, or a reconnect overlaps
+  independent trade activity without a verified snapshot bridge. The interval
+  must not enter backtests until replacement data passes every acceptance rule.
+- `REPAIR_REQUIRED`: evidence is inconclusive but a deterministic repair can be
+  attempted. Name the missing source and do not claim the interval is valid.
+
+## Required report fields
+
+Every non-accept decision must include the affected time or update-ID range,
+the violated invariant, the source that proves it, and a remediation. For a
+snapshot boundary gap, redownload a fresh snapshot plus diff-depth overlap that
+starts before or at `lastUpdateId + 1`, replay the bridge check, and replace the
+entire quarantined interval rather than splicing isolated book levels.

--- a/packages/core/examples/fixtures/market-data-integrity-verify-loop/depth-updates.json
+++ b/packages/core/examples/fixtures/market-data-integrity-verify-loop/depth-updates.json
@@ -1,0 +1,58 @@
+{
+  "fixture": {
+    "classification": "MOCK",
+    "description": "Synthetic Binance-style BTCUSDT diff-depth events"
+  },
+  "symbol": "BTCUSDT",
+  "capture_interval": {
+    "start": "2026-08-18T09:30:00.000Z",
+    "end": "2026-08-18T09:30:01.000Z"
+  },
+  "events": [
+    {
+      "event_time": "2026-08-18T09:30:00.210Z",
+      "first_update_id": 900105,
+      "final_update_id": 900106,
+      "bids": [["115000.10", "0.420"]],
+      "asks": [["115000.20", "0.380"]],
+      "reconstructed_best_bid_after": "115000.10",
+      "reconstructed_best_ask_after": "115000.20"
+    },
+    {
+      "event_time": "2026-08-18T09:30:00.330Z",
+      "first_update_id": 900107,
+      "final_update_id": 900107,
+      "bids": [["115000.00", "0.510"]],
+      "asks": [],
+      "reconstructed_best_bid_after": "115000.10",
+      "reconstructed_best_ask_after": "115000.20"
+    },
+    {
+      "event_time": "2026-08-18T09:30:00.470Z",
+      "first_update_id": 900108,
+      "final_update_id": 900109,
+      "bids": [],
+      "asks": [["115000.30", "0.295"]],
+      "reconstructed_best_bid_after": "115000.10",
+      "reconstructed_best_ask_after": "115000.20"
+    },
+    {
+      "event_time": "2026-08-18T09:30:00.650Z",
+      "first_update_id": 900110,
+      "final_update_id": 900110,
+      "bids": [["115000.10", "0.000"]],
+      "asks": [["115000.20", "0.440"]],
+      "reconstructed_best_bid_after": "115000.00",
+      "reconstructed_best_ask_after": "115000.20"
+    },
+    {
+      "event_time": "2026-08-18T09:30:00.880Z",
+      "first_update_id": 900111,
+      "final_update_id": 900112,
+      "bids": [["114999.90", "0.620"]],
+      "asks": [["115000.40", "0.210"]],
+      "reconstructed_best_bid_after": "115000.00",
+      "reconstructed_best_ask_after": "115000.20"
+    }
+  ]
+}

--- a/packages/core/examples/fixtures/market-data-integrity-verify-loop/snapshot-metadata.json
+++ b/packages/core/examples/fixtures/market-data-integrity-verify-loop/snapshot-metadata.json
@@ -1,0 +1,25 @@
+{
+  "fixture": {
+    "classification": "MOCK",
+    "description": "Synthetic REST snapshot and first retained stream-event metadata"
+  },
+  "symbol": "BTCUSDT",
+  "snapshot": {
+    "captured_at": "2026-08-18T09:30:00.052Z",
+    "last_update_id": 900100,
+    "best_bid": ["115000.10", "0.600"],
+    "best_ask": ["115000.20", "0.540"]
+  },
+  "first_retained_event": {
+    "event_time": "2026-08-18T09:30:00.210Z",
+    "first_update_id": 900105,
+    "final_update_id": 900106
+  },
+  "required_bridge_invariant": "first_update_id <= last_update_id + 1 <= final_update_id",
+  "expected_next_update_id": 900101,
+  "observed_first_update_id": 900105,
+  "missing_update_id_range": {
+    "from": 900101,
+    "to": 900104
+  }
+}

--- a/scripts/example-catalog.test.mjs
+++ b/scripts/example-catalog.test.mjs
@@ -26,7 +26,7 @@ function copyCatalog() {
 }
 
 test('the checked-in catalog covers every discovered example unit', () => {
-  assert.equal(catalog.examples.length, 62)
+  assert.equal(catalog.examples.length, 63)
   assert.deepEqual(validateExampleCatalog(catalog, examplesRoot), [])
 })
 
@@ -43,8 +43,9 @@ test('the public schema and runtime validator use the same controlled vocabulary
 
 test('discovery uses standalone scripts and immediate example directories as units', () => {
   const discovered = discoverExampleUnits(examplesRoot)
-  assert.equal(discovered.length, 62)
+  assert.equal(discovered.length, 63)
   assert.ok(discovered.includes('basics/single-agent.ts'))
+  assert.ok(discovered.includes('cookbook/market-data-integrity-verify-loop.ts'))
   assert.ok(discovered.includes('patterns/event-driven-dag.ts'))
   assert.ok(discovered.includes('patterns/durable-approval.ts'))
   assert.ok(discovered.includes('patterns/rich-tool-results.ts'))


### PR DESCRIPTION
## Summary

- add a Binance L2 market-data integrity cookbook recipe built around the per-task verify loop
- isolate MOCK depth, trade, snapshot, collector, and policy evidence across extractors and source-specific judges
- seed a provisional `ACCEPT` that must be revised to an actionable `QUARANTINE` report
- register the example in the catalog and examples README, including the updated inventory assertion

## Why this is a verify-loop recipe

The proposer receives only locally continuous retained depth events and independent aggregate-trade activity. Snapshot-boundary metadata and collector lifecycle evidence are deliberately withheld for the judges:

- `protocol-continuity-judge` checks `snapshot-metadata.json`
- `backtest-risk-judge` checks `collector-log.txt` plus `data-quality-policy.md`

The task sets `quorum: 2`, `maxRounds: 2`, and `onDissent: "revise"`. It uses `judgePrompt: (judge) => string` for source isolation and intentionally does not set `mode`, because the custom judge prompt replaces the built-in mode instruction.

Runtime assertions require the observable path `ACCEPT -> QUARANTINE`, both judges in round one, both judges accepting round two, the exact `900101-900104` gap, the reconnect time window, source citations, and replacement-data remediation.

All fixtures are synthetic and explicitly marked **MOCK**. The example makes no exchange request and uses no exchange credentials.

## Validation

- `npm run test:example-catalog` — 9 tests passed; 63 entries validated
- strict standalone example typecheck with `tsc --noEmit` — passed
- `npm run lint -w @open-multi-agent/core` — passed
- `npm run build -w @open-multi-agent/core` — passed
- focused consensus suite — 23 tests passed
- `npm run test -w @open-multi-agent/core` — 1949 tests passed
- deterministic fixture validation — retained sequence continuous, reconstructed books uncrossed, snapshot bridge fails, and independent trades occur in the gap window
- `git diff --check` — passed

The real-provider example itself was not executed because it requires `ANTHROPIC_API_KEY`; no contributor or exchange credential was used. CI and the deterministic checks above cover compilation, catalog registration, verify-loop behavior, and fixture consistency.

Closes #540
Context: #147

@JackChen-me this implements the accepted verify-loop direction with `quorum: 2`, judge-specific source prompts, and no `mode` override.