### PR TITLE
feat(release-bot): publish release notes that are not a changelog copy

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -194,6 +194,14 @@ jq -Rs '{text: ., mode: "gfm"}' < notes.md | gh api /markdown --input - | grep -
 That endpoint matches what the release page renders. A correct release body
 returns `0`.
 
+The published body is the version's changelog section followed by three sections
+the changelog does not carry. `## Packages` names every workspace version and
+says which ones were not republished. `## Thanks` credits contributors from
+outside the project, resolved from the commits between the previous release tag
+and the release commit, with the maintainer's own commits and bot commits
+excluded. `## Install` is copy-pasteable. All three are derived from the release
+commit and its own manifests, so no model output reaches them.
+
 ## What CI proves
 
 ### Before merge

--- a/packages/release-bot/src/apply-plan.ts
+++ b/packages/release-bot/src/apply-plan.ts
@@ -102,9 +102,82 @@ export function renderChangelogSections(sections: ChangelogSections): string {
     .join('\n\n')
 }
 
+const CORE_PACKAGE_NAME = '@open-multi-agent/core'
+const SCAFFOLDER_PACKAGE_NAME = 'create-oma-app'
+
 export function renderReleaseNotes(changelog: string, coreVersion: string): string {
   const section = findTopLevelSection(changelog, coreVersion, true)
   return unwrapMarkdown(changelog.slice(section.bodyStart, section.end).trim())
+}
+
+/** One published workspace as the release body reports it. */
+export interface ReleasePackageSummary {
+  readonly name: string
+  readonly version: string
+  /** False when this release left the package's version where it already was. */
+  readonly changed: boolean
+}
+
+/** One outside contributor and what they landed in this release. */
+export interface ReleaseContributor {
+  /** GitHub login when the commit carried a noreply address, else the author name. */
+  readonly name: string
+  /** What they landed, one entry per merged commit, already stripped of its type prefix. */
+  readonly contributions: readonly string[]
+}
+
+export interface ReleaseBodyInput {
+  /** Output of {@link renderReleaseNotes}. */
+  readonly notes: string
+  readonly coreVersion: string
+  readonly packages: readonly ReleasePackageSummary[]
+  /** Outside contributors only; omitted entirely when there are none. */
+  readonly contributors?: readonly ReleaseContributor[]
+}
+
+/**
+ * Compose the published release body.
+ *
+ * The changelog section alone answers "what changed" but not "what do I
+ * install", which is the first thing a reader of a release page needs. Both
+ * added sections are derived from the release commit's own manifests, so no
+ * model output reaches them.
+ */
+export function composeReleaseBody(input: ReleaseBodyInput): string {
+  const core = input.packages.find(item => item.name === CORE_PACKAGE_NAME)
+  if (!core) throw new Error(`Release body is missing the ${CORE_PACKAGE_NAME} package summary.`)
+  if (core.version !== input.coreVersion) {
+    throw new Error(`Release body core version ${core.version} does not match the rendered notes ${input.coreVersion}.`)
+  }
+
+  const packageLines = input.packages.map(item => {
+    if (!item.changed) return `- \`${item.name}\`: remains at \`${item.version}\` and is not republished`
+    if (item.name === SCAFFOLDER_PACKAGE_NAME) {
+      return `- \`${item.name}\`: \`${item.version}\`; generated starters pin core \`${input.coreVersion}\``
+    }
+    return `- \`${item.name}\`: \`${item.version}\``
+  })
+
+  // Plain names, never `@handle`: a release body that mentions an account
+  // notifies it, and this text is published without the person reviewing it.
+  const thanks = (input.contributors ?? [])
+    .filter(contributor => contributor.contributions.length > 0)
+    .map(contributor => `- ${contributor.name}: ${contributor.contributions.join('; ')}`)
+  const thanksSection = thanks.length > 0 ? `\n## Thanks\n\n${thanks.join('\n')}\n` : ''
+
+  return `${input.notes}
+
+## Packages
+
+${packageLines.join('\n')}
+${thanksSection}
+## Install
+
+\`\`\`bash
+npm i ${CORE_PACKAGE_NAME}@${input.coreVersion}
+npm create oma-app@latest my-oma
+\`\`\`
+`
 }
 
 export function buildReleasePrTitle(plan: ReleasePlan): string {

--- a/packages/release-bot/src/publisher.ts
+++ b/packages/release-bot/src/publisher.ts
@@ -1,10 +1,19 @@
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { renderReleaseNotes } from './apply-plan.js'
+import { composeReleaseBody, renderReleaseNotes, type ReleaseContributor } from './apply-plan.js'
 import type { CommandRunner } from './command.js'
 import type { GitHubClient } from './github.js'
 import type { RegistryClient } from './registry.js'
 import { compareVersions } from './semver.js'
+
+/**
+ * Accounts the Thanks section never credits.
+ *
+ * The section exists to credit people outside the project, so the maintainer's
+ * own commits are excluded. Both forms appear depending on whether a commit
+ * carried a GitHub noreply address.
+ */
+const DEFAULT_EXCLUDED_CONTRIBUTORS: readonly string[] = ['Jack Chen', 'JackChen-me']
 
 interface PackageManifest {
   readonly name?: unknown
@@ -37,6 +46,8 @@ export interface PublishReleaseOptions {
   readonly sleep?: (milliseconds: number) => Promise<void>
   /** Test seam; production always uses the npm trusted-publishing preflight. */
   readonly preflightRuntime?: () => Promise<void>
+  /** Accounts the Thanks section skips. Defaults to the maintainer's own. */
+  readonly excludedContributors?: readonly string[]
 }
 
 interface PublishTarget {
@@ -57,7 +68,20 @@ export async function publishRelease(
   const core = targets[0]
   if (!core) throw new Error('Core publish target is missing.')
   const changelog = await readFile(join(options.repoRoot, 'CHANGELOG.md'), 'utf8')
-  const releaseNotes = renderReleaseNotes(changelog, core.version)
+  // Composed before anything is published so a malformed changelog or an
+  // inconsistent manifest set still fails ahead of the registry, exactly as the
+  // notes rendering alone used to.
+  const parentVersions = await readParentVersions(options)
+  const releaseNotes = composeReleaseBody({
+    notes: renderReleaseNotes(changelog, core.version),
+    coreVersion: core.version,
+    packages: targets.map(target => ({
+      name: target.name,
+      version: target.version,
+      changed: parentVersions.get(target.path) !== target.version,
+    })),
+    contributors: await collectReleaseContributors(options),
+  })
   const tag = `v${core.version}`
 
   const localTag = await resolveTag(options.runner, options.repoRoot, tag)
@@ -131,6 +155,84 @@ export async function publishRelease(
     releaseAction: 'created',
     releaseUrl: release.htmlUrl,
   }
+}
+
+
+/** Versions this release commit's first parent carried, keyed by manifest path. */
+async function readParentVersions(
+  options: PublishReleaseOptions,
+): Promise<ReadonlyMap<string, string>> {
+  const parent = (await options.runner.run('git', ['rev-parse', `${options.expectedSha}^`], {
+    cwd: options.repoRoot,
+  })).stdout.trim()
+  const versions = new Map<string, string>()
+  for (const path of [
+    'packages/core/package.json',
+    'packages/otel/package.json',
+    'packages/create-oma-app/package.json',
+  ]) {
+    const raw = await options.runner.run('git', ['show', `${parent}:${path}`], { cwd: options.repoRoot })
+    const manifest = JSON.parse(raw.stdout) as PackageManifest
+    if (typeof manifest.version !== 'string') {
+      throw new Error(`${path} has no readable version at the release commit's parent.`)
+    }
+    versions.set(path, manifest.version)
+  }
+  return versions
+}
+
+
+/**
+ * Outside contributors whose commits land in this release, newest first.
+ *
+ * Resolved from the previous release tag reachable from the release commit's
+ * parent, not from HEAD: on an idempotent re-run this release's tag already
+ * exists, and describing from HEAD would then report an empty range and drop
+ * every contributor from the body.
+ */
+export async function collectReleaseContributors(
+  options: PublishReleaseOptions,
+): Promise<readonly ReleaseContributor[]> {
+  const previousTag = (await options.runner.run(
+    'git',
+    ['describe', '--tags', '--abbrev=0', '--match', 'v[0-9]*', `${options.expectedSha}^`],
+    { cwd: options.repoRoot },
+  )).stdout.trim()
+  if (!/^v\d+\.\d+\.\d+$/.test(previousTag)) {
+    throw new Error(`Cannot resolve a previous release tag from the release commit's parent; got "${previousTag}".`)
+  }
+
+  const log = await options.runner.run(
+    'git',
+    ['log', '--format=%an%x1f%ae%x1f%s%x1e', `${previousTag}..${options.expectedSha}`],
+    { cwd: options.repoRoot },
+  )
+  const excluded = new Set(options.excludedContributors ?? DEFAULT_EXCLUDED_CONTRIBUTORS)
+  const byName = new Map<string, string[]>()
+  for (const record of log.stdout.split('\u001e')) {
+    const line = record.trim()
+    if (line === '') continue
+    const [author = '', email = '', subject = ''] = line.split('\u001f')
+    const name = resolveContributorName(author, email)
+    if (name === '' || name.endsWith('[bot]') || excluded.has(name)) continue
+    const contribution = describeContribution(subject)
+    if (contribution === '') continue
+    const existing = byName.get(name)
+    if (existing) existing.push(contribution)
+    else byName.set(name, [contribution])
+  }
+  return [...byName].map(([name, contributions]) => ({ name, contributions }))
+}
+
+/** A GitHub noreply address carries the login; anything else only has a display name. */
+function resolveContributorName(author: string, email: string): string {
+  const noreply = /^(?:\d+\+)?(.+)@users\.noreply\.github\.com$/.exec(email.trim())
+  return (noreply?.[1] ?? author).trim()
+}
+
+/** `feat(examples): add a thing (#12)` becomes `add a thing (#12)`. */
+function describeContribution(subject: string): string {
+  return subject.replace(/^[a-z]+(?:\([^)]*\))?!?:\s*/i, '').trim()
 }
 
 async function assertReleaseCommit(options: PublishReleaseOptions): Promise<void> {

--- a/packages/release-bot/tests/apply-plan.test.ts
+++ b/packages/release-bot/tests/apply-plan.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import {
   applyReleasePlan,
   buildReleasePrBody,
+  composeReleaseBody,
   insertReleaseEntry,
   renderReleaseNotes,
 } from '../src/apply-plan.js'
@@ -165,3 +166,48 @@ async function writeText(root: string, path: string, value: string): Promise<voi
 async function version(root: string, path: string): Promise<string> {
   return (JSON.parse(await readFile(join(root, path), 'utf8')) as { version: string }).version
 }
+
+describe('published release body', () => {
+  const packages = [
+    { name: '@open-multi-agent/core', version: '1.15.0', changed: true },
+    { name: '@open-multi-agent/otel', version: '0.1.1', changed: false },
+    { name: 'create-oma-app', version: '0.8.0', changed: true },
+  ]
+
+  it('states what shipped, what did not, and how to install it', () => {
+    const body = composeReleaseBody({ notes: '### Added\n\n- Something.', coreVersion: '1.15.0', packages })
+
+    expect(body).toContain('### Added')
+    expect(body).toContain('- `@open-multi-agent/core`: `1.15.0`')
+    expect(body).toContain('- `@open-multi-agent/otel`: remains at `0.1.1` and is not republished')
+    expect(body).toContain('- `create-oma-app`: `0.8.0`; generated starters pin core `1.15.0`')
+    expect(body).toContain('npm i @open-multi-agent/core@1.15.0')
+  })
+
+  it('keeps every line unwrapped so GFM hard breaks add no line breaks', () => {
+    // A release body renders with GFM hard line breaks, where a wrapped
+    // paragraph becomes a column of <br>-separated fragments.
+    const body = composeReleaseBody({ notes: '### Added\n\n- Something.', coreVersion: '1.15.0', packages })
+    const continuations = body
+      .split('\n')
+      .filter(line => line.length > 0 && /^\s+\S/.test(line))
+
+    expect(continuations).toEqual([])
+  })
+
+  it('refuses a package set that does not carry core', () => {
+    expect(() => composeReleaseBody({
+      notes: '### Added',
+      coreVersion: '1.15.0',
+      packages: packages.filter(item => item.name !== '@open-multi-agent/core'),
+    })).toThrow(/missing the @open-multi-agent\/core package summary/)
+  })
+
+  it('refuses a core version that disagrees with the rendered notes', () => {
+    expect(() => composeReleaseBody({
+      notes: '### Added',
+      coreVersion: '1.15.1',
+      packages,
+    })).toThrow(/does not match the rendered notes/)
+  })
+})

--- a/packages/release-bot/tests/publisher.test.ts
+++ b/packages/release-bot/tests/publisher.test.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { CommandResult, CommandRunner, RunCommandOptions } from '../src/command.js'
 import type { CreatePullRequestInput, CreateReleaseInput, GitHubClient, GitHubPullRequest, GitHubRelease } from '../src/github.js'
-import { publishRelease } from '../src/publisher.js'
+import { collectReleaseContributors, publishRelease } from '../src/publisher.js'
 import type { RegistryClient, RegistryVersion } from '../src/registry.js'
 
 const roots: string[] = []
@@ -49,7 +49,21 @@ describe('deterministic publisher', () => {
       tagName: 'v1.15.0',
       targetCommitish: sha,
     })
-    expect(github.createdRelease?.body).toContain('### Added')
+    const body = github.createdRelease?.body ?? ''
+    expect(body).toContain('### Added')
+    // A reader of the release page needs what shipped and how to install it,
+    // neither of which the changelog section carries.
+    expect(body).toContain('## Packages')
+    expect(body).toContain('- `@open-multi-agent/core`: `1.15.0`')
+    expect(body).toContain('- `create-oma-app`: `0.8.0`; generated starters pin core `1.15.0`')
+    expect(body).toContain('- `@open-multi-agent/otel`: remains at `0.1.1` and is not republished')
+    expect(body).toContain('## Install')
+    expect(body).toContain('@open-multi-agent/core@1.15.0')
+    // Outside contributors only: the maintainer and the bot are filtered out.
+    expect(body).toContain('## Thanks')
+    expect(body).toContain('- green3sf: add a verify loop (#541)')
+    expect(body).not.toContain('Jack Chen')
+    expect(body).not.toContain('oma-release-bot')
 
     runner.publishedWorkspaces.length = 0
     const resumed = await publishRelease({
@@ -137,6 +151,21 @@ class PublishRunner implements CommandRunner {
     if (args[0] === 'show' && args[1]?.endsWith(':packages/create-oma-app/package.json')) {
       return success('{"name":"create-oma-app","version":"0.7.0"}\n')
     }
+    // Unchanged across the release commit, so the body must report it as not republished.
+    if (args[0] === 'show' && args[1]?.endsWith(':packages/otel/package.json')) {
+      return success('{"name":"@open-multi-agent/otel","version":"0.1.1"}\n')
+    }
+    if (args[0] === 'describe' && args[args.length - 1] === `${this.sha}^`) {
+      return success('v1.14.0\n')
+    }
+    if (args[0] === 'log' && args[2] === `v1.14.0..${this.sha}`) {
+      // One outside contributor, the maintainer, and the release bot itself.
+      return success([
+        'green3sf\u001f222944370+green3sf@users.noreply.github.com\u001ffeat(examples): add a verify loop (#541)\u001e',
+        'Jack Chen\u001fchenkaijie01@gmail.com\u001ffix(core): export public config types (#533)\u001e',
+        'oma-release-bot[bot]\u001f1+oma-release-bot[bot]@users.noreply.github.com\u001fchore: release core v1.15.0 (#543)\u001e',
+      ].join(''))
+    }
     if (args[0] === 'rev-parse' && args[1] === 'refs/tags/v1.15.0^{commit}') {
       return this.tagSha ? success(`${this.tagSha}\n`) : { stdout: '', stderr: 'missing', exitCode: 128 }
     }
@@ -208,3 +237,61 @@ async function writeText(root: string, path: string, value: string): Promise<voi
   await mkdir(dirname(absolute), { recursive: true })
   await writeFile(absolute, value)
 }
+
+describe('release contributor collection', () => {
+  const runner = (log: string, tag = 'v1.14.0'): CommandRunner => ({
+    run: async (command: string, args: readonly string[] = []): Promise<CommandResult> => {
+      if (command === 'git' && args[0] === 'describe') return success(`${tag}\n`)
+      if (command === 'git' && args[0] === 'log') return success(log)
+      throw new Error(`unexpected: ${command} ${args.join(' ')}`)
+    },
+  })
+
+  const record = (author: string, email: string, subject: string) =>
+    `${author}\u001f${email}\u001f${subject}\u001e`
+
+  it('groups a contributor and strips the conventional-commit prefix', async () => {
+    const contributors = await collectReleaseContributors({
+      repoRoot: '/tmp/unused', expectedSha: 'c'.repeat(40),
+      runner: runner([
+        record('green3sf', '9+green3sf@users.noreply.github.com', 'feat(examples): add a verify loop (#541)'),
+        record('green3sf', '9+green3sf@users.noreply.github.com', 'fix(orchestrator): refresh output (#536)'),
+      ].join('')),
+    } as Parameters<typeof collectReleaseContributors>[0])
+
+    expect(contributors).toEqual([
+      { name: 'green3sf', contributions: ['add a verify loop (#541)', 'refresh output (#536)'] },
+    ])
+  })
+
+  it('falls back to the author name when the address is not a GitHub noreply', async () => {
+    const contributors = await collectReleaseContributors({
+      repoRoot: '/tmp/unused', expectedSha: 'c'.repeat(40),
+      runner: runner(record('Ada Lovelace', 'ada@example.com', 'fix(core): tighten a guard (#12)')),
+    } as Parameters<typeof collectReleaseContributors>[0])
+
+    expect(contributors).toEqual([
+      { name: 'Ada Lovelace', contributions: ['tighten a guard (#12)'] },
+    ])
+  })
+
+  it('honours an explicit exclusion list', async () => {
+    const contributors = await collectReleaseContributors({
+      repoRoot: '/tmp/unused', expectedSha: 'c'.repeat(40),
+      excludedContributors: ['Ada Lovelace'],
+      runner: runner(record('Ada Lovelace', 'ada@example.com', 'fix(core): tighten a guard (#12)')),
+    } as Parameters<typeof collectReleaseContributors>[0])
+
+    expect(contributors).toEqual([])
+  })
+
+  it('fails closed when no previous release tag resolves', async () => {
+    // Silently returning an empty list here would drop every contributor from
+    // a published release body without anything reporting it.
+    await expect(collectReleaseContributors({
+      repoRoot: '/tmp/unused', expectedSha: 'c'.repeat(40),
+      runner: runner('', 'not-a-tag'),
+    } as Parameters<typeof collectReleaseContributors>[0]))
+      .rejects.toThrow(/Cannot resolve a previous release tag/)
+  })
+})


### PR DESCRIPTION
## Why

`renderReleaseNotes` returned the version's changelog section, unwrapped, and
that was the entire published body. The section heading in the release contract
is titled "Release notes are not a copy of the changelog", but nothing made that
true, and the section itself only described line wrapping.

The concrete cost showed up in 1.16.1, published today. green3sf landed #536 and
#541 in that release. The release page credits nobody. The hand-written notes
from before the bot existed did credit contributors: v1.14.0 names HarperZ9 and
says what they contributed.

## What the body carries now

Three sections follow the changelog section, all derived from the release commit
itself so no model output reaches them:

    ## Packages

    - `@open-multi-agent/core`: `1.16.1`
    - `@open-multi-agent/otel`: remains at `0.1.2` and is not republished
    - `create-oma-app`: `0.8.2`; generated starters pin core `1.16.1`

    ## Thanks

    - green3sf: add market data integrity verify loop (#541); refresh structured output after verify revision (#536)

    ## Install

    ```bash
    npm i @open-multi-agent/core@1.16.1
    npm create oma-app@latest my-oma
    ```

`Packages` compares each manifest against the release commit's first parent, so
"not republished" reflects what this release actually moved rather than what the
registry happened to hold at publish time.

`Thanks` lists contributors from outside the project. Bot commits and the
maintainer's own are excluded, so the section says what its heading claims; it is
omitted entirely when nothing remains. Logins come from GitHub noreply addresses
when a commit carries one, and fall back to the author's display name otherwise.
Names are plain rather than mentions: this body is published without the person
reviewing it, and a mention would notify them.

## Ordering

The body is still composed before the first publish, so a malformed changelog or
an inconsistent manifest set fails ahead of the registry exactly as it did
before. Nothing moved to after the publish loop.

The previous release tag is resolved from the release commit's first parent, not
from HEAD. On an idempotent re-run this release's tag already exists, and
describing from HEAD would report an empty range and drop every contributor
without anything reporting it. Failing to resolve a previous tag throws rather
than returning an empty list, for the same reason.

## Verification

- Ran the collection against the real 1.16.1 history: it returns green3sf with
  both contributions, conventional-commit prefixes stripped, and excludes both
  the maintainer and the release bot.
- Rendered the full body from the current changelog and ran the contract's own
  check, `jq -Rs '{text: ., mode: "gfm"}' | gh api /markdown | grep -c '<br>'`.
  It returns `0`, which is what the contract requires.
- A test asserts no line in the body is an indented continuation, which is the
  structural property that check depends on.
- `npm run lint`: exit 0. `npm test`: exit 0; release-bot goes from 35 to 43
  tests. `git diff --check`: clean.

## Not included

The hand-written notes grouped changes under feature headings ordered by impact
rather than under the changelog's Added/Changed/Fixed taxonomy. Reproducing that
means changing the planner's changelog schema, which would change `CHANGELOG.md`
structure too. That is a separate decision, not a rendering change.
