### PR TITLE
test(core): drive the journal batching window with fake timers

### DIFF
--- a/packages/core/tests/journal-backends.test.ts
+++ b/packages/core/tests/journal-backends.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   InMemoryRunJournal,
   JournalRecorder,
@@ -80,32 +80,42 @@ describe('JsonlRunJournal', () => {
 
   it('opens the batching window on the first pending event and does not reset it', async () => {
     const path = await tempFile('batched.jsonl')
-    // Whether the window reset is a question about *when* the batch flushed, so
-    // it can only be answered against the clock. What keeps that from being
-    // flaky is the size of the gap: with the sleep at exactly half the
-    // interval, correct behavior settles ~300ms after the second append and a
-    // reset one ~600ms, either side of a 450ms bound. Every margin here is
-    // ~150ms rather than the single-digit one this assertion used to ride on,
-    // which is what made it fail under parallel load. Do not tighten these.
+    // Whether the window reset is a question about *when* the batch flushed.
+    // Measuring that against the wall clock made this test ride on how promptly
+    // a loaded runner fires a timer, and it failed twice on margins that looked
+    // generous. Driving the clock instead makes the answer exact: the flush
+    // either lands on the deadline the first append opened or it does not.
     const flushIntervalMs = 600
     const journal = new JsonlRunJournal(path, { flushIntervalMs })
+    const readRaw = async (): Promise<string> => await readFile(path, 'utf8').catch(() => '')
 
-    const first = journal.append([event(1)])
-    // A later append lands inside the window opened by the first one. If the
-    // window reset, this batch would flush a full interval after *this* call.
-    await new Promise((resolve) => setTimeout(resolve, flushIntervalMs / 2))
-    const second = journal.append([event(2)])
-    // Still inside the original window, so nothing can have been written yet.
-    // This also fails loudly if the setup drifts the other way: had the first
-    // window already fired, these would be separate batches and the timing
-    // assertion below would be measuring nothing.
-    expect(await readFile(path, 'utf8').catch(() => '')).toBe('')
+    vi.useFakeTimers()
+    try {
+      const first = journal.append([event(1)])
+      // A later append lands inside the window opened by the first one. A
+      // window that reset here would move the deadline from 600ms to 900ms.
+      await vi.advanceTimersByTimeAsync(flushIntervalMs / 2)
+      const second = journal.append([event(2)])
+      // Still inside the original window, so nothing can have been written yet.
+      // This also fails loudly if the setup drifts the other way: had the first
+      // window already fired, these would be two batches and the assertions
+      // below would be measuring nothing.
+      expect(await readRaw()).toBe('')
+      expect(vi.getTimerCount()).toBe(1)
 
-    const startedWaiting = Date.now()
-    await Promise.all([first, second])
-    // Settled on the deadline the *first* append opened, about half an interval
-    // away, rather than on a full interval reopened by the second.
-    expect(Date.now() - startedWaiting).toBeLessThan(flushIntervalMs * 0.75)
+      // One tick short of the deadline the first append opened.
+      await vi.advanceTimersByTimeAsync(flushIntervalMs / 2 - 1)
+      expect(await readRaw()).toBe('')
+
+      // Reaching that deadline flushes both appends. flushPending() clears the
+      // timer before writing, so an empty queue afterwards is what rules out a
+      // second, later deadline left behind by the reopened window.
+      await vi.advanceTimersByTimeAsync(1)
+      expect(vi.getTimerCount()).toBe(0)
+      await Promise.all([first, second])
+    } finally {
+      vi.useRealTimers()
+    }
 
     // One write, so both lines are in the file at the same instant.
     const raw = await readFile(path, 'utf8')


### PR DESCRIPTION
## Why

The `JsonlRunJournal` batching test asserted `Date.now() - startedWaiting` against `flushIntervalMs * 0.75`, so it measured how promptly a loaded runner fires a timer rather than the invariant it names.

It has now failed twice for that reason. #556 widened the margin from 5ms to roughly 150ms after the first failure, and it failed again during the v1.17.0 release CI on `test (24)` with `expected 450 to be less than 450`: the timer overshot by about 150ms and consumed the entire margin. Node 20, Node 22, and coverage passed on that same commit and a rerun went green, which is what a load-dependent assertion looks like.

Widening it again is not the fix. Timer overshoot and a genuinely reset window push the measurement in the same direction, so every millisecond added to the bound trades discrimination for stability.

## What

Drive the clock with `vi.useFakeTimers()` and assert facts instead of durations:

- at the second append, the file is empty and one timer is pending
- one tick short of the first append's deadline, the file is still empty
- at that deadline, the timer queue is empty, both appends settle, and the file holds both lines

`flushPending()` clears the timer before it writes, so an empty queue at the deadline is what rules out a second, later deadline left behind by a reopened window.

Two details worth calling out.

Changing `this.timer ??= setTimeout(...)` to `=` does not reproduce the bug: the stale timer is never cleared and still fires on the original deadline, so behavior is unchanged. The mutation that does reproduce it clears the old timer and sets a new one, and that is what this test was checked against.

The timer-count assertion sits before `await Promise.all(...)` deliberately. After it, a real reset would leave that await hanging until the test times out, reporting nothing about the cause.

## Verification

- `npm run lint -w @open-multi-agent/core`: passes
- `npm run test -w @open-multi-agent/core`: 137 files, 2027 tests, all passing
- Mutation check: introducing a real window reset fails the test in 12ms with `expected 1 to be +0`; reverting it makes the test pass
- `git diff packages/core/src/` is empty, so only the test changed
- `git diff --check`: clean

The file now runs in about 53ms rather than roughly 615ms, since the test no longer sleeps through a real interval.
