### PR TITLE
feat(core): opt-in append-only run event journal (#527)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@ These constraints span multiple files and can cause behavioral or compatibility 
 | Providers, environment variables, local servers, and AI SDK | [docs/providers.md](docs/providers.md) |
 | Shared memory and custom stores | [docs/shared-memory.md](docs/shared-memory.md) |
 | Checkpoint and restore | [docs/checkpoint.md](docs/checkpoint.md) |
+| Run event journal, lineage, and the model-visible boundary | [docs/run-journal.md](docs/run-journal.md) |
 | Tracing, stores, progress, Run Viewer, privacy, and OpenTelemetry | [docs/observability.md](docs/observability.md) |
 | Evaluation, scorers, stores, reports, sampling, and gates | [docs/evaluation.md](docs/evaluation.md) |
 | CLI commands and JSON schemas | [docs/cli.md](docs/cli.md) |

--- a/docs/run-journal.md
+++ b/docs/run-journal.md
@@ -1,0 +1,175 @@
+# Run Event Journal
+
+The run journal is an append-only log of what happened inside one run: which messages entered a conversation, which blocks the model actually saw, which tools ran and what they returned, how the plan and task states moved, and where checkpoints landed. It answers a question the other three records cannot — **why did the model see this?**
+
+It is **opt-in and off by default**, and costs nothing when it is off: no recorder is allocated and every emission site is guarded, so a run without a journal behaves exactly as it did before the feature existed.
+
+The journal is not the recovery mechanism. [Checkpoint snapshots](checkpoint.md) remain the durable recovery anchor; the journal is additive audit state alongside them.
+
+## Enable it
+
+Pass a backend per call, or set a default for every run via `OrchestratorConfig.journal`. Per-call values override the config default, and `journal: false` disables it for one run.
+
+```typescript
+import { OpenMultiAgent, Team, InMemoryRunJournal } from '@open-multi-agent/core'
+
+const journal = new InMemoryRunJournal()
+const orchestrator = new OpenMultiAgent()
+
+await orchestrator.runTasks(team, tasks, { journal })
+
+for (const event of await journal.readFrom(0)) {
+  console.log(event.seq, event.type)
+}
+```
+
+You always supply the instance, because a journal nobody can read back is useless. There is deliberately no `journal: true` shorthand, and the framework never calls `close()` on your backend — you own its lifecycle, exactly as you own a `MemoryStore`.
+
+`runAgent`, `runTeam`, `runTasks`, `runFromPlan`, and `restore` all accept `journal`. `RestoreOptions` inherits the field from `RunTasksOptions`.
+
+### `RunJournalOptions`
+
+Pass a bare backend for the common case, or the options object when you need the switches:
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `journal` | `RunJournal` | — | The backend. Required. |
+| `enabled` | `boolean` | `true` | Set `false` to disable while keeping the field. |
+| `enforceLineage` | `boolean` | `false` | Throw instead of recording an unexplained model-visible block. See [Lineage](#lineage-and-the-model-visible-boundary). |
+
+```typescript
+await orchestrator.runTasks(team, tasks, {
+  journal: { journal, enforceLineage: true },
+})
+```
+
+## Backends
+
+`RunJournal` is a small append-only interface, deliberately separate from `MemoryStore`: `MemoryStore` is key/value shaped and `FileStore` rewrites its whole file per write, so appending one event per model call through either would cost O(store size) per event.
+
+```typescript
+interface RunJournal {
+  append(events: readonly RunEvent[]): Promise<void>
+  readFrom(seq: number): Promise<RunEvent[]>
+  close(): Promise<void>
+}
+```
+
+### `InMemoryRunJournal`
+
+A bounded ring buffer for auditing a run inside one process. `maxEvents` defaults to 10 000; eviction drops the oldest events, so `readFrom` returns the retained tail rather than the whole run. Exposes `size`.
+
+```typescript
+const journal = new InMemoryRunJournal({ maxEvents: 50_000 })
+```
+
+### `JsonlRunJournal`
+
+A zero-dependency JSONL file — one event per line, append-only, Node built-ins only.
+
+```typescript
+import { JsonlRunJournal } from '@open-multi-agent/core'
+
+const journal = new JsonlRunJournal('./.oma/run.jsonl', { flushIntervalMs: 50 })
+try {
+  await orchestrator.runTasks(team, tasks, { journal })
+} finally {
+  await journal.close() // flushes the open batch and closes the fd
+}
+```
+
+- **Batched flush with a fixed deadline.** The first pending event opens the window; later events do not reset it. A burst of turns costs one write instead of one per event, while a quiet run still lands within `flushIntervalMs` (default 50 ms).
+- **One write per batch, then `fsync`.** A reader sees whole records, never half of one.
+- **Crash window = the current unflushed batch.** Everything up to the last completed batch is on disk. `close()` flushes the rest.
+- **`readFrom` tolerates one trailing partial line**, which is what a crash mid-write leaves behind. Corruption anywhere else throws rather than silently dropping events.
+- **One writer per file, no cross-process lock** — the same scope statement `FileStore` makes.
+
+Redaction uses the same option shape as [`RedactingStore`](shared-memory.md) and runs at write time, so `readFrom` returns what was persisted:
+
+```typescript
+new JsonlRunJournal('./.oma/run.jsonl', { redact: { patterns: [/\bcust-\d+\b/g] } })
+```
+
+## Event vocabulary
+
+Every event carries `seq` (1-based, strictly increasing per `runId` across attempts), `timestampUnixMs`, `runId`, `attempt`, and — where they apply — `taskId`, `agentName`, `traceId`/`spanId`, and `sourceEventSeqs`.
+
+| `type` | Payload beyond the base | Emitted when |
+|---|---|---|
+| `run/start` | `mode`, `goal?`, `metadata?` | A run begins, once per entry point |
+| `run/end` | `status`, `error?` | The run's trace closes, on every exit path |
+| `plan/set` | `revision`, `source`, `tasks`, `detail?` | A plan is loaded (`'initial'`) or repaired (`'recovery'`) |
+| `task/status` | `status`, `reason?` | A task moves to `in_progress`, `completed`, `failed`, or `skipped` |
+| `turn/start` | `turn` | A model turn opens |
+| `turn/end` | `turn`, `outcome` | A model turn closes, with why |
+| `user/message` | `message`, `origin` | A user-role message enters the conversation |
+| `assistant/message` | `message`, `origin`, `usage?`, `model?`, `stopReason?` | An assistant message enters the conversation |
+| `llm/request` | `turn`, `model`, `blocks`, `systemPromptHash?`, `toolsHash?` | Immediately before an adapter call |
+| `tool/call` | `call` | The model requested a tool, before execution |
+| `tool/result` | `toolCallId`, `result`, `record?` | A tool result committed |
+| `memory/set` | `agent`, `key`, `valueBytes?` | A task result was written to shared memory |
+| `approval/request` | `request` | A durable approval boundary was persisted |
+| `approval/decision` | `decision` | A durable decision was reconciled or made |
+| `checkpoint/saved` | `mode`, `version`, `watermarkSeq` | A snapshot was persisted |
+
+`sourceEventSeqs` conventions: an `assistant/message` names its `llm/request`; a `tool/call` names its `assistant/message`; a `tool/result` names its `tool/call`; a `user/message` with `origin: 'tool_results'` names the `tool/result` events assembled into it.
+
+**`task/status` records four states, not six.** The `pending` and `blocked` starting states are already carried by `plan/set`, so the journal does not repeat them. Terminal transitions are recorded from the task queue rather than the dispatch loop, which is why cascaded failures and skips — transitions no dispatch site ever sees — appear too.
+
+**`checkpoint/saved.watermarkSeq`** names the last event the snapshot folds, which is the event before the save record itself. Snapshots stay at schema v4 in this release; the watermark becomes part of the snapshot in a later one.
+
+### Scope
+
+Journaling follows the standard runner plumbing, so it covers `runAgent`, coordinator decomposition and synthesis, `runTeam` short-circuit runs, worker tasks, and delegated child runs. Delegated conversations journal under their own `agentName` within the same task scope, interleaved into one ordered stream — which is the correct reading of a run where several agents were live at once.
+
+Not journaled in this release: `runConsensus` and per-task consensus judges, the semantic execution-router profiler, and orchestrator decision events (`routing/decision`, `consensus/verdict`, `recovery/decision`). Plan repairs still land as `plan/set` with `source: 'recovery'`.
+
+## Lineage and the model-visible boundary
+
+**The model-visible boundary is the IR conversation (`LLMMessage[]`) handed to `adapter.chat()` / `adapter.stream()`.** Everything below it — provider wire format, reasoning echo and downgrade rules, `preserveReasoningAsText` — is deterministic per adapter and out of scope. The system prompt and tool definitions are caller-supplied config rather than conversation state, so `llm/request` records `systemPromptHash` and `toolsHash` instead of their bytes.
+
+`llm/request` does not store the conversation. The conversation is re-sent every turn, so storing it verbatim would grow the journal with the square of the turn count. It stores one descriptor per block:
+
+```typescript
+interface RequestBlockDescriptor {
+  messageIndex: number
+  blockIndex: number
+  role: 'user' | 'assistant'
+  blockType: ContentBlock['type']
+  sourceEventSeqs: readonly number[] | null  // null = no recorded lineage
+  contentHash: string                        // sha256 of canonical JSON
+}
+```
+
+Lineage is keyed on **block identity**, not message identity: context strategies rebuild message objects but pass untouched blocks through by reference, so block identity survives a rewrite where message identity does not. `canonicalContentHash` is exported so an offline reader can recompute the same digest from a journal read cold off disk.
+
+### `enforceLineage`
+
+With `enforceLineage: false` (the default), a block whose origin was never recorded is written as the gap it is: `sourceEventSeqs: null`. With `enforceLineage: true`, it throws `JournalLineageError` (`code: 'MISSING_CONTEXT_REPLACE'`, carrying `messageIndex`, `blockIndex`, and `blockType`) before the adapter call, at the exact request that would otherwise have hidden it. The error is terminal for orchestrator retries — the same conversation would fail identically on every attempt.
+
+**In this release, `enforceLineage: true` correctly fails any run that configures a context strategy.** `sliding-window`, `summarize`, `compact`, `compressToolResults`, and custom strategies all rewrite the conversation into blocks no journal event produced, and there is no event yet that can name a rewrite. That is the invariant working, not a bug: the journal is telling you it cannot explain what the model saw. A later release adds a `context/replace` event that gives each derived block a lineage, after which enforcement passes with every built-in strategy.
+
+Two other gaps are worth naming while they exist:
+
+- **Restored runs.** A run resumed from a checkpoint does not re-emit the conversation the previous attempt journaled — that would duplicate the events the seqs point at — so the restored blocks carry no lineage until checkpoint-persisted lineage lands.
+- **Structured-output repair.** The corrective retry behind `outputSchema` is a second model-visible conversation, so it is journaled as one: its messages are re-seeded rather than deduplicated against the first attempt.
+
+## Writes are best-effort
+
+A failed append is reported once per failure through `onProgress` and never fails the run:
+
+```typescript
+new OpenMultiAgent({
+  onProgress(event) {
+    if (event.type === 'error' && (event.data as { kind?: string }).kind === 'journal_append_failed') {
+      metrics.increment('oma.journal.append_failed')
+    }
+  },
+})
+```
+
+This holds at approval boundaries too, where ordinary checkpoint saves escalate. Durability there is the [durable approval ledger](durable-approvals.md)'s job; the journal only records that the boundary existed. Losing the audit trail must never roll back a run that actually happened.
+
+## Journal versus telemetry
+
+[Trace records](observability.md) and journal events describe the same run and deliberately do not depend on each other. Traces are **telemetry**: losing them must never roll back durable state, and they may be sampled, batched, exported, or dropped. Journal events are **execution state**: they record what the run did and what the model saw. The `journal/` module does not import from `observability/`, so trace loss cannot imply journal loss and neither can the reverse. Events carry `traceId`/`spanId` when a trace runtime is active, which is enough to join the two streams without coupling them.

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -42,7 +42,10 @@ import type {
   ApprovalRequest,
   ToolCallApprovalContent,
 } from '../types.js'
-import { LLMCallTimeoutError, TokenBudgetExceededError } from '../errors.js'
+import { JournalLineageError, LLMCallTimeoutError, TokenBudgetExceededError } from '../errors.js'
+import type { RequestBlockDescriptor, TurnOutcome } from '../journal/events.js'
+import { canonicalJsonHash } from '../journal/hash.js'
+import type { JournalRecorder } from '../journal/journal.js'
 import { LoopDetector } from './loop-detector.js'
 import { emitTrace, generateSpanId } from '../utils/trace.js'
 import { mergeAbortSignals } from '../utils/abort.js'
@@ -205,6 +208,12 @@ export interface RunOptions {
   readonly onToolResult?: (name: string, result: ToolResult<any>) => void
   /** Fired after each complete {@link LLMMessage} is appended. */
   readonly onMessage?: (message: LLMMessage) => void
+  /**
+   * Internal per-run journal emitter. Present only when the caller configured a
+   * journal; every emission site guards on it, so an unjournaled run allocates
+   * nothing and behaves exactly as before. Custom backends may ignore it.
+   */
+  readonly journal?: JournalRecorder
   /**
    * Internal checkpoint state supplied by the orchestrator when resuming an
    * interrupted task. Custom backends may ignore it.
@@ -905,6 +914,35 @@ export class AgentRunner implements AgentBackend {
     let pendingToolResultText = restored?.pendingToolResultText
     let loopWarned = restored?.loopWarned ?? false
 
+    // --- Run journal (absent unless the caller configured one) -------------
+    const journal = options.journal
+    const journalScope = journal ? this.journalScope(options) : undefined
+    /** Turn awaiting a `turn/end`, so every exit path closes exactly one. */
+    let journalOpenTurn: number | undefined
+    let journalAssistantSeq: number | undefined
+    const journalToolResultSeqs = new Map<string, number>()
+    const emitTurnEnd = (outcome: TurnOutcome): void => {
+      if (!journal || journalOpenTurn === undefined) return
+      journal.emit({ type: 'turn/end', ...journalScope, turn: journalOpenTurn, outcome })
+      journalOpenTurn = undefined
+    }
+    if (journal && restored === undefined) {
+      // A restored run's conversation was already journaled by the attempt that
+      // built it; re-emitting it here would duplicate the events its seqs point
+      // at. Its blocks therefore carry no lineage until checkpoint-restored
+      // lineage lands.
+      for (const message of conversationMessages) {
+        const seq = message.role === 'user'
+          ? journal.emit({
+              type: 'user/message', ...journalScope, message, origin: 'input',
+            })
+          : journal.emit({
+              type: 'assistant/message', ...journalScope, message, origin: 'seed',
+            })
+        journal.registerMessage(message, [seq])
+      }
+    }
+
     // Build the stable LLM options once; model / tokens / temp don't change.
     // resolveTools() returns LLMToolDef[] with default-deny + filtering applied.
     const toolDefs = this.resolveTools()
@@ -968,6 +1006,18 @@ export class AgentRunner implements AgentBackend {
       abortSignal: effectiveAbortSignal,
     }
 
+    // The system prompt and tool definitions are caller-supplied config, not
+    // conversation state, so `llm/request` records digests of them once rather
+    // than their bytes on every turn.
+    const journalRequestConfig = journal
+      ? {
+          ...(this.options.systemPrompt !== undefined
+            ? { systemPromptHash: canonicalJsonHash(this.options.systemPrompt) }
+            : {}),
+          ...(toolDefs.length > 0 ? { toolsHash: canonicalJsonHash(toolDefs) } : {}),
+        }
+      : undefined
+
     // Loop detection state — only allocated when configured.
     const detector = this.options.loopDetection
       ? new LoopDetector(this.options.loopDetection)
@@ -1003,6 +1053,23 @@ export class AgentRunner implements AgentBackend {
             options,
             runShellExecutor,
           )
+          if (journal) {
+            for (const pending of pendingToolCalls) {
+              // Restored commits already happened, and a re-entered round
+              // (an uncommitted sibling) must not announce a call twice.
+              if (pending.commit) continue
+              if (journal.toolCallSeq(pending.call.id) !== undefined) continue
+              const callSeq = journal.emit({
+                type: 'tool/call',
+                ...journalScope,
+                call: pending.call,
+                ...(journalAssistantSeq !== undefined
+                  ? { sourceEventSeqs: [journalAssistantSeq] }
+                  : {}),
+              })
+              journal.recordToolCallSeq(pending.call.id, callSeq)
+            }
+          }
           const executions = await Promise.all(pendingToolCalls.map(async (pending, index) => {
             if (pending.commit) {
               return { commit: pending.commit, shouldCommit: true } satisfies ToolExecution
@@ -1058,6 +1125,17 @@ export class AgentRunner implements AgentBackend {
                 await options.onApprovalConsumed?.(pending.approvalRequest.id)
               }
               pendingToolCalls[index] = { call: pending.call, commit: execution.commit }
+              if (journal) {
+                const callSeq = journal.toolCallSeq(pending.call.id)
+                journalToolResultSeqs.set(pending.call.id, journal.emit({
+                  type: 'tool/result',
+                  ...journalScope,
+                  toolCallId: pending.call.id,
+                  result: execution.commit.result,
+                  record: execution.commit.record,
+                  ...(callSeq !== undefined ? { sourceEventSeqs: [callSeq] } : {}),
+                }))
+              }
               // Await the checkpoint before any fallible result callback so a
               // callback failure cannot turn a returned side effect into a
               // missing commit that restore would execute again.
@@ -1075,6 +1153,7 @@ export class AgentRunner implements AgentBackend {
           )
           if (suspendedExecutions.length > 0) {
             suspended = true
+            emitTurnEnd('suspended')
             await persistCheckpoint(true)
             break
           }
@@ -1108,6 +1187,21 @@ export class AgentRunner implements AgentBackend {
             role: 'user',
             content: toolResultBlocks,
           }
+          if (journal) {
+            // One event on the assembled message, so the injected
+            // `pendingToolResultText` warning block is recorded verbatim too.
+            const sourceEventSeqs = executions
+              .map((execution) => journalToolResultSeqs.get(execution.commit.result.tool_use_id))
+              .filter((seq): seq is number => seq !== undefined)
+            const messageSeq = journal.emit({
+              type: 'user/message',
+              ...journalScope,
+              message: toolResultMessage,
+              origin: 'tool_results',
+              ...(sourceEventSeqs.length > 0 ? { sourceEventSeqs } : {}),
+            })
+            journal.registerMessage(toolResultMessage, [messageSeq])
+          }
           conversationMessages.push(toolResultMessage)
           newMessages.push(toolResultMessage)
           options.onMessage?.(toolResultMessage)
@@ -1119,6 +1213,7 @@ export class AgentRunner implements AgentBackend {
             // later restore re-executes only the call that never committed.
             if (effectiveAbortSignal?.aborted) {
               aborted = true
+              emitTurnEnd('aborted')
               break
             }
             continue
@@ -1143,6 +1238,7 @@ export class AgentRunner implements AgentBackend {
           }
 
           phase = budgetExceeded ? 'completed' : 'awaiting_model'
+          emitTurnEnd(budgetExceeded ? 'budget_exceeded' : 'tool_use')
           await persistCheckpoint()
           if (phase === 'completed') break
           continue
@@ -1160,6 +1256,10 @@ export class AgentRunner implements AgentBackend {
         }
 
         const nextTurn = turns + 1
+        if (journal) {
+          journalOpenTurn = nextTurn
+          journal.emit({ type: 'turn/start', ...journalScope, turn: nextTurn })
+        }
 
         // Compress consumed tool results before context strategy (lightweight,
         // no LLM calls) so the strategy operates on already-reduced messages.
@@ -1183,6 +1283,20 @@ export class AgentRunner implements AgentBackend {
         // ------------------------------------------------------------------
         // Step 1: Call the LLM and collect the full response for this turn.
         // ------------------------------------------------------------------
+        // The journal's model-visible boundary is this conversation, recorded
+        // per block. Only the `'turn'` call is journaled: the summarize
+        // strategy's own `'summary'` call is an implementation detail of the
+        // rewrite it produces, not a turn of this conversation.
+        const llmRequestSeq = journal
+          ? journal.emit({
+              type: 'llm/request',
+              ...journalScope,
+              turn: nextTurn,
+              model: baseChatOptions.model,
+              blocks: this.describeRequestBlocks(journal, conversationMessages),
+              ...journalRequestConfig,
+            })
+          : undefined
         const response = await this.tracedChat(
           conversationMessages, baseChatOptions, options, 'turn', nextTurn,
         )
@@ -1196,6 +1310,21 @@ export class AgentRunner implements AgentBackend {
         const assistantMessage: LLMMessage = {
           role: 'assistant',
           content: response.content,
+        }
+        if (journal) {
+          journalAssistantSeq = journal.emit({
+            type: 'assistant/message',
+            ...journalScope,
+            message: assistantMessage,
+            origin: 'response',
+            usage: response.usage,
+            model: response.model,
+            stopReason: response.stop_reason,
+            ...(llmRequestSeq !== undefined ? { sourceEventSeqs: [llmRequestSeq] } : {}),
+          })
+          // `response.content` is pushed by reference, so registering these
+          // block objects is what later requests match against.
+          journal.registerBlocks(response.content, [journalAssistantSeq])
         }
 
         conversationMessages.push(assistantMessage)
@@ -1254,6 +1383,7 @@ export class AgentRunner implements AgentBackend {
               loopDetected = true
               finalOutput = turnText
               phase = 'completed'
+              emitTurnEnd('loop_detected')
               await persistCheckpoint()
               break
             } else if (action === 'warn' || action === 'inject') {
@@ -1262,6 +1392,7 @@ export class AgentRunner implements AgentBackend {
                 loopDetected = true
                 finalOutput = turnText
                 phase = 'completed'
+                emitTurnEnd('loop_detected')
                 await persistCheckpoint()
                 break
               }
@@ -1284,6 +1415,7 @@ export class AgentRunner implements AgentBackend {
         if (toolUseBlocks.length === 0) {
           if (budgetExceeded) {
             phase = 'completed'
+            emitTurnEnd('budget_exceeded')
             await persistCheckpoint()
             break
           }
@@ -1292,10 +1424,22 @@ export class AgentRunner implements AgentBackend {
               role: 'user',
               content: [{ type: 'text', text: loopWarningText(injectWarningKind) }],
             }
+            if (journal) {
+              journal.registerMessage(warningMessage, [journal.emit({
+                type: 'user/message',
+                ...journalScope,
+                message: warningMessage,
+                origin: 'input',
+                ...(journalAssistantSeq !== undefined
+                  ? { sourceEventSeqs: [journalAssistantSeq] }
+                  : {}),
+              })])
+            }
             conversationMessages.push(warningMessage)
             newMessages.push(warningMessage)
             options.onMessage?.(warningMessage)
             phase = 'awaiting_model'
+            emitTurnEnd('loop_detected')
             await persistCheckpoint()
             continue
           }
@@ -1311,6 +1455,7 @@ export class AgentRunner implements AgentBackend {
           // No tools requested — this is the terminal assistant turn.
           finalOutput = turnText
           phase = 'completed'
+          emitTurnEnd('completed')
           await persistCheckpoint()
           break
         }
@@ -1331,6 +1476,7 @@ export class AgentRunner implements AgentBackend {
       }
     } catch (err) {
       streamError = err instanceof Error ? err : new Error(String(err))
+      emitTurnEnd('error')
     } finally {
       try {
         await runShellExecutor?.release()
@@ -1387,6 +1533,54 @@ export class AgentRunner implements AgentBackend {
   // -------------------------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------------------------
+
+  /** Scoping fields stamped on every journal event this runner emits. */
+  private journalScope(options: RunOptions): {
+    readonly taskId?: string
+    readonly agentName?: string
+    readonly spanId?: string
+  } {
+    const agentName = options.traceAgent ?? this.options.agentName
+    return {
+      ...(options.taskId !== undefined ? { taskId: options.taskId } : {}),
+      ...(agentName !== undefined ? { agentName } : {}),
+      ...(options.traceSpan ? { spanId: options.traceSpan.spanId } : {}),
+    }
+  }
+
+  /**
+   * Describe every block the model is about to see, with the journal event it
+   * came from.
+   *
+   * A block with no recorded lineage is normally recorded as the gap it is
+   * (`sourceEventSeqs: null`); under `enforceLineage` it throws instead, at the
+   * exact request that would otherwise have hidden it.
+   */
+  private describeRequestBlocks(
+    recorder: JournalRecorder,
+    messages: readonly LLMMessage[],
+  ): RequestBlockDescriptor[] {
+    const descriptors: RequestBlockDescriptor[] = []
+    for (let messageIndex = 0; messageIndex < messages.length; messageIndex++) {
+      const message = messages[messageIndex]!
+      for (let blockIndex = 0; blockIndex < message.content.length; blockIndex++) {
+        const block = message.content[blockIndex]!
+        const sourceEventSeqs = recorder.lineageFor(block)
+        if (sourceEventSeqs === null && recorder.enforceLineage) {
+          throw new JournalLineageError(messageIndex, blockIndex, block.type)
+        }
+        descriptors.push({
+          messageIndex,
+          blockIndex,
+          role: message.role,
+          blockType: block.type,
+          sourceEventSeqs,
+          contentHash: recorder.hashFor(block),
+        })
+      }
+    }
+    return descriptors
+  }
 
   private async executeToolCall(
     block: ToolUseBlock,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -2,7 +2,7 @@
  * @fileoverview Framework-specific error classes.
  */
 
-import type { SemanticRoutingAssessment, TaskRequirementIssue } from './types.js'
+import type { ContentBlock, SemanticRoutingAssessment, TaskRequirementIssue } from './types.js'
 
 /**
  * Raised before task execution when a task has no eligible agent or its
@@ -229,6 +229,32 @@ export class UnsupportedToolResultContentError extends Error {
 }
 
 /**
+ * Raised before an adapter call when `enforceLineage` is on and a model-visible
+ * block cannot name the journal event it came from.
+ *
+ * Failing here rather than at verification time turns "the model saw something
+ * the journal cannot explain" into a run-time error at the exact request that
+ * would have hidden it. Enforcement is off by default; see
+ * `docs/run-journal.md` for which configurations currently satisfy it.
+ */
+export class JournalLineageError extends Error {
+  readonly code = 'MISSING_CONTEXT_REPLACE'
+
+  constructor(
+    readonly messageIndex: number,
+    readonly blockIndex: number,
+    readonly blockType: ContentBlock['type'],
+  ) {
+    super(
+      `Journal lineage is missing for the ${blockType} block at message ` +
+        `${messageIndex}, block ${blockIndex}: it is model-visible but names no ` +
+        'journal event that reproduces it.',
+    )
+    this.name = 'JournalLineageError'
+  }
+}
+
+/**
  * Read an HTTP-style status code off an unknown error, if present. Provider
  * SDK errors (`Anthropic.APIError`, `OpenAI.APIError`) expose it as `.status`;
  * some libraries use `.statusCode`. Returns `undefined` for network/unknown
@@ -276,6 +302,9 @@ export function isRetryableError(error: unknown): boolean {
   if (error instanceof UnsupportedToolCallError) return false
   if (error instanceof EgressPolicyError) return false
   if (error instanceof UnsupportedToolResultContentError) return false
+  // A lineage gap is a property of the conversation, not of the transport:
+  // the same request would fail the same way on every attempt.
+  if (error instanceof JournalLineageError) return false
   if (error instanceof LLMCallTimeoutError) return true
   if (error instanceof RoutingTimeoutError) return true
   if (error instanceof RoutingProfilerFailedError) return false

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -195,6 +195,7 @@ export {
   TokenBudgetExceededError,
   CostBudgetExceededError,
   InvalidMessageError,
+  JournalLineageError,
   StructuredOutputValidationError,
   InvalidTaskRequirementsError,
   LLMCallTimeoutError,
@@ -303,6 +304,46 @@ export {
   checkpointKey,
   isCheckpointKey,
 } from './memory/checkpoint.js'
+
+// ---------------------------------------------------------------------------
+// Run journal
+// ---------------------------------------------------------------------------
+
+export { InMemoryRunJournal, resolveRunJournal } from './journal/journal.js'
+export { JsonlRunJournal } from './journal/jsonl-journal.js'
+export { canonicalContentHash, canonicalJsonHash } from './journal/hash.js'
+export { isMessageEvent, isRunEvent, RUN_EVENT_TYPES } from './journal/events.js'
+export type {
+  InMemoryRunJournalOptions,
+  ResolvedRunJournal,
+  RunJournal,
+  RunJournalConfig,
+  RunJournalOptions,
+} from './journal/journal.js'
+export type { JsonlRunJournalOptions } from './journal/jsonl-journal.js'
+export type {
+  ApprovalDecisionEvent,
+  ApprovalRequestEvent,
+  AssistantMessageEvent,
+  CheckpointSavedEvent,
+  LLMRequestEvent,
+  MemorySetEvent,
+  PlanSetEvent,
+  PlanSetTask,
+  RequestBlockDescriptor,
+  RunEndEvent,
+  RunEvent,
+  RunEventBase,
+  RunJournalMode,
+  RunStartEvent,
+  TaskStatusEvent,
+  ToolCallEvent,
+  ToolResultEvent,
+  TurnEndEvent,
+  TurnOutcome,
+  TurnStartEvent,
+  UserMessageEvent,
+} from './journal/events.js'
 
 // ---------------------------------------------------------------------------
 // Types — all public interfaces re-exported for consumer type-checking

--- a/packages/core/src/journal/events.ts
+++ b/packages/core/src/journal/events.ts
@@ -1,0 +1,284 @@
+/**
+ * @fileoverview The `RunEvent` vocabulary — one append-only record per thing
+ * that happened inside a run.
+ *
+ * Every payload here must stay JSON-safe: {@link JsonlRunJournal} serializes
+ * events verbatim, and `verifyRun()` re-reads them cold. Shared shapes are
+ * imported from `types.ts` rather than redeclared, so an event and the run
+ * result it describes never drift apart.
+ *
+ * This module deliberately does not import from `observability/`. Trace records
+ * are telemetry and may be lost without affecting a run; journal events are
+ * execution state. Keeping the two module graphs separate is what makes
+ * "losing telemetry never loses the journal" a structural fact rather than a
+ * convention.
+ */
+
+import type {
+  ApprovalDecisionRecord,
+  ApprovalRequest,
+  CheckpointSnapshot,
+  ContentBlock,
+  LLMMessage,
+  PlanRevision,
+  RunStatus,
+  StructuredTraceError,
+  TaskStatus,
+  TokenUsage,
+  ToolCallRecord,
+  ToolResultBlock,
+  ToolUseBlock,
+  TraceAttributeValue,
+} from '../types.js'
+
+// ---------------------------------------------------------------------------
+// Base
+// ---------------------------------------------------------------------------
+
+/** Top-level entry point that produced the run a journal describes. */
+export type RunJournalMode =
+  | 'runAgent'
+  | 'runTeam'
+  | 'runTasks'
+  | 'runFromPlan'
+  | 'restore'
+
+/** Fields carried by every {@link RunEvent}. */
+export interface RunEventBase {
+  /** 1-based, strictly increasing per `runId` across attempts. */
+  readonly seq: number
+  readonly timestampUnixMs: number
+  readonly runId: string
+  readonly attempt: number
+  readonly taskId?: string
+  readonly agentName?: string
+  /** Link to telemetry when a trace runtime is active. Never required. */
+  readonly traceId?: string
+  readonly spanId?: string
+  /** Journal events this one derives from. See the conventions below. */
+  readonly sourceEventSeqs?: readonly number[]
+}
+
+// ---------------------------------------------------------------------------
+// Variants
+// ---------------------------------------------------------------------------
+
+export interface RunStartEvent extends RunEventBase {
+  readonly type: 'run/start'
+  readonly mode: RunJournalMode
+  readonly goal?: string
+  readonly metadata?: Readonly<Record<string, TraceAttributeValue>>
+}
+
+export interface RunEndEvent extends RunEventBase {
+  readonly type: 'run/end'
+  readonly status: RunStatus
+  readonly error?: StructuredTraceError
+}
+
+/** One task as it stood when a plan was set or revised. */
+export interface PlanSetTask {
+  readonly taskId: string
+  readonly description?: string
+  readonly assignee?: string
+  readonly dependsOn?: readonly string[]
+}
+
+export interface PlanSetEvent extends RunEventBase {
+  readonly type: 'plan/set'
+  readonly revision: number
+  readonly source: 'initial' | 'recovery'
+  readonly tasks: readonly PlanSetTask[]
+  readonly detail?: PlanRevision
+}
+
+/**
+ * A task transition the run observed. v1 records `in_progress`, `completed`,
+ * `failed`, and `skipped`; the `pending` / `blocked` starting states are
+ * already carried by `plan/set`.
+ */
+export interface TaskStatusEvent extends RunEventBase {
+  readonly type: 'task/status'
+  readonly status: TaskStatus
+  readonly reason?: string
+}
+
+export interface TurnStartEvent extends RunEventBase {
+  readonly type: 'turn/start'
+  readonly turn: number
+}
+
+/** Why a turn stopped. Mirrors the runner's phase-transition boundaries. */
+export type TurnOutcome =
+  | 'tool_use'
+  | 'completed'
+  | 'loop_detected'
+  | 'budget_exceeded'
+  | 'suspended'
+  | 'aborted'
+  | 'error'
+
+export interface TurnEndEvent extends RunEventBase {
+  readonly type: 'turn/end'
+  readonly turn: number
+  readonly outcome: TurnOutcome
+}
+
+export interface UserMessageEvent extends RunEventBase {
+  readonly type: 'user/message'
+  readonly message: LLMMessage
+  readonly origin: 'input' | 'seed' | 'tool_results'
+}
+
+export interface AssistantMessageEvent extends RunEventBase {
+  readonly type: 'assistant/message'
+  readonly message: LLMMessage
+  readonly origin: 'response' | 'seed'
+  readonly usage?: TokenUsage
+  readonly model?: string
+  readonly stopReason?: string
+}
+
+/**
+ * Per-block lineage for one model-visible request.
+ *
+ * The request itself is not stored: the conversation is re-sent every turn, so
+ * recording it verbatim would grow the journal with the square of the turn
+ * count. A descriptor names where each block came from and hashes what it
+ * contained, which is what reproducibility checks actually need.
+ */
+export interface RequestBlockDescriptor {
+  readonly messageIndex: number
+  readonly blockIndex: number
+  readonly role: 'user' | 'assistant'
+  readonly blockType: ContentBlock['type']
+  /** `null` when no journal event is known to have produced this block. */
+  readonly sourceEventSeqs: readonly number[] | null
+  /** sha256 hex of the block's canonical JSON encoding. */
+  readonly contentHash: string
+}
+
+export interface LLMRequestEvent extends RunEventBase {
+  readonly type: 'llm/request'
+  readonly turn: number
+  readonly model: string
+  readonly blocks: readonly RequestBlockDescriptor[]
+  /** System prompt and tool definitions are caller config, not conversation. */
+  readonly systemPromptHash?: string
+  readonly toolsHash?: string
+}
+
+export interface ToolCallEvent extends RunEventBase {
+  readonly type: 'tool/call'
+  readonly call: ToolUseBlock
+}
+
+export interface ToolResultEvent extends RunEventBase {
+  readonly type: 'tool/result'
+  readonly toolCallId: string
+  readonly result: ToolResultBlock
+  readonly record?: ToolCallRecord
+}
+
+/** A shared-memory write attributable to a task. The store owns the value. */
+export interface MemorySetEvent extends RunEventBase {
+  readonly type: 'memory/set'
+  readonly agent: string
+  readonly key: string
+  readonly valueBytes?: number
+}
+
+export interface ApprovalRequestEvent extends RunEventBase {
+  readonly type: 'approval/request'
+  readonly request: ApprovalRequest
+}
+
+export interface ApprovalDecisionEvent extends RunEventBase {
+  readonly type: 'approval/decision'
+  readonly decision: ApprovalDecisionRecord
+}
+
+export interface CheckpointSavedEvent extends RunEventBase {
+  readonly type: 'checkpoint/saved'
+  readonly mode: CheckpointSnapshot['mode']
+  readonly version: number
+  /** Recorder high-water mark at snapshot build time. */
+  readonly watermarkSeq: number
+}
+
+/**
+ * One append-only record of run execution state.
+ *
+ * `sourceEventSeqs` conventions: `assistant/message` names its `llm/request`;
+ * `tool/call` names its `assistant/message`; `tool/result` names its
+ * `tool/call`; a `user/message` with `origin: 'tool_results'` names the
+ * `tool/result` events assembled into it.
+ */
+export type RunEvent =
+  | RunStartEvent
+  | RunEndEvent
+  | PlanSetEvent
+  | TaskStatusEvent
+  | TurnStartEvent
+  | TurnEndEvent
+  | UserMessageEvent
+  | AssistantMessageEvent
+  | LLMRequestEvent
+  | ToolCallEvent
+  | ToolResultEvent
+  | MemorySetEvent
+  | ApprovalRequestEvent
+  | ApprovalDecisionEvent
+  | CheckpointSavedEvent
+
+/** Every `type` discriminator in the {@link RunEvent} union. */
+export const RUN_EVENT_TYPES = [
+  'run/start',
+  'run/end',
+  'plan/set',
+  'task/status',
+  'turn/start',
+  'turn/end',
+  'user/message',
+  'assistant/message',
+  'llm/request',
+  'tool/call',
+  'tool/result',
+  'memory/set',
+  'approval/request',
+  'approval/decision',
+  'checkpoint/saved',
+] as const satisfies readonly RunEvent['type'][]
+
+const RUN_EVENT_TYPE_SET: ReadonlySet<string> = new Set(RUN_EVENT_TYPES)
+
+// ---------------------------------------------------------------------------
+// Guards
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural check applied to anything parsed back from a persisted journal.
+ *
+ * Validates the base envelope only. A stricter per-variant schema would reject
+ * events written by a newer minor version that added an optional payload
+ * field, which is the opposite of what an append-only log needs.
+ */
+export function isRunEvent(value: unknown): value is RunEvent {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false
+  const event = value as Partial<RunEventBase> & { type?: unknown }
+  return typeof event.type === 'string'
+    && RUN_EVENT_TYPE_SET.has(event.type)
+    && typeof event.seq === 'number'
+    && Number.isInteger(event.seq)
+    && event.seq > 0
+    && typeof event.timestampUnixMs === 'number'
+    && typeof event.runId === 'string'
+    && typeof event.attempt === 'number'
+}
+
+/** True for the two events that carry a full {@link LLMMessage} payload. */
+export function isMessageEvent(
+  event: RunEvent,
+): event is UserMessageEvent | AssistantMessageEvent {
+  return event.type === 'user/message' || event.type === 'assistant/message'
+}

--- a/packages/core/src/journal/hash.ts
+++ b/packages/core/src/journal/hash.ts
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview Canonical content hashing for journal lineage.
+ *
+ * Lineage answers "which event produced this block?"; the hash answers "and
+ * does that event still reproduce it byte for byte?". `JSON.stringify` alone
+ * cannot: key order follows insertion order, so two structurally identical
+ * blocks built by different code paths would hash differently. Sorting keys
+ * recursively removes that difference while leaving array order — which is
+ * semantic in content blocks — untouched.
+ */
+
+import { createHash } from 'node:crypto'
+import type { ContentBlock } from '../types.js'
+
+/** Serialize a JSON-safe value with object keys sorted at every depth. */
+function canonicalize(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null'
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(',')}]`
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([key, entryValue]) => `${JSON.stringify(key)}:${canonicalize(entryValue)}`)
+  return `{${entries.join(',')}}`
+}
+
+/**
+ * sha256 hex of a content block's canonical JSON encoding.
+ *
+ * Exported because `verifyRun()` and lineage tests must compute the same digest
+ * from a journal read cold off disk as the runner computed in process.
+ */
+export function canonicalContentHash(block: ContentBlock): string {
+  return createHash('sha256').update(canonicalize(block)).digest('hex')
+}
+
+/** sha256 hex of any JSON-safe value, used for the request's config digests. */
+export function canonicalJsonHash(value: unknown): string {
+  return createHash('sha256').update(canonicalize(value)).digest('hex')
+}

--- a/packages/core/src/journal/journal.ts
+++ b/packages/core/src/journal/journal.ts
@@ -1,0 +1,344 @@
+/**
+ * @fileoverview The run journal side channel: the {@link RunJournal} backend
+ * contract, the bundled in-memory backend, and the per-run
+ * {@link JournalRecorder} that stamps and orders every emission.
+ *
+ * `MemoryStore` is key/value shaped and `FileStore` rewrites its whole file per
+ * write, so appending one event per model call through either would cost
+ * O(store size) per event. The journal therefore owns a small append-only
+ * interface of its own and leaves the KV stores untouched.
+ *
+ * Journal writes are best-effort, exactly like checkpoint saves: a failed
+ * append is surfaced to the caller and never fails the run it observes. That
+ * holds at approval boundaries too — durability there is the
+ * `DurableApprovalLedger`'s job, not the journal's.
+ */
+
+import type { ContentBlock, LLMMessage } from '../types.js'
+import { canonicalContentHash } from './hash.js'
+import type { RunEvent } from './events.js'
+
+// ---------------------------------------------------------------------------
+// Backend contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Append-only per-run event log.
+ *
+ * The caller owns the instance's lifecycle. The orchestrator never calls
+ * {@link RunJournal.close}, the same contract memory stores already have.
+ */
+export interface RunJournal {
+  /** Append events in the given order. Rejecting reports a write failure. */
+  append(events: readonly RunEvent[]): Promise<void>
+  /** Every retained event with `seq >= seq`, in order. */
+  readFrom(seq: number): Promise<RunEvent[]>
+  /** Flush anything pending and release resources. */
+  close(): Promise<void>
+}
+
+/** Journal configuration with the per-run switches spelled out. */
+export interface RunJournalOptions {
+  /** Defaults to `true`. Set `false` to keep the field but disable journaling. */
+  readonly enabled?: boolean
+  readonly journal: RunJournal
+  /**
+   * Throw {@link JournalLineageError} instead of recording `null` lineage when
+   * a model-visible block cannot name the event it came from. Defaults to
+   * `false`; see `docs/run-journal.md` for what currently passes.
+   */
+  readonly enforceLineage?: boolean
+}
+
+/** Journal configuration accepted by orchestrator config and run options. */
+export type RunJournalConfig = RunJournal | RunJournalOptions
+
+/** The journal and switches a single run resolved to. */
+export interface ResolvedRunJournal {
+  readonly journal: RunJournal
+  readonly enforceLineage: boolean
+}
+
+function isRunJournal(value: RunJournalConfig): value is RunJournal {
+  return typeof (value as RunJournal).append === 'function'
+}
+
+/**
+ * Resolve the journal for one run: a per-call value overrides orchestrator
+ * config, and `false` disables journaling for that call only. Mirrors how
+ * `checkpoint` resolves.
+ */
+export function resolveRunJournal(
+  configured: RunJournalConfig | undefined,
+  override: RunJournalConfig | false | undefined,
+): ResolvedRunJournal | undefined {
+  if (override === false) return undefined
+  const selected = override ?? configured
+  if (selected === undefined) return undefined
+  if (isRunJournal(selected)) return { journal: selected, enforceLineage: false }
+  if (selected.enabled === false) return undefined
+  return {
+    journal: selected.journal,
+    enforceLineage: selected.enforceLineage ?? false,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// In-memory backend
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_EVENTS = 10_000
+
+/** Options for {@link InMemoryRunJournal}. */
+export interface InMemoryRunJournalOptions {
+  /** Retained event ceiling. Defaults to 10 000; oldest events are evicted. */
+  readonly maxEvents?: number
+}
+
+/**
+ * Bounded ring buffer, for auditing a run inside one process.
+ *
+ * Eviction drops the oldest events, so `readFrom` returns the retained tail
+ * rather than the whole run. That gap is legal and detectable: a verification
+ * pass reports a reference into an evicted window as inconclusive, not as a
+ * lineage failure.
+ */
+export class InMemoryRunJournal implements RunJournal {
+  private readonly capacity: number
+  private readonly buffer: RunEvent[] = []
+  /** Index of the oldest retained event once the buffer is full. */
+  private start = 0
+
+  constructor(options: InMemoryRunJournalOptions = {}) {
+    const maxEvents = options.maxEvents ?? DEFAULT_MAX_EVENTS
+    if (!Number.isInteger(maxEvents) || maxEvents < 1) {
+      throw new Error('InMemoryRunJournal: maxEvents must be a positive integer.')
+    }
+    this.capacity = maxEvents
+  }
+
+  /** Number of retained events. */
+  get size(): number {
+    return this.buffer.length
+  }
+
+  append(events: readonly RunEvent[]): Promise<void> {
+    for (const event of events) {
+      if (this.buffer.length < this.capacity) {
+        this.buffer.push(event)
+        continue
+      }
+      this.buffer[this.start] = event
+      this.start = (this.start + 1) % this.capacity
+    }
+    return Promise.resolve()
+  }
+
+  readFrom(seq: number): Promise<RunEvent[]> {
+    const retained: RunEvent[] = []
+    const length = this.buffer.length
+    for (let i = 0; i < length; i++) {
+      const event = this.buffer[(this.start + i) % length]!
+      if (event.seq >= seq) retained.push(event)
+    }
+    return Promise.resolve(retained)
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Recorder
+// ---------------------------------------------------------------------------
+
+/** Fields {@link JournalRecorder} stamps; callers supply everything else. */
+type RecorderAssignedField = 'seq' | 'timestampUnixMs' | 'runId' | 'attempt'
+
+/** A {@link RunEvent} minus the fields the recorder fills in. */
+export type RunEventDraft<E extends RunEvent = RunEvent> =
+  E extends RunEvent ? Omit<E, RecorderAssignedField> : never
+
+/** Construction inputs for {@link JournalRecorder.open}. */
+export interface JournalRecorderOptions {
+  readonly journal: RunJournal
+  readonly runId: string
+  readonly attempt: number
+  /** Stamped on every event when a trace runtime is active. */
+  readonly traceId?: string
+  readonly enforceLineage?: boolean
+  /** Called once per append failure. Must not throw. */
+  readonly onError?: (error: unknown) => void
+}
+
+interface BlockLineage {
+  /** `null` when the block entered the conversation with no recorded event. */
+  readonly seqs: readonly number[] | null
+  /** Filled lazily on first request walk; blocks are immutable by convention. */
+  hash?: string
+}
+
+/**
+ * Per-run emitter shared by the orchestrator and every runner beneath it.
+ *
+ * `emit` assigns `seq` synchronously before any `await`, so concurrent tasks
+ * sharing one recorder still produce a strictly increasing stream. Appends are
+ * then drained through a single non-rejecting chain (modelled on
+ * `ActiveCheckpoint.saveChain`), batching whatever accumulated while the
+ * previous append was in flight.
+ */
+export class JournalRecorder {
+  private readonly journal: RunJournal
+  private readonly runId: string
+  private readonly attempt: number
+  private readonly traceId: string | undefined
+  private readonly onError: ((error: unknown) => void) | undefined
+
+  /** See {@link RunJournalOptions.enforceLineage}. */
+  readonly enforceLineage: boolean
+
+  private seq: number
+  private pending: RunEvent[] = []
+  private draining = false
+  private chain: Promise<void> = Promise.resolve()
+
+  private readonly lineage = new WeakMap<ContentBlock, BlockLineage>()
+  private readonly toolCallSeqs = new Map<string, number>()
+
+  private constructor(options: JournalRecorderOptions, startSeq: number) {
+    this.journal = options.journal
+    this.runId = options.runId
+    this.attempt = options.attempt
+    this.traceId = options.traceId
+    this.onError = options.onError
+    this.enforceLineage = options.enforceLineage ?? false
+    this.seq = startSeq
+  }
+
+  /**
+   * Attach a recorder to a journal, continuing its sequence.
+   *
+   * A restored attempt shares the logical run's numbering, so the tail is read
+   * once at run start to find the high-water mark. One full read per run is
+   * acceptable at this size; a backend-supplied `lastSeq()` would remove it.
+   */
+  static async open(options: JournalRecorderOptions): Promise<JournalRecorder> {
+    let startSeq = 0
+    try {
+      for (const event of await options.journal.readFrom(0)) {
+        if (event.seq > startSeq) startSeq = event.seq
+      }
+    } catch (error) {
+      // A journal that cannot be read is still worth writing to; report the
+      // failure and number from scratch rather than failing the run.
+      options.onError?.(error)
+    }
+    return new JournalRecorder(options, startSeq)
+  }
+
+  /** Highest sequence number assigned so far. */
+  get lastSeq(): number {
+    return this.seq
+  }
+
+  /** Stamp and enqueue one event. Returns the sequence number assigned to it. */
+  emit(draft: RunEventDraft): number {
+    const seq = ++this.seq
+    const event = {
+      ...draft,
+      seq,
+      timestampUnixMs: Date.now(),
+      runId: this.runId,
+      attempt: this.attempt,
+      ...(this.traceId !== undefined && draft.traceId === undefined
+        ? { traceId: this.traceId }
+        : {}),
+    } as RunEvent
+    this.pending.push(event)
+    if (!this.draining) {
+      this.draining = true
+      this.chain = this.chain.then(() => this.drain())
+    }
+    return seq
+  }
+
+  /** Wait until every emitted event has been handed to the backend. */
+  async flush(): Promise<void> {
+    let awaited: Promise<void> | undefined
+    while (awaited !== this.chain) {
+      awaited = this.chain
+      await awaited
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Lineage tracking
+  // -------------------------------------------------------------------------
+
+  /**
+   * Record that `blocks` entered the conversation through the events named by
+   * `seqs`. Keyed on block identity: context strategies rebuild message
+   * objects but pass untouched blocks through by reference, so block identity
+   * survives a rewrite where message identity does not.
+   */
+  registerBlocks(blocks: readonly ContentBlock[], seqs: readonly number[]): void {
+    for (const block of blocks) {
+      this.lineage.set(block, { seqs })
+    }
+  }
+
+  /** Convenience wrapper for the common "register a whole message" case. */
+  registerMessage(message: LLMMessage, seqs: readonly number[]): void {
+    this.registerBlocks(message.content, seqs)
+  }
+
+  /** Events that produced `block`, or `null` when none was recorded. */
+  lineageFor(block: ContentBlock): readonly number[] | null {
+    return this.lineage.get(block)?.seqs ?? null
+  }
+
+  /**
+   * Canonical hash of `block`, cached per block. The conversation is re-sent
+   * every turn, so without the cache a long run would rehash its whole history
+   * on every request.
+   */
+  hashFor(block: ContentBlock): string {
+    const existing = this.lineage.get(block)
+    if (existing !== undefined) {
+      existing.hash ??= canonicalContentHash(block)
+      return existing.hash
+    }
+    const entry: BlockLineage = { seqs: null, hash: canonicalContentHash(block) }
+    this.lineage.set(block, entry)
+    return entry.hash!
+  }
+
+  /** Remember which `tool/call` event announced `toolCallId`. */
+  recordToolCallSeq(toolCallId: string, seq: number): void {
+    this.toolCallSeqs.set(toolCallId, seq)
+  }
+
+  /** Sequence of the `tool/call` event for `toolCallId`, when this run emitted one. */
+  toolCallSeq(toolCallId: string): number | undefined {
+    return this.toolCallSeqs.get(toolCallId)
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private async drain(): Promise<void> {
+    try {
+      while (this.pending.length > 0) {
+        const batch = this.pending
+        this.pending = []
+        await this.journal.append(batch)
+      }
+    } catch (error) {
+      this.onError?.(error)
+    } finally {
+      this.draining = false
+    }
+  }
+}

--- a/packages/core/src/journal/jsonl-journal.ts
+++ b/packages/core/src/journal/jsonl-journal.ts
@@ -1,0 +1,223 @@
+/**
+ * @fileoverview Zero-dependency JSONL {@link RunJournal} — one event per line,
+ * append-only, using only Node built-ins.
+ *
+ * Writes are batched behind a fixed deadline: the first pending event opens the
+ * window and later events do not reset it, so a burst of turns costs one write
+ * instead of one per event while a quiet run still lands within the interval.
+ * Each batch is a single `write` to an fd opened `'a'` followed by `fsync`,
+ * which is the same "a reader sees whole records, never half of one" property
+ * `FileStore` gets from its temp-file rename.
+ *
+ * **Crash window.** Everything up to the last completed batch is on disk; the
+ * batch still inside the current window is not. `close()` flushes it.
+ * `readFrom` tolerates one trailing partial line, which is what a crash in the
+ * middle of a write leaves behind.
+ *
+ * **Scope.** One writer per file, no cross-process lock — the same statement
+ * `FileStore` makes, and the same reason: the resume story it serves is
+ * inherently sequential.
+ */
+
+import { mkdir, open, readFile } from 'node:fs/promises'
+import type { FileHandle } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import type { RedactingStoreOptions } from '../memory/redacting-store.js'
+import { redactSensitiveObject } from '../utils/redaction.js'
+import { isRunEvent, type RunEvent } from './events.js'
+import type { RunJournal } from './journal.js'
+
+/** Default batching deadline in milliseconds. */
+const DEFAULT_FLUSH_INTERVAL_MS = 50
+
+/** Options for {@link JsonlRunJournal}. */
+export interface JsonlRunJournalOptions {
+  /** Batching deadline in milliseconds. Defaults to 50. */
+  readonly flushIntervalMs?: number
+  /**
+   * Scrub secrets from each event before it is written, using the same option
+   * shape as `RedactingStore`. Redaction happens at write time, so `readFrom`
+   * returns what was persisted, not the original.
+   */
+  readonly redact?: RedactingStoreOptions
+}
+
+interface PendingBatchWaiter {
+  readonly resolve: () => void
+  readonly reject: (error: unknown) => void
+}
+
+export class JsonlRunJournal implements RunJournal {
+  private readonly filePath: string
+  private readonly flushIntervalMs: number
+  private readonly redactPatterns: readonly RegExp[] | undefined
+
+  private pendingLines: string[] = []
+  private waiters: PendingBatchWaiter[] = []
+  private timer: ReturnType<typeof setTimeout> | null = null
+  private handle: FileHandle | null = null
+  /** Serializes batch writes so appended lines land in emission order. */
+  private writeChain: Promise<void> = Promise.resolve()
+  private closed = false
+
+  /**
+   * @param path - JSONL file to append to. Parent directories are created on
+   *   the first write; a missing file is an empty journal.
+   */
+  constructor(path: string, options: JsonlRunJournalOptions = {}) {
+    this.filePath = resolve(path)
+    const interval = options.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS
+    if (!Number.isFinite(interval) || interval < 0) {
+      throw new Error('JsonlRunJournal: flushIntervalMs must be a non-negative finite number.')
+    }
+    this.flushIntervalMs = interval
+    this.redactPatterns = options.redact === undefined
+      ? undefined
+      : options.redact.patterns ?? []
+  }
+
+  /**
+   * Queue `events` for the current batch. The returned promise settles when the
+   * batch containing them has been written and synced, so an append failure
+   * reaches the caller rather than disappearing into a timer.
+   */
+  append(events: readonly RunEvent[]): Promise<void> {
+    if (this.closed) {
+      return Promise.reject(new Error('JsonlRunJournal: journal is closed.'))
+    }
+    if (events.length === 0) return Promise.resolve()
+    for (const event of events) {
+      this.pendingLines.push(JSON.stringify(this.redactEvent(event)))
+    }
+    const settled = new Promise<void>((resolve_, reject) => {
+      this.waiters.push({ resolve: resolve_, reject })
+    })
+    // The first pending event opens the window; later events do not reset it.
+    this.timer ??= setTimeout(() => {
+      void this.flushPending()
+    }, this.flushIntervalMs)
+    return settled
+  }
+
+  /**
+   * Parse the persisted file and return every event with `seq >= seq`.
+   *
+   * Reads what is on disk: events still inside the current batching window are
+   * not visible until they flush or the journal is closed.
+   */
+  async readFrom(seq: number): Promise<RunEvent[]> {
+    let raw: string
+    try {
+      raw = await readFile(this.filePath, 'utf8')
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+      throw error
+    }
+
+    const lines = raw.split('\n')
+    const events: RunEvent[] = []
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i]!
+      if (line.length === 0) continue
+      // Only the final line can be a torn write; anything else is corruption.
+      const trailing = i === lines.length - 1
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(line)
+      } catch {
+        if (trailing) continue
+        throw new Error(
+          `JsonlRunJournal: line ${i + 1} of "${this.filePath}" is not valid JSON.`,
+        )
+      }
+      if (!isRunEvent(parsed)) {
+        if (trailing) continue
+        throw new Error(
+          `JsonlRunJournal: line ${i + 1} of "${this.filePath}" is not a run event.`,
+        )
+      }
+      if (parsed.seq >= seq) events.push(parsed)
+    }
+    return events
+  }
+
+  /** Flush the open batch, then close the file descriptor. */
+  async close(): Promise<void> {
+    if (this.closed) return
+    this.closed = true
+    if (this.timer !== null) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+    const settled = this.pendingLines.length > 0
+      ? new Promise<void>((resolve_, reject) => {
+          this.waiters.push({ resolve: resolve_, reject })
+        })
+      : Promise.resolve()
+    await this.flushPending()
+    await this.writeChain
+    const handle = this.handle
+    this.handle = null
+    try {
+      await settled
+    } finally {
+      await handle?.close()
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private redactEvent(event: RunEvent): RunEvent {
+    return this.redactPatterns === undefined
+      ? event
+      : redactSensitiveObject(event, this.redactPatterns)
+  }
+
+  /**
+   * Write everything accumulated so far as one batch and settle its waiters.
+   * Never rejects: a write failure is delivered to the waiters instead, so the
+   * timer callback cannot produce an unhandled rejection.
+   */
+  private async flushPending(): Promise<void> {
+    if (this.timer !== null) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
+    const lines = this.pendingLines
+    const waiters = this.waiters
+    this.pendingLines = []
+    this.waiters = []
+    if (lines.length === 0) {
+      for (const waiter of waiters) waiter.resolve()
+      return
+    }
+
+    const payload = `${lines.join('\n')}\n`
+    const write = this.writeChain.then(() => this.writeBatch(payload))
+    this.writeChain = write.then(() => undefined, () => undefined)
+    try {
+      await write
+      for (const waiter of waiters) waiter.resolve()
+    } catch (error) {
+      for (const waiter of waiters) waiter.reject(error)
+    }
+  }
+
+  private async writeBatch(payload: string): Promise<void> {
+    const handle = await this.ensureHandle()
+    await handle.write(payload, null, 'utf8')
+    // fsync the batch so a power loss cannot leave the run resuming from
+    // events the OS never wrote.
+    await handle.sync()
+  }
+
+  private async ensureHandle(): Promise<FileHandle> {
+    if (this.handle === null) {
+      await mkdir(dirname(this.filePath), { recursive: true })
+      this.handle = await open(this.filePath, 'a')
+    }
+    return this.handle
+  }
+}

--- a/packages/core/src/orchestrator/coordinator.ts
+++ b/packages/core/src/orchestrator/coordinator.ts
@@ -26,6 +26,7 @@ import type { Team } from '../team/team.js'
 import type { TaskQueue } from '../task/queue.js'
 import { createTask, validateTaskDependencies } from '../task/task.js'
 import { classifyRunFailure } from '../observability/status.js'
+import type { JournalRecorder } from '../journal/journal.js'
 import type { TraceRuntime, TraceSpan } from '../observability/runtime.js'
 import { totalTokens, DEFAULT_MODEL } from './run-context.js'
 import { applyBudgetAccounting, buildCostEstimateContext, emitBudgetExceeded } from './budget.js'
@@ -564,6 +565,7 @@ export async function runCoordinatorSynthesis(
     readonly estimateCost?: OrchestratorConfig['estimateCost']
     readonly traceRuntime?: TraceRuntime
     readonly consumedTaskSpans?: readonly TraceSpan[]
+    readonly journal?: JournalRecorder
   },
 ): Promise<{ readonly result: AgentRunResult; readonly cumulativeUsage: TokenUsage; readonly cumulativeCost: number } | null> {
   if (opts.abortSignal?.aborted) return null
@@ -604,6 +606,7 @@ export async function runCoordinatorSynthesis(
       ? { onTrace: config.onTrace, traceAgent: 'coordinator' }
       : {}),
     ...(opts.abortSignal ? { abortSignal: opts.abortSignal } : {}),
+    ...(opts.journal ? { journal: opts.journal } : {}),
   }
   let result = await synthesisAgent.run(synthesisPrompt, synthTraceOptions)
   const accounting = applyBudgetAccounting({

--- a/packages/core/src/orchestrator/orchestrator.ts
+++ b/packages/core/src/orchestrator/orchestrator.ts
@@ -98,6 +98,12 @@ import { Team } from '../team/team.js'
 import { TaskQueue } from '../task/queue.js'
 import { Checkpoint } from '../memory/checkpoint.js'
 import { InMemoryStore } from '../memory/store.js'
+import type { RunJournalMode } from '../journal/events.js'
+import {
+  JournalRecorder,
+  resolveRunJournal,
+  type RunJournalConfig,
+} from '../journal/journal.js'
 import { validateTaskDependencies } from '../task/task.js'
 import { validateTaskMetadata } from '../task/metadata.js'
 import { Scheduler } from './scheduler.js'
@@ -273,6 +279,7 @@ type EffectiveOrchestratorConfig = Required<
     | 'defaultToolPreset'
     | 'checkpoint'
     | 'recovery'
+    | 'journal'
   >
 > & Pick<
   OrchestratorConfig,
@@ -295,6 +302,7 @@ type EffectiveOrchestratorConfig = Required<
   | 'defaultToolPreset'
   | 'checkpoint'
   | 'recovery'
+  | 'journal'
 >
 
 interface SemanticProfileRun {
@@ -358,15 +366,57 @@ function validateExecutionRoutingConfig(config?: ExecutionRoutingConfig): void {
   }
 }
 
-function closeTraceForFailure(
+async function closeTraceForFailure(
   traceRuntime: TraceRuntime | undefined,
   error: unknown,
-): void {
+  journal?: JournalRecorder,
+): Promise<void> {
   const classified = classifyRunFailure(error)
+  journal?.emit({
+    type: 'run/end',
+    status: classified.status,
+    error: classified.errorInfo,
+  })
   traceRuntime?.close({
     status: classified.status,
     error: classified.errorInfo,
   })
+  await journal?.flush()
+}
+
+/**
+ * Record the plan a run is about to execute, whatever produced it: a
+ * coordinator decomposition, an explicit task list, a frozen plan artifact, or
+ * a restored queue. `plan/set` also carries the `pending` / `blocked` starting
+ * states, which `task/status` never emits.
+ */
+function emitInitialPlanSet(
+  journal: JournalRecorder | undefined,
+  queue: TaskQueue,
+): void {
+  if (!journal) return
+  journal.emit({
+    type: 'plan/set',
+    revision: queue.getPlanRevision(),
+    source: 'initial',
+    tasks: queue.list().map((task) => ({
+      taskId: task.id,
+      ...(task.description !== undefined ? { description: task.description } : {}),
+      ...(task.assignee !== undefined ? { assignee: task.assignee } : {}),
+      ...(task.dependsOn !== undefined ? { dependsOn: task.dependsOn } : {}),
+    })),
+  })
+}
+
+/** Emit `run/end` and drain the journal wherever a run's trace closes. */
+async function endRunJournal(
+  journal: JournalRecorder | undefined,
+  status: RunStatus,
+  error?: StructuredTraceError,
+): Promise<void> {
+  if (!journal) return
+  journal.emit({ type: 'run/end', status, ...(error ? { error } : {}) })
+  await journal.flush()
 }
 
 function resolveRunBudgets(
@@ -483,6 +533,7 @@ export class OpenMultiAgent {
       defaultToolPreset: config.defaultToolPreset,
       checkpoint: config.checkpoint,
       recovery: config.recovery,
+      journal: config.journal,
       onApproval: config.onApproval,
       onTaskDispatch: config.onTaskDispatch,
       onPlanReady: config.onPlanReady,
@@ -825,6 +876,47 @@ export class OpenMultiAgent {
     )
   }
 
+  /**
+   * Resolve the journal for one run and open a recorder on it, emitting
+   * `run/start`.
+   *
+   * Returns `undefined` when no journal is configured, which is the default:
+   * every emission site guards on the recorder, so an unjournaled run
+   * allocates nothing and behaves exactly as it did before.
+   */
+  private async startRunJournal(
+    override: RunJournalConfig | false | undefined,
+    identity: RunIdentity,
+    mode: RunJournalMode,
+    goal?: string,
+    metadata?: RunMetadata,
+  ): Promise<JournalRecorder | undefined> {
+    const resolved = resolveRunJournal(this.config.journal, override)
+    if (!resolved) return undefined
+    const recorder = await JournalRecorder.open({
+      journal: resolved.journal,
+      runId: identity.runId,
+      attempt: identity.attempt,
+      traceId: identity.traceId,
+      enforceLineage: resolved.enforceLineage,
+      // A journal write failure is reported and dropped, exactly like a
+      // failed checkpoint save. Losing the audit trail cannot fail the run.
+      onError: (error) => {
+        this.config.onProgress?.({
+          type: 'error',
+          data: { kind: 'journal_append_failed', error },
+        } satisfies OrchestratorEvent)
+      },
+    })
+    recorder.emit({
+      type: 'run/start',
+      mode,
+      ...(goal !== undefined ? { goal } : {}),
+      ...(metadata !== undefined ? { metadata } : {}),
+    })
+    return recorder
+  }
+
   // -------------------------------------------------------------------------
   // Team management
   // -------------------------------------------------------------------------
@@ -877,6 +969,9 @@ export class OpenMultiAgent {
     )
     const { identity, metadata } = createRunFacts(options)
     const traceRuntime = this.startTrace(identity, metadata)
+    const journal = await this.startRunJournal(
+      options?.journal, identity, 'runAgent', undefined, metadata,
+    )
     const effectiveBudget = resolveBudgetCeiling(config.maxTokenBudget, this.config.maxTokenBudget)
     const effective: AgentConfig = applyDefaultToolPreset({
       ...applyAgentDefaults(config, runConfig),
@@ -905,6 +1000,7 @@ export class OpenMultiAgent {
         }
       : null
     const abortFields = options?.abortSignal ? { abortSignal: options.abortSignal } : null
+    const journalFields = journal ? { journal } : null
     const runOptions: Partial<RunOptions> | undefined =
       traceFields || abortFields
         ? {
@@ -914,12 +1010,14 @@ export class OpenMultiAgent {
             tracePhase: 'agent',
             ...(traceFields ?? {}),
             ...(abortFields ?? {}),
+            ...(journalFields ?? {}),
           }
         : {
             identity,
             runId: identity.runId,
             ...(traceRuntime ? { traceRuntime, traceSpan: traceRuntime.root } : {}),
             tracePhase: 'agent',
+            ...(journalFields ?? {}),
           }
 
     const result = await agent.run(
@@ -982,8 +1080,11 @@ export class OpenMultiAgent {
     if (completedResult.success) {
       this.completedTaskCount++
     }
+    const agentStatus = completedResult.status
+      ?? statusOnly(completedResult.success ? 'ok' : 'error')
+    await endRunJournal(journal, agentStatus, completedResult.errorInfo)
     traceRuntime?.close({
-      status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
+      status: agentStatus,
       ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
     })
     this.completeOnlineEvaluation(pendingEvaluation, completedResult)
@@ -1052,6 +1153,10 @@ export class OpenMultiAgent {
       if (options?.planOnly) {
         const { identity, metadata } = createRunFacts(identityOptionsForRun(options))
         const traceRuntime = this.startTrace(identity, metadata)
+        const journal = await this.startRunJournal(
+          options.journal, identity, 'runTeam', goal, metadata,
+        )
+        emitInitialPlanSet(journal, queue)
         const routingDecision = recordRoutingDecision(identity, traceRuntime, {
           source: 'declared',
           mode: 'team',
@@ -1062,7 +1167,9 @@ export class OpenMultiAgent {
           routingDecision,
           ...(metadata !== undefined ? { metadata } : {}),
         }
-        traceRuntime?.close({ status: result.status ?? statusOnly('ok') })
+        const planOnlyStatus = result.status ?? statusOnly('ok')
+        await endRunJournal(journal, planOnlyStatus)
+        traceRuntime?.close({ status: planOnlyStatus })
         this.completeOnlineEvaluation(pendingEvaluation, result)
         return result
       }
@@ -1083,6 +1190,7 @@ export class OpenMultiAgent {
           mode: 'team',
           reasons: ['Structured governance roles declared the execution topology.'],
         },
+        'runTeam',
       )
     }
 
@@ -1092,6 +1200,9 @@ export class OpenMultiAgent {
     )
     const { identity, metadata } = createRunFacts(identityOptionsForRun(options))
     const traceRuntime = this.startTrace(identity, metadata)
+    const journal = await this.startRunJournal(
+      options?.journal, identity, 'runTeam', goal, metadata,
+    )
     const routingContext = buildRoutingContext(
       goal,
       agentConfigs,
@@ -1115,7 +1226,7 @@ export class OpenMultiAgent {
           )
         : undefined
     } catch (error) {
-      closeTraceForFailure(traceRuntime, error)
+      await closeTraceForFailure(traceRuntime, error, journal)
       throw error
     }
     let semanticProfileRun: SemanticProfileRun | undefined
@@ -1151,7 +1262,7 @@ export class OpenMultiAgent {
           },
         )
       } catch (error) {
-        closeTraceForFailure(traceRuntime, error)
+        await closeTraceForFailure(traceRuntime, error, journal)
         throw error
       }
       if (semanticProfileRun.assessment.recommendation === 'team') {
@@ -1268,9 +1379,11 @@ export class OpenMultiAgent {
         semanticProfileRun.reasons,
         semanticProfileRun.assessment,
       )
+      const declarationErrorInfo = classifyRunFailure(error).errorInfo
+      await endRunJournal(journal, statusOnly('error'), declarationErrorInfo)
       traceRuntime?.close({
         status: statusOnly('error'),
-        error: classifyRunFailure(error).errorInfo,
+        error: declarationErrorInfo,
       })
       throw error
     }
@@ -1284,7 +1397,7 @@ export class OpenMultiAgent {
       return hasGrantedConsequentialTool(effective, { includeDelegateTool: true })
     })
 
-    const finish = (result: TeamRunResult): TeamRunResult => {
+    const finish = async (result: TeamRunResult): Promise<TeamRunResult> => {
       const resultWithRouting = {
         ...result,
         routingDecision,
@@ -1318,8 +1431,11 @@ export class OpenMultiAgent {
         consequentialUndeclared,
         confirmationState,
       )
+      const teamStatus = completedResult.status
+        ?? statusOnly(completedResult.success ? 'ok' : 'error')
+      await endRunJournal(journal, teamStatus, completedResult.errorInfo)
       traceRuntime?.close({
-        status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
+        status: teamStatus,
         ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
       })
       this.completeOnlineEvaluation(pendingEvaluation, completedResult)
@@ -1389,6 +1505,7 @@ export class OpenMultiAgent {
         ? { onTrace: this.config.onTrace, traceAgent: bestAgent.name }
         : null
       const abortFields = options?.abortSignal ? { abortSignal: options.abortSignal } : null
+      const journalFields = journal ? { journal } : null
       const runOptions: Partial<RunOptions> | undefined =
         traceFields || abortFields
           ? {
@@ -1398,12 +1515,14 @@ export class OpenMultiAgent {
               tracePhase: 'short-circuit',
               ...(traceFields ?? {}),
               ...(abortFields ?? {}),
+              ...(journalFields ?? {}),
             }
           : {
               identity,
               runId: identity.runId,
               ...(traceRuntime ? { traceRuntime, traceSpan: traceRuntime.root } : {}),
               tracePhase: 'short-circuit',
+              ...(journalFields ?? {}),
             }
 
       const scStartMs = Date.now()
@@ -1532,6 +1651,7 @@ export class OpenMultiAgent {
           traceAgent: 'coordinator',
           ...(coordinatorDecomposeSpanId ? { traceSpanId: coordinatorDecomposeSpanId } : {}),
           ...(options?.abortSignal ? { abortSignal: options.abortSignal } : {}),
+          ...(journal ? { journal } : {}),
         }
       : {
           identity,
@@ -1539,6 +1659,7 @@ export class OpenMultiAgent {
           ...(traceRuntime ? { traceRuntime, traceSpan: traceRuntime.root } : {}),
           tracePhase: 'decomposition',
           ...(options?.abortSignal ? { abortSignal: options.abortSignal } : {}),
+          ...(journal ? { journal } : {}),
         }
     const decompositionResult = await coordinatorAgent.run(decompositionPrompt, decompTraceOptions)
     const agentResults = new Map<string, AgentRunResult>()
@@ -1707,6 +1828,8 @@ export class OpenMultiAgent {
       ))
     }
 
+    emitInitialPlanSet(journal, queue)
+
     const requirementIssues = validateTaskRequirements(
       queue.list(),
       agentConfigs,
@@ -1763,6 +1886,7 @@ export class OpenMultiAgent {
       agentResults,
       config: runConfig,
       ...(activeCheckpoint ? { checkpoint: activeCheckpoint } : {}),
+      ...(journal ? { journal } : {}),
       runId,
       identity,
       ...(metadata !== undefined ? { metadata } : {}),
@@ -1961,6 +2085,7 @@ export class OpenMultiAgent {
       maxCostBudget,
       estimateCost: this.config.estimateCost,
       ...(traceRuntime ? { traceRuntime, consumedTaskSpans: [...ctx.taskSpans.values()] } : {}),
+      ...(journal ? { journal } : {}),
     })
     if (synthesis === null) {
       // Aborted or already over budget — return raw task outputs, no synthesis.
@@ -2093,6 +2218,9 @@ export class OpenMultiAgent {
       undefined,
       undefined,
       pendingEvaluation,
+      undefined,
+      undefined,
+      'runFromPlan',
     )
   }
 
@@ -2181,6 +2309,9 @@ export class OpenMultiAgent {
             input: tasksOrOptions,
             startedAtMs: evaluationStartedAtMs,
           },
+          undefined,
+          undefined,
+          'restore',
         )
       }
       if (this.isPlanArtifact(tasksOrOptions)) {
@@ -2208,6 +2339,9 @@ export class OpenMultiAgent {
             input: tasksOrOptions,
             startedAtMs: evaluationStartedAtMs,
           },
+          undefined,
+          undefined,
+          'restore',
         )
       }
 
@@ -2226,6 +2360,9 @@ export class OpenMultiAgent {
           input: { kind: 'restore', goal: options?.goal },
           startedAtMs: evaluationStartedAtMs,
         },
+        undefined,
+        undefined,
+        'restore',
       )
     }
 
@@ -2479,6 +2616,9 @@ export class OpenMultiAgent {
         input: { kind: 'restore', goal: snapshot.goal ?? options?.goal },
         startedAtMs: evaluationStartedAtMs,
       },
+      undefined,
+      undefined,
+      'restore',
     )
   }
 
@@ -2820,6 +2960,7 @@ export class OpenMultiAgent {
     pendingEvaluation?: PendingOnlineEvaluation,
     governanceDeclaration?: GovernanceDeclaration,
     routingDecisionInput?: RoutingDecisionRecordInput,
+    journalMode: RunJournalMode = 'runTasks',
   ): Promise<TeamRunResult> {
     const runConfig = this.configForRun(options?.egressPolicy)
     const agentConfigs = team.getAgents()
@@ -2847,6 +2988,10 @@ export class OpenMultiAgent {
     const runIdentity = identity ?? newRunFacts!.identity
     const metadata = restoreMetadata?.metadata ?? newRunFacts?.metadata
     const traceRuntime = this.startTrace(runIdentity, metadata, restoreMetadata?.overridden)
+    const journal = await this.startRunJournal(
+      options?.journal, runIdentity, journalMode, goal, metadata,
+    )
+    emitInitialPlanSet(journal, queue)
     const routingDecision = routingDecisionInput
       ? recordRoutingDecision(runIdentity, traceRuntime, routingDecisionInput)
       : undefined
@@ -2863,6 +3008,14 @@ export class OpenMultiAgent {
       'runTasks',
       goal,
     )
+    // Restore reconciles approval decisions against the primary ledger before
+    // this point, when no recorder exists yet. Recording them here is what
+    // makes an attempt's journal say which boundaries it resumed under.
+    if (journal && checkpoint) {
+      for (const decision of checkpoint.approvalDecisions.values()) {
+        journal.emit({ type: 'approval/decision', decision })
+      }
+    }
     const restoredConfirmationState = checkpoint?.mode === 'runTeam'
       && this.config.requireConsequentialConfirmation
       && [...checkpoint.approvalDecisions.values()].some(
@@ -2879,6 +3032,7 @@ export class OpenMultiAgent {
       agentResults,
       config: runConfig,
       ...(checkpoint ? { checkpoint } : {}),
+      ...(journal ? { journal } : {}),
       identity: runIdentity,
       ...(metadata !== undefined ? { metadata } : {}),
       runId: runIdentity.runId,
@@ -2928,6 +3082,7 @@ export class OpenMultiAgent {
           maxCostBudget: ctx.maxCostBudget,
           estimateCost: ctx.estimateCost,
           ...(traceRuntime ? { traceRuntime, consumedTaskSpans: [...ctx.taskSpans.values()] } : {}),
+          ...(journal ? { journal } : {}),
         })
         if (synthesis !== null && synthesis.result.success) {
           agentResults.set('coordinator', synthesis.result)
@@ -3006,8 +3161,11 @@ export class OpenMultiAgent {
       governanceDeclaration,
       buildExecutionReceipt(resultWithRouting),
     )
+    const queueStatus = completedResult.status
+      ?? statusOnly(completedResult.success ? 'ok' : 'error')
+    await endRunJournal(journal, queueStatus, completedResult.errorInfo)
     traceRuntime?.close({
-      status: completedResult.status ?? statusOnly(completedResult.success ? 'ok' : 'error'),
+      status: queueStatus,
       ...(completedResult.errorInfo ? { error: completedResult.errorInfo } : {}),
     })
     this.completeOnlineEvaluation(pendingEvaluation, completedResult)

--- a/packages/core/src/orchestrator/run-context.ts
+++ b/packages/core/src/orchestrator/run-context.ts
@@ -30,6 +30,7 @@ import type { AgentPool } from '../agent/pool.js'
 import type { Team } from '../team/team.js'
 import type { Scheduler } from './scheduler.js'
 import type { Checkpoint } from '../memory/checkpoint.js'
+import type { JournalRecorder } from '../journal/journal.js'
 import type { DurableApprovalLedger } from '../approval/durable.js'
 import type { TraceRuntime, TraceSpan } from '../observability/runtime.js'
 import type { ResolvedRecoveryOptions } from './recovery.js'
@@ -145,6 +146,8 @@ export interface RunContext {
   readonly agentResults: Map<string, AgentRunResult>
   readonly config: OrchestratorConfig
   readonly checkpoint?: ActiveCheckpoint
+  /** Present only when the run resolved a journal. Every emission guards on it. */
+  readonly journal?: JournalRecorder
   /** Stable top-level execution identity, independent of trace callbacks. */
   readonly identity: RunIdentity
   /** Validated facts echoed on the result and persisted with checkpoints. */

--- a/packages/core/src/orchestrator/task-execution.ts
+++ b/packages/core/src/orchestrator/task-execution.ts
@@ -263,6 +263,14 @@ export async function saveRunCheckpoint(queue: TaskQueue, ctx: RunContext): Prom
   try {
     await nextSave
     checkpointSpan?.end({ status: statusOnly('ok') })
+    // The watermark is the recorder's high-water mark at save time: which
+    // journal events this snapshot already folds in.
+    ctx.journal?.emit({
+      type: 'checkpoint/saved',
+      mode: active.mode,
+      version: 4,
+      watermarkSeq: ctx.journal.lastSeq,
+    })
     return true
   } catch (error) {
     const classified = classifyRunFailure(error, { kind: 'store' })
@@ -366,6 +374,9 @@ export async function persistPendingApproval(
     )
   }
   await active.approvalLedger.ensureRequest(request)
+  // Journaled after the ledger accepted it. Durability here is the ledger's
+  // job; the journal only records that the boundary existed.
+  ctx.journal?.emit({ type: 'approval/request', request })
   ctx.config.onProgress?.({
     type: 'approval_pending',
     data: request,
@@ -631,6 +642,22 @@ async function applyRecoveryAtOutcome(
     status: statusOnly('ok'),
     attributes: { 'oma.plan.revision': applied.revision.version },
   })
+  // Journaled only after the patch committed and its checkpoint survived the
+  // rollback check above, so the journal never names a revision the run
+  // discarded.
+  ctx.journal?.emit({
+    type: 'plan/set',
+    taskId: task.id,
+    revision: applied.revision.version,
+    source: 'recovery',
+    tasks: tasks.map((candidate) => ({
+      taskId: candidate.id,
+      ...(candidate.description !== undefined ? { description: candidate.description } : {}),
+      ...(candidate.assignee !== undefined ? { assignee: candidate.assignee } : {}),
+      ...(candidate.dependsOn !== undefined ? { dependsOn: candidate.dependsOn } : {}),
+    })),
+    detail: applied.revision,
+  })
   ctx.config.onProgress?.({
     type: 'plan_revision',
     task: task.id,
@@ -733,6 +760,27 @@ export async function executeQueue(
           data: task,
         } satisfies OrchestratorEvent)
       })
+    : undefined
+
+  // Terminal task transitions are journaled from the queue rather than the
+  // dispatch loop, so cascaded failures and skips — which no dispatch site
+  // ever sees — are recorded too.
+  const unsubJournal = ctx.journal
+    ? (['task:complete', 'task:failed', 'task:skipped'] as const).map((event) =>
+        queue.on(event, (task) => {
+          ctx.journal!.emit({
+            type: 'task/status',
+            taskId: task.id,
+            ...(task.assignee !== undefined ? { agentName: task.assignee } : {}),
+            status: task.status,
+            // `result` is the failure or skip explanation on those paths; on
+            // completion it is the task output, which `memory/set` and the
+            // run result already carry.
+            ...(task.status !== 'completed' && task.result !== undefined
+              ? { reason: task.result }
+              : {}),
+          })
+        }))
     : undefined
 
   const unsubReady = !legacyRoundMode
@@ -1015,8 +1063,15 @@ export async function executeQueue(
         throw new InvalidTaskRequirementsError(requirementIssues)
       }
 
-      // Mark in-progress
+      // Mark in-progress. The queue has no event for this transition, so it is
+      // the one status the journal records from the dispatch site.
       queue.update(task.id, { status: 'in_progress' as TaskStatus })
+      ctx.journal?.emit({
+        type: 'task/status',
+        taskId: task.id,
+        ...(task.assignee !== undefined ? { agentName: task.assignee } : {}),
+        status: 'in_progress',
+      })
 
       const dependencyLinks = (task.dependsOn ?? []).flatMap((dependencyId) => {
         const dependencySpan = ctx.taskSpans.get(dependencyId)
@@ -1186,6 +1241,12 @@ export async function executeQueue(
           ? async (request: ApprovalRequest) => {
               ctx.checkpoint!.pendingApprovals.set(request.id, request)
               await ctx.checkpoint!.approvalLedger.ensureRequest(request)
+              ctx.journal?.emit({
+                type: 'approval/request',
+                taskId: task.id,
+                agentName: assignee,
+                request,
+              })
               config.onProgress?.({
                 type: 'approval_pending',
                 task: task.id,
@@ -1221,7 +1282,11 @@ export async function executeQueue(
               }
             : {}),
           ...(ctx.abortSignal ? { abortSignal: ctx.abortSignal } : {}),
+          ...(ctx.journal ? { journal: ctx.journal } : {}),
         }
+        // On `traceBase` rather than `runOptions`, so delegated child runs
+        // inherit the same recorder through `buildTaskAgentTeamInfo` and
+        // journal under their own agent name in the one ordered stream.
         const runOptions: Partial<RunOptions> = {
           ...traceBase,
           team: buildTaskAgentTeamInfo(ctx, task.id, traceBase, 0, [assignee]),
@@ -1457,6 +1522,16 @@ export async function executeQueue(
           // Persist result into shared memory so other agents can read it
           if (sharedMem) {
             await sharedMem.write(assignee, `task:${task.id}:result`, effective.output)
+            // The store stays authoritative for the value; the journal records
+            // only that the write happened and how large it was.
+            ctx.journal?.emit({
+              type: 'memory/set',
+              taskId: task.id,
+              agentName: assignee,
+              agent: assignee,
+              key: `task:${task.id}:result`,
+              valueBytes: Buffer.byteLength(effective.output, 'utf8'),
+            })
             // Advance the turn counter so any TTL-tagged entries written during
             // this task can be expired by subsequent reads.
             sharedMem.advanceTurn()
@@ -1625,6 +1700,7 @@ export async function executeQueue(
     unsubAllComplete?.()
     unsubReady?.()
     unsubSkipped?.()
+    for (const unsubscribe of unsubJournal ?? []) unsubscribe()
   }
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ZodSchema } from 'zod'
+import type { RunJournalConfig } from './journal/journal.js'
 import type { SupportedProvider } from './llm/adapter.js'
 import type {
   SchedulingStrategy,
@@ -306,6 +307,12 @@ export interface RunIdentityOptions {
 /** Per-call options for {@link OpenMultiAgent.runAgent}. */
 export interface RunAgentOptions extends RunIdentityOptions {
   readonly abortSignal?: AbortSignal
+  /**
+   * Opt-in run event journal for this call. Overrides
+   * {@link OrchestratorConfig.journal}; `false` disables journaling for this
+   * run only. See `docs/run-journal.md`.
+   */
+  readonly journal?: RunJournalConfig | false
 }
 
 export type RunStatusCode =
@@ -1600,6 +1607,12 @@ export interface RunTasksOptions extends RunIdentityOptions {
    * a frozen plan remains an exact replay contract.
    */
   readonly recovery?: RecoveryOptions
+  /**
+   * Opt-in run event journal for this call. Overrides
+   * {@link OrchestratorConfig.journal}; `false` disables journaling for this
+   * run only. Inherited by {@link RestoreOptions}. See `docs/run-journal.md`.
+   */
+  readonly journal?: RunJournalConfig | false
 }
 
 /**
@@ -2323,6 +2336,13 @@ export interface OrchestratorConfig {
   readonly evaluation?: import('./eval/online.js').OnlineEvaluationConfig
   /** Observability v2 sinks. User code owns forceFlush/shutdown lifecycle. */
   readonly observability?: import('./observability/sink.js').ObservabilityConfig
+  /**
+   * Default opt-in run event journal. Off unless set; per-call `journal`
+   * options override it, and `false` disables it for a single run. The caller
+   * supplies and owns the backend instance — the framework never closes it.
+   * See `docs/run-journal.md`.
+   */
+  readonly journal?: RunJournalConfig
   readonly onTrace?: (event: TraceEvent) => void | Promise<void>
   /**
    * Optional per-call tool gate inherited by agents that do not define their own

--- a/packages/core/tests/journal-backends.test.ts
+++ b/packages/core/tests/journal-backends.test.ts
@@ -1,0 +1,318 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  InMemoryRunJournal,
+  JournalRecorder,
+  resolveRunJournal,
+  type RunJournal,
+} from '../src/journal/journal.js'
+import { JsonlRunJournal } from '../src/journal/jsonl-journal.js'
+import { isRunEvent } from '../src/journal/events.js'
+import type { RunEvent } from '../src/journal/events.js'
+
+function event(seq: number, overrides: Partial<RunEvent> = {}): RunEvent {
+  return {
+    type: 'turn/start',
+    seq,
+    timestampUnixMs: 1_700_000_000_000 + seq,
+    runId: 'run-1',
+    attempt: 1,
+    turn: seq,
+    ...overrides,
+  } as RunEvent
+}
+
+const tempDirs: string[] = []
+
+async function tempFile(name: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'oma-journal-'))
+  tempDirs.push(dir)
+  return join(dir, name)
+}
+
+afterEach(async () => {
+  while (tempDirs.length > 0) {
+    await rm(tempDirs.pop()!, { recursive: true, force: true })
+  }
+})
+
+describe('InMemoryRunJournal', () => {
+  it('retains the tail and evicts the oldest events past its bound', async () => {
+    const journal = new InMemoryRunJournal({ maxEvents: 3 })
+    await journal.append([event(1), event(2)])
+    expect(journal.size).toBe(2)
+
+    await journal.append([event(3), event(4), event(5)])
+    expect(journal.size).toBe(3)
+
+    const retained = await journal.readFrom(0)
+    expect(retained.map((e) => e.seq)).toEqual([3, 4, 5])
+  })
+
+  it('readFrom returns only events at or above the requested sequence', async () => {
+    const journal = new InMemoryRunJournal()
+    await journal.append([event(1), event(2), event(3)])
+
+    expect((await journal.readFrom(2)).map((e) => e.seq)).toEqual([2, 3])
+    expect(await journal.readFrom(9)).toEqual([])
+    expect(await journal.readFrom(0)).toHaveLength(3)
+  })
+
+  it('rejects a non-positive bound rather than silently retaining nothing', () => {
+    expect(() => new InMemoryRunJournal({ maxEvents: 0 })).toThrow(/positive integer/)
+    expect(() => new InMemoryRunJournal({ maxEvents: 1.5 })).toThrow(/positive integer/)
+  })
+})
+
+describe('JsonlRunJournal', () => {
+  it('round-trips appended events through the file', async () => {
+    const path = await tempFile('run.jsonl')
+    const journal = new JsonlRunJournal(path, { flushIntervalMs: 0 })
+    await journal.append([event(1), event(2)])
+    await journal.append([event(3)])
+    await journal.close()
+
+    const read = await new JsonlRunJournal(path).readFrom(2)
+    expect(read.map((e) => e.seq)).toEqual([2, 3])
+  })
+
+  it('opens the batching window on the first pending event and does not reset it', async () => {
+    const path = await tempFile('batched.jsonl')
+    const journal = new JsonlRunJournal(path, { flushIntervalMs: 60 })
+
+    const first = journal.append([event(1)])
+    // A later append lands inside the window opened by the first one. If the
+    // window reset, this batch would flush 60ms after *this* call instead.
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    const second = journal.append([event(2)])
+    expect(await readFile(path, 'utf8').catch(() => '')).toBe('')
+
+    const startedWaiting = Date.now()
+    await Promise.all([first, second])
+    // Both settled together, ~30ms after the second append rather than ~60ms.
+    expect(Date.now() - startedWaiting).toBeLessThan(55)
+
+    // One write, so both lines are in the file at the same instant.
+    const raw = await readFile(path, 'utf8')
+    expect(raw.split('\n').filter((line) => line.length > 0)).toHaveLength(2)
+    await journal.close()
+  })
+
+  it('ignores a trailing partial line left by a crash mid-write', async () => {
+    const path = await tempFile('torn.jsonl')
+    const journal = new JsonlRunJournal(path, { flushIntervalMs: 0 })
+    await journal.append([event(1), event(2)])
+    await journal.close()
+
+    const raw = await readFile(path, 'utf8')
+    await writeFile(path, `${raw}{"type":"turn/start","seq":3,"run`, 'utf8')
+
+    const read = await new JsonlRunJournal(path).readFrom(0)
+    expect(read.map((e) => e.seq)).toEqual([1, 2])
+  })
+
+  it('rejects corruption that is not a trailing partial line', async () => {
+    const path = await tempFile('corrupt.jsonl')
+    await writeFile(path, 'not json\n{"type":"turn/start","seq":2,"timestampUnixMs":1,"runId":"r","attempt":1}\n', 'utf8')
+    await expect(new JsonlRunJournal(path).readFrom(0)).rejects.toThrow(/line 1/)
+  })
+
+  it('treats a missing file as an empty journal', async () => {
+    const path = await tempFile('absent.jsonl')
+    expect(await new JsonlRunJournal(path).readFrom(0)).toEqual([])
+  })
+
+  it('redacts at write time, so readFrom returns what was persisted', async () => {
+    const path = await tempFile('redacted.jsonl')
+    const journal = new JsonlRunJournal(path, {
+      flushIntervalMs: 0,
+      redact: { patterns: [/hunter2/g] },
+    })
+    await journal.append([event(1, {
+      type: 'user/message',
+      origin: 'input',
+      message: { role: 'user', content: [{ type: 'text', text: 'password is hunter2' }] },
+    } as Partial<RunEvent>)])
+    await journal.close()
+
+    const [persisted] = await new JsonlRunJournal(path).readFrom(0)
+    expect(persisted?.type).toBe('user/message')
+    expect(JSON.stringify(persisted)).not.toContain('hunter2')
+    expect(JSON.stringify(persisted)).toContain('[redacted]')
+  })
+
+  it('flushes the open batch on close', async () => {
+    const path = await tempFile('closed.jsonl')
+    const journal = new JsonlRunJournal(path, { flushIntervalMs: 10_000 })
+    void journal.append([event(1)])
+    expect(await readFile(path, 'utf8').catch(() => '')).toBe('')
+
+    await journal.close()
+    expect((await readFile(path, 'utf8')).trim().split('\n')).toHaveLength(1)
+  })
+
+  it('refuses appends after close instead of dropping them silently', async () => {
+    const path = await tempFile('after-close.jsonl')
+    const journal = new JsonlRunJournal(path, { flushIntervalMs: 0 })
+    await journal.close()
+    await expect(journal.append([event(1)])).rejects.toThrow(/closed/)
+  })
+})
+
+describe('isRunEvent', () => {
+  it('accepts a well-formed event and rejects malformed envelopes', () => {
+    expect(isRunEvent(event(1))).toBe(true)
+    expect(isRunEvent({ ...event(1), type: 'not/a/type' })).toBe(false)
+    expect(isRunEvent({ ...event(1), seq: 0 })).toBe(false)
+    expect(isRunEvent({ ...event(1), seq: 1.5 })).toBe(false)
+    expect(isRunEvent({ ...event(1), runId: 7 })).toBe(false)
+    expect(isRunEvent(null)).toBe(false)
+    expect(isRunEvent([event(1)])).toBe(false)
+  })
+})
+
+describe('JournalRecorder', () => {
+  it('assigns strictly increasing sequences and flushes them to the backend', async () => {
+    const journal = new InMemoryRunJournal()
+    const recorder = await JournalRecorder.open({ journal, runId: 'run-1', attempt: 1 })
+
+    const first = recorder.emit({ type: 'turn/start', turn: 1 })
+    const second = recorder.emit({ type: 'turn/end', turn: 1, outcome: 'completed' })
+    expect([first, second]).toEqual([1, 2])
+    expect(recorder.lastSeq).toBe(2)
+
+    await recorder.flush()
+    const written = await journal.readFrom(0)
+    expect(written.map((e) => e.seq)).toEqual([1, 2])
+    expect(written[0]).toMatchObject({ runId: 'run-1', attempt: 1, type: 'turn/start' })
+  })
+
+  it('continues the sequence when it re-attaches to a non-empty journal', async () => {
+    const journal = new InMemoryRunJournal()
+    const first = await JournalRecorder.open({ journal, runId: 'run-1', attempt: 1 })
+    first.emit({ type: 'turn/start', turn: 1 })
+    first.emit({ type: 'turn/end', turn: 1, outcome: 'completed' })
+    await first.flush()
+
+    const resumed = await JournalRecorder.open({ journal, runId: 'run-1', attempt: 2 })
+    expect(resumed.emit({ type: 'turn/start', turn: 2 })).toBe(3)
+    await resumed.flush()
+    expect((await journal.readFrom(0)).map((e) => e.seq)).toEqual([1, 2, 3])
+  })
+
+  it('batches whatever accumulated while the previous append was in flight', async () => {
+    const batches: number[][] = []
+    let release: (() => void) | undefined
+    const gate = new Promise<void>((resolve) => { release = resolve })
+    const journal: RunJournal = {
+      async append(events) {
+        batches.push(events.map((e) => e.seq))
+        if (batches.length === 1) await gate
+      },
+      async readFrom() { return [] },
+      async close() {},
+    }
+    const recorder = await JournalRecorder.open({ journal, runId: 'run-1', attempt: 1 })
+
+    recorder.emit({ type: 'turn/start', turn: 1 })
+    await Promise.resolve()
+    recorder.emit({ type: 'turn/start', turn: 2 })
+    recorder.emit({ type: 'turn/start', turn: 3 })
+    release!()
+    await recorder.flush()
+
+    expect(batches).toEqual([[1], [2, 3]])
+  })
+
+  it('reports an append failure once and keeps recording', async () => {
+    const errors: unknown[] = []
+    let failNext = true
+    const journal: RunJournal = {
+      async append() {
+        if (failNext) {
+          failNext = false
+          throw new Error('disk full')
+        }
+      },
+      async readFrom() { return [] },
+      async close() {},
+    }
+    const recorder = await JournalRecorder.open({
+      journal,
+      runId: 'run-1',
+      attempt: 1,
+      onError: (error) => errors.push(error),
+    })
+
+    recorder.emit({ type: 'turn/start', turn: 1 })
+    await recorder.flush()
+    expect(errors).toHaveLength(1)
+
+    recorder.emit({ type: 'turn/start', turn: 2 })
+    await expect(recorder.flush()).resolves.toBeUndefined()
+    expect(errors).toHaveLength(1)
+  })
+
+  it('reports an unreadable tail and still records from a fresh sequence', async () => {
+    const errors: unknown[] = []
+    const journal: RunJournal = {
+      async append() {},
+      async readFrom() { throw new Error('unreadable') },
+      async close() {},
+    }
+    const recorder = await JournalRecorder.open({
+      journal,
+      runId: 'run-1',
+      attempt: 1,
+      onError: (error) => errors.push(error),
+    })
+    expect(errors).toHaveLength(1)
+    expect(recorder.emit({ type: 'turn/start', turn: 1 })).toBe(1)
+  })
+
+  it('tracks block lineage by identity and caches the content hash', async () => {
+    const recorder = await JournalRecorder.open({
+      journal: new InMemoryRunJournal(),
+      runId: 'run-1',
+      attempt: 1,
+    })
+    const tracked = { type: 'text', text: 'hello' } as const
+    const untracked = { type: 'text', text: 'hello' } as const
+
+    recorder.registerBlocks([tracked], [7])
+    expect(recorder.lineageFor(tracked)).toEqual([7])
+    expect(recorder.lineageFor(untracked)).toBeNull()
+    // Structurally identical blocks hash identically; identity only decides lineage.
+    expect(recorder.hashFor(tracked)).toBe(recorder.hashFor(untracked))
+    expect(recorder.hashFor(tracked)).toMatch(/^[0-9a-f]{64}$/)
+    // Hashing an unlineaged block must not invent lineage for it.
+    expect(recorder.lineageFor(untracked)).toBeNull()
+  })
+})
+
+describe('resolveRunJournal', () => {
+  const journal = new InMemoryRunJournal()
+  const other = new InMemoryRunJournal()
+
+  it('accepts a bare journal instance as enabled with enforcement off', () => {
+    expect(resolveRunJournal(undefined, journal)).toEqual({ journal, enforceLineage: false })
+  })
+
+  it('lets a per-call value override config and false disable one run', () => {
+    expect(resolveRunJournal(journal, other)?.journal).toBe(other)
+    expect(resolveRunJournal(journal, undefined)?.journal).toBe(journal)
+    expect(resolveRunJournal(journal, false)).toBeUndefined()
+  })
+
+  it('honours enabled: false and enforceLineage on the options form', () => {
+    expect(resolveRunJournal({ journal, enabled: false }, undefined)).toBeUndefined()
+    expect(resolveRunJournal({ journal, enforceLineage: true }, undefined))
+      .toEqual({ journal, enforceLineage: true })
+  })
+
+  it('returns undefined when nothing is configured', () => {
+    expect(resolveRunJournal(undefined, undefined)).toBeUndefined()
+  })
+})

--- a/packages/core/tests/journal-emission.test.ts
+++ b/packages/core/tests/journal-emission.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { Team } from '../src/team/team.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import { defineTool } from '../src/tool/framework.js'
+import { InMemoryRunJournal } from '../src/journal/journal.js'
+import type { RunEvent } from '../src/journal/events.js'
+import type {
+  AgentConfig,
+  LLMAdapter,
+  LLMResponse,
+  RunTaskSpec,
+} from '../src/types.js'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function textResponse(text: string): LLMResponse {
+  return {
+    id: `resp-${text}`,
+    content: [{ type: 'text', text }],
+    model: 'mock-model',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 3, output_tokens: 5 },
+  }
+}
+
+function toolResponse(id: string, name: string, input: Record<string, unknown>): LLMResponse {
+  return {
+    id: `resp-${id}`,
+    content: [{ type: 'tool_use', id, name, input }],
+    model: 'mock-model',
+    stop_reason: 'tool_use',
+    usage: { input_tokens: 2, output_tokens: 4 },
+  }
+}
+
+/** Serves one scripted response per chat call, repeating the last one. */
+function sequencedAdapter(steps: LLMResponse[]): LLMAdapter {
+  let calls = 0
+  return {
+    name: 'journal-fixture',
+    async chat(): Promise<LLMResponse> {
+      const step = steps[Math.min(calls, steps.length - 1)]!
+      calls += 1
+      return step
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: textResponse('stream-unused') }
+    },
+  }
+}
+
+function throwingAdapter(message: string): LLMAdapter {
+  return {
+    name: 'journal-fixture-throwing',
+    async chat(): Promise<LLMResponse> {
+      throw new Error(message)
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: textResponse('stream-unused') }
+    },
+  }
+}
+
+const echoTool = defineTool({
+  name: 'echo',
+  description: 'Echo a value back.',
+  inputSchema: z.object({ value: z.string() }),
+  execute: async ({ value }) => ({ data: `echo:${value}` }),
+})
+
+function worker(name: string, adapter: LLMAdapter, overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return { name, model: 'mock-model', adapter, ...overrides }
+}
+
+function types(events: readonly RunEvent[]): string[] {
+  return events.map((event) => event.type)
+}
+
+function only<T extends RunEvent['type']>(
+  events: readonly RunEvent[],
+  type: T,
+): Array<Extract<RunEvent, { type: T }>> {
+  return events.filter((event): event is Extract<RunEvent, { type: T }> => event.type === type)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('run journal emission', () => {
+  it('records a tool-using runTasks run as one linked event stream', async () => {
+    const journal = new InMemoryRunJournal()
+    const store = new InMemoryStore()
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', sequencedAdapter([
+        toolResponse('tu-1', 'echo', { value: 'hi' }),
+        textResponse('all done'),
+      ]), { customTools: [echoTool], tools: ['echo'] })],
+      sharedMemoryStore: store,
+    })
+    const tasks: RunTaskSpec[] = [{ title: 'only', description: 'do it', assignee: 'worker' }]
+
+    const result = await new OpenMultiAgent().runTasks(team, tasks, { journal })
+    expect(result.success).toBe(true)
+
+    const events = await journal.readFrom(0)
+    expect(types(events)).toEqual([
+      'run/start',
+      'plan/set',
+      'task/status',
+      'user/message',
+      'turn/start',
+      'llm/request',
+      'assistant/message',
+      'tool/call',
+      'tool/result',
+      'user/message',
+      'turn/end',
+      'turn/start',
+      'llm/request',
+      'assistant/message',
+      'turn/end',
+      'memory/set',
+      'task/status',
+      'run/end',
+    ])
+
+    const byType = new Map(events.map((event) => [`${event.type}:${event.seq}`, event]))
+    expect(byType.size).toBe(events.length)
+
+    const [taskId] = only(events, 'plan/set')[0]!.tasks.map((task) => task.taskId)
+    expect(only(events, 'run/start')[0]).toMatchObject({ mode: 'runTasks' })
+    expect(only(events, 'task/status').map((event) => event.status))
+      .toEqual(['in_progress', 'completed'])
+    expect(only(events, 'run/end')[0]!.status).toEqual({ code: 'ok' })
+    expect(only(events, 'memory/set')[0]).toMatchObject({
+      agent: 'worker',
+      key: `task:${taskId}:result`,
+    })
+
+    // Lineage links: assistant → its request, tool/call → that assistant
+    // message, tool/result → its call, tool-result user message → the results.
+    const request = only(events, 'llm/request')[0]!
+    const assistant = only(events, 'assistant/message')[0]!
+    const call = only(events, 'tool/call')[0]!
+    const toolResult = only(events, 'tool/result')[0]!
+    const resultMessage = only(events, 'user/message')
+      .find((event) => event.origin === 'tool_results')!
+    expect(assistant.sourceEventSeqs).toEqual([request.seq])
+    expect(call.sourceEventSeqs).toEqual([assistant.seq])
+    expect(toolResult.sourceEventSeqs).toEqual([call.seq])
+    expect(toolResult.toolCallId).toBe('tu-1')
+    expect(resultMessage.sourceEventSeqs).toEqual([toolResult.seq])
+
+    // Every runner event is scoped to the task and the agent that produced it.
+    for (const event of events.filter((candidate) => candidate.type === 'llm/request')) {
+      expect(event).toMatchObject({ taskId, agentName: 'worker' })
+    }
+  })
+
+  it('assigns strictly increasing sequences starting at 1', async () => {
+    const journal = new InMemoryRunJournal()
+    const team = new Team({
+      name: 'team',
+      agents: [worker('a', sequencedAdapter([textResponse('a done')])),
+        worker('b', sequencedAdapter([textResponse('b done')]))],
+      sharedMemory: true,
+    })
+    await new OpenMultiAgent().runTasks(team, [
+      { title: 'first', description: 'one', assignee: 'a' },
+      { title: 'second', description: 'two', assignee: 'b' },
+    ], { journal })
+
+    const seqs = (await journal.readFrom(0)).map((event) => event.seq)
+    expect(seqs[0]).toBe(1)
+    for (let i = 1; i < seqs.length; i++) {
+      expect(seqs[i]!).toBeGreaterThan(seqs[i - 1]!)
+    }
+  })
+
+  it('records checkpoint saves with the recorder watermark', async () => {
+    const journal = new InMemoryRunJournal()
+    const store = new InMemoryStore()
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', sequencedAdapter([textResponse('done')]))],
+      sharedMemoryStore: store,
+    })
+    await new OpenMultiAgent().runTasks(
+      team,
+      [{ title: 'only', description: 'do it', assignee: 'worker' }],
+      { journal, checkpoint: { store } },
+    )
+
+    const events = await journal.readFrom(0)
+    const saves = only(events, 'checkpoint/saved')
+    expect(saves.length).toBeGreaterThan(0)
+    for (const save of saves) {
+      // v5 arrives with the derivation phase; PR 1 keeps writing v4.
+      expect(save).toMatchObject({ mode: 'runTasks', version: 4 })
+      // The watermark names the last event the snapshot folds, which is the
+      // event before this one — the save record itself is not folded into it.
+      expect(save.watermarkSeq).toBe(save.seq - 1)
+    }
+  })
+
+  it('covers a standalone runAgent run', async () => {
+    const journal = new InMemoryRunJournal()
+    const orchestrator = new OpenMultiAgent()
+    const result = await orchestrator.runAgent(
+      worker('solo', sequencedAdapter([textResponse('answered')])),
+      'a question',
+      { journal },
+    )
+    expect(result.success).toBe(true)
+
+    const events = await journal.readFrom(0)
+    expect(types(events)).toEqual([
+      'run/start',
+      'user/message',
+      'turn/start',
+      'llm/request',
+      'assistant/message',
+      'turn/end',
+      'run/end',
+    ])
+    expect(only(events, 'run/start')[0]).toMatchObject({ mode: 'runAgent' })
+    expect(only(events, 'turn/end')[0]).toMatchObject({ turn: 1, outcome: 'completed' })
+    expect(only(events, 'assistant/message')[0]).toMatchObject({
+      origin: 'response',
+      model: 'mock-model',
+      stopReason: 'end_turn',
+      usage: { input_tokens: 3, output_tokens: 5 },
+    })
+    // No task scoping outside an orchestrated task.
+    expect(only(events, 'llm/request')[0]!.taskId).toBeUndefined()
+  })
+
+  it('records a failed run with the failing status and closes the open turn', async () => {
+    const journal = new InMemoryRunJournal()
+    const result = await new OpenMultiAgent().runAgent(
+      worker('solo', throwingAdapter('provider exploded')),
+      'a question',
+      { journal },
+    )
+    expect(result.success).toBe(false)
+
+    const events = await journal.readFrom(0)
+    expect(only(events, 'turn/end')[0]).toMatchObject({ turn: 1, outcome: 'error' })
+    const end = only(events, 'run/end')[0]!
+    expect(end.status.code).not.toBe('ok')
+    expect(end.error?.message).toContain('provider exploded')
+  })
+
+  it('records cascaded task failures the dispatch loop never sees', async () => {
+    const journal = new InMemoryRunJournal()
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', throwingAdapter('boom'), { maxRetries: 0 })],
+      sharedMemory: true,
+    })
+    await new OpenMultiAgent().runTasks(team, [
+      { title: 'first', description: 'one', assignee: 'worker', maxRetries: 0 },
+      { title: 'second', description: 'two', assignee: 'worker', dependsOn: ['first'], maxRetries: 0 },
+    ], { journal })
+
+    const events = await journal.readFrom(0)
+    const statuses = only(events, 'task/status')
+    // The cascaded dependent never dispatches, so only the queue can report it.
+    expect(statuses.filter((event) => event.status === 'failed')).toHaveLength(2)
+    expect(statuses.filter((event) => event.status === 'in_progress')).toHaveLength(1)
+    for (const failure of statuses.filter((event) => event.status === 'failed')) {
+      expect(typeof failure.reason).toBe('string')
+    }
+  })
+
+  it('journals delegated child conversations under their own agent name', async () => {
+    const journal = new InMemoryRunJournal()
+    const team = new Team({
+      name: 'team',
+      agents: [
+        worker('lead', sequencedAdapter([
+          toolResponse('tu-d', 'delegate_to_agent', {
+            target_agent: 'helper',
+            prompt: 'do the sub-task',
+          }),
+          textResponse('lead done'),
+        ]), { tools: ['delegate_to_agent'] }),
+        worker('helper', sequencedAdapter([textResponse('helper done')])),
+      ],
+      sharedMemory: true,
+    })
+    await new OpenMultiAgent().runTasks(
+      team,
+      [{ title: 'only', description: 'delegate', assignee: 'lead' }],
+      { journal },
+    )
+
+    const events = await journal.readFrom(0)
+    const agents = new Set(only(events, 'llm/request').map((event) => event.agentName))
+    expect(agents).toEqual(new Set(['lead', 'helper']))
+    // Both conversations share one ordered stream and one task scope.
+    const taskIds = new Set(only(events, 'llm/request').map((event) => event.taskId))
+    expect(taskIds.size).toBe(1)
+  })
+
+  it('records the coordinator plan and its own conversation in runTeam', async () => {
+    const journal = new InMemoryRunJournal()
+    const plan = JSON.stringify([
+      { title: 'step', description: 'do the step', assignee: 'worker' },
+    ])
+    const orchestrator = new OpenMultiAgent({ defaultModel: 'mock-model' })
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', sequencedAdapter([textResponse('step done')]))],
+      sharedMemory: true,
+    })
+
+    const result = await orchestrator.runTeam(team, 'ship the thing', {
+      mode: 'team',
+      journal,
+      coordinator: {
+        model: 'mock-model',
+        adapter: sequencedAdapter([textResponse(plan), textResponse('synthesised')]),
+      },
+    })
+    expect(result.success).toBe(true)
+
+    const events = await journal.readFrom(0)
+    expect(only(events, 'run/start')[0]).toMatchObject({
+      mode: 'runTeam',
+      goal: 'ship the thing',
+    })
+    const planSet = only(events, 'plan/set')
+    expect(planSet).toHaveLength(1)
+    expect(planSet[0]).toMatchObject({ source: 'initial', revision: 0 })
+    expect(planSet[0]!.tasks[0]).toMatchObject({ assignee: 'worker' })
+    // The coordinator's decomposition precedes the plan it produced.
+    const coordinatorRequests = only(events, 'llm/request')
+      .filter((event) => event.agentName === 'coordinator')
+    expect(coordinatorRequests.length).toBeGreaterThanOrEqual(1)
+    expect(coordinatorRequests[0]!.seq).toBeLessThan(planSet[0]!.seq)
+  })
+
+  it('emits nothing when the journal is disabled for one run', async () => {
+    const journal = new InMemoryRunJournal()
+    const team = new Team({
+      name: 'team',
+      agents: [worker('worker', sequencedAdapter([textResponse('done')]))],
+      sharedMemory: true,
+    })
+    const orchestrator = new OpenMultiAgent({ journal })
+
+    await orchestrator.runTasks(
+      team,
+      [{ title: 'only', description: 'do it', assignee: 'worker' }],
+      { journal: false },
+    )
+    expect(journal.size).toBe(0)
+
+    // The same orchestrator default still journals a run that does not opt out.
+    await orchestrator.runTasks(
+      team,
+      [{ title: 'only', description: 'do it', assignee: 'worker' }],
+    )
+    expect(journal.size).toBeGreaterThan(0)
+  })
+
+  it('records the request config digests without the config itself', async () => {
+    const journal = new InMemoryRunJournal()
+    await new OpenMultiAgent().runAgent(
+      worker('solo', sequencedAdapter([textResponse('done')]), {
+        systemPrompt: 'You are terse.',
+        customTools: [echoTool],
+        tools: ['echo'],
+      }),
+      'hello',
+      { journal },
+    )
+
+    const request = only(await journal.readFrom(0), 'llm/request')[0]!
+    expect(request.systemPromptHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(request.toolsHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(JSON.stringify(request)).not.toContain('You are terse.')
+  })
+})

