### PR TITLE
fix(release-bot): credit contributors by GitHub login

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -232,7 +232,10 @@ the changelog does not carry. `## Packages` names every workspace version and
 says which ones were not republished. `## Thanks` credits contributors from
 outside the project, resolved from the commits between the previous release tag
 and the release commit, with the maintainer's own commits and bot commits
-excluded. `## Install` is copy-pasteable. All three are derived from the release
+excluded. Each contributor is credited by GitHub login: a noreply address
+carries it, and any other address is resolved by asking GitHub which account
+claims the commit, falling back to the commit's display name when no account
+does. `## Install` is copy-pasteable. All three are derived from the release
 commit and its own manifests, so no model output reaches them.
 
 ## What CI proves

--- a/packages/release-bot/src/github.ts
+++ b/packages/release-bot/src/github.ts
@@ -33,6 +33,8 @@ export interface GitHubClient {
   createPullRequest(input: CreatePullRequestInput): Promise<GitHubPullRequest>
   getReleaseByTag(tag: string): Promise<GitHubRelease | null>
   createRelease(input: CreateReleaseInput): Promise<GitHubRelease>
+  /** The GitHub login linked to a commit, or null when no account claims it. */
+  getCommitAuthorLogin(sha: string): Promise<string | null>
 }
 
 interface PullResponse {
@@ -51,6 +53,10 @@ interface ReleaseResponse {
 
 interface RefResponse {
   object: { sha: string }
+}
+
+interface CommitResponse {
+  author: { login: string } | null
 }
 
 export class GitHubApiClient implements GitHubClient {
@@ -131,6 +137,16 @@ export class GitHubApiClient implements GitHubClient {
       }),
     })
     return mapRelease(release)
