### PR TITLE
fix(release-bot): restore the Unreleased changelog anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## 1.16.0 - 2026-08-16
 
 ### Added

--- a/packages/release-bot/src/evidence.ts
+++ b/packages/release-bot/src/evidence.ts
@@ -266,7 +266,7 @@ function parseNumstat(output: string): Map<string, Pick<ChangedFile, 'additions'
   return result
 }
 
-function extractUnreleased(changelog: string): string {
+export function extractUnreleased(changelog: string): string {
   const match = /^## Unreleased[ \t]*(?:\n|$)/m.exec(changelog)
   if (!match) throw new Error('CHANGELOG.md is missing the "## Unreleased" section.')
   const bodyStart = match.index + match[0].length

--- a/packages/release-bot/tests/changelog-invariant.test.ts
+++ b/packages/release-bot/tests/changelog-invariant.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { extractUnreleased } from '../src/evidence.js'
+
+// The scheduled release bot resolves this header before it does any analysis,
+// so a dropped `## Unreleased` surfaces as a failed Friday run instead of a
+// failed pull request. RELEASING.md requires the section to stay at the top.
+describe('repository changelog invariant', () => {
+  it('keeps Unreleased as the first section the release bot anchors on', () => {
+    const changelog = readFileSync(fileURLToPath(new URL('../../../CHANGELOG.md', import.meta.url)), 'utf8')
+
+    expect(extractUnreleased(changelog)).toBeTypeOf('string')
+    expect(/^## .*/m.exec(changelog)?.[0]).toBe('## Unreleased')
+  })
+
+  it('rejects a changelog whose Unreleased section was removed', () => {
+    expect(() => extractUnreleased('# Changelog\n\n## 1.16.0 - 2026-08-16\n\n- Shipped.\n')).toThrow(
+      /missing the "## Unreleased" section/,
+    )
+  })
+})


### PR DESCRIPTION
## Problem

The scheduled release bot run on 2026-08-21 failed 25 seconds in, before any
analysis:

    release-bot: CHANGELOG.md is missing the "## Unreleased" section.

`collectReleaseEvidence` resolves that header first and throws when it is absent.

## Root cause

`## Unreleased` was dropped from main in #523. The bot's own commit kept the
header; the follow-up manual commit that collapsed the duplicated 1.16.0
sections removed it. That duplication was itself a bot bug, fixed the same day
in #525, but the header was never restored on main. Nothing failed in between,
because no check covered the invariant that RELEASING.md states.

## Fix

Restore the header, and add a test that feeds the repository's own CHANGELOG.md
through the real extractor. It asserts the section parses and is still the first
section in the file, since the extractor alone would accept it anywhere.
`extractUnreleased` is exported for that; it stays a pure function.

An empty Unreleased body is valid and intentional here: this change is release
tooling, not core public behavior, so it earns no changelog entry.

## Verification

- Real `collectReleaseEvidence` path against this branch: baseTag v1.16.0,
  10 commits, 32 changed files, no throw.
- Negative control: removing the header again fails the new test with the exact
  message from the failed run.
- `npm run test -w @open-multi-agent/release-bot`: 35 passed across 10 files.
- `npm run lint -w @open-multi-agent/release-bot`: clean.
- `git diff --check`: clean.