--- a/packages/core/tests/journal-lineage.test.ts
+++ b/packages/core/tests/journal-lineage.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import { AgentRunner } from '../src/agent/runner.js'
+import { JournalLineageError } from '../src/errors.js'
+import { InMemoryRunJournal, JournalRecorder } from '../src/journal/journal.js'
+import type { RunEvent } from '../src/journal/events.js'
+import type { RunJournal } from '../src/journal/journal.js'
+import { canonicalContentHash } from '../src/journal/hash.js'
+import { OpenMultiAgent } from '../src/orchestrator/orchestrator.js'
+import { InMemoryStore } from '../src/memory/store.js'
+import { Team } from '../src/team/team.js'
+import { defineTool, ToolRegistry } from '../src/tool/framework.js'
+import { ToolExecutor } from '../src/tool/executor.js'
+import type {
+  AgentConfig,
+  ContextStrategy,
+  LLMAdapter,
+  LLMMessage,
+  LLMResponse,
+  OrchestratorEvent,
+} from '../src/types.js'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function textResponse(text: string): LLMResponse {
+  return {
+    id: `resp-${text}`,
+    content: [{ type: 'text', text }],
+    model: 'mock-model',
+    stop_reason: 'end_turn',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function toolResponse(id: string): LLMResponse {
+  return {
+    id: `resp-${id}`,
+    content: [{ type: 'tool_use', id, name: 'echo', input: { value: 'hi' } }],
+    model: 'mock-model',
+    stop_reason: 'tool_use',
+    usage: { input_tokens: 1, output_tokens: 1 },
+  }
+}
+
+function sequencedAdapter(steps: LLMResponse[]): LLMAdapter {
+  let calls = 0
+  return {
+    name: 'lineage-fixture',
+    async chat(): Promise<LLMResponse> {
+      const step = steps[Math.min(calls, steps.length - 1)]!
+      calls += 1
+      return step
+    },
+    async *stream() {
+      yield { type: 'done' as const, data: textResponse('stream-unused') }
+    },
+  }
+}
+
+const echoTool = defineTool({
+  name: 'echo',
+  description: 'Echo a value back.',
+  inputSchema: z.object({ value: z.string() }),
+  execute: async ({ value }) => ({ data: `echo:${value}` }),
+})
+
+/** Replaces the whole conversation with a block no journal event produced. */
+const rewritingStrategy: ContextStrategy = {
+  type: 'custom',
+  compress: (messages) => [{
+    role: 'user',
+    content: [{ type: 'text', text: `[rewritten from ${messages.length} messages]` }],
+  }],
+}
+
+function runnerWith(
+  adapter: LLMAdapter,
+  options: { contextStrategy?: ContextStrategy } = {},
+): AgentRunner {
+  const registry = new ToolRegistry()
+  registry.register(echoTool)
+  return new AgentRunner(adapter, registry, new ToolExecutor(registry), {
+    model: 'mock-model',
+    agentName: 'worker',
+    allowedTools: ['echo'],
+    ...options,
+  })
+}
+
+const seedMessages: LLMMessage[] = [
+  { role: 'user', content: [{ type: 'text', text: 'do the thing' }] },
+]
+
+function requestBlocks(events: readonly RunEvent[]) {
+  return events
+    .filter((event): event is Extract<RunEvent, { type: 'llm/request' }> =>
+      event.type === 'llm/request')
+    .flatMap((event) => event.blocks.map((block) => ({ ...block, requestSeq: event.seq })))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('journal lineage', () => {
+  it('gives every model-visible block a lineage when no strategy rewrites the conversation', async () => {
+    const journal = new InMemoryRunJournal()
+    const recorder = await JournalRecorder.open({ journal, runId: 'run-1', attempt: 1 })
+    const runner = runnerWith(sequencedAdapter([toolResponse('tu-1'), textResponse('done')]))
+
+    await runner.run(seedMessages, { journal: recorder })
+    await recorder.flush()
+
+    const events = await journal.readFrom(0)
+    const blocks = requestBlocks(events)
+    expect(blocks.length).toBeGreaterThan(1)
+    expect(blocks.filter((block) => block.sourceEventSeqs === null)).toEqual([])
+
+    // Each named event exists and precedes the request that cites it.
+    const bySeq = new Map(events.map((event) => [event.seq, event]))
+    for (const block of blocks) {
+      for (const seq of block.sourceEventSeqs!) {
+        expect(bySeq.has(seq)).toBe(true)
+        expect(seq).toBeLessThan(block.requestSeq)
+      }
+      expect(block.contentHash).toMatch(/^[0-9a-f]{64}$/)
+    }
+  })
+
+  it('reproduces a request block from the event it names', async () => {
+    const journal = new InMemoryRunJournal()
+    const recorder = await JournalRecorder.open({ journal, runId: 'run-1', attempt: 1 })
+
+    await runnerWith(sequencedAdapter([textResponse('done')])).run(seedMessages, {
+      journal: recorder,
+    })
+    await recorder.flush()
+
+    const events = await journal.readFrom(0)
+    const [block] = requestBlocks(events)
+    const source = events.find((event) => event.seq === block!.sourceEventSeqs![0])
+    expect(source?.type).toBe('user/message')
+    const hashes = (source as Extract<RunEvent, { type: 'user/message' }>).message.content
+      .map(canonicalContentHash)
+    expect(hashes).toContain(block!.contentHash)
+  })
+
+  it('records the gap when a context strategy derives a block from nothing recorded', async () => {
+    const journal = new InMemoryRunJournal()
+    const recorder = await JournalRecorder.open({ journal, runId: 'run-1', attempt: 1 })
+    const runner = runnerWith(sequencedAdapter([textResponse('done')]), {
+      contextStrategy: rewritingStrategy,
+    })
+
+    await runner.run(seedMessages, { journal: recorder })
+    await recorder.flush()
+
+    const blocks = requestBlocks(await journal.readFrom(0))
+    // Until `context/replace` ships, a strategy-derived block names nothing.
+    expect(blocks).toHaveLength(1)
+    expect(blocks[0]!.sourceEventSeqs).toBeNull()
+    expect(blocks[0]!.blockType).toBe('text')
+  })
+
+  it('throws JournalLineageError under enforceLineage when a block names nothing', async () => {
+    const recorder = await JournalRecorder.open({
+      journal: new InMemoryRunJournal(),
+      runId: 'run-1',
+      attempt: 1,
+      enforceLineage: true,
+    })
+    const runner = runnerWith(sequencedAdapter([textResponse('done')]), {
+      contextStrategy: rewritingStrategy,
+    })
+
+    await expect(runner.run(seedMessages, { journal: recorder }))
+      .rejects.toThrow(JournalLineageError)
+    await expect(runner.run(seedMessages, { journal: recorder }))
+      .rejects.toMatchObject({
+        code: 'MISSING_CONTEXT_REPLACE',
+        messageIndex: 0,
+        blockIndex: 0,
+        blockType: 'text',
+      })
+  })
+
+  it('passes enforceLineage when no strategy is configured', async () => {
+    const journal = new InMemoryRunJournal()
+    const recorder = await JournalRecorder.open({
+      journal,
+      runId: 'run-1',
+      attempt: 1,
+      enforceLineage: true,
+    })
+    const runner = runnerWith(sequencedAdapter([toolResponse('tu-1'), textResponse('done')]))
+
+    const result = await runner.run(seedMessages, { journal: recorder })
+    expect(result.output).toBe('done')
+    await recorder.flush()
+    expect(requestBlocks(await journal.readFrom(0)).every(
+      (block) => block.sourceEventSeqs !== null,
+    )).toBe(true)
+  })
+
+  it('surfaces a failed append through onProgress and still completes the run', async () => {
+    const failures: OrchestratorEvent[] = []
+    const failing: RunJournal = {
+      async append() {
+        throw new Error('journal backend unavailable')
+      },
+      async readFrom() {
+        return []
+      },
+      async close() {},
+    }
+    const worker: AgentConfig = {
+      name: 'worker',
+      model: 'mock-model',
+      adapter: sequencedAdapter([textResponse('done')]),
+    }
+    const orchestrator = new OpenMultiAgent({
+      onProgress: (event) => {
+        if (event.type === 'error') failures.push(event)
+      },
+    })
+    const team = new Team({
+      name: 'team',
+      agents: [worker],
+      sharedMemoryStore: new InMemoryStore(),
+    })
+
+    const result = await orchestrator.runTasks(
+      team,
+      [{ title: 'only', description: 'do it', assignee: 'worker' }],
+      { journal: failing },
+    )
+
+    expect(result.success).toBe(true)
+    const appendFailures = failures.filter((event) =>
+      (event.data as { kind?: string }).kind === 'journal_append_failed')
+    expect(appendFailures.length).toBeGreaterThan(0)
+    expect((appendFailures[0]!.data as { error: Error }).error.message)
+      .toBe('journal backend unavailable')
+  })
+})


### PR DESCRIPTION
Phase 1 of #527.

After a long multi-agent run, three records describe what happened — checkpoint snapshots, trace spans, and the conversation itself — and none of them can answer "why did the model see this?". Context strategies rewrite the conversation silently, so the bytes that actually reached the adapter are not reconstructable afterwards.

This adds an opt-in run event journal that closes that gap:

- **Reconstruct exactly what each agent saw.** Every adapter call records one descriptor per model-visible block: where it came from (`sourceEventSeqs`) and a sha256 of its canonical form. Lineage is per block, not per request, because a request's blocks can have different origins.
- **See the whole run as one ordered stream.** Messages, tool calls and results, turn boundaries, task transitions (including cascaded failures and skips the dispatch loop never sees), plan revisions, shared-memory writes, approval boundaries, and checkpoint saves — all with strictly increasing sequence numbers that continue across restore attempts. Delegated child runs and coordinator calls journal under their own agent name in the same stream.
- **Fail closed when you want to.** `enforceLineage: true` throws `JournalLineageError` (`MISSING_CONTEXT_REPLACE`) before the adapter call when a model-visible block cannot name what produced it, instead of discovering it later during replay.

## Using it

```ts
const journal = new InMemoryRunJournal()
await orchestrator.runTasks(team, tasks, { journal })
for (const event of await journal.readFrom(0)) { /* ... */ }
```

`JsonlRunJournal` writes one event per line to a file with batched, fsynced appends and the same redaction hook shape as `RedactingStore`. You supply and own the backend; the framework never closes it.

## Cost when you do not use it

Off by default. No recorder is allocated, every emission site is guarded, and checkpoint snapshots still write schema v4 unchanged. The full existing test suite passes untouched — 1950 tests before, all still green.

Journal appends are best-effort, exactly like checkpoint saves: a failure is reported once through `onProgress` as `journal_append_failed` and never fails the run. That holds at approval boundaries too, where durability is the durable approval ledger's job.

## Deliberate gaps, documented rather than hidden

With a context strategy configured, strategy-derived blocks record `sourceEventSeqs: null` and `enforceLineage: true` correctly rejects the run. That is the invariant working — there is no event yet that can name a rewrite. The follow-up phase adds `context/replace`, checkpoint v5 with a journal watermark, and tail replay; verification tooling lands after that. Restored runs and the structured-output corrective retry have their own documented behavior in `docs/run-journal.md`.

## Scope

New: `packages/core/src/journal/` and `docs/run-journal.md`. Orchestrator decision events (`routing/decision`, `consensus/verdict`, `recovery/decision`), `runConsensus`, and the routing profiler are not journaled in this release. No checkpoint schema change, no README entry yet — the README paragraph lands when the feature story is complete.

## Validation

`git diff --check`, `npm run test -w @open-multi-agent/core` (134 files / 1988 tests), `npm run lint -w @open-multi-agent/core`, `npm run build -w @open-multi-agent/core`, then `npm run lint` and `npm test` at the repository root. All pass.
