### PR TITLE
docs: list Atlas Cloud voucher codes in the setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Paid sponsors supporting `open-multi-agent`. Sponsorship does not affect technic
 
 **Providers**
 
-- **[Atlas Cloud](https://www.atlascloud.ai/console/coding-plan)**: Full-modal AI inference platform giving one API for video, image, and LLM across 300+ curated models. OMA users can request a limited $5 credit voucher. See the [Atlas Cloud setup guide](docs/providers-atlascloud.md).
+- **[Atlas Cloud](https://www.atlascloud.ai/console/coding-plan)**: Full-modal AI inference platform giving one API for video, image, and LLM across 300+ curated models. $5 credit vouchers for OMA users, first come first served. See the [Atlas Cloud setup guide](docs/providers-atlascloud.md).
 
 ## When OMA fits
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -158,7 +158,7 @@ OMA 将动态编排与生产所需的控制、证据和恢复能力结合起来�
 
 **Provider**
 
-- **[Atlas Cloud](https://www.atlascloud.ai/console/coding-plan)**：全模态 AI 推理平台，单一 API 打通视频、图像与 LLM，覆盖 300+ 精选模型。OMA 用户可申请限量 $5 credit 兑换码。见 [Atlas Cloud 接入指南](docs/providers-atlascloud_zh.md)。
+- **[Atlas Cloud](https://www.atlascloud.ai/console/coding-plan)**：全模态 AI 推理平台，单一 API 打通视频、图像与 LLM，覆盖 300+ 精选模型。$5 credit 兑换码面向 OMA 用户开放，先到先得。见 [Atlas Cloud 接入指南](docs/providers-atlascloud_zh.md)。
 
 ## OMA 适合什么场景
 

--- a/docs/providers-atlascloud.md
+++ b/docs/providers-atlascloud.md
@@ -6,9 +6,19 @@ Atlas Cloud is a full-modal AI inference platform that gives developers a single
 
 ## OMA user vouchers
 
-20 limited vouchers ($5 each) available to OMA users on a first-come-first-serve basis.
+$5 Atlas Cloud vouchers for OMA users, first come first served. Take one code and leave the rest for others.
 
-**How to apply**: Email [jack@yuanasi.com](mailto:jack@yuanasi.com) with your GitHub username and a one-line use case. We'll reply with a voucher code by email (limited supply).
+```
+37699C92-8CCC-4224-963E-126CC2475C3B
+E4D81992-9FB2-4823-A970-D90E58DB0377
+29A2888B-F8B3-4157-A6EA-705781815EA6
+BDA10EA7-1F2D-48EF-BF26-F37EEE325B1B
+DCD47541-22BE-4314-BF6B-9EE031E5F421
+```
+
+Redeem a code on the Atlas Cloud [Claim Your Model Rewards](https://www.atlascloud.ai/event/claim-model-rewards) page.
+
+If every code above has already been claimed, email [jack@yuanasi.com](mailto:jack@yuanasi.com) with your GitHub username and a one-line use case. Supply is limited, so we can't promise one.
 
 Disclosure: Sponsorship from Atlas Cloud; vouchers are limited and don't constitute paid endorsement of any model or feature.
 

--- a/docs/providers-atlascloud_zh.md
+++ b/docs/providers-atlascloud_zh.md
@@ -6,9 +6,19 @@ Atlas Cloud 是一个全模态 AI 推理平台，通过单一 API 为开发者�
 
 ## OMA 用户专属兑换码
 
-OMA 用户可申请 20 张 $5 兑换码（先到先得）。
+面向 OMA 用户的 $5 Atlas Cloud 兑换码，先到先得。每人取用一张，其余留给他人。
 
-**申请方式**：邮件 [jack@yuanasi.com](mailto:jack@yuanasi.com)，附 GitHub 用户名 + 一句话用途。我们会邮件回复 code（数量有限）。
+```
+37699C92-8CCC-4224-963E-126CC2475C3B
+E4D81992-9FB2-4823-A970-D90E58DB0377
+29A2888B-F8B3-4157-A6EA-705781815EA6
+BDA10EA7-1F2D-48EF-BF26-F37EEE325B1B
+DCD47541-22BE-4314-BF6B-9EE031E5F421
+```
+
+在 Atlas Cloud [领取模型奖励](https://www.atlascloud.ai/zh/event/claim-model-rewards)页面兑换。
+
+若上述兑换码均已被领取，可邮件 [jack@yuanasi.com](mailto:jack@yuanasi.com)，附 GitHub 用户名与一句话用途。数量有限，恕不保证仍有余量。
 
 声明：赞助来自 Atlas Cloud；兑换码数量有限，不构成对任何模型或功能的付费背书。
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -228,7 +228,7 @@ See [Providers](https://github.com/open-multi-agent/open-multi-agent/blob/main/d
 
 Paid sponsors supporting `open-multi-agent`. Sponsorship does not affect technical decisions or model recommendations.
 
-- **[Atlas Cloud](https://www.atlascloud.ai/console/coding-plan)**: Full-modal AI inference platform giving one API for video, image, and LLM across 300+ curated models. OMA users can request a limited $5 credit voucher. See the [Atlas Cloud setup guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers-atlascloud.md).
+- **[Atlas Cloud](https://www.atlascloud.ai/console/coding-plan)**: Full-modal AI inference platform giving one API for video, image, and LLM across 300+ curated models. $5 credit vouchers for OMA users, first come first served. See the [Atlas Cloud setup guide](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers-atlascloud.md).
 
 ## Production
 

--- a/packages/core/README_zh.md
+++ b/packages/core/README_zh.md
@@ -223,7 +223,7 @@ Coordinator -> 任务 DAG -> Scheduler -> AgentPool
 
 支持 `open-multi-agent` 的付费赞助商。赞助不影响技术决策与模型推荐。
 
-- **[Atlas Cloud](https://www.atlascloud.ai/console/coding-plan)**：全模态 AI 推理平台，单一 API 打通视频、图像与 LLM，覆盖 300+ 精选模型。OMA 用户可申请限量 $5 credit 兑换码。见 [Atlas Cloud 接入指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers-atlascloud_zh.md)。
+- **[Atlas Cloud](https://www.atlascloud.ai/console/coding-plan)**：全模态 AI 推理平台，单一 API 打通视频、图像与 LLM，覆盖 300+ 精选模型。$5 credit 兑换码面向 OMA 用户开放，先到先得。见 [Atlas Cloud 接入指南](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/providers-atlascloud_zh.md)。
 
 ## 生产配置
 


### PR DESCRIPTION
## What

- List five Atlas Cloud voucher codes directly in `docs/providers-atlascloud.md` and `docs/providers-atlascloud_zh.md`, replacing the "email to apply" instruction.
- Add the Atlas Cloud redemption link to each guide, language matched: `/event/claim-model-rewards` for EN, `/zh/event/claim-model-rewards` for ZH.
- Keep an email fallback for readers who arrive after every listed code is claimed.
- Update the root and core package READMEs (EN + ZH) so the sponsor bullet no longer says vouchers are requested by email.

## Why

Emailing for a $5 credit is more friction than the credit is worth, so readers who would have tried Atlas Cloud through OMA mostly did not ask. Publishing the codes removes the wait between wanting to try a provider and being able to.

## Notes

- The section deliberately states no total. Naming a number turns the doc into inventory state that cannot be kept accurate, and the list already carries that information: refreshing a batch means editing the list, not rewording the section.
- Redeemed codes get deleted from the list rather than struck through, so a reader never works through dead codes.
- Both redemption URLs were checked: HTTP 200, no redirect, and each link text matches that page's own title.
- Docs only. Validation: `git diff --check` clean; no code, catalog metadata, or executable examples touched.

Follow-up to #415.
