### PR TITLE
fix(core): align JSON Schema required fields with Zod

### DIFF
--- a/packages/core/src/tool/framework.ts
+++ b/packages/core/src/tool/framework.ts
@@ -370,12 +370,7 @@ function convertZodType(schema: ZodSchema): Record<string, unknown> {
       for (const [key, value] of Object.entries(objectDef.shape())) {
         properties[key] = convertZodType(value as ZodSchema)
 
-        const innerDef = ((value as ZodSchema) as unknown as { _def: ZodTypeDef })._def
-        const isOptional =
-          innerDef.typeName === ZodTypeName.ZodOptional ||
-          innerDef.typeName === ZodTypeName.ZodDefault ||
-          innerDef.typeName === ZodTypeName.ZodNullable
-        if (!isOptional) {
+        if (!(value as ZodSchema).isOptional()) {
           required.push(key)
         }
       }

--- a/packages/core/tests/tool-executor.test.ts
+++ b/packages/core/tests/tool-executor.test.ts
@@ -317,6 +317,26 @@ describe('ToolRegistry', () => {
     expect(defs[0].name).toBe('echo')
     expect(defs[0].inputSchema).toHaveProperty('properties')
   })
+
+  it('marks nullable inputs as required when Zod rejects omission', () => {
+    const inputSchema = z.object({
+      requiredNullable: z.string().nullable(),
+      optional: z.string().optional(),
+    })
+    const registry = new ToolRegistry()
+    registry.register(defineTool({
+      name: 'nullable_input',
+      description: 'Accepts a required nullable value.',
+      inputSchema,
+      execute: async () => ({ data: 'ok' }),
+    }))
+
+    const [definition] = registry.toToolDefs()
+
+    expect(inputSchema.safeParse({}).success).toBe(false)
+    expect(inputSchema.safeParse({ requiredNullable: null }).success).toBe(true)
+    expect(definition.inputSchema).toMatchObject({ required: ['requiredNullable'] })
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Align generated JSON Schema `required` fields with Zod's actual missing-input behavior.
- Add a regression test for a required nullable tool input alongside an optional input.

## Motivation

`z.string().nullable()` accepts `null`, but it still rejects an omitted field. The converter treated every `ZodNullable` field as optional, so an LLM could omit an input that the tool executor would immediately reject. Using Zod's own optionality check keeps the advertised contract and runtime validation in sync.

## Scope and impact

- Affected area: `@open-multi-agent/core` tool and structured-output JSON Schema generation.
- Behavior change: required nullable fields now appear in the generated `required` array; genuinely optional fields remain excluded.
- Public TypeScript API, dependencies, migration, security, and privacy impact: None.
- Non-goals: no changes to how nullable values are represented or how unsupported Zod types are converted.

## Validation

- Regression before the fix: `npm exec --workspace @open-multi-agent/core vitest -- run tests/tool-executor.test.ts -t 'marks nullable inputs as required when Zod rejects omission'` failed as expected because `required` was absent.
- Regression after the fix: the same command passed.
- `npm run test -w @open-multi-agent/core` — 131 files and 1,950 tests passed.
- `npm test` — all workspace, example-catalog, and benchmark tests passed.
- `npm run lint` — passed.
- `npm run build` — passed.
- `git diff --cached --check` — passed.

## Checklist

- [x] Tests were added or updated for changed behavior, or a rationale is provided
- [x] User-facing documentation and examples were updated, or this is not applicable
- [x] Compatibility, breaking changes, and migration requirements are documented, or this is not applicable
- [x] Dependency changes are justified and preserve the package ownership boundaries documented in CONTRIBUTING
