### PR TITLE
ci(release-bot): move the weekly cron off the top of the hour

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -176,8 +176,8 @@ the full set of template traps.
 
 ## Order
 
-1. **Prepare a release PR.** `release-bot.yml` runs each Friday at 10:00 UTC
-   (18:00 Asia/Taipei) and is also manually dispatchable. It exits successfully
+1. **Prepare a release PR.** `release-bot.yml` runs each Friday at 10:23 UTC
+   (18:23 Asia/Taipei) and is also manually dispatchable. It exits successfully
    without calling a model when a release PR is already open, no commits exist
    after the latest core tag, or `packages/core` did not change. Otherwise it
    plans the release,

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -3,9 +3,11 @@ name: OMA Release Bot
 on:
   workflow_dispatch:
   schedule:
-    # Friday 18:00 Asia/Taipei. The offset is intentionally documented because
-    # GitHub schedules are UTC and can be delayed during high load.
-    - cron: '0 10 * * 5'
+    # Friday 18:23 Asia/Taipei. The offset is intentionally documented because
+    # GitHub schedules are UTC and can be delayed during high load. The :23
+    # keeps the trigger off the top of the hour, the most contended slot: the
+    # 2026-08-28 trigger was never delivered at all, not merely delayed.
+    - cron: '23 10 * * 5'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Why

GitHub never delivered the scheduled trigger for Friday 2026-08-28. There is no workflow run record for it at all: not a failure, not a skipped job. The workflow was active, the cron was on the default branch, Actions was enabled, and nothing was queued or waiting.

The daily provider canary in this repository shows what happened. Its `17 3 * * *` schedule fired between 03:53 and 04:03 UTC through 08-26, roughly 40 minutes late, which is its normal behavior. It then fired at 14:07 UTC on 08-27 and 15:18 UTC on 08-28, 10h50m and 12h01m late. GitHub's scheduler for this repository was running hours behind, and GitHub documents that scheduled workflows can be delayed or dropped entirely under high load. The top of the hour is the most contended slot.

## What

Move the weekly trigger from `0 10 * * 5` to `23 10 * * 5`, Friday 18:23 Asia/Taipei, and update `.github/RELEASING.md` so the documented time matches the workflow.

This does not touch the two earlier scheduled failures, which had unrelated causes and are already resolved: the 08-14 run reported `OMA release analysis failed.` with a blank cause, which #545 fixed, and the 08-21 run failed on a missing `## Unreleased` section, which the 1.16.1 release restored.

## Verification

- Workflow YAML parses; triggers are `workflow_dispatch` and `schedule`, schedule is `23 10 * * 5`
- `git diff --check` is clean
- A repository-wide grep confirms no other reference to the old time
- No test asserts this schedule, so no test changes are needed

The new time takes effect only once this is merged, since GitHub schedules from the default branch.