+  }
+
+  async getCommitAuthorLogin(sha: string): Promise<string | null> {
+    const response = await this.rawRequest(
+      `/repos/${this.repository}/commits/${encodeURIComponent(sha)}`,
+    )
+    if (response.status === 404) return null
+    if (!response.ok) await throwGitHubError(response)
+    // A commit whose email is not linked to any account has a null author.
+    return (await response.json() as CommitResponse).author?.login ?? null
   }
 
   private async request<T>(path: string, init?: RequestInit): Promise<T> {

--- a/packages/release-bot/src/publisher.ts
+++ b/packages/release-bot/src/publisher.ts
@@ -204,16 +204,17 @@ export async function collectReleaseContributors(
 
   const log = await options.runner.run(
     'git',
-    ['log', '--format=%an%x1f%ae%x1f%s%x1e', `${previousTag}..${options.expectedSha}`],
+    ['log', '--format=%H%x1f%an%x1f%ae%x1f%s%x1e', `${previousTag}..${options.expectedSha}`],
     { cwd: options.repoRoot },
   )
   const excluded = new Set(options.excludedContributors ?? DEFAULT_EXCLUDED_CONTRIBUTORS)
   const byName = new Map<string, string[]>()
+  const loginByEmail = new Map<string, string | null>()
   for (const record of log.stdout.split('\u001e')) {
     const line = record.trim()
     if (line === '') continue
-    const [author = '', email = '', subject = ''] = line.split('\u001f')
-    const name = resolveContributorName(author, email)
+    const [sha = '', author = '', email = '', subject = ''] = line.split('\u001f')
+    const name = await resolveContributorName(sha, author, email, options.github, loginByEmail)
     if (name === '' || name.endsWith('[bot]') || excluded.has(name)) continue
     const contribution = describeContribution(subject)
     if (contribution === '') continue
@@ -224,10 +225,38 @@ export async function collectReleaseContributors(
   return [...byName].map(([name, contributions]) => ({ name, contributions }))
 }
 
-/** A GitHub noreply address carries the login; anything else only has a display name. */
-function resolveContributorName(author: string, email: string): string {
-  const noreply = /^(?:\d+\+)?(.+)@users\.noreply\.github\.com$/.exec(email.trim())
-  return (noreply?.[1] ?? author).trim()
+/**
+ * The handle to credit, preferring what GitHub itself says over the display
+ * name recorded in the commit.
+ *
+ * A GitHub noreply address already carries the login and needs no lookup. Any
+ * other address leaves only a display name, which is not a handle and can
+ * collide with an unrelated account: v1.17.0 credited `s4kura` for #549 when
+ * the author was `Iams4kura`, an account someone else holds. Asking GitHub
+ * which account claims the commit resolves that.
+ *
+ * The lookup is best-effort. An unlinked address, a missing client, or a
+ * failed request degrades to the display name, which is the behavior this
+ * function had before, rather than failing a publish over a name. The result
+ * is cached per address, so a contributor with several commits costs one
+ * request and a transient failure degrades that contributor consistently.
+ */
+async function resolveContributorName(
+  sha: string,
+  author: string,
+  email: string,
+  github: GitHubClient | undefined,
+  loginByEmail: Map<string, string | null>,
+): Promise<string> {
+  const address = email.trim()
+  const noreply = /^(?:\d+\+)?(.+)@users\.noreply\.github\.com$/.exec(address)
+  if (noreply?.[1]) return noreply[1].trim()
+  if (!github || sha === '') return author.trim()
+
+  if (!loginByEmail.has(address)) {
+    loginByEmail.set(address, await github.getCommitAuthorLogin(sha).catch(() => null))
+  }
+  return (loginByEmail.get(address) ?? author).trim()
 }
 
 /** `feat(examples): add a thing (#12)` becomes `add a thing (#12)`. */

--- a/packages/release-bot/tests/prepare.test.ts
+++ b/packages/release-bot/tests/prepare.test.ts
@@ -145,6 +145,10 @@ class FakeGitHubClient implements GitHubClient {
   async createRelease(_input: CreateReleaseInput): Promise<GitHubRelease> {
     throw new Error('not used')
   }
+
+  async getCommitAuthorLogin(): Promise<string | null> {
+    throw new Error('not used')
+  }
 }
 
 function scriptedRun(evidence: ReleaseEvidence): ReleaseBotRun {

--- a/packages/release-bot/tests/publisher.test.ts
+++ b/packages/release-bot/tests/publisher.test.ts
@@ -161,9 +161,9 @@ class PublishRunner implements CommandRunner {
     if (args[0] === 'log' && args[2] === `v1.14.0..${this.sha}`) {
       // One outside contributor, the maintainer, and the release bot itself.
       return success([
-        'green3sf\u001f222944370+green3sf@users.noreply.github.com\u001ffeat(examples): add a verify loop (#541)\u001e',
-        'Jack Chen\u001fchenkaijie01@gmail.com\u001ffix(core): export public config types (#533)\u001e',
-        'oma-release-bot[bot]\u001f1+oma-release-bot[bot]@users.noreply.github.com\u001fchore: release core v1.15.0 (#543)\u001e',
+        `${'1'.repeat(40)}\u001fgreen3sf\u001f222944370+green3sf@users.noreply.github.com\u001ffeat(examples): add a verify loop (#541)\u001e`,
+        `${'2'.repeat(40)}\u001fJack Chen\u001fchenkaijie01@gmail.com\u001ffix(core): export public config types (#533)\u001e`,
+        `${'3'.repeat(40)}\u001foma-release-bot[bot]\u001f1+oma-release-bot[bot]@users.noreply.github.com\u001fchore: release core v1.15.0 (#543)\u001e`,
       ].join(''))
     }
     if (args[0] === 'rev-parse' && args[1] === 'refs/tags/v1.15.0^{commit}') {
@@ -191,6 +191,8 @@ class PublishGitHub implements GitHubClient {
     this.release = { id: 1, htmlUrl: 'https://github.test/releases/v1.15.0', tagName: input.tagName }
     return this.release
   }
+
+  async getCommitAuthorLogin(): Promise<string | null> { return null }
 }
 
 function success(stdout = ''): CommandResult {
@@ -247,8 +249,16 @@ describe('release contributor collection', () => {
     },
   })
 
-  const record = (author: string, email: string, subject: string) =>
-    `${author}\u001f${email}\u001f${subject}\u001e`
+  const record = (author: string, email: string, subject: string, sha = 'a'.repeat(40)) =>
+    `${sha}\u001f${author}\u001f${email}\u001f${subject}\u001e`
+
+  const lookup = (result: string | null | Error, calls: string[] = []): GitHubClient => ({
+    getCommitAuthorLogin: async (sha: string): Promise<string | null> => {
+      calls.push(sha)
+      if (result instanceof Error) throw result
+      return result
+    },
+  } as unknown as GitHubClient)
 
   it('groups a contributor and strips the conventional-commit prefix', async () => {
     const contributors = await collectReleaseContributors({
@@ -264,7 +274,58 @@ describe('release contributor collection', () => {
     ])
   })
 
-  it('falls back to the author name when the address is not a GitHub noreply', async () => {
+  it('resolves the login from GitHub when the address is not a noreply', async () => {
+    // v1.17.0 credited `s4kura`, the commit's display name, for #549. The
+    // author was `Iams4kura`, and `s4kura` is an unrelated real account.
+    const contributors = await collectReleaseContributors({
+      repoRoot: '/tmp/unused', expectedSha: 'c'.repeat(40),
+      github: lookup('Iams4kura'),
+      runner: runner(record('s4kura', 'someone@qq.com', 'fix(core): align required fields (#549)')),
+    } as Parameters<typeof collectReleaseContributors>[0])
+
+    expect(contributors).toEqual([
+      { name: 'Iams4kura', contributions: ['align required fields (#549)'] },
+    ])
+  })
+
+  it('does not look up a noreply address, which already carries the login', async () => {
+    const calls: string[] = []
+    const contributors = await collectReleaseContributors({
+      repoRoot: '/tmp/unused', expectedSha: 'c'.repeat(40),
+      github: lookup('wrong-login', calls),
+      runner: runner(record('green3sf', '9+green3sf@users.noreply.github.com', 'fix(core): a fix (#1)')),
+    } as Parameters<typeof collectReleaseContributors>[0])
+
+    expect(calls).toEqual([])
+    expect(contributors).toEqual([{ name: 'green3sf', contributions: ['a fix (#1)'] }])
+  })
+
+  it('falls back to the author name when no account claims the commit', async () => {
+    const contributors = await collectReleaseContributors({
+      repoRoot: '/tmp/unused', expectedSha: 'c'.repeat(40),
+      github: lookup(null),
+      runner: runner(record('Ada Lovelace', 'ada@example.com', 'fix(core): tighten a guard (#12)')),
+    } as Parameters<typeof collectReleaseContributors>[0])
+
+    expect(contributors).toEqual([
+      { name: 'Ada Lovelace', contributions: ['tighten a guard (#12)'] },
+    ])
+  })
+
+  it('falls back to the author name when the lookup fails', async () => {
+    // A name lookup must not fail a publish that is otherwise complete.
+    const contributors = await collectReleaseContributors({
+      repoRoot: '/tmp/unused', expectedSha: 'c'.repeat(40),
+      github: lookup(new Error('502 from GitHub')),
+      runner: runner(record('Ada Lovelace', 'ada@example.com', 'fix(core): tighten a guard (#12)')),
+    } as Parameters<typeof collectReleaseContributors>[0])
+
+    expect(contributors).toEqual([
+      { name: 'Ada Lovelace', contributions: ['tighten a guard (#12)'] },
+    ])
+  })
+
+  it('falls back to the author name when there is no client to ask', async () => {
     const contributors = await collectReleaseContributors({
       repoRoot: '/tmp/unused', expectedSha: 'c'.repeat(40),
       runner: runner(record('Ada Lovelace', 'ada@example.com', 'fix(core): tighten a guard (#12)')),
@@ -273,6 +334,35 @@ describe('release contributor collection', () => {
     expect(contributors).toEqual([
       { name: 'Ada Lovelace', contributions: ['tighten a guard (#12)'] },
     ])
+  })
+
+  it('resolves one address once across several commits', async () => {
+    const calls: string[] = []
+    const contributors = await collectReleaseContributors({
+      repoRoot: '/tmp/unused', expectedSha: 'c'.repeat(40),
+      github: lookup('Iams4kura', calls),
+      runner: runner([
+        record('s4kura', 'someone@qq.com', 'fix(core): first (#1)', 'a'.repeat(40)),
+        record('s4kura', 'someone@qq.com', 'fix(core): second (#2)', 'b'.repeat(40)),
+      ].join('')),
+    } as Parameters<typeof collectReleaseContributors>[0])
+
+    expect(calls).toEqual(['a'.repeat(40)])
+    expect(contributors).toEqual([
+      { name: 'Iams4kura', contributions: ['first (#1)', 'second (#2)'] },
+    ])
+  })
+
+  it('excludes the maintainer by the login a lookup resolves', async () => {
+    // The default exclusion list carries both the display name and the login
+    // precisely because either can be what this resolves to.
+    const contributors = await collectReleaseContributors({
+      repoRoot: '/tmp/unused', expectedSha: 'c'.repeat(40),
+      github: lookup('JackChen-me'),
+      runner: runner(record('Jack Chen', 'jack@yuanasi.com', 'fix(core): tighten a guard (#12)')),
+    } as Parameters<typeof collectReleaseContributors>[0])
+
+    expect(contributors).toEqual([])
   })
 
   it('honours an explicit exclusion list', async () => {


### PR DESCRIPTION
## Why

`## Thanks` in a release body credited the commit's display name whenever the author's email was not a GitHub noreply address. A display name is not a handle, and it can belong to a different real account.

v1.17.0 shipped exactly that: it credited `s4kura` for #549, but that author's login is `Iams4kura`, and `s4kura` is a separate real account. The published release body has been corrected by hand. v1.16.1 only looked right because that contributor's commits carried `222944370+green3sf@users.noreply.github.com`, which already contains the login. Whether a credit was correct therefore depended on a contributor's email privacy setting.

## What

`GitHubClient` gains `getCommitAuthorLogin(sha)`, backed by `GET /repos/{repo}/commits/{sha}`. `resolveContributorName` now resolves in three steps: a noreply address still yields the login with no request, any other address asks GitHub which account claims the commit, and anything unresolved falls back to the display name.

The lookup is best-effort by design. `collectReleaseContributors` runs before the Release is created, so failing it would fail an otherwise complete publish over a name. An unlinked address, a missing client, or a failed request degrades to the previous behavior. Results are cached per address, so a contributor with several commits costs one request, and a transient failure degrades that contributor consistently rather than half-correctly.

The default exclusion list already carried both `Jack Chen` and `JackChen-me` because either form could be what this resolves to. That still holds, and a test now covers the login path.

## Verification

- `npm run lint` at the root, including the bench project: passes
- `npm test` at the root: core 2027, create-oma-app 31, otel 15, release-bot 54, all passing
- Reverting the resolver makes the new regression test fail with the production symptom, `s4kura` instead of `Iams4kura`; restoring it makes the test pass again
- `git diff --check`: clean

Six tests were added: login resolved from the API, a noreply address skipping the request, an unlinked account, a failed request, no client available, one request per address across several commits, and maintainer exclusion by resolved login.

`.github/RELEASING.md` documents the Thanks section, so it gains a sentence on how the handle is now resolved.
